### PR TITLE
fix(scripts): run-all-tests.sh reported success regardless of test results [skip changelog]

### DIFF
--- a/changelog.d/20260810_130000_fix_run_all_tests_pipefail.md
+++ b/changelog.d/20260810_130000_fix_run_all_tests_pipefail.md
@@ -1,0 +1,31 @@
+### Fixed
+
+#### `scripts/run-all-tests.sh` reported "All tests passed" no matter what failed
+
+All three steps in the script had the shape
+
+    if <test command> 2>&1 | tee <log>; then
+
+and a shell pipeline's exit status is that of its **last** command — `tee`,
+which essentially always succeeds. So `GO_TESTS_PASSED`, `FRONTEND_UNIT_PASSED`
+and `E2E_TESTS_PASSED` were unconditionally `true`, which made the script's
+careful three-way summary and its final `exit 0` / `exit 1` logic completely
+inert. `set -e` does not help — commands in an `if` condition are exempt from it
+by design.
+
+Measured on the real script with all three test commands stubbed to fail:
+
+| Variant | Summary | Exit |
+|---|---|---|
+| before | 🎉 All tests passed! | **0** |
+| after (`set -o pipefail`) | ❌ Go / Frontend / E2E: FAILED | **1** |
+
+The Go step also now passes `-timeout 25m`, matching the Makefile's `./...`
+targets. Go's default is 10 minutes **per package** and `internal/server` alone
+runs ~500s, so a contended run dies with `panic: test timed out` naming
+whichever test happened to be mid-flight — which reads as a failure in an
+unrelated test.
+
+The script is a manual runner, not wired into CI or the Makefile, so no CI
+result was ever affected. A repo-wide sweep found no other shell script using a
+pipe inside an `if`/`while` condition.

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
 # file: scripts/run-all-tests.sh
-# version: 1.0.0
+# version: 1.1.0
 # guid: f1e2d3c4-b5a6-7980-1234-567890abcdef
+# last-edited: 2026-08-10
 # description: Run all tests (Go backend + Frontend E2E + Frontend unit) and generate reports
 
 set -e
+
+# pipefail is load-bearing here, not hygiene. Every one of the three test steps
+# below has the shape `if <test command> 2>&1 | tee <log>; then`, and a shell
+# pipeline's exit status is that of its LAST command — `tee`, which essentially
+# always succeeds. Without this line all three `if`s take the PASSED branch
+# unconditionally, so GO_TESTS_PASSED / FRONTEND_UNIT_PASSED / E2E_TESTS_PASSED
+# are always true and the summary reports "🎉 All tests passed!" and exits 0 no
+# matter how many tests actually failed. `set -e` does not help: commands in an
+# `if` condition are exempt from it by design.
+set -o pipefail
 
 echo "🧪 Running Comprehensive Test Suite"
 echo "===================================="
@@ -26,7 +37,11 @@ mkdir -p test-reports
 
 echo "📊 Step 1: Running Go Backend Tests"
 echo "------------------------------------"
-if go test -v -coverprofile=test-reports/go-coverage.out ./... 2>&1 | tee test-reports/go-tests.log; then
+# -timeout 25m matches the Makefile's ./... targets. Go's default is 10m PER
+# PACKAGE and internal/server alone runs ~500s, so a contended run dies with
+# "panic: test timed out" naming whichever test was mid-flight — which reads as
+# a failure in an unrelated test. See the comment above `coverage:` in Makefile.
+if go test -v -coverprofile=test-reports/go-coverage.out -timeout 25m ./... 2>&1 | tee test-reports/go-tests.log; then
     echo -e "${GREEN}✅ Go tests passed${NC}"
     GO_TESTS_PASSED=true
 


### PR DESCRIPTION
## Why

`scripts/run-all-tests.sh` printed **🎉 All tests passed!** and exited **0** regardless of how many tests failed.

All three steps had this shape:

```bash
if <test command> 2>&1 | tee <log>; then
```

A shell pipeline's exit status is that of its **last** command — `tee` — which essentially always succeeds. So `GO_TESTS_PASSED`, `FRONTEND_UNIT_PASSED` and `E2E_TESTS_PASSED` were unconditionally `true`, which makes the script's careful three-way summary and its final `exit 0` / `exit 1` block (lines 102–108) entirely inert. They were computing over three constants.

`set -e` on line 7 does not help: commands in an `if` condition are exempt from it by design.

## Measured, not argued

The real script, with only the three test commands stubbed to a failing command and the report-generation steps neutralised:

| Variant | Summary line | Exit |
|---|---|---|
| **before** (as on `main`) | `🎉 All tests passed!` | **0** |
| **after** (`set -o pipefail`) | `❌ Go Backend / Frontend Unit / E2E: FAILED` | **1** |

Both variants were generated from the committed script itself rather than hand-written, so the control exercises the real control flow — including the summary block — not a paraphrase of it.

## Scope of the impact — deliberately not overstated

This script is **not** wired into CI or the Makefile. It is a manual runner, already flagged as TOOL-8 in [`docs/audits/2026-06-22-repo-optimization-security-sweep.md`](docs/audits/2026-06-22-repo-optimization-security-sweep.md) ("Legacy/manual script test surfaces are not integrated — retire or wrap"). **No CI result was ever affected by this.** What was affected is anyone who ran it by hand and read the summary.

I fixed rather than retired it: retiring is TOOL-8's open question and the owner's call, and fixing is the non-destructive option in the meantime.

## Recurrence check

Swept every shell script in the repo for a pipe inside an `if`/`while`/`until` condition. `run-all-tests.sh` was the only one, and it now sets `pipefail`.

Separately, the sweep found `go test` invocations without an explicit `-timeout` in `Makefile.mockery.example` (an example file), `scripts/gen_pipeline_bot_tasks.py` (generated `-run`-scoped one-liners), and `scripts/org-migration/*` (historical). None are on a live path; left alone rather than touched.

## Also: TODO-SRVTIMEOUT

The Go step now carries `-timeout 25m`, matching the Makefile's four `./...` targets. Go's default is 10 minutes **per package**, `internal/server` alone runs ~500s, and `./...` runs packages in parallel so they contend — a contended run dies with `panic: test timed out` naming whichever test was mid-flight, which reads as a failure in an unrelated test and sent a 2026-07-31 investigation down a false trail on #2083.

This closes the last live invocation that lacked the flag; #2270 had already covered the Makefile. TODO-SRVTIMEOUT stays **open** — its other half (shard or speed up the package) is untouched, and a bare `go test ./internal/server/` still runs on the 10m default.

## Gates

`bash -n` clean. `shellcheck` reports one warning, `SC2034 YELLOW appears unused`, which is pre-existing on `main` and left alone.

No Go or frontend code changed; suite counts unaffected. Last full e2e run on `main`: **556 passed / 0 failed / 8 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp
