### PR TITLE
fix(database): version-group index self-heals; backfill v2 repairs prod [skip changelog]

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3526,9 +3526,10 @@ deleted rather than rewritten, since the capabilities themselves are gone. Relat
   tells us how much of owner item 1 was a DATA problem rather than a classifier
   problem, and should be taken before investing in recommendation tuning.
 
-- [ ] 🐛 **`GetBooksByVersionGroup` silently under-reports group membership, which
+- [x] ✅ 🐛 **`GetBooksByVersionGroup` silently under-reports group membership, which
   breaks the one-primary-per-group invariant.** Found in production 2026-08-06
   while version-grouping the two copies of *The Successors*.
+  **FIXED 2026-08-10 — see RESOLUTION at the end of this entry.**
 
   **Symptom.** Two books both carry `version_group_id =
   01KNDBPNB289W2Y6TMXS2DDSEG`, but `GET /api/v1/version-groups/<gid>` returns
@@ -3645,6 +3646,49 @@ deleted rather than rewritten, since the capabilities themselves are gone. Relat
   raw secondary-index rows", meaning no caller has ever constructed a partial
   index for it to inspect. The invariant was never wrong; nothing ever put it in
   front of the failing state.
+
+  **RESOLUTION 2026-08-10.** Owner directed "fix the root cause" rather than
+  taking the one-off prod repair. Directions **2 and 3 shipped; 1 and 4 did
+  not** — see below for why each was left alone.
+
+  - **Direction 2 (write path, the durable guard).** `UpdateBook` now writes the
+    current group's index row unconditionally; only the delete of the *old* row
+    is still gated on `oldVG != newVG`. Any book touched by any write path now
+    repairs its own index entry, so a missing row can no longer persist.
+  - **Direction 3 (repair).** The backfill sentinel moved
+    `versiongroup_index_v1_done` → `..._v2_done`, so every deployment rebuilds
+    the index once on next start. This *is* the prod repair — no manual op, no
+    maintenance run. Bump again if the key format or indexed set changes.
+  - **Direction 1 (read-path completeness oracle) — NOT done, deliberately.**
+    The `len(books) > 0` guard stays. Gating the fallback on the backfill
+    sentinel was drafted and rejected: a genuinely missing row would then return
+    EMPTY instead of the full scan's correct answer, trading a silent
+    under-report for a silent zero on a path that also feeds `/versions`,
+    `regroup_apply`, and metafetch writeback. A real fix needs a completeness
+    signal that does not depend on the result being non-empty (an authoritative
+    per-group member count); that does not exist yet. The limitation is now
+    documented in-code at the fallback rather than left implicit.
+  - **Direction 4 (read through memdb) — NOT done.** Unchanged reasoning: it
+    necessarily returns MORE members than today and metafetch enumerates
+    siblings through this call before writing to them. Still wants owner review.
+
+  Also fixed in passing: all three writers of this index (`CreateBook`,
+  `UpdateBook`, `BackfillVersionGroupIndex`) now store the **book ID** as the row
+  value. `CreateBook`/`UpdateBook` previously stored a full serialized `Book`
+  "to eliminate point lookups", but the read path had long since stopped
+  trusting that copy and takes the ID from the key instead — so it was never
+  read. Making the update write unconditional would have doubled write
+  amplification had the fat value stayed.
+
+  **Tests** — `internal/database/pebble_store_versiongroup_index_test.go` (new).
+  Damages exactly ONE index row, asserts the under-report reproduces (2 of 3),
+  then asserts a same-group `UpdateBook` heals it back to 3. Negative control
+  run: with the self-heal reverted the suite exits 1 on
+  `self-heal failed: want 3 books after a same-group update, got 2`. Two
+  companion tests pin the empty-index fallback (still returns the correct 3) and
+  `CreateBook`'s index write + value format. The whole-index-wipe case is
+  covered precisely because it passes *with the bug present* — it is the reason
+  the defect stayed invisible.
 
   **Also needs an invariant test**: after linking N books into a group and
   setting one primary, exactly one member must have `IsPrimaryVersion == true`.

--- a/changelog.d/20260810_191500_fix_versiongroup_index_completeness.md
+++ b/changelog.d/20260810_191500_fix_versiongroup_index_completeness.md
@@ -1,0 +1,61 @@
+### Fixed
+
+#### Version groups no longer lose members (two "primary" copies of the same book)
+
+Grouping two copies of a book as versions of each other could leave the library
+showing **both** tiles as the primary edition, and pressing "set primary" on
+either one would not fix it. Found in production on *The Successors*: two books
+carried the same version-group ID, but asking for that group's members returned
+only one of them.
+
+Because the lookup returned a short list, everything built on top of it was
+quietly wrong. `set-primary` demotes "every other member of the group" — with a
+member missing from the list, it never demoted the stray, so two primaries
+survived. The same lookup backs `ApplyVersionGroup`, the safety net that keeps
+one primary per group when a regrouping hold is approved, so approving a hold
+could leave two primaries behind as well.
+
+Root cause, in two halves:
+
+**The read path treated "found something" as "found everything."**
+`GetBooksByVersionGroup` reads a `book:versiongroup:<gid>:<id>` index and falls
+back to a full scan only when the index yields *zero* rows:
+
+    if len(books) > 0 { sortVersions(books); return books, nil }
+
+A *partially* populated index returns its partial set and never reaches the
+fallback. The paradox this creates is worth stating plainly: deleting the
+**entire** index returns the **correct** answer, while deleting **one row**
+returns a wrong one. More data loss produced a better result, which is why the
+defect survived so long without ever surfacing an error.
+
+**The write path could not heal.** `UpdateBook` wrote a book's index row only
+when its `VersionGroupID` actually *changed*. A row missing for any reason — a
+book that acquired its group through a path that did not trip that comparison,
+or one written before the index existed — could never come back, because every
+later edit left the group unchanged and so skipped the write. Re-submitting the
+grouping did not repair it either: the group ID was already correct, so nothing
+changed and nothing was written.
+
+The fix is on the write side, where the incompleteness originates:
+
+- `UpdateBook` now writes the current group's index row unconditionally, so any
+  book touched by any write path repairs its own entry. Deleting the *old* row
+  is still gated on the group actually changing.
+- The one-time index backfill's sentinel moved from `v1` to `v2`, so every
+  existing deployment rebuilds the index once on next start. Installations
+  repair themselves — there is no manual step and no maintenance op to run.
+- All three writers of this index now store the book ID as the row value. The
+  index is a pointer index — the reader takes the ID from the key and looks up
+  the authoritative book row — so the full copy of the book that `CreateBook`
+  and `UpdateBook` used to store was never read, and rewriting it on every
+  update would have been pure write amplification.
+
+The zero-result fallback is deliberately **kept**. Gating it on the backfill
+sentinel was considered and rejected: a genuinely missing row would then return
+an empty group rather than the full scan's correct answer, trading a silent
+under-report for a silent zero on a path that also feeds version listings and
+metadata writeback.
+
+Regression tests damage exactly **one** index row rather than all of them, since
+wiping the whole index hits the fallback and passes even with the bug present.

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.120.0
+// version: 1.121.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-08-06
+// last-edited: 2026-08-10
 
 package database
 
@@ -1751,15 +1751,18 @@ func (p *PebbleStore) CreateBook(book *Book) (*Book, error) {
 	// Version-group index (PERF-VERSIONS): O(N) full-scan in
 	// GetBooksByVersionGroup was costing ~15s on a 10K-book library.
 	// Indexed by group_id so the read can iterate only matching keys.
-	// Also store full Book JSON to eliminate point lookups.
+	//
+	// POINTER INDEX: the value is the book ID and nothing reads it —
+	// GetBooksByVersionGroup takes the ID from the trailing key segment and
+	// point-looks-up the authoritative book:<id> row. An earlier version
+	// stored the full Book JSON here "to eliminate point lookups", but the
+	// read path stopped trusting it (a same-group edit never refreshed it),
+	// so that copy was pure write amplification. Keep every writer of this
+	// index — CreateBook, UpdateBook, BackfillVersionGroupIndex — writing
+	// the ID, so the row stays cheap enough to rewrite unconditionally.
 	if book.VersionGroupID != nil && *book.VersionGroupID != "" {
 		vgKey := []byte(fmt.Sprintf("book:versiongroup:%s:%s", *book.VersionGroupID, book.ID))
-		bookJSON, err := serializeBookForIndex(book)
-		if err != nil {
-			batch.Close()
-			return nil, err
-		}
-		if err := batch.Set(vgKey, bookJSON, nil); err != nil {
+		if err := batch.Set(vgKey, []byte(book.ID), nil); err != nil {
 			batch.Close()
 			return nil, err
 		}
@@ -1959,7 +1962,19 @@ func (p *PebbleStore) UpdateBook(id string, book *Book) (*Book, error) {
 		return nil, err
 	}
 
-	// Update version-group index if changed (PERF-VERSIONS).
+	// Update version-group index (PERF-VERSIONS).
+	//
+	// SELF-HEAL: the delete of the OLD row is gated on the group actually
+	// changing, but the write of the CURRENT row is unconditional. It used to
+	// be gated too (`if oldVG != newVG { ...set... }`), which meant a row that
+	// was missing for any reason — never backfilled, lost to a partial commit,
+	// written before this index existed — could never come back, because every
+	// later edit to that book left the group unchanged and so skipped the
+	// write. That is what let a partial index survive indefinitely and made
+	// GetBooksByVersionGroup silently under-report a group's members.
+	// The row is a book ID keyed by (group, id), so rewriting it on every
+	// update is one small idempotent Set, and any book touched by any write
+	// path now repairs its own index entry.
 	oldVG := ""
 	if oldBook.VersionGroupID != nil {
 		oldVG = *oldBook.VersionGroupID
@@ -1968,25 +1983,18 @@ func (p *PebbleStore) UpdateBook(id string, book *Book) (*Book, error) {
 	if book.VersionGroupID != nil {
 		newVG = *book.VersionGroupID
 	}
-	if oldVG != newVG {
-		if oldVG != "" {
-			oldVGKey := []byte(fmt.Sprintf("book:versiongroup:%s:%s", oldVG, id))
-			if err := batch.Delete(oldVGKey, nil); err != nil {
-				batch.Close()
-				return nil, err
-			}
+	if oldVG != newVG && oldVG != "" {
+		oldVGKey := []byte(fmt.Sprintf("book:versiongroup:%s:%s", oldVG, id))
+		if err := batch.Delete(oldVGKey, nil); err != nil {
+			batch.Close()
+			return nil, err
 		}
-		if newVG != "" {
-			newVGKey := []byte(fmt.Sprintf("book:versiongroup:%s:%s", newVG, id))
-			bookJSON, err := serializeBookForIndex(book)
-			if err != nil {
-				batch.Close()
-				return nil, err
-			}
-			if err := batch.Set(newVGKey, bookJSON, nil); err != nil {
-				batch.Close()
-				return nil, err
-			}
+	}
+	if newVG != "" {
+		newVGKey := []byte(fmt.Sprintf("book:versiongroup:%s:%s", newVG, id))
+		if err := batch.Set(newVGKey, []byte(id), nil); err != nil {
+			batch.Close()
+			return nil, err
 		}
 	}
 
@@ -2708,14 +2716,11 @@ func (p *PebbleStore) GetBooksByVersionGroup(groupID string) ([]Book, error) {
 	// PERF-VERSIONS so we touch O(|group|) keys instead of full-scanning
 	// the entire books table (was ~15s on 10K books).
 	//
-	// INDEX-CONSISTENCY: like GetBooksByWorkID, the index value embeds a
-	// serialized Book snapshot that UpdateBook only refreshes when the
-	// VersionGroupID changes, so a same-group edit (SoftDeleteBook sets
-	// MarkedForDeletion via UpdateBook without touching the group) leaves it
-	// stale. Treat the index as a POINTER: the trailing key segment is the book
-	// ID (a ULID, no nested colons); point-look-up the authoritative book:<id>
-	// row and skip anything absent (hard-deleted) or MarkedForDeletion
-	// (soft-deleted). This can never desync from the source of truth.
+	// INDEX-CONSISTENCY: treat the index as a POINTER. The trailing key segment
+	// is the book ID (a ULID, no nested colons); point-look-up the
+	// authoritative book:<id> row and skip anything absent (hard-deleted) or
+	// MarkedForDeletion (soft-deleted). The index VALUE is never read, so it
+	// can never desync from the source of truth.
 	prefix := []byte(fmt.Sprintf("book:versiongroup:%s:", groupID))
 	upper := append([]byte(nil), prefix...)
 	upper[len(upper)-1] = ';' // ':' + 1
@@ -2745,9 +2750,27 @@ func (p *PebbleStore) GetBooksByVersionGroup(groupID string) ([]Book, error) {
 		return books, nil
 	}
 
-	// Fallback: full scan for groups whose index hasn't been backfilled
-	// yet. The backfill goroutine writes index entries on startup; this
-	// path keeps the API correct in the meantime.
+	// Fallback: full scan for groups whose index hasn't been backfilled yet.
+	// The backfill goroutine writes index entries on startup; this path keeps
+	// the API correct in the meantime.
+	//
+	// KNOWN LIMITATION, deliberately kept: `len(books) > 0` is a completeness
+	// oracle that assumes "found something" means "found everything". A
+	// PARTIALLY indexed group returns only its indexed members and never
+	// reaches this scan, so it silently under-reports; an EMPTY one falls
+	// through here and returns the correct set. Losing more index data
+	// produced a more correct answer.
+	//
+	// The fix is upstream, not here: CreateBook/UpdateBook now write the
+	// current-group row unconditionally (self-heal) and the v2 backfill
+	// rebuilds the whole index once per deployment, so a partial index should
+	// not exist. Gating this scan on the backfill sentinel instead was
+	// considered and REJECTED — a genuinely missing row would then return
+	// EMPTY rather than the full scan's correct answer, trading a silent
+	// under-report for a silent zero on a path that feeds /versions,
+	// regroup_apply, and metafetch writeback. Keep the fallback until a
+	// completeness signal exists that does not depend on the result being
+	// non-empty (e.g. an authoritative per-group member count).
 	books = nil // Reset for fallback scan
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte("book:0"),

--- a/internal/database/pebble_store_versiongroup_backfill.go
+++ b/internal/database/pebble_store_versiongroup_backfill.go
@@ -1,5 +1,7 @@
 // file: internal/database/pebble_store_versiongroup_backfill.go
-// version: 1.0.1
+// version: 1.1.0
+// guid: 9f3b7c21-6d84-4a5e-b0c9-2e7fa1d85b36
+// last-edited: 2026-08-10
 // PERF-VERSIONS: one-time backfill that writes the
 // book:versiongroup:<gid>:<id> secondary index for every existing book
 // that has a VersionGroupID. Without this, /audiobooks/:id/versions
@@ -17,7 +19,18 @@ import (
 	"github.com/cockroachdb/pebble/v2"
 )
 
-const versionGroupBackfillKey = "system:backfill:versiongroup_index_v1_done"
+// versionGroupBackfillKey gates the one-time backfill.
+//
+// BUMPED v1 -> v2 (2026-08-10): existing deployments already have the v1
+// sentinel set, so they would never rebuild. Their index can be incomplete
+// because UpdateBook used to write a book's index row only when its
+// VersionGroupID *changed* — a row missing after the v1 run could never heal,
+// and GetBooksByVersionGroup then under-reported that group without ever
+// erroring. Bumping the key makes every deployment rebuild the index once on
+// next start; UpdateBook's now-unconditional write keeps it complete after
+// that. This IS the production repair — no manual step. Bump again if the key
+// format or the set of indexed books ever changes.
+const versionGroupBackfillKey = "system:backfill:versiongroup_index_v2_done"
 
 // BackfillVersionGroupIndex writes the secondary index for every book with
 // a non-empty VersionGroupID. Idempotent — gated by a sentinel key so

--- a/internal/database/pebble_store_versiongroup_index_test.go
+++ b/internal/database/pebble_store_versiongroup_index_test.go
@@ -1,0 +1,168 @@
+// file: internal/database/pebble_store_versiongroup_index_test.go
+// version: 1.0.0
+// guid: c21ecc4a-5ca1-4492-b1a9-c1bf8c4c9d4f
+// last-edited: 2026-08-10
+
+package database
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// 🔴 GetBooksByVersionGroup silently under-reports a group whose
+// book:versiongroup:<gid>:<id> index is PARTIALLY populated.
+//
+// The read path trusts a non-empty result: `if len(books) > 0 { return books }`,
+// falling back to a full scan only when the index yields NOTHING. So an index
+// missing one row returns the other members and never scans — the caller gets a
+// short list with no error. The paradox that makes this worth a regression test:
+// deleting the WHOLE index returns the CORRECT set (the fallback fires), while
+// deleting ONE row returns a WRONG one. More data loss, better answer.
+//
+// The root cause was on the WRITE side. UpdateBook maintained the index only
+// when a book's VersionGroupID *changed* (`if oldVG != newVG { ...set... }`), so
+// a row that was missing for any reason could never come back: every later edit
+// left the group unchanged and therefore skipped the write. These tests damage
+// exactly ONE row — not all of them — because damaging all of them hits the
+// fallback and passes even with the bug present.
+func TestGetBooksByVersionGroup_PartialIndexUnderReports(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+	s.WaitForWarmup()
+
+	gid := "vg-partial-index"
+	var ids []string
+	for i := 1; i <= 3; i++ {
+		b, err := s.CreateBook(&Book{Title: fmt.Sprintf("Edition %d", i), VersionGroupID: &gid})
+		if err != nil {
+			t.Fatalf("CreateBook %d: %v", i, err)
+		}
+		ids = append(ids, b.ID)
+	}
+
+	got, err := s.GetBooksByVersionGroup(gid)
+	if err != nil {
+		t.Fatalf("GetBooksByVersionGroup: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("baseline: want 3 books in group, got %d", len(got))
+	}
+
+	// Damage exactly ONE index row, leaving the authoritative book:<id> row
+	// intact. This is the shape a real partial index has: the book exists and
+	// is in the group, but nothing points at it.
+	victim := ids[1]
+	victimKey := []byte(fmt.Sprintf("book:versiongroup:%s:%s", gid, victim))
+	if err := s.db.Delete(victimKey, pebble.Sync); err != nil {
+		t.Fatalf("damage index row: %v", err)
+	}
+
+	// Confirm the damage reproduces the under-report. This assertion documents
+	// the broken behaviour on purpose — it is the bug, not the fix.
+	damaged, err := s.GetBooksByVersionGroup(gid)
+	if err != nil {
+		t.Fatalf("GetBooksByVersionGroup after damage: %v", err)
+	}
+	if len(damaged) != 2 {
+		t.Fatalf("expected the partial index to under-report 2 of 3 books, got %d — "+
+			"if this is 3, the read path changed and this test's premise is stale", len(damaged))
+	}
+
+	// THE FIX: a same-group edit must repair the missing row. Before the fix
+	// UpdateBook skipped the index write whenever the group was unchanged, so
+	// this returned 2 forever no matter how many times the book was updated.
+	b, err := s.GetBookByID(victim)
+	if err != nil || b == nil {
+		t.Fatalf("GetBookByID(%s): %v", victim, err)
+	}
+	b.Title = "Edition 2 (edited, same group)"
+	if _, err := s.UpdateBook(victim, b); err != nil {
+		t.Fatalf("UpdateBook: %v", err)
+	}
+
+	healed, err := s.GetBooksByVersionGroup(gid)
+	if err != nil {
+		t.Fatalf("GetBooksByVersionGroup after update: %v", err)
+	}
+	if len(healed) != 3 {
+		t.Fatalf("self-heal failed: want 3 books after a same-group update, got %d — "+
+			"UpdateBook is not writing the current-group index row unconditionally", len(healed))
+	}
+}
+
+// The companion to the test above: with the index entirely gone the full-scan
+// fallback fires and the answer is correct. Losing MORE index data returns a
+// MORE correct result, which is exactly why the partial case went unnoticed.
+//
+// This also pins the fallback in place. Gating it on the backfill sentinel was
+// considered and rejected: a genuinely missing row would then return EMPTY
+// instead of the correct set, trading a silent under-report for a silent zero.
+func TestGetBooksByVersionGroup_EmptyIndexFallsBackToCorrectAnswer(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+	s.WaitForWarmup()
+
+	gid := "vg-empty-index"
+	for i := 1; i <= 3; i++ {
+		if _, err := s.CreateBook(&Book{Title: fmt.Sprintf("Edition %d", i), VersionGroupID: &gid}); err != nil {
+			t.Fatalf("CreateBook %d: %v", i, err)
+		}
+	}
+
+	prefix := []byte(fmt.Sprintf("book:versiongroup:%s:", gid))
+	upper := append([]byte(nil), prefix...)
+	upper[len(upper)-1] = ';'
+	if err := s.db.DeleteRange(prefix, upper, pebble.Sync); err != nil {
+		t.Fatalf("delete whole index range: %v", err)
+	}
+
+	got, err := s.GetBooksByVersionGroup(gid)
+	if err != nil {
+		t.Fatalf("GetBooksByVersionGroup: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("empty-index fallback: want 3 books from the full scan, got %d", len(got))
+	}
+}
+
+// CreateBook must write the index row itself, so a freshly created book is
+// discoverable by its group without waiting for the startup backfill.
+func TestCreateBook_WritesVersionGroupIndexRow(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+	s.WaitForWarmup()
+
+	gid := "vg-create-writes"
+	b, err := s.CreateBook(&Book{Title: "Only Edition", VersionGroupID: &gid})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	key := []byte(fmt.Sprintf("book:versiongroup:%s:%s", gid, b.ID))
+	val, closer, err := s.db.Get(key)
+	if err != nil {
+		t.Fatalf("index row missing after CreateBook: %v", err)
+	}
+	got := string(val)
+	closer.Close()
+
+	// The index is a POINTER index: the value is the book ID and no reader
+	// consumes it. Asserting it here keeps all three writers (CreateBook,
+	// UpdateBook, BackfillVersionGroupIndex) on one format, so the row stays
+	// cheap enough to rewrite on every update.
+	if got != b.ID {
+		t.Fatalf("index value: want the book ID %q, got %q", b.ID, got)
+	}
+}


### PR DESCRIPTION
## Problem

`GetBooksByVersionGroup` silently under-reported group membership. Found in production on *The Successors*: two books carrying the same `version_group_id`, but the group lookup returned only one. `set-primary` demotes "every other member of the group" — with a member missing from the list it never demoted the stray, so **both books stayed flagged primary**. `ApplyVersionGroup`'s one-primary-per-group safety net uses the same call and was equally blind.

## Root cause — two halves

**Read path treated "found something" as "found everything."** The fallback to a full scan fires only when the index yields *zero* rows:

```go
if len(books) > 0 { sortVersions(books); return books, nil }
```

A *partially* populated index returns its partial set and never scans. The paradox, measured:

| Index state | `GetBooksByVersionGroup` |
|---|---|
| both members indexed | **2** ✓ |
| **one** row dropped | **1** ✗ — the book vanishes |
| **both** rows dropped | **2** ✓ — fallback engages |

Losing *more* index data produced a *more* correct answer. Damage in the range `1..n-1` is the only damage that is invisible — which is why this never surfaced an error.

**Write path could not heal.** `UpdateBook` wrote a book's index row only when `VersionGroupID` **changed**, so a row missing for any reason could never come back: every later edit left the group unchanged and skipped the write. Re-submitting the grouping didn't repair it either — the group ID was already correct, so nothing was written.

## Fix — on the write side, where the incompleteness originates

- **`UpdateBook` writes the current-group row unconditionally** (self-heal). The delete of the *old* row stays gated on the group actually changing.
- **Backfill sentinel `v1` → `v2`**, so every deployment rebuilds the index once on next start. **This is the prod repair** — no manual step, no maintenance op.
- **All three writers store the book ID as the row value.** The index is a pointer index (the reader takes the ID from the key and looks up the authoritative row), so the full serialized `Book` that `CreateBook`/`UpdateBook` stored was never read — and would have doubled write amplification once the update write became unconditional.

## What was deliberately NOT changed

The zero-result fallback **stays**. Gating it on the backfill sentinel was drafted and **rejected**: a genuinely missing row would then return **empty** rather than the full scan's correct answer — trading a silent under-report for a silent zero on a path that also feeds `/versions`, `regroup_apply`, and metafetch writeback. A real fix needs a completeness signal that doesn't depend on the result being non-empty (an authoritative per-group member count); that doesn't exist yet. The limitation is now documented in-code instead of implicit.

Reading through memdb (`memIdxVersionGroupID`) is still unadopted — it returns *more* members than today and metafetch enumerates siblings through this call before writing to them.

## Tests

`internal/database/pebble_store_versiongroup_index_test.go` (new). Damages exactly **one** index row — wiping the whole index passes *with the bug present*, which is the trap this defect lived in.

**Negative control** (the instrument was watched going red): with the self-heal reverted, the suite exits 1 on
`self-heal failed: want 3 books after a same-group update, got 2`.

## Verification

| Check | Result |
|---|---|
| `go build ./...` | clean |
| `go vet ./internal/database/` | clean |
| `internal/database` | **ok** 353.9s |
| `internal/merge` | **ok** 31.7s |
| `internal/plugins/maintenance` | **ok** 25.8s |

The last two exercise `dbtest.AssertStoreInvariants` against a **real** `PebbleStore`, including invariant (b) — "a live book must be discoverable by its own version-group listing."

Closes the `GetBooksByVersionGroup` entry in `TODO.md` (directions 2 + 3 shipped; 1 and 4 documented as deliberately not taken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp