### PR TITLE
fix(web): stuck closing menu left an invisible overlay swallowing all clicks [skip changelog]

### DIFF
--- a/changelog.d/20260810_113000_fix_stuck_menu_blocks_page.md
+++ b/changelog.d/20260810_113000_fix_stuck_menu_blocks_page.md
@@ -1,0 +1,30 @@
+### Fixed
+
+#### A closing dropdown could leave the page unclickable until reload
+
+Choosing an option from a dropdown — the library filter selects are the ones
+this was found on — could leave the menu stuck part-way through closing. When
+that happened, every subsequent click anywhere on the page did nothing, and the
+only way out was to reload.
+
+Nothing looked wrong when it happened, which is what made it hard to spot. The
+menu had already faded to fully transparent, so the screen looked normal. But
+MUI's modal layer is a full-viewport element that only stops capturing clicks
+once the close has *completely* finished, and in this case it never did. So an
+invisible sheet stayed over the whole page and swallowed everything.
+
+The fix closes menus immediately instead of animating them out. Opening is
+unchanged — only the closing animation was involved, and only the closing
+animation is removed.
+
+For the record, since this was mis-diagnosed twice before: the failure is a
+race, not a broken timer. Measured on a 48-core host, running 20 copies of the
+affected end-to-end test across 12 workers, the failure rate tracked the length
+of the close animation — 0 of 20 passed at the default ~280ms, 8 of 20 at
+250ms, and 20 of 20 with the animation removed. Why the animation fails to
+report completion is still unexplained; supplying an independent fallback timer
+did not help, which rules out the previously-assumed cause. Removing the window
+the race needs is what fixes it.
+
+This was not only a test-environment problem. It reproduced on an otherwise
+idle machine running a single worker, at roughly 1 occurrence per 282 tests.

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -1,6 +1,7 @@
 // file: web/src/theme.ts
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e
+// last-edited: 2026-08-10
 
 import { createTheme } from '@mui/material/styles';
 
@@ -51,6 +52,51 @@ export function createAppTheme(mode: PaletteMode = 'dark') {
           paper: {
             backgroundImage: 'none',
           },
+        },
+      },
+      // Close Menus with NO exit animation. This is a correctness fix, not a
+      // styling preference.
+      //
+      // THE BUG: a Select menu could get stuck part-way through closing and
+      // leave the page unusable. MUI's Modal root is `position: fixed` with
+      // `inset: 0`, and it only becomes `visibility: hidden` once the modal
+      // has fully exited. If the exit stalls, that root keeps covering the
+      // entire viewport with `pointer-events: auto`, so every subsequent
+      // click anywhere on the page is swallowed until a reload. The menu
+      // itself has already faded to `opacity: 0`, so nothing looks wrong —
+      // which is exactly why this was mis-filed twice before.
+      //
+      // WHAT WAS MEASURED (2026-08-10, 48-core host, 20 copies of the
+      // library-browser `clears all filters` e2e test across 12 workers):
+      //   - The exit STARTS correctly: paper reaches opacity 0 at ~270ms.
+      //   - It never finishes: the paper never receives the inline
+      //     `visibility: hidden` that Grow applies in the `exited` state, so
+      //     react-transition-group is stuck in `exiting` indefinitely —
+      //     observed unchanged 4.8s later, and through a full 30s timeout.
+      //   - Stall rate scales with exit duration, which is what makes this a
+      //     race rather than a dead timer:
+      //         'auto' (~280ms) -> 0/20 passed
+      //         250ms           -> 8/20 passed
+      //         0ms             -> 20/20 passed
+      //
+      // NOT EXPLAINED, and deliberately not guessed at here: why RTG's
+      // completion callback never runs. Supplying a numeric duration gives
+      // RTG its own fallback `setTimeout` and the stall still happened
+      // 12/20, so "MUI's auto-timeout is lost" is DISPROVEN as the cause.
+      // Zeroing the exit removes the window the race needs, rather than
+      // claiming to have fixed the race itself.
+      //
+      // `enter: 225` keeps the opening animation, which was never implicated
+      // — only the exit path stalls. Applied to MuiMenu alone rather than
+      // MuiPopover, to avoid changing every Autocomplete and picker popper on
+      // the strength of a defect only observed on Select menus.
+      //
+      // Repro (fails 20/20 without this):
+      //   CI=true npx playwright test --config=tests/e2e/playwright.config.ts \
+      //     --project=chromium -g "clears all filters" --repeat-each=20 --workers=12
+      MuiMenu: {
+        defaultProps: {
+          transitionDuration: { enter: 225, exit: 0 },
         },
       },
     },

--- a/web/tests/e2e/playwright.config.ts
+++ b/web/tests/e2e/playwright.config.ts
@@ -1,7 +1,7 @@
 // file: tests/e2e/playwright.config.ts
-// version: 1.11.0
+// version: 1.12.0
 // guid: 7c8d9e0f-1a2b-3c4d-5e6f-7a8b9c0d1e2f
-// last-edited: 2026-08-08
+// last-edited: 2026-08-10
 
 import { defineConfig, devices } from '@playwright/test';
 import { fileURLToPath } from 'url';
@@ -30,14 +30,29 @@ export default defineConfig({
   //   workers=1 -> 27 passed, 0 failed
   // The failures were 30s `locator.click` timeouts with a MUI modal backdrop
   // (Drawer in one case, Select menu in the other) still intercepting pointer
-  // events. Two browser workers plus the Go server on 2 cores starve the close
-  // TRANSITION, so the backdrop outlives any timeout worth setting. Neither the
-  // app nor the tests are wrong — a real user is not running two headless
-  // browsers on two pinned cores.
+  // events.
   //
-  // The cost is wall-clock: chromium goes from ~4.5min to ~9min. That is the
-  // right trade for a gate that is supposed to block merges — a fast check
-  // people learn to distrust is worth less than a slow one they believe.
+  // CORRECTION 2026-08-10 — the explanation that used to sit here was wrong,
+  // and wrong in the way that stops the next person from looking. It said the
+  // two workers starved the close transition and concluded "neither the app
+  // nor the tests are wrong". Both halves are false:
+  //
+  //   - It reproduces at workers=1 on an IDLE 48-core host. A clean-room full
+  //     chromium run there failed this same test 1 in 282. Core starvation is
+  //     not the trigger; lowering the worker count only lowers the hit rate.
+  //   - It is a real product defect, since fixed: MUI's Select menu could get
+  //     stuck mid-close with its Modal root still covering the viewport and
+  //     swallowing every click. See the MuiMenu note in web/src/theme.ts.
+  //
+  // Reproduction, if it is ever needed again (20/20 failed before the fix):
+  //   CI=true npx playwright test --config=tests/e2e/playwright.config.ts \
+  //     --project=chromium -g "clears all filters" --repeat-each=20 --workers=12
+  //
+  // workers=1 on CI stays, on its own merits: it is the configuration the gate
+  // has been measured green in, and it keeps runs reproducible. The cost is
+  // wall-clock: chromium goes from ~4.5min to ~9min. That is the right trade
+  // for a gate that is supposed to block merges — a fast check people learn to
+  // distrust is worth less than a slow one they believe.
   workers: process.env.CI ? 1 : 2,
   reporter: [
     ['list'],


### PR DESCRIPTION
## What

Selecting an option from a MUI Select could leave the menu stuck in its `exiting`
state. MUI's Modal root is `position: fixed; inset: 0` and only becomes
`visibility: hidden` once the modal has **fully** exited — so a stalled exit
leaves a full-viewport element with `pointer-events: auto` sitting over the
page, swallowing every subsequent click until reload. The menu has already
faded to `opacity: 0`, so nothing looks wrong.

## Evidence

Reproduction (48-core host, 20 copies of the library-browser `clears all
filters` test across 12 workers). The stall rate tracks exit duration, which is
what makes this a **race**, not a dead timer:

| exit duration | passed / 20 |
|---|---|
| `'auto'` (~280ms) | **0** |
| 250ms | 8 |
| `exit: 0` | **20** |

Instrumented timeline: the exit *starts* correctly (paper reaches `opacity: 0`
at ~270ms) but the paper never receives the inline `visibility: hidden` that
Grow applies in the `exited` state — so react-transition-group sits in
`exiting` indefinitely, unchanged 4.8s later and through a full 30s timeout.

Isolated, the test passes 3/3. Under contention it failed 20/20. That contrast
is the negative control this fix is verified against.

## Not claimed

**Why RTG's completion callback never runs is unexplained.** Supplying a
numeric duration gives RTG its own fallback `setTimeout` and the stall still
happened 12/20 — which **disproves** the "MUI's auto-timeout is lost" theory I
started with. This change removes the window the race needs; it does not claim
to have fixed the race itself.

## Scope

- `MuiMenu` only, not `MuiPopover` — Autocompletes and pickers are untouched by
  a defect only observed on Select menus.
- `enter: 225` keeps the opening animation, which was never implicated.

## Also corrected

`playwright.config.ts` blamed "two workers on two pinned cores" and concluded
"neither the app nor the tests are wrong". Both halves are false: it reproduces
at **workers=1 on an idle 48-core host**, ~1 occurrence per 282 tests. That
comment is why this went unexamined twice. `workers: 1` on CI stays, on its own
merits.

## Counts

- Contention harness, `MuiMenu` fix: **20 passed / 0 failed**
- Same harness before the fix: **0 passed / 20 failed**
- Full chromium suite at gate config (`workers: 1`): running, will post

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp