### PR TITLE
docs(todo): browse-by-tag cleanup + iTunes playlist sync is unwired [skip changelog]

### DIFF
--- a/changelog.d/20260810_193000_todo_only_noop.md
+++ b/changelog.d/20260810_193000_todo_only_noop.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op changelog fragment.
+
+This PR adds TODO backlog fragments only (todo.d/) — no product code changes,
+so there is nothing user-visible to announce. The fragment exists to satisfy
+changelog-check.yml, which requires one per PR.
+-->

--- a/todo.d/20260810-browse-by-tag-cleanup.md
+++ b/todo.d/20260810-browse-by-tag-cleanup.md
@@ -1,0 +1,52 @@
+- [ ] 🏷️ **"Browse by Tag" surfaces internal bookkeeping tags and formats them
+      badly.** Owner report 2026-08-10 with a screenshot of the Library page on
+      mobile (`books.jdfalk.com`, "Browse by Tag (149)"). The widget is *almost*
+      right; every problem below is presentation, not tagging.
+
+      Observed, top five chips in order:
+
+      | Chip as rendered | Count | Verdict |
+      |---|---:|---|
+      | `dedup:duration-match` | 24,883 | **Strip** — internal dedup bookkeeping |
+      | `metadata:language:en` | 15,036 | Keep, but **reformat** (see below) |
+      | `metadata:source:audible` | 14,895 | **Strip** — provenance, not a browse axis |
+      | `dedup:duration-abridged` | 3,573 | **Strip**, and the count is **suspect** |
+      | `science fiction & fantasy` | 1,109 | ✅ this is what the widget is for |
+
+      **What the owner asked for:**
+
+      1. **Strip `dedup:duration-match` entirely.** Nobody browses their library
+         by "the deduper thought these two durations matched."
+      2. **Strip `metadata:source:audible`** and its siblings (`google-books`,
+         etc.). *"For those weird ones like audible metadata source or google
+         books or whatever don't put those at the top ever if we can. If we just
+         have to hide them that's fine too."* — so a hide/allow-list is an
+         acceptable implementation; they do not have to be deleted from the data.
+      3. **Strip the `metadata:` prefix and put a space between key and value.**
+         `metadata:language:en` should read `language: en`, not
+         `metadata:language:en`. Owner: *"for gosh sakes."*
+      4. **`dedup:duration-abridged` (3,573) — verify the number before trusting
+         it.** Owner: *"not sure on the abridged. That's a weird one. I don't
+         think it's as high as you think it is."* Treat this as a **separate
+         data question** from the display cleanup: 3,573 abridged editions out of
+         the library is a claim the tagger is making, and the owner's intuition
+         is that it is over-firing. Do not "fix" it by hiding the tag — measure
+         whether the abridged detection is correct first, then decide. Hiding a
+         wrong number makes it unfalsifiable.
+      5. **Confirm tags are per-BOOK, not per-file.** Owner: *"Also tags are per
+         book right?"* This needs a definitive answer from the schema, not an
+         assumption — if any tag is stored per `book_file`, a multi-file
+         audiobook would inflate every count in this widget by its file count,
+         which would independently explain why several of these numbers look too
+         high. **Check this before touching the display**, because it changes
+         whether the counts above are even meaningful.
+
+      **Suggested shape** (not locked): an ordering/visibility policy for tag
+      namespaces rather than per-tag special cases — genuine subject tags
+      (`science fiction & fantasy`) rank first, `metadata:*` renders
+      prefix-stripped and `key: value` formatted below them, and `dedup:*` plus
+      other machine-internal namespaces are hidden from Browse by Tag entirely
+      while remaining searchable/filterable for anyone who wants them.
+
+      Screenshot in the 2026-08-10 session; widget renders on the Library page
+      under the search box, above `Select All`.

--- a/todo.d/20260810-playlists-itunes-import-and-sync-unwired.md
+++ b/todo.d/20260810-playlists-itunes-import-and-sync-unwired.md
@@ -1,0 +1,84 @@
+- [ ] 🎧 **iTunes dynamic-playlist import and playlist push-back are fully
+      implemented and NEVER CALLED.** Owner request 2026-08-10: *"I want all my
+      dynamic playlists from iTunes imported"* and *"I'd like it if we could sync
+      our dynamic playlists."* Measured the same day — this is a **wiring gap,
+      not a build gap.**
+
+      `internal/itunes/service/playlist_sync.go` (v2.1.0) implements both halves
+      of spec 3.4:
+
+      - `MigrateSmartPlaylists(lib *itunes.ITLLibrary) (imported, skipped int)`
+        — reads smart playlists from the ITL, parses the Smart Criteria blob,
+        translates it to our DSL, creates `UserPlaylist` rows with `type=smart`,
+        and stores the raw blob in `ITunesRawCriteriaB64` for audit. Idempotent,
+        skips playlists already imported by iTunes PID.
+      - `PushDirty() int` — creates an ITL playlist for dirty playlists with no
+        PID, updates the track list for those that have one.
+
+      **Both have ZERO non-test callers.** Verified by enumerating every method
+      on `*PlaylistSync` and grepping for call sites across `internal/` and
+      `cmd/` excluding `_test.go`:
+
+          MigrateSmartPlaylists -> 0 non-test callers
+          PushDirty             -> 0 non-test callers
+
+      The service *constructs* `PlaylistSync` (`itunes/service/service.go:124`,
+      "M1 step 4") and the store side is complete — `ListDirtyUserPlaylists()`
+      exists, `idx:upl:dirty:` is maintained, `idx:upl:itunes:<pid>` maps PIDs
+      back to playlists. Everything is in place except an invocation. So the
+      owner's iTunes smart playlists have never been imported, and no playlist
+      has ever been pushed back, while the code to do both sits tested and idle.
+
+      This is the same failure shape as the rest of the 2026-08-10 backlog: a
+      mechanism that reports nothing because it never runs. It will not show up
+      as an error, a warning, or a failed op — there is simply no op.
+
+      **Work:**
+      1. Decide the trigger for `MigrateSmartPlaylists` — a one-shot maintenance
+         op (consistent with the rest of the codebase), a step in the existing
+         iTunes import flow, or an explicit endpoint. It needs an `*ITLLibrary`,
+         so it has to hang off whatever already parses the ITL.
+      2. Decide the trigger for `PushDirty` — this one WRITES to the iTunes
+         library, so it must respect the standing rule that the active iTunes
+         tree is hands-off, and it must be dry-run-gated on first run like every
+         other apply path here. Import (read-only) and push (write) should ship
+         as **separate** units; the owner asked for import first.
+      3. Report exact counts on the first import run (imported / skipped), and
+         verify by re-reading the DB rather than trusting the return values.
+
+- [ ] ✅ **Confirm playlists are book-level, not file-level — and delete the dead
+      file-level path.** Owner requirement 2026-08-10: *"we need to be sure
+      playlists operate at the book level not the file level."*
+
+      **Checked 2026-08-10 — the live model is already book-level.**
+      `database.UserPlaylist` (`internal/database/store.go:391`) stores
+      `BookIDs []string` (book ULIDs) for static playlists and
+      `MaterializedBookIDs []string` for evaluated smart ones. `Type` is
+      `"static"` or `"smart"`. `MaterializeSmartPlaylist` evaluates to book IDs.
+      No `book_file` reference anywhere in the type. ✅
+
+      **But a legacy file-level path still exists** in `internal/playlist/playlist.go`:
+
+          type PlaylistItem struct {
+              BookID   int      // ← book IDs are ULID strings, not ints
+              FilePath string   // ← ONE path per book; audiobooks are multi-file
+              ...
+          }
+
+      `generatePlaylistFile` writes an M3U with a single `FilePath` line per
+      item, which is wrong for any multi-file audiobook, and `BookID int` is a
+      leftover from the removed SQLite schema. Its only sibling,
+      `GeneratePlaylistsForSeries`, was already gutted in fable5 TASK-022 and now
+      just returns an error telling callers to use the Store-backed API.
+
+      `generatePlaylistFile` has **no non-test callers** — its only references
+      are in `internal/playlist/playlist_test.go`. So the file-level model is
+      dead code that four tests keep alive, and it is exactly the sort of thing
+      that gets copied back into service later because it looks like the
+      playlist implementation. **Delete it and its tests**, or, if M3U export is
+      wanted as a real feature, rewrite it against `UserPlaylist` with all of a
+      book's files expanded in order.
+
+      No production behaviour should change either way — but do not close this
+      by inspection alone; grep for `PlaylistItem` at the time of the fix in case
+      something has picked it up since.


### PR DESCRIPTION
Two owner-reported items from the 2026-08-10 session, captured as `todo.d` fragments. **No product code changes.**

## 1. Browse by Tag surfaces internal bookkeeping

Owner screenshot of the Library page. Top five chips:

| Chip | Count | Verdict |
|---|---:|---|
| `dedup:duration-match` | 24,883 | strip — internal dedup bookkeeping |
| `metadata:language:en` | 15,036 | keep, reformat to `language: en` |
| `metadata:source:audible` | 14,895 | strip — provenance, not a browse axis |
| `dedup:duration-abridged` | 3,573 | strip **and** the count is suspect |
| `science fiction & fantasy` | 1,109 | ✅ what the widget is actually for |

Two of these are more than cosmetic:

- **`dedup:duration-abridged` (3,573)** — owner believes the number is too high. Recorded as a **data** question, deliberately separate from the display cleanup: hiding a wrong number makes it unfalsifiable.
- **"tags are per book right?"** — needs a schema answer, not an assumption. If any tag is stored per `book_file`, a multi-file audiobook inflates every count in this widget by its file count, which would independently explain why several numbers look too high. Flagged to check **first**, since it decides whether the counts are meaningful at all.

## 2. iTunes playlist import/sync is implemented and never called

`internal/itunes/service/playlist_sync.go` (v2.1.0) implements both halves of spec 3.4 — `MigrateSmartPlaylists` (import iTunes smart playlists, translate Smart Criteria to our DSL, idempotent by PID) and `PushDirty` (push playlists back to the ITL). Enumerated every method on `*PlaylistSync` and grepped for call sites:

```
MigrateSmartPlaylists -> 0 non-test callers
PushDirty             -> 0 non-test callers
```

The service constructs `PlaylistSync`, the store side is complete (`ListDirtyUserPlaylists`, `idx:upl:dirty:`, `idx:upl:itunes:<pid>`). Everything is in place except an invocation — so no dynamic playlist has ever been imported, and none pushed. It produces no error and no failed op, because there is no op.

Import (read-only) and push (writes to the iTunes library) are recorded as **separate** units; push must respect the hands-off rule for the active iTunes tree and be dry-run gated.

### Playlists are already book-level ✅

`database.UserPlaylist` stores `BookIDs []string` (book ULIDs) and `MaterializedBookIDs []string`. No `book_file` reference in the type. But a dead file-level path survives in `internal/playlist/playlist.go` — `PlaylistItem{BookID int; FilePath string}`, a leftover from the removed SQLite schema, writing one path per book (wrong for multi-file audiobooks). `generatePlaylistFile` has no non-test callers; only its own tests keep it alive. Recorded for deletion or a rewrite against `UserPlaylist`.

---

Includes an intentional no-op `changelog.d` fragment (todo-only PR, nothing user-visible to announce).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp