### PR TITLE
docs(ci): correct e2e.yml's false "job BLOCKS" claim; file the enforcement gap [skip changelog]

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/e2e.yml
-# version: 1.3.0
+# version: 1.3.1
 # guid: 6a2f47c9-1e83-4d05-b7f6-92c4a0d81b3e
 # last-edited: 2026-08-10
 
@@ -27,22 +27,40 @@
 
 name: E2E
 
-# The `pull_request` trigger is live as of 2026-08-09, and on that path the job
-# BLOCKS. It was withheld while the suite was ~50% red, because a
-# permanently-failing check on every PR is worse than no check: people learn to
-# ignore it, which is the same failure that let six specs rot for four months,
-# only louder.
+# The `pull_request` trigger is live as of 2026-08-09. It was withheld while the
+# suite was ~50% red, because a permanently-failing check on every PR is worse
+# than no check: people learn to ignore it, which is the same failure that let
+# six specs rot for four months, only louder.
 #
 # Measured on the real runner before enabling it:
-#   chromium (the PR path)   272 passed /  0 failed /  8 skipped   <- blocking
-#   chromium + webkit        543 passed /  1 failed / 16 skipped   <- not blocking
+#   chromium (the PR path)   272 passed /  0 failed /  8 skipped
+#   chromium + webkit        543 passed /  1 failed / 16 skipped
 #
-# Both configurations are now green on the real runner, so the job blocks on
-# every trigger. The webkit tail was closed by giving webkit its own 60s
-# per-test budget (chromium keeps 30s): webkit had a POPULATION of tests
-# sitting close to the shared limit, and roughly one lost per run — two
-# consecutive runs scored an identical 543/1/16 while failing DIFFERENT tests
-# in different spec files.
+# Both configurations are now green on the real runner. The webkit tail was
+# closed by giving webkit its own 60s per-test budget (chromium keeps 30s):
+# webkit had a POPULATION of tests sitting close to the shared limit, and
+# roughly one lost per run — two consecutive runs scored an identical 543/1/16
+# while failing DIFFERENT tests in different spec files.
+#
+# ENFORCEMENT: this job does NOT block a merge, and never has. An earlier
+# version of this comment asserted that it "BLOCKS on every trigger" — that was
+# never true, and a comment claiming a gate exists is worse than no comment,
+# because it stops anyone from going to look.
+#
+# Verified 2026-08-10 with
+#   gh api repos/falkcorp/audiobook-organizer/rules/branches/main
+# which returns every rule applying to main INCLUDING org-inherited ones. All
+# four come from the `falkcorp` Organization ruleset — required_linear_history,
+# deletion, repository_delete, repository_transfer. There is no
+# required_status_checks rule and no pull_request rule, and classic branch
+# protection returns 404. So a red run here merges exactly as easily as a green
+# one, and `gh pr merge --admin` bypasses nothing because nothing is required.
+#
+# Whether to require this check is an owner decision, and it carries a real
+# footgun: a required status check that also has `paths:` filters (see below)
+# can leave a filtered-out PR sitting at "Expected — Waiting for status"
+# indefinitely. That interaction has NOT been measured on this repo. Tracked as
+# E2EGATE-NOTREQUIRED in TODO.md.
 #
 on:
   pull_request:

--- a/changelog.d/20260810_160000_e2e_gate_not_enforced.md
+++ b/changelog.d/20260810_160000_e2e_gate_not_enforced.md
@@ -1,0 +1,24 @@
+<!-- Workflow-comment correction plus TODO evidence — no code, no behaviour
+     change, so this fragment is deliberately a no-op comment. See
+     changelog.d/README.md.
+
+     e2e.yml's header comment asserted that the E2E job "BLOCKS on every
+     trigger". It never has. Verified via
+     `gh api repos/falkcorp/audiobook-organizer/rules/branches/main`, which
+     returns org-inherited rules too: the only rules on main are
+     required_linear_history, deletion, repository_delete and
+     repository_transfer, all from the falkcorp Organization ruleset. No
+     required_status_checks rule, no pull_request rule, and classic branch
+     protection 404s. So a red E2E run merges as easily as a green one, and
+     `gh pr merge --admin` bypasses nothing.
+
+     Files E2EGATE-NOTREQUIRED (enable enforcement, but only after measuring
+     the required-check-plus-paths-filter interaction, which can strand
+     filtered-out PRs at "Expected — Waiting for status") and TODO-HEADERLEAK
+     (75 todo.d fragment headers folded verbatim into TODO.md, which
+     todo.d/README.md forbids and nothing checks).
+
+     The paths filter itself was checked and is sound: every spec plus
+     playwright.config.ts, global-setup.ts and utils/test-helpers.ts lives
+     under web/tests/e2e/, which web/** matches. No enforcement was changed in
+     this PR — that is an owner decision. -->

--- a/todo.d/20260810-e2e-gate-not-required.md
+++ b/todo.d/20260810-e2e-gate-not-required.md
@@ -1,0 +1,58 @@
+- [ ] **E2EGATE-NOTREQUIRED** The E2E suite runs on every qualifying PR and its
+      result is enforced by nothing. A red run merges exactly as easily as a
+      green one. **Owner decision required — do not enable unattended.**
+
+      This is the April-2026 spec-rot incident one layer up. That incident was
+      "the suite existed and nothing ran it." The state now is "the suite runs
+      and nothing acts on the answer," which is quieter and looks healthier.
+
+      **Measured 2026-08-10 ~09:5x EDT**, on `main` at `dc724b80`:
+
+          gh api repos/falkcorp/audiobook-organizer/rules/branches/main
+
+      That endpoint is the authoritative one — it returns every rule applying to
+      the branch **including org-inherited rulesets**, which a repo-scoped
+      `/rulesets` query misses. It returned exactly four rules, all from the
+      `falkcorp` **Organization** ruleset:
+
+          required_linear_history
+          deletion
+          repository_delete
+          repository_transfer
+
+      There is **no `required_status_checks` rule and no `pull_request` rule**,
+      and classic protection (`/branches/main/protection`) returns 404 "Branch
+      not protected". Consequences, all of which follow directly:
+
+      - A PR whose E2E run fails can be merged with the normal green button.
+      - `gh pr merge --admin` bypasses nothing on this repo, because nothing is
+        required. Tonight's four merges (#2277–#2280) were gated only by the
+        agent session's own bash poll loop, not by GitHub.
+      - Nothing requires a pull request at all; a direct push to `main` is
+        blocked only by `required_linear_history`.
+
+      **The fix is not simply "turn on required status checks."** `e2e.yml`
+      carries `paths: ['web/**', '**.go', 'go.mod', 'go.sum',
+      '.github/workflows/e2e.yml']`. A required check that is filtered out of a
+      given PR can leave that PR pinned at *"Expected — Waiting for status"*
+      forever, which would strand every docs-only PR — the exact shape of
+      #2279 and #2280. GitHub's behaviour here depends on how the check is
+      registered, and **this has not been measured on this repo.** Resolve that
+      before enabling, e.g. with an always-runs `E2E Summary` job that reports
+      success when the real job is skipped by path.
+
+      **What was checked and found sound**, so it is not the problem: the
+      `paths` filter does cover the whole suite. Every spec, plus
+      `playwright.config.ts`, `global-setup.ts` and `utils/test-helpers.ts`,
+      lives under `web/tests/e2e/`, which `web/**` matches. A fixture or config
+      change like the one that caused the original four-month rot *would*
+      trigger the job today.
+
+      **NOT claimed:** that enabling enforcement is safe as-is; that the
+      `paths`/required-check interaction behaves any particular way here; or
+      that any PR has actually merged red. No merged-red PR was searched for.
+
+      Fixed in the same PR as this fragment: `e2e.yml`'s header comment
+      asserted the job "BLOCKS on every trigger", which was never true. A
+      comment claiming a gate exists is worse than no comment, because it stops
+      anyone from checking.

--- a/todo.d/20260810-todo-fragment-header-leak.md
+++ b/todo.d/20260810-todo-fragment-header-leak.md
@@ -1,0 +1,49 @@
+- [ ] **TODO-HEADERLEAK** 75 `todo.d` fragment headers have leaked verbatim
+      into `TODO.md`, which `todo.d/README.md` explicitly forbids. Strip them
+      and decide whether the rule gets a check or gets dropped.
+
+      `todo.d/README.md` states the rule and its reason correctly: *"Fragments
+      are exempt from the file-header rule — do not add the
+      `file`/`version`/`guid` header. The body is folded into `TODO.md`
+      verbatim, so a header would leak into the assembled document."* The same
+      README then says *"There is deliberately no PR check for TODO
+      fragments"*, so nothing has ever verified it.
+
+      **Measured 2026-08-10** on `main` at `dc724b80`:
+
+          grep -c 'last-edited:'   TODO.md   ->  75
+          grep -c '<!-- version:'  TODO.md   ->  75
+
+      They are unambiguously leaked fragment headers, not quoted examples —
+      e.g. at line 20:
+
+          <!-- file: todo.d/20260809-abs-series-collections-playlists.md -->
+          <!-- version: 1.0.0 -->
+          <!-- guid: 8f61b3d2-0a47-4e95-9c38-52e7b04af1d6 -->
+          <!-- last-edited: 2026-08-09 -->
+
+      Dates run from 2026-07-24 to 2026-08-09, i.e. almost entirely *after* the
+      2026-07-19 README rule. The rule is not being followed and nothing says
+      so.
+
+      **Why it is worth fixing rather than tolerating.** These 75 blocks make
+      any unanchored stream edit of `TODO.md`'s own header dangerous. Hit for
+      real on 2026-08-10 in PR #2280: a `gsed -i 's|<!-- last-edited: ... -->|
+      ...|' TODO.md` intended for line 2 silently rewrote all 75, turning a
+      +63-line diff into 138 insertions / 75 deletions. Caught only by reading
+      `git diff --stat` against a pre-decided number; reverted before it
+      reached `main` (verified: `main` now has exactly one `last-edited:
+      2026-08-10`). The correct form is line-anchored — `gsed -i '2s|...|'`.
+
+      **Two things to decide, they are separable:**
+
+      1. A one-off cleanup pass stripping the 75 leaked blocks from `TODO.md`.
+         Mechanical and safe — they carry no task content.
+      2. Whether `scripts/assemble_todo.py` should strip a leading header block
+         at collect time (belt-and-braces, fixes it for every future fragment
+         regardless of author), or whether the README rule stands on its own.
+         Stripping at assembly is the layer that was silent here; the README
+         has already demonstrated it cannot enforce itself.
+
+      **NOT claimed:** that any task text was lost or corrupted by the leak, or
+      that the `gsed` damage reached `main` — it did not.


### PR DESCRIPTION
## What this found

`e2e.yml`'s header comment asserted that on the `pull_request` path the job **BLOCKS**, and that "the job blocks on every trigger." **Neither was ever true.**

Verified 2026-08-10 on `main` at `dc724b80`:

```
gh api repos/falkcorp/audiobook-organizer/rules/branches/main
```

That endpoint is the authoritative one — it returns every rule applying to the branch **including org-inherited rulesets**, which a repo-scoped `/rulesets` query misses. It returns exactly four rules, all from the `falkcorp` **Organization** ruleset:

| rule | source |
|---|---|
| `required_linear_history` | falkcorp (Organization) |
| `deletion` | falkcorp (Organization) |
| `repository_delete` | falkcorp (Organization) |
| `repository_transfer` | falkcorp (Organization) |

There is **no `required_status_checks` rule and no `pull_request` rule**, and classic protection (`/branches/main/protection`) returns `404 Branch not protected`.

**Consequences, all following directly:**

- A PR whose E2E run fails can be merged with the normal green button.
- `gh pr merge --admin` bypasses **nothing** on this repo, because nothing is required. Tonight's four merges (#2277–#2280) were gated only by an agent session's bash poll loop, not by GitHub.
- Nothing requires a pull request at all; a direct push to `main` is blocked only by `required_linear_history`.

This is the April-2026 spec-rot incident **one layer up**. That incident was "the suite exists and nothing runs it." This is "the suite runs and nothing acts on the answer" — quieter, and it looks healthier.

## What this PR does and does not change

**Does:** corrects the false comment, and files two `todo.d` fragments.

**Does not:** change enforcement. That is an owner decision and it carries a real footgun — a required status check that also has `paths:` filters can strand filtered-out PRs at *"Expected — Waiting for status"* indefinitely, which is the exact shape of #2279 and #2280. **That interaction has not been measured on this repo.** Filed, not flipped.

## Checked and found sound

The `paths` filter is **not** the problem. Every spec, plus `playwright.config.ts`, `global-setup.ts` and `utils/test-helpers.ts`, lives under `web/tests/e2e/`, which `web/**` matches. A fixture or config change like the one that caused the original four-month rot *would* trigger the job today.

## Second finding — `TODO-HEADERLEAK`

`todo.d/README.md` forbids fragment headers because "the body is folded into `TODO.md` verbatim, so a header would leak." It then says "there is deliberately no PR check for TODO fragments." Result, measured on `main`:

```
grep -c 'last-edited:'  TODO.md  ->  75
grep -c '<!-- version:' TODO.md  ->  75
```

75 leaked header blocks, dated 2026-07-24 → 2026-08-09 — almost entirely *after* the rule was written. This is what made the unanchored-`gsed` footgun in #2280 possible.

## Safety of the workflow edit

Comment-only. Verified mechanically: filtering the staged diff for added/removed lines that are not comments, blanks, or hunk headers yields **0 lines**. The job's behaviour is untouched.

## Counts

- Workflow files changed: 1 (comment + version header only, 0 non-comment lines)
- `todo.d` fragments added: 2 — `E2EGATE-NOTREQUIRED`, `TODO-HEADERLEAK`
- `changelog.d` fragments added: 1 (no-op comment; docs/CI-comment change only)
- `TODO.md` modified: 0 files — deliberately, fragments exist to avoid that collision
- Enforcement rules changed: 0

E2E pass/fail for this PR's own run is recorded in a follow-up comment once the check set settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp
