### PR TITLE
docs(todo): trace the aggregates-staleness entry; its suspect does not fit [skip changelog]

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.27.0 -->
+<!-- version: 10.28.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-08-10 -->
 
@@ -3987,6 +3987,55 @@ deleted rather than rewritten, since the capabilities themselves are gone. Relat
 
       Until it is fixed, `dedupe-book-file-rows` says so in its completion
       message rather than letting an operator conclude the run did nothing.
+
+      **Traced 2026-08-10 — the stated suspect does not fit the symptom. Read
+      this before spending time on `RecomputeBookAggregates`.** Four things were
+      verified by reading the code at `65e63135`; **none of this is a
+      reproduction**, and the bug is NOT explained yet.
+
+      1. **The op does not call `DeleteBookFile`.** `dedupe-book-file-rows` uses
+         the batched `store.DeleteBookFilesByIDs`
+         (`internal/plugins/maintenance/dedupe_book_file_rows.go:368`). The entry
+         above says "where to look: `DeleteBookFile`" — that is a different code
+         path from the one the canary actually ran.
+      2. **The batched path already does the memdb delete.**
+         `DeleteBookFilesByIDs` (`pebble_store_bookfiles.go:990`) calls
+         `s.DeleteBookFilesFromMemDB(resolvedIDs)` at :1073 and then
+         `notifyBookFileChange(bookID)` per affected book at :1078. So the
+         book_file rows ARE removed from memdb on the delete path, independently
+         of whether any later `UpdateBook` runs.
+      3. **`total_file_count` is not a stored field**, so a skipped `UpdateBook`
+         cannot stale it. It is derived at read time —
+         `enriched[i].TotalFileCount = len(files)`
+         (`internal/server/audiobooks_helpers.go:95`, and again at
+         `internal/server/handlers/audiobooks/handler.go:387`) — from
+         `FetchBookFilesForBooks` → `GetBookFilesForIDsCore`, whose memdb
+         implementation (`memdb_reads.go:917`) reads `memTableBookFiles` by
+         `memIdxBookID`.
+      4. Consistent with that, `RecomputeBookAggregates` never touches
+         `TotalFileCount` at all — its early return at
+         `pebble_store_book_aggregates.go:131-134` compares only `Duration` and
+         `FileSize`.
+
+      Taken together: if the delete path removes the rows from memdb (2) and the
+      count is derived from memdb at read time (3), then the early return in
+      `RecomputeBookAggregates` cannot be what left `total_file_count` at 50.
+      Something else kept those rows visible.
+
+      **Where to look next**, in rough order of suspicion — all unverified:
+      `DeleteBookFilesFromMemDB` routes through `memSync`, which during warmup
+      either buffers or, on buffer overflow, abandons memdb entirely
+      (`memdb_pending.go`). The canary ran against a production-sized library
+      where warmup takes ~2 minutes, so a delete landing in that window is the
+      first thing to rule in or out — including whether a warmup snapshot taken
+      before the delete could be published after it. Note the observed fix was a
+      **service restart**, which is consistent with a memdb-population problem
+      and not with a missed `UpdateBook`.
+
+      **To reproduce**, the shape that matters is a delete concurrent with
+      warmup, not a delete on a quiet store — a quiet-store test will likely pass
+      and prove nothing, the same way `dbtest` invariant (b) passes everywhere
+      while the version-group under-report is real.
 
 - [x] ~~**Restore the duration on `The Trapped Mind Project`**~~ **RETRACTED
       2026-08-04 — nothing to restore.** The original claim here was that the

--- a/changelog.d/20260810_150000_aggregates_trace.md
+++ b/changelog.d/20260810_150000_aggregates_trace.md
@@ -1,0 +1,13 @@
+<!-- TODO.md evidence only — no code, no behaviour change, so this fragment is
+     deliberately a no-op comment. See changelog.d/README.md.
+
+     Traces the "corrected book aggregates are invisible until memdb refreshes"
+     entry and records that its stated suspect does not fit the symptom: the op
+     uses the batched DeleteBookFilesByIDs (not DeleteBookFile), that path
+     already calls DeleteBookFilesFromMemDB plus notifyBookFileChange, and
+     total_file_count is derived at read time from memdb rather than stored --
+     so RecomputeBookAggregates' early return cannot have staled it.
+
+     NOT a reproduction and NOT a root cause. Redirects the next investigator
+     toward memSync's warmup buffering, which is consistent with the observed
+     fix being a service restart. -->


### PR DESCRIPTION
## Why

The entry "Corrected book aggregates are invisible until memdb refreshes" names a suspect: `RecomputeBookAggregates` early-returns without calling `UpdateBook` when the recomputed values match the stored ones, so the memdb refresh never happens.

I went to reproduce that. **The suspect does not fit the symptom.** This PR records why, so the next person does not spend the time I did confirming a dead end.

**This is a trace, not a reproduction, and the bug is not explained.**

## Verified by reading the code at `65e63135`

1. **The op does not call `DeleteBookFile`.** `dedupe-book-file-rows` uses the batched `store.DeleteBookFilesByIDs` (`dedupe_book_file_rows.go:368`). The entry says "where to look: `DeleteBookFile`" — a different path from the one the canary ran.
2. **The batched path already does the memdb delete.** `DeleteBookFilesByIDs` (`pebble_store_bookfiles.go:990`) calls `DeleteBookFilesFromMemDB(resolvedIDs)` at `:1073`, then `notifyBookFileChange(bookID)` per affected book at `:1078`. The rows leave memdb on the delete path regardless of any later `UpdateBook`.
3. **`total_file_count` is not stored**, so a skipped `UpdateBook` cannot stale it. It is derived at read time — `enriched[i].TotalFileCount = len(files)` (`audiobooks_helpers.go:95`, and `handlers/audiobooks/handler.go:387`) — from `FetchBookFilesForBooks` → `GetBookFilesForIDsCore`, whose memdb implementation (`memdb_reads.go:917`) reads `memTableBookFiles` by `memIdxBookID`.
4. `RecomputeBookAggregates` never touches `TotalFileCount` at all; its early return (`pebble_store_book_aggregates.go:131-134`) compares only `Duration` and `FileSize`.

If the delete path removes the rows from memdb (2) and the count is derived from memdb at read time (3), the early return cannot be what left `total_file_count` reading 50.

## Where to look next — unverified

`DeleteBookFilesFromMemDB` routes through `memSync`, which during warmup either buffers writes or, on buffer overflow, abandons memdb entirely (`memdb_pending.go`). The canary ran against a production-sized library where warmup takes ~2 minutes, so a delete landing in that window is the first thing to rule in or out — including whether a warmup snapshot taken before the delete can be published after it.

The observed fix was a **service restart**, which is consistent with a memdb-population problem and not with a missed `UpdateBook`.

## A note on how to reproduce it

The shape that matters is a delete **concurrent with warmup**, not a delete on a quiet store. A quiet-store test will likely pass and prove nothing — the same way `dbtest` invariant (b) passes at all 19 call sites while the version-group under-report in #2277 is real. That is the trap this backlog keeps re-finding, so it is written into the entry.

## Scope

`TODO.md` plus a no-op changelog fragment. No code, no test, no behaviour change; suite counts unaffected.

**Ordering note:** #2279 also edits `TODO.md` (a far-apart region, but the same version-header line). Whichever merges second needs a rebase and a version bump; I'll handle that rather than let a gate merge a conflicted tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp
