### PR TITLE
docs(todo): measure internal/server, redirecting TODO-SRVTIMEOUT's fix [skip changelog]

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.25.0 -->
+<!-- version: 10.26.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-08-10 -->
 
@@ -4832,6 +4832,52 @@ far more than chapters.
       load. Either shard the package, or set an explicit generous `-timeout` in
       the Makefile test targets so a slow run fails as "too slow" rather than
       masquerading as a lock bug.
+
+      **The `-timeout` half is DONE.** #2270 put `-timeout 25m` on the Makefile's
+      four `./...` targets (with a comment above `coverage:` explaining this exact
+      masquerade); #2278 did the last live invocation that lacked it,
+      `scripts/run-all-tests.sh`. A repo-wide sweep found no other. A bare
+      `go test ./internal/server/` still runs on Go's 10m-per-package default.
+
+      **Measured 2026-08-10 — the premise has drifted and the proposed fix is
+      aimed at the wrong thing.**
+
+      - Runtime is now **543 s** solo (`real 553 s`), not 434–480 s. Headroom
+        against the 600 s default is **9.5%**, not "under 30%" — it has gotten
+        worse, and that is *without* the `./...` contention the entry blames.
+      - **~85% of wall time is idle**: `user 40.7 s + sys 40.0 s ≈ 81 s` CPU
+        against 553 s wall. The package is not compute-bound; it is waiting.
+      - **There is no slow test to fix.** 855 top-level tests summing to 540.5 s
+        — so the time is inside tests, not compile or global fixture. The
+        distribution: **4** tests ≥5 s (slowest `TestServerStartGracefulShutdown`
+        at 14.1 s), **296** at 1–5 s, 89 at 0.1–1 s, 466 under 0.1 s. The top 25
+        tests account for only ~85 s of 543 s.
+      - **The cost is a fixed per-test fixture charge.** `setupTestServer` +
+        `cleanup`, timed directly over 10 iterations, is **1.44 s mean**. There
+        are **261 static call sites** (250 `setupTestServer`, 11
+        `setupTestServerWithStore`), so ≈ **376 s, about 69% of the package**.
+        That matches the 296-test 1–5 s band independently.
+
+      Per call the fixture makes a temp dir, opens a **disk-backed** PebbleStore,
+      runs ALL migrations, constructs `NewServer` (hub, queue, write-back
+      batcher, fileIO pool) and calls `opRegistry.Start`; cleanup then calls
+      `opRegistry.Shutdown` — which blocks on `sync.WaitGroup.Wait`, *the very
+      goroutine the #2083 panic dump named*. So the thing that made the timeout
+      look like a deadlock is also the thing making the package slow.
+
+      **This redirects the fix.** Sharding redistributes a 69% fixture charge
+      across shards without removing it, and each shard still pays 1.44 s per
+      test. The lever is amortising the fixture: share one store/server across a
+      suite where tests do not mutate global state, skip `opRegistry.Start` for
+      the many tests that never enqueue an op, or keep Pebble in a tmpfs/memory
+      configuration. Any of these is a large, isolation-sensitive refactor across
+      ~260 call sites and wants its own plan — not a drive-by.
+
+      *Not claimed:* the 543 s and 1.44 s figures are each a **single sample** on
+      one idle Mac; 261 is **static call sites**, not dynamic invocations; and
+      which part of the 1.44 s dominates (Pebble open, migrations, registry
+      start, or `Shutdown`'s wait) was **not** isolated — that is the first thing
+      to measure before choosing among the three levers above.
 
 <!-- file: todo.d/2026-08-01-origin-lan-exposure-finding.md -->
 <!-- version: 1.0.0 -->

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.26.0 -->
+<!-- version: 10.27.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-08-10 -->
 
@@ -4858,26 +4858,56 @@ far more than chapters.
         `setupTestServerWithStore`), so ≈ **376 s, about 69% of the package**.
         That matches the 296-test 1–5 s band independently.
 
-      Per call the fixture makes a temp dir, opens a **disk-backed** PebbleStore,
-      runs ALL migrations, constructs `NewServer` (hub, queue, write-back
-      batcher, fileIO pool) and calls `opRegistry.Start`; cleanup then calls
-      `opRegistry.Shutdown` — which blocks on `sync.WaitGroup.Wait`, *the very
-      goroutine the #2083 panic dump named*. So the thing that made the timeout
-      look like a deadlock is also the thing making the package slow.
+      **Which phase costs what** — measured per iteration over 5 iterations by
+      timing each step of the fixture separately. The phases sum to **1.4425 s**,
+      independently reproducing the 1.44 s figure above:
 
-      **This redirects the fix.** Sharding redistributes a 69% fixture charge
-      across shards without removing it, and each shard still pays 1.44 s per
-      test. The lever is amortising the fixture: share one store/server across a
-      suite where tests do not mutate global state, skip `opRegistry.Start` for
-      the many tests that never enqueue an op, or keep Pebble in a tmpfs/memory
-      configuration. Any of these is a large, isolation-sensitive refactor across
-      ~260 call sites and wants its own plan — not a drive-by.
+      | Phase | Mean | Share |
+      |---|---|---|
+      | `RunMigrations` | **828 ms** | **57.4%** |
+      | `NewServer` (hub, queue, write-back batcher, fileIO pool) | 473 ms | 32.8% |
+      | `NewPebbleStore` (disk-backed) | 134 ms | 9.3% |
+      | `pools + store.Close` | 5.0 ms | 0.3% |
+      | `RemoveAll` | 1.4 ms | 0.1% |
+      | `MkdirTemp` | 0.44 ms | 0.0% |
+      | `opRegistry.Shutdown` | **0.30 ms** | **0.0%** |
+      | `opRegistry.Start` | 0.08 ms | 0.0% |
 
-      *Not claimed:* the 543 s and 1.44 s figures are each a **single sample** on
-      one idle Mac; 261 is **static call sites**, not dynamic invocations; and
-      which part of the 1.44 s dominates (Pebble open, migrations, registry
-      start, or `Shutdown`'s wait) was **not** isolated — that is the first thing
-      to measure before choosing among the three levers above.
+      **The registry teardown is NOT the cost.** It is tempting to connect the
+      slowness to `opRegistry.Shutdown` blocking on `sync.WaitGroup.Wait`, since
+      that is the goroutine the #2083 panic dump named — and an earlier draft of
+      this entry asserted exactly that. The measurement refutes it: `Shutdown` is
+      **297 µs**, four orders of magnitude below the fixture cost. The #2083
+      panic dump named a goroutine that is normally free and only blocks under
+      the contention that caused the timeout. Slowness and the deadlock-shaped
+      panic are two separate phenomena that happen to name the same symbol.
+
+      **This redirects the fix**, and not where sharding points. Sharding
+      redistributes a 69% fixture charge without removing it; each shard still
+      pays 1.44 s per test. **90% of that charge is `RunMigrations` +
+      `NewServer`,** so those are the levers:
+
+      1. **Migrations (57%)** — every test replays the FULL migration chain onto
+         an empty store, producing a byte-identical result every time. Build one
+         migrated Pebble directory once per package and copy/clone it per test,
+         or share a migrated store where tests do not mutate global state.
+      2. **`NewServer` (33%)** — construct the hub/queue/batcher/fileIO pool
+         lazily, or let tests that only exercise handlers skip the parts they
+         never touch.
+      3. **Pebble open (9%)** — tmpfs or an in-memory VFS; worth doing only after
+         the first two.
+
+      Skipping `opRegistry.Start` — a lever an earlier draft proposed — would
+      save **0.08 ms** and is not worth doing. Any of 1–3 is an
+      isolation-sensitive refactor across ~260 call sites (`setupTestServer` also
+      sets `database.SetGlobalStore`, so shared state is exactly where isolation
+      would break) and wants its own plan, not a drive-by.
+
+      *Not claimed:* the 543 s figure is a **single sample** on one idle Mac
+      (the 1.44 s fixture cost has two independent samples that agree); 261 is
+      **static call sites**, not dynamic invocations; and the phase table is one
+      run of 5 iterations, so treat the shares as approximate rather than the
+      millisecond values as exact.
 
 <!-- file: todo.d/2026-08-01-origin-lan-exposure-finding.md -->
 <!-- version: 1.0.0 -->

--- a/changelog.d/20260810_140000_srvtimeout_measurement.md
+++ b/changelog.d/20260810_140000_srvtimeout_measurement.md
@@ -8,6 +8,11 @@
      296 tests at 1-5s), and setupTestServer+cleanup measures 1.44s mean across
      261 static call sites -- about 69% of the package.
 
+     Phase breakdown: RunMigrations 57.4%, NewServer 32.8%, NewPebbleStore 9.3%.
+     opRegistry.Shutdown -- the goroutine the #2083 panic dump named -- is 297us,
+     0.0%, so the slowness and the deadlock-shaped panic are separate phenomena.
+
      This redirects the entry's proposed fix: sharding redistributes the fixture
-     charge without removing it. Amortising the fixture is the lever. No code
-     change here; the refactor spans ~260 call sites and wants its own plan. -->
+     charge without removing it. Amortising migrations and NewServer is the
+     lever. No code change here; the refactor spans ~260 call sites and wants its
+     own plan. -->

--- a/changelog.d/20260810_140000_srvtimeout_measurement.md
+++ b/changelog.d/20260810_140000_srvtimeout_measurement.md
@@ -1,0 +1,13 @@
+<!-- TODO.md evidence only — no code, no behaviour change, so this fragment is
+     deliberately a no-op comment. See changelog.d/README.md.
+
+     Records a measurement of the internal/server test package for
+     TODO-SRVTIMEOUT. The package now runs 543s (was recorded as 434-480s),
+     leaving 9.5% headroom under Go's 600s default rather than ~30%. ~85% of
+     wall time is idle, there is no slow test to fix (4 tests >=5s; the mass is
+     296 tests at 1-5s), and setupTestServer+cleanup measures 1.44s mean across
+     261 static call sites -- about 69% of the package.
+
+     This redirects the entry's proposed fix: sharding redistributes the fixture
+     charge without removing it. Amortising the fixture is the lever. No code
+     change here; the refactor spans ~260 call sites and wants its own plan. -->


### PR DESCRIPTION
## Why

TODO-SRVTIMEOUT says to "split or speed up" `internal/server`, on the premise that it runs 434–480s of slow tests. I measured it before picking that up. **Both halves of the premise have moved**, and the proposed fix is aimed at the wrong thing.

No code changes here — this records the measurement and redirects the entry.

## What the package actually does

| | Recorded in the entry | Measured 2026-08-10 |
|---|---|---|
| Runtime | 434–480s | **543s** (`real 553s`) |
| Headroom under Go's 600s default | "under 30%" | **9.5%** — 57 seconds |

That was a **solo** run, without the `./...` contention the entry blames for tipping it over.

Then the two numbers that reframe it:

- **~85% of wall time is idle.** `user 40.7s + sys 40.0s ≈ 81s` CPU against 553s wall. The package is not compute-bound; it is waiting.
- **There is no slow test to fix.** 855 top-level tests sum to 540.5s, so the time is inside the tests rather than compile or global setup. The distribution:

  | Band | Tests |
  |---|---|
  | ≥5s | **4** (slowest: `TestServerStartGracefulShutdown`, 14.1s) |
  | 1–5s | **296** |
  | 0.1–1s | 89 |
  | <0.1s | 466 |

  The top 25 tests together account for only ~85s of 543s. Optimising them is worth nothing.

## Where the time actually goes

The 1–5s band is a **fixed per-test fixture charge**. Timed directly over 10 iterations:

```
setupTestServer+cleanup x10 = 14.42s  (mean 1.44s per test)
```

Against **261 static call sites** (250 `setupTestServer`, 11 `setupTestServerWithStore`) that is ≈ **376s — about 69% of the package.** The 296-test 1–5s band corroborates the count independently of the grep.

Timing each phase separately, over 5 iterations — the phases sum to **1.4425s**, independently reproducing the 1.44s above:

| Phase | Mean | Share |
|---|---|---|
| `RunMigrations` | **828ms** | **57.4%** |
| `NewServer` (hub, queue, batcher, fileIO pool) | 473ms | 32.8% |
| `NewPebbleStore` (disk-backed) | 134ms | 9.3% |
| `pools + store.Close` | 5.0ms | 0.3% |
| `RemoveAll` | 1.4ms | 0.1% |
| `MkdirTemp` | 0.44ms | 0.0% |
| **`opRegistry.Shutdown`** | **0.30ms** | **0.0%** |
| `opRegistry.Start` | 0.08ms | 0.0% |

## A claim in the first commit of this PR was wrong

That first commit asserted the cost was `opRegistry.Shutdown` blocking on `sync.WaitGroup.Wait` — the goroutine the #2083 panic dump named — and concluded "the thing that made the timeout look like a deadlock is also the thing making the package slow."

**The measurement refutes it.** `Shutdown` is **297µs**, four orders of magnitude below the fixture charge. The inference was plausible — a `WaitGroup.Wait` in teardown, named in a real panic dump, in a package that is 85% idle — and plausible was not good enough.

The #2083 panic named a goroutine that is normally free and only blocks under the contention that caused the timeout. The slowness and the deadlock-shaped panic are **separate phenomena that happen to name the same symbol**. The correction is in the second commit.

## Why this redirects the fix

Sharding **redistributes** a 69% fixture charge across shards without removing it; each shard still pays 1.44s per test. **90% of that charge is `RunMigrations` + `NewServer`**, so those are the levers:

1. **Migrations (57%)** — every test replays the full migration chain onto an empty store, producing a byte-identical result each time. Build one migrated Pebble directory per package and clone it per test, or share a migrated store where tests do not mutate global state.
2. **`NewServer` (33%)** — construct the hub/queue/batcher/pool lazily, or let handler-only tests skip what they never touch.
3. **Pebble open (9%)** — tmpfs or an in-memory VFS, worth doing only after the first two.

Skipping `opRegistry.Start`, which the first commit proposed as a lever, would save **0.08ms** and is not worth doing.

Each of 1–3 is a large, isolation-sensitive refactor across ~260 call sites — `setupTestServer` also sets `database.SetGlobalStore`, so shared state is exactly where isolation would break. That wants its own plan, not a drive-by, so the entry stays **open**.

## Not claimed

- 543s is a **single sample** on one idle Mac. The 1.44s fixture cost has two independent samples that agree.
- 261 is **static call sites**, not dynamic invocations — some sit in loops or helpers.
- The phase table is one run of 5 iterations: treat the **shares** as approximate rather than the millisecond values as exact.

## Scope

`TODO.md` (10.25.0 → 10.26.0) plus a no-op changelog fragment. The `-timeout` half of the entry is separately noted as done: #2270 covered the Makefile's four `./...` targets, #2278 the last live invocation lacking it. No code, no test, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp
