### PR TITLE
feat(maintenance): wire the iTunes smart-playlist importer that was never called [skip changelog]

### DIFF
--- a/changelog.d/20260810_200000_itunes_playlist_import_op.md
+++ b/changelog.d/20260810_200000_itunes_playlist_import_op.md
@@ -1,0 +1,36 @@
+### Added
+
+#### Import your iTunes smart (dynamic) playlists
+
+There is now a maintenance operation, **Import iTunes smart (dynamic)
+playlists**, that reads smart playlists out of an iTunes library, translates
+each one's Smart Criteria into our own query language, and creates a matching
+smart playlist here. It is idempotent — playlists already imported are skipped
+by their iTunes ID — and it defaults to a dry run that tells you what it would
+import before it writes anything.
+
+The translation code for this had existed and been tested for months. Nothing
+ever called it, so no playlist had ever been imported, and because there was no
+operation there was also no error to notice. This adds the missing invocation.
+
+The import only ever *reads* the iTunes library and writes to our own database.
+
+Two things were fixed while wiring it up, both of which would have made a
+successful-looking run do nothing useful:
+
+- **Imported playlists would have been invisible.** They were stamped as owned
+  by the internal `_local` identity, but the playlist list is scoped to the
+  signed-in account, so every imported playlist would have been hidden from
+  every real user while the importer reported a healthy count. The owning
+  account is now explicit.
+- **Dry run now means something.** The underlying importer had no dry-run mode,
+  so a dry-run setting would have been a switch wired to nothing. It now parses
+  and translates every playlist and reports exactly what it would create,
+  without writing a row.
+
+**Known limitation, stated up front:** on real iTunes 12.13 libraries the binary
+`.itl` reader currently surfaces no smart playlists at all, even though the same
+library's XML export contains hundreds of them. The operation detects this case
+and says so loudly instead of reporting a clean "0 imported" that would read
+like an empty library. Until that is resolved the import will not find your
+playlists — the tracking entry has the measurements and the two candidate fixes.

--- a/internal/itunes/service/playlist_sync.go
+++ b/internal/itunes/service/playlist_sync.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/playlist_sync.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: 1e9f0a8b-2c3d-4a70-b8c5-3d7e0f1b9a99
 //
 // iTunes playlist sync (spec 3.4 tasks 5-6).
@@ -49,34 +49,106 @@ func newPlaylistSync(store playlistSyncStore, enqueuer Enqueuer) *PlaylistSync {
 	return &PlaylistSync{store: store, enqueuer: enqueuer}
 }
 
+// NewPlaylistImporter builds a PlaylistSync for the IMPORT direction only.
+//
+// The enqueuer is nil, so PushDirty's ITL write-back enqueue is disabled — this
+// constructor exists for callers (the maintenance op) that must never write to
+// the iTunes library. Import reads an already-parsed *ITLLibrary and writes only
+// UserPlaylist rows in our own store.
+func NewPlaylistImporter(store database.UserPlaylistStore) *PlaylistSync {
+	return &PlaylistSync{store: store, enqueuer: nil}
+}
+
+// PlaylistImportOptions controls a smart-playlist migration run.
+type PlaylistImportOptions struct {
+	// OwnerUserID is stamped on every created playlist as CreatedByUserID.
+	//
+	// This matters more than it looks. The playlist API scopes list results per
+	// user (ListUserPlaylistsForUser), and handlers.CallingUserID returns the
+	// sentinel "_local" ONLY when no user is authenticated. So playlists
+	// imported under "_local" are invisible to every logged-in account — the
+	// import would report a healthy count while the Playlists page stayed
+	// empty. Set this to the account that should own the imported playlists.
+	// Empty falls back to adminUserID for backwards compatibility.
+	OwnerUserID string
+
+	// DryRun parses and translates every smart playlist and reports what WOULD
+	// be imported, without creating a single row. Note that the underlying
+	// per-playlist work (PID lookup, criteria parse, DSL translation) is
+	// identical in both modes — only CreateUserPlaylist is withheld — so a dry
+	// run exercises every failure mode the apply would hit.
+	DryRun bool
+}
+
+// PlaylistImportItem records one smart playlist's outcome.
+type PlaylistImportItem struct {
+	Title  string `json:"title"`
+	PID    string `json:"pid"`
+	Query  string `json:"query,omitempty"`
+	Status string `json:"status"` // "imported" | "would-import" | "already-imported" | "unparseable" | "create-failed"
+	Err    string `json:"err,omitempty"`
+}
+
+// PlaylistImportResult is the full outcome of a migration run.
+type PlaylistImportResult struct {
+	SmartFound int                  `json:"smart_found"`
+	Imported   int                  `json:"imported"`
+	Skipped    int                  `json:"skipped"`
+	Items      []PlaylistImportItem `json:"items"`
+}
+
 // MigrateSmartPlaylists reads smart playlists from the ITL library
 // and creates UserPlaylist rows for each. Idempotent — playlists
 // already imported (by iTunes PID) are skipped.
-func (p *PlaylistSync) MigrateSmartPlaylists(lib *itunes.ITLLibrary) (imported, skipped int) {
+//
+// Read-only with respect to the iTunes library: it consumes an already-parsed
+// *ITLLibrary and writes only to our own store.
+func (p *PlaylistSync) MigrateSmartPlaylists(lib *itunes.ITLLibrary, opts PlaylistImportOptions) PlaylistImportResult {
+	res := PlaylistImportResult{}
 	if lib == nil {
-		return 0, 0
+		return res
+	}
+
+	owner := opts.OwnerUserID
+	if owner == "" {
+		owner = adminUserID
 	}
 
 	for _, pl := range lib.Playlists {
 		if !pl.IsSmart || len(pl.SmartCriteria) == 0 {
 			continue
 		}
+		res.SmartFound++
 
 		pid := hex.EncodeToString(pl.PersistentID[:])
+		item := PlaylistImportItem{Title: pl.Title, PID: pid}
 
 		existing, _ := p.store.GetUserPlaylistByITunesPID(pid)
 		if existing != nil {
-			skipped++
+			res.Skipped++
+			item.Status = "already-imported"
+			res.Items = append(res.Items, item)
 			continue
 		}
 
 		parsed, err := itunes.ParseSmartCriteria(pl.SmartCriteria)
 		if err != nil {
 			slog.Warn("parse smart criteria for playlist", "pl", pl.Title, "pid", pid, "err", err)
-			skipped++
+			res.Skipped++
+			item.Status = "unparseable"
+			item.Err = err.Error()
+			res.Items = append(res.Items, item)
 			continue
 		}
 		dslQuery := itunes.TranslateSmartCriteria(parsed)
+		item.Query = dslQuery
+
+		if opts.DryRun {
+			res.Imported++
+			item.Status = "would-import"
+			res.Items = append(res.Items, item)
+			continue
+		}
 
 		rawB64 := base64.StdEncoding.EncodeToString(pl.SmartCriteria)
 
@@ -87,20 +159,22 @@ func (p *PlaylistSync) MigrateSmartPlaylists(lib *itunes.ITLLibrary) (imported, 
 			ITunesPersistentID:   pid,
 			ITunesRawCriteriaB64: rawB64,
 			Description:          fmt.Sprintf("Imported from iTunes smart playlist %q", pl.Title),
-			// Stamp ownership so the API's per-user playlist isolation does not
-			// hide iTunes-imported playlists. The sync worker runs as the local
-			// admin identity (no per-request user context).
-			CreatedByUserID: adminUserID,
+			CreatedByUserID:      owner,
 		})
 		if err != nil {
 			slog.Warn("create playlist", "pl", pl.Title, "err", err)
-			skipped++
+			res.Skipped++
+			item.Status = "create-failed"
+			item.Err = err.Error()
+			res.Items = append(res.Items, item)
 			continue
 		}
-		imported++
+		res.Imported++
+		item.Status = "imported"
+		res.Items = append(res.Items, item)
 	}
 
-	return imported, skipped
+	return res
 }
 
 // PushDirty writes dirty playlists to the ITL. Smart playlists are

--- a/internal/itunes/service/playlist_sync_test.go
+++ b/internal/itunes/service/playlist_sync_test.go
@@ -16,7 +16,8 @@ func TestMigrateSmartPlaylists_NilLibrary(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	ps := newPlaylistSync(nil, nil)
-	imported, skipped := ps.MigrateSmartPlaylists(nil)
+	res := ps.MigrateSmartPlaylists(nil, PlaylistImportOptions{})
+	imported, skipped := res.Imported, res.Skipped
 	if imported != 0 || skipped != 0 {
 		t.Errorf("nil library: imported=%d skipped=%d, want 0/0", imported, skipped)
 	}
@@ -42,7 +43,8 @@ func TestMigrateSmartPlaylists_SkipsNonSmart(t *testing.T) {
 	}
 
 	ps := newPlaylistSync(store, nil)
-	imported, skipped := ps.MigrateSmartPlaylists(lib)
+	res := ps.MigrateSmartPlaylists(lib, PlaylistImportOptions{})
+	imported, skipped := res.Imported, res.Skipped
 	if imported != 0 || skipped != 0 {
 		t.Errorf("non-smart: imported=%d skipped=%d, want 0/0", imported, skipped)
 	}
@@ -80,7 +82,8 @@ func TestMigrateSmartPlaylists_SkipsAlreadyImported(t *testing.T) {
 	}
 
 	ps := newPlaylistSync(store, nil)
-	imported, skipped := ps.MigrateSmartPlaylists(lib)
+	res := ps.MigrateSmartPlaylists(lib, PlaylistImportOptions{})
+	imported, skipped := res.Imported, res.Skipped
 	if imported != 0 {
 		t.Errorf("expected 0 imported (already exists), got %d", imported)
 	}

--- a/internal/plugins/maintenance/itunes_playlist_import.go
+++ b/internal/plugins/maintenance/itunes_playlist_import.go
@@ -1,0 +1,194 @@
+// file: internal/plugins/maintenance/itunes_playlist_import.go
+// version: 1.0.0
+// guid: 7c4e91a3-58bd-42f6-9e0a-1d6b3f8c25e4
+// last-edited: 2026-08-10
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/itunes"
+	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// iTunes smart-playlist import (spec 3.4 task 5).
+//
+// The importer itself has existed and been tested since PlaylistSync v2.0 —
+// it was simply never called. `MigrateSmartPlaylists` and `PushDirty` had ZERO
+// non-test callers, so no dynamic playlist was ever imported and none pushed.
+// That produced no error and no failed op, because there was no op. This file
+// is the missing invocation.
+//
+// READ-ONLY with respect to iTunes. It parses an .itl and writes only
+// UserPlaylist rows into our own store, so it is safe against the hands-off
+// Original tree. It declares CapLibraryRead only — deliberately NOT
+// CapLibraryWrite, which would both misdescribe it and invite a future caller
+// to assume writing is allowed. The push direction (PushDirty) is a separate,
+// still-unwired unit and is intentionally not exposed here.
+
+type itunesPlaylistImportParams struct {
+	// DryRun reports what would be imported without creating rows.
+	DryRun bool `json:"dryRun"`
+	// ITLPath is the binary iTunes Library.itl to read.
+	//
+	// Required in practice. It is NOT defaulted from config.LibraryReadPath
+	// because that field resolves to Libraries.Original.XMLPath whenever
+	// ImportSource is "original" or unset (itunes_libraries.go Resolve()) —
+	// i.e. an XML file, which the binary ITL parser cannot read. Silently
+	// feeding XML to ParseITL would fail in a way that looks like "no
+	// playlists found".
+	ITLPath string `json:"itlPath"`
+	// OwnerUserID is stamped as CreatedByUserID on every imported playlist.
+	//
+	// The playlist API scopes list results per user, and CallingUserID returns
+	// "_local" only when nobody is authenticated. Importing under "_local"
+	// therefore hides every playlist from every logged-in account while the op
+	// still reports a healthy count. Set this to the account that should see
+	// them.
+	OwnerUserID string `json:"ownerUserId"`
+}
+
+func (p *Plugin) itunesPlaylistImportDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:              "maintenance.itunes-playlist-import",
+		Plugin:          "maintenance",
+		DisplayName:     "Import iTunes smart (dynamic) playlists",
+		Description:     "Reads smart playlists from a binary iTunes Library.itl, translates each Smart Criteria blob into our query DSL, and creates a matching smart UserPlaylist. Read-only with respect to iTunes — writes only to our own store. Idempotent: playlists already imported are skipped by iTunes persistent ID. Default dry-run reports what would be imported; set dryRun=false to apply.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.itunes-playlist-import",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         30 * time.Minute,
+		Schedule:        nil,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead},
+		Run:             p.runITunesPlaylistImport,
+	}
+}
+
+func (p *Plugin) runITunesPlaylistImport(ctx context.Context, raw json.RawMessage, reporter sdk.Reporter) error {
+	params := itunesPlaylistImportParams{DryRun: true} // safe default
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return fmt.Errorf("itunes-playlist-import: bad params: %w", err)
+		}
+	}
+
+	itlPath := strings.TrimSpace(params.ITLPath)
+	if itlPath == "" {
+		// Fall back to the configured read path ONLY if it actually is an ITL.
+		// See the ITLPath doc comment: LibraryReadPath is commonly an XML.
+		if cand := config.AppConfig.ITunes.LibraryReadPath; strings.HasSuffix(strings.ToLower(cand), ".itl") {
+			itlPath = cand
+		}
+	}
+	if itlPath == "" {
+		return fmt.Errorf("itunes-playlist-import: itlPath is required " +
+			"(the configured itunes.library_read_path is empty or not a .itl — " +
+			"it resolves to the Original XML export unless import_source is \"ao\")")
+	}
+
+	st, err := os.Stat(itlPath)
+	if err != nil {
+		return fmt.Errorf("itunes-playlist-import: cannot read %q: %w", itlPath, err)
+	}
+	_ = reporter.UpdateProgress(0, 3, fmt.Sprintf("Phase 1/3: parsing %s (%.1f MB)…", itlPath, float64(st.Size())/(1024*1024)))
+
+	lib, err := itunes.ParseITL(itlPath)
+	if err != nil {
+		return fmt.Errorf("itunes-playlist-import: parse %q: %w", itlPath, err)
+	}
+	if lib == nil {
+		return fmt.Errorf("itunes-playlist-import: parse %q returned no library", itlPath)
+	}
+
+	smart := 0
+	for _, pl := range lib.Playlists {
+		if pl.IsSmart && len(pl.SmartCriteria) > 0 {
+			smart++
+		}
+	}
+	_ = reporter.UpdateProgress(1, 3, fmt.Sprintf("Phase 2/3: %d playlists in library, %d smart", len(lib.Playlists), smart))
+
+	// MEASURED 2026-08-10 and unresolved: the binary ITL parser extracts ZERO
+	// smart playlists from real iTunes 12.13.10.3 libraries, while the XML
+	// export of the SAME library contains 292 "Smart Criteria" blobs (351
+	// playlists total). Reproduced on the live library and on an April backup,
+	// so it is a parser gap, not writeback data loss. The extraction code does
+	// exist (itl_be.go / itl_le.go populate IsSmart + SmartCriteria) — it just
+	// does not fire on these files.
+	//
+	// Without this branch the op's honest output ("0 smart playlists found, 0
+	// imported") is indistinguishable from "you have no smart playlists", which
+	// is precisely the failure mode this whole op exists to end. Say it loudly.
+	if smart == 0 && len(lib.Playlists) > 0 {
+		msg := fmt.Sprintf(
+			"parsed %d playlists but found 0 with smart criteria — nothing to import. "+
+				"This is a KNOWN GAP, not necessarily an empty library: the XML export of the "+
+				"same library can contain hundreds of smart playlists the binary ITL parser "+
+				"does not surface. Verify with: grep -c 'Smart Criteria' '<library>.xml'",
+			len(lib.Playlists))
+		slog.Warn("itunes-playlist-import: no smart playlists extracted", "itl", itlPath, "playlists", len(lib.Playlists))
+		_ = reporter.Log(slog.LevelWarn, msg)
+		_ = reporter.UpdateProgress(3, 3, "0 smart playlists extracted — see log")
+		return nil
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	importer := itunesservice.NewPlaylistImporter(p.deps.Store())
+	res := importer.MigrateSmartPlaylists(lib, itunesservice.PlaylistImportOptions{
+		OwnerUserID: strings.TrimSpace(params.OwnerUserID),
+		DryRun:      params.DryRun,
+	})
+
+	// Report by RE-READING the store, not by trusting the returned counter.
+	// On an apply run the authoritative number is how many smart playlists
+	// actually exist afterwards.
+	verified := -1
+	if !params.DryRun {
+		if _, total, lerr := p.deps.Store().ListUserPlaylists("smart", 1, 0); lerr == nil {
+			verified = total
+		} else {
+			slog.Warn("itunes-playlist-import: verification re-read failed", "err", lerr)
+		}
+	}
+
+	mode := "APPLY"
+	if params.DryRun {
+		mode = "DRY-RUN"
+	}
+	slog.Info("itunes-playlist-import complete",
+		"mode", mode, "itl", itlPath,
+		"playlistsInLibrary", len(lib.Playlists),
+		"smartFound", res.SmartFound,
+		"imported", res.Imported, "skipped", res.Skipped,
+		"smartPlaylistsInStoreAfter", verified,
+		"owner", params.OwnerUserID)
+
+	summary := fmt.Sprintf("%s: %d smart playlists found, %d imported, %d skipped",
+		mode, res.SmartFound, res.Imported, res.Skipped)
+	if verified >= 0 {
+		summary += fmt.Sprintf("; %d smart playlists in store after", verified)
+	}
+	_ = reporter.UpdateProgress(3, 3, summary)
+
+	_ = reporter.Log(slog.LevelInfo, summary)
+	for _, it := range res.Items {
+		if it.Status == "unparseable" || it.Status == "create-failed" {
+			_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("%s: %s (%s)", it.Status, it.Title, it.Err))
+		}
+	}
+	return nil
+}

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/plugin.go
-// version: 1.15.0
+// version: 1.16.0
 // guid: b2c3d4e5-f6a7-8901-bcde-123456789012
-// last-edited: 2026-08-06
+// last-edited: 2026-08-10
 
 package maintenance
 
@@ -46,6 +46,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.seriesDenumberDef(),
 		p.purgeMillisecondDurationsDef(),
 		p.integrityCheckDef(),
+		p.itunesPlaylistImportDef(),
 
 		// --- database ---
 		p.dbOptimizeDef(),

--- a/todo.d/20260810-itl-smart-criteria-not-extracted.md
+++ b/todo.d/20260810-itl-smart-criteria-not-extracted.md
@@ -1,0 +1,54 @@
+- [ ] 🔴 **The binary ITL parser extracts ZERO smart playlists from real iTunes
+      libraries, while the XML export of the same library has 292.** Measured
+      2026-08-10 against the owner's live library. This is the blocker standing
+      between `maintenance.itunes-playlist-import` and the owner's request
+      *"I want all my dynamic playlists from iTunes imported."*
+
+      | Source | Playlists | Smart |
+      |---|---:|---:|
+      | `/mnt/bigdata/books/itunes/iTunes Library.itl` (live, Jul 19, 32 MB) | 357 | **0** |
+      | `.../bkup/itunesgood/iTunes Library.itl` (Apr 2, 28 MB) | 335 | **0** |
+      | `/mnt/bigdata/books/itunes/iTunes Library.xml` (same library) | 351 | **292** |
+
+      **Not writeback data loss.** Both the live ITL and an April backup return
+      zero, so this is not our ITL writer stripping records — it is extraction
+      that never fires on real files. Both parse cleanly otherwise (97,999 and
+      90,900 tracks, correct titles, `ver=12.13.10.3`).
+
+      **Not an unimplemented stub either** — that was the first hypothesis and it
+      was wrong. `itl_be.go:341-354` and `itl_le.go:429-441` do populate
+      `IsSmart`, `SmartCriteria` (hohm `0x65`) and `SmartInfo` (hohm `0x66`).
+      The code exists and presumably works on the synthetic fixtures the unit
+      tests build by hand — `playlist_sync_test.go` constructs `ITLPlaylist`
+      values with `IsSmart: true` directly, so **no test has ever exercised the
+      parser that fills those fields.** A third instance of the session's theme:
+      the tests pass because they bypass the thing that is broken.
+
+      The XML proves the data exists and is recoverable: 292 `Smart Criteria`
+      blobs, with names that are clearly the owner's real playlists (series and
+      author names — "A Mage's Cultivation", "Aether's Revival", "Aaron Oster",
+      "All the Skills").
+
+      **Two candidate directions — needs a decision:**
+      1. **Fix ITL extraction.** Find why the `0x65`/`0x66` branch does not fire
+         on 12.13.10.3 files (offset/section assumption, playlist record layout,
+         BE-vs-LE path). Highest value: the ITL is the write/authority surface,
+         so push-back will need this too. Start by dumping the hohm types
+         actually encountered while parsing one real playlist record — the
+         parser reaches these playlists (titles are correct), so the records are
+         either absent from the stream or skipped.
+      2. **Import from the XML export instead.** The criteria are present and
+         base64-encoded; `ParseSmartCriteria`/`TranslateSmartCriteria` already
+         consume that blob shape. Much cheaper, unblocks the owner immediately,
+         and read-only against a file we already parse elsewhere. Downside: the
+         XML is an export, not the authority, so it can lag the ITL.
+
+      Recommend **2 to unblock, then 1** — but confirm the XML's base64 blob is
+      byte-identical in shape to what `ParseSmartCriteria` expects before
+      assuming it drops in.
+
+      `maintenance.itunes-playlist-import` already guards this case explicitly:
+      when it parses playlists but extracts zero smart ones it logs a warning
+      naming the XML discrepancy and the `grep -c 'Smart Criteria'` check,
+      rather than reporting a clean "0 imported" that reads like an empty
+      library.


### PR DESCRIPTION
Owner asked for their iTunes dynamic playlists to be imported. The importer already existed — it had just never been called.

## The wiring gap

`MigrateSmartPlaylists` (import) and `PushDirty` (push back) have existed and been tested since `PlaylistSync` v2.0. Both had **zero non-test callers**:

```
MigrateSmartPlaylists -> 0 non-test callers
PushDirty             -> 0 non-test callers
```

So no dynamic playlist had ever been imported and none pushed — producing no error and no failed op, because there **was** no op. This adds it: `maintenance.itunes-playlist-import`, dry-run by default, declaring `CapLibraryRead` **only** (it parses an `.itl` and writes solely to our own store; the push direction is deliberately not exposed here).

## Two defects found while wiring, both of which would have made a green run do nothing

**1. Imported playlists would have been invisible to you.**
The importer stamped `CreatedByUserID = adminUserID` (`"_local"`). But `handlers.CallingUserID` returns `"_local"` only when *nobody is authenticated*, and `ListPlaylists` scopes per user. A signed-in owner would have seen an empty Playlists page while the op reported a healthy count. `OwnerUserID` is now an explicit option.

**2. Dry-run would have been a switch wired to nothing.**
`MigrateSmartPlaylists` had no dry-run mode. Passing a `dryRun` param through would have applied regardless. It now withholds only `CreateUserPlaylist` — so a dry run still exercises PID lookup, criteria parse and DSL translation, and returns a per-playlist plan (`would-import` / `already-imported` / `unparseable` / `create-failed`).

Apply runs report by **re-reading** the store, not by trusting the returned counter.

## Known gap — measured, guarded, not hidden

On real iTunes 12.13.10.3 libraries the binary ITL parser surfaces **zero** smart playlists, while the XML export of the *same* library has **292**:

| Source | Playlists | Smart |
|---|---:|---:|
| live `iTunes Library.itl` (32 MB, Jul 19) | 357 | **0** |
| `bkup/itunesgood/iTunes Library.itl` (Apr 2) | 335 | **0** |
| `iTunes Library.xml` (same library) | 351 | **292** |

**Not writeback data loss** — an April backup returns zero too. **Not an unimplemented stub** — that was my first hypothesis and it was wrong: `itl_be.go:341-354` and `itl_le.go:429-441` do populate `IsSmart`/`SmartCriteria`/`SmartInfo`. No test ever covered it because `playlist_sync_test.go` constructs `ITLPlaylist` values by hand with `IsSmart: true`, bypassing the parser entirely.

Rather than let the op report a clean `0 imported` that reads identically to "you have no smart playlists", it now detects "parsed playlists but extracted zero smart" and logs the discrepancy plus the `grep -c 'Smart Criteria'` check that confirms it. Tracked in `todo.d` with both candidate directions (fix ITL extraction vs. import from the XML export).

## Verification

| Check | Result |
|---|---|
| `go build ./...` | clean |
| `go vet` (maintenance, itunes/service) | clean |
| `internal/itunes/service` | **ok** 12.5s |
| `internal/plugins/maintenance` | **ok** 13.8s |
| Real-library parse probe | 97,999 tracks / 357 playlists from the live 32 MB `.itl` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp