### PR TITLE
fix(web): stuck closing Drawer left an invisible overlay swallowing all clicks [skip changelog]

### DIFF
--- a/changelog.d/20260810_120500_fix_stuck_drawer_blocks_page.md
+++ b/changelog.d/20260810_120500_fix_stuck_drawer_blocks_page.md
@@ -1,0 +1,25 @@
+### Fixed
+
+#### A closing side panel could leave the page unclickable until reload
+
+Same defect as the stuck dropdown fixed alongside this, on a different control:
+closing the filter side panel could leave it part-way shut, and every click
+afterwards did nothing until the page was reloaded.
+
+As before, nothing looked wrong. The panel had already slid away visually, but
+the dimming layer behind it stayed active and invisible over the whole page,
+absorbing every click.
+
+Side panels now close immediately rather than sliding out. Opening is
+unchanged.
+
+This is worth recording precisely, because it rules out the explanation this
+bug was originally given. The side panel already used fixed, explicit animation
+timings — the thing that was assumed to be missing from the dropdown case and
+assumed to be the cause. It stalls anyway: 17 of 20 runs of the affected
+end-to-end test failed with the dimming layer still present after 15 seconds.
+So the cause is not a missing fallback timer. Removing the closing animation
+removes the window the race needs, which is what actually fixes it.
+
+Why the animation fails to report completion is still unexplained, and is
+deliberately not guessed at in the code.

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -1,5 +1,5 @@
 // file: web/src/theme.ts
-// version: 1.2.0
+// version: 1.3.0
 // guid: 2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-08-10
 
@@ -48,6 +48,24 @@ export function createAppTheme(mode: PaletteMode = 'dark') {
         },
       },
       MuiDrawer: {
+        // exit: 0 for the same reason as MuiMenu below — see that comment for
+        // the mechanism and the measurements. This is the SECOND component hit
+        // by the same stuck-modal defect, and it was named alongside the Select
+        // menu in playwright.config.ts long before either was understood.
+        //
+        // Measured 2026-08-10 on current main (which already carries the
+        // MuiMenu fix), 20 copies of the scan-import-organize "complete
+        // workflow" e2e test across 12 workers: 17/20 FAILED with
+        // `.MuiDrawer-modal .MuiBackdrop-root` still visible after 15s.
+        //
+        // Note Drawer already used NUMERIC durations (enteringScreen /
+        // leavingScreen), so this is direct evidence against the "a numeric
+        // duration restores react-transition-group's fallback timer and fixes
+        // it" theory — the Drawer had that fallback all along and stalls
+        // anyway. Only removing the exit window helps.
+        defaultProps: {
+          transitionDuration: { enter: 225, exit: 0 },
+        },
         styleOverrides: {
           paper: {
             backgroundImage: 'none',

--- a/web/tests/e2e/scan-import-organize.spec.ts
+++ b/web/tests/e2e/scan-import-organize.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/scan-import-organize.spec.ts
-// version: 1.8.0
+// version: 1.9.0
 // guid: 6a7b8c9d-0e1f-2a3b-4c5d-6e7f8a9b0c1d
-// last-edited: 2026-08-09
+// last-edited: 2026-08-10
 
 import { test, expect, type Page } from '@playwright/test';
 import {
@@ -319,6 +319,14 @@ test.describe('Scan/Import/Organize Workflow', () => {
     // chromium stopped failing once CI dropped to one worker (#2249); webkit is
     // slower and kept failing, so this wait is required rather than belt-and-
     // braces.
+    //
+    // UPDATE 2026-08-10 — the worker count was never the cause, only a way to
+    // change the odds. This close could STALL outright: the backdrop stayed
+    // visible past any timeout, on an idle 48-core host, at 17/20 runs under
+    // contention. That was a real product defect (a dead, unclickable page for
+    // the user, not just a red test) and is fixed by giving MuiDrawer
+    // `exit: 0` in web/src/theme.ts. This wait stays: it is correct, and it is
+    // the assertion that would catch a regression.
     //
     // The assertion shape is load-bearing and two obvious forms are both wrong:
     //   toBeHidden()   -> strict-mode violation: Sidebar renders its content


### PR DESCRIPTION
## What

Second component hit by the **same** stuck-modal defect fixed for `MuiMenu` in
#2282. Closing the filter Drawer could stall part-way through: MUI's Modal
backdrop stayed **visible** over the whole page and swallowed every subsequent
click until reload. The drawer had already slid away, so nothing looked wrong.

## Evidence

Idle 48-core host, against current `main` (which already carries the `MuiMenu`
fix), 20 copies of the `scan-import-organize` "complete workflow" test across
12 workers:

| | passed / 20 |
|---|---|
| before | **3** (17 failed — backdrop still visible after 15s) |
| after | **20** |

## This disproves the theory #2282 started from

I originally believed the stall came from MUI's `'auto'` duration removing
react-transition-group's fallback timer. **Drawer already used numeric
durations** (`enteringScreen`/`leavingScreen`) — it had that fallback all
along — and it stalls anyway. So the missing-timer explanation is dead.

Only removing the exit window helps. **Why the transition never reports
completion is still unexplained**, and is deliberately not guessed at in the
code.

## How it was found

The full chromium suite at gate config (`workers: 1`) on the #2282 commit came
back **277 passed / 1 failed / 4 skipped** — the failure *moved* from the Select
menu to the Drawer rather than disappearing. `playwright.config.ts` had named
both victims ("Drawer in one case, Select menu in the other") before either was
understood.

## Also corrected

The `scan-import-organize` comment attributing this to CI worker count. Worker
count only changed the odds; it reproduces at `workers: 1` on an idle host. The
existing backdrop wait is **kept** — it is correct, and it is the assertion that
would catch a regression.

## Counts

- Contention harness before: **3 passed / 17 failed**
- Contention harness after: **20 passed / 0 failed**
- Full chromium suite at gate config: running, will post

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp