### PR TITLE
feat(web): MUI 5.14 → 6.5 (upgrade step 1) [skip changelog]

### DIFF
--- a/changelog.d/20260810_205000_mui_v6_upgrade.md
+++ b/changelog.d/20260810_205000_mui_v6_upgrade.md
@@ -1,0 +1,22 @@
+### Changed
+
+#### Material UI upgraded from 5.14 to 6.5 (step 1 of the path to v9)
+
+This is the first of three version hops that bring the interface library up to
+date. Nothing about the app should look or behave differently — this step exists
+to move the foundation, not to change the UI.
+
+Two automated migrations were applied: one that rewrites conditional styling
+into the form version 6 expects (40 files), and one for the theme file, which
+turned out to need no changes at all. Nothing was migrated by hand.
+
+The upgrade was unusually quiet, and the reason is worth recording: an inventory
+taken on 2026-08-07 found this codebase uses none of the patterns that normally
+make these upgrades painful — no legacy styling engine, no custom theme type
+extensions, no deep imports into library internals, and none of the optional
+add-on packages that have to move in lockstep. The 1,726 inline style props
+throughout the app carry over untouched.
+
+Notes for the next step: the real cost in this migration is the grid layout
+rewrite, which lands in the 6→7 hop, not this one. Emotion remains the styling
+engine — the zero-runtime alternative is deliberately not being adopted.

--- a/changelog.d/20260811_080000_fix_drawer_stuck_backdrop_exit_false.md
+++ b/changelog.d/20260811_080000_fix_drawer_stuck_backdrop_exit_false.md
@@ -1,0 +1,32 @@
+### Fixed
+
+- **The filter Drawer could stall mid-close and leave an invisible full-viewport
+  backdrop that swallowed every click until reload — and the 2026-08-10 "fix"
+  for it had only narrowed the race, not closed it.** `web/src/theme.ts` now
+  sets `MuiDrawer.defaultProps.slotProps.transition = { exit: false }`, which
+  makes react-transition-group take its synchronous branch in `performExit`
+  (`safeSetState({status: EXITED})` from inside `componentDidUpdate`) instead of
+  deferring completion to a `setTimeout`. Instrumented traces show the deferred
+  update is the thing that gets lost: the timer fires, RTG calls `setState` on a
+  mounted instance, and React never applies it — the same instance re-renders
+  4 ms later still reporting `exiting`, and is still reporting `exiting` 300 ms
+  later. `onExited` therefore never runs, MUI's `Modal` never unmounts, and its
+  `position: fixed; inset: 0` backdrop keeps eating clicks while looking
+  perfectly closed.
+
+  Measured on chromium at `workers=1`, n=10 per cell. Before, on the MUI 6.5.0
+  branch: an Escape with no preceding CDP round-trip stalled **10/10**. After:
+  **0/10**, and the real gate (`scan-import-organize.spec.ts` "complete
+  workflow") went from failing to **10/10 passing**.
+
+  The previously shipped `transitionDuration: { exit: 0 }` is retained for the
+  enter animation but is *not* the fix; on `main` (MUI 5.18.0), which already
+  carried it, the same defect still reproduced 9/10 when the Escape was preceded
+  by a round-trip. MUI v6 did not introduce this bug — it moved the timing
+  window onto the common path. The comment in `theme.ts` that credited `exit: 0`
+  has been corrected in place with the measurements that disprove it.
+
+  Still unexplained, and labelled as such in-code: why React silently drops a
+  `setState` issued from a `setTimeout` on a mounted class component inside a
+  portal. Duplicate React copies, StrictMode, `flushSync`/`startTransition`,
+  uncaught exceptions and unmounting are all ruled out.

--- a/docs/executive-summaries/2026-08-11-the-fix-that-only-moved-the-window-executive-summary.md
+++ b/docs/executive-summaries/2026-08-11-the-fix-that-only-moved-the-window-executive-summary.md
@@ -1,0 +1,93 @@
+<!-- file: docs/executive-summaries/2026-08-11-the-fix-that-only-moved-the-window-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 65822952-722b-4f17-9d40-d7b614cbfc6a -->
+<!-- last-edited: 2026-08-11 -->
+
+# The fix that only moved the window
+
+## Short version
+
+Yesterday we reported that the "invisible sheet" bug — the one where the page
+went completely dead after using the filter panel, with nothing on screen to
+show why — had been fixed. That report was premature. The change we made had
+made the bug much rarer, not impossible. It could still happen to you.
+
+It is now actually fixed, and we can demonstrate the difference rather than
+assert it.
+
+## What was still wrong
+
+The original problem: closing the filter panel occasionally left an invisible
+sheet stretched across the entire window. The panel looked shut. The page looked
+normal. But every click landed on that sheet instead of on the page, so nothing
+responded, and the only escape was to reload and lose whatever you were part-way
+through.
+
+Yesterday's fix removed the closing animation on the panel, on the theory that
+the bug needed the animation's duration as a window in which to happen. Shorten
+the window to nothing, and the bug has nowhere to live.
+
+That theory was close enough to look right. Shortening the animation genuinely
+did make the failure much rarer, and the tests went green. What we did not
+realise is that removing the animation's *duration* does not remove the
+*deferred step* underneath it. The software still scheduled "now finish closing"
+as a separate later task, just a task set to happen immediately instead of a
+fifth of a second later. Immediately is not the same as never, and the bug lived
+in that gap.
+
+## How we caught it
+
+Two things had been hiding it.
+
+The first was a measuring instrument that changed the thing it measured. The
+diagnostic used to investigate this took a reading from the browser immediately
+before each test action. Taking that reading is itself a pause — and the pause
+was enough to make the bug not happen. So the diagnostic had been reporting, in
+good faith, that everything worked, while the real product without the
+diagnostic attached did not.
+
+The second was that we had only ever run the comparison twice per side. Two runs
+out of two is not enough to tell "this version is broken" apart from "this
+version happens to lose the race more often". Running it ten times per side told
+a different story: the old version was not safe at all. It failed nine times out
+of ten under a slightly different sequence of actions — a sequence a real person
+can easily produce.
+
+So the upgrade we were blocking on did not introduce this bug. It made an
+existing bug easy to hit. We had been about to congratulate ourselves for fixing
+a regression that was never a regression.
+
+## What we changed
+
+The panel now closes without scheduling anything for later. It finishes closing
+as part of the same step that starts it. There is no deferred task left to be
+lost, so there is no window for the failure to occur in — as opposed to a window
+so short we could not catch it.
+
+Visually nothing changed. The panel disappeared instantly before this change and
+disappears instantly after it.
+
+Measured on the same machine, ten runs per configuration: the failing case went
+from failing ten times out of ten to passing ten times out of ten, and the
+end-to-end test that had been blocking the upgrade went from failing to passing
+ten out of ten.
+
+## What we still do not know
+
+The underlying reason the deferred step gets lost — a task that we can see run,
+that asks the page to update, on a component that is demonstrably still alive,
+and the update simply never takes effect — remains unexplained. We have
+eliminated the usual suspects and written the elimination list into the code so
+the next person does not repeat it.
+
+We have also corrected the comment in the code that credited yesterday's change
+with fixing this, and replaced it with the measurements that disprove it. A
+confident wrong explanation left in place is how this survived three
+investigations.
+
+## The lesson worth keeping
+
+A fix that makes a failure rarer looks exactly like a fix that makes it
+impossible, right up until it doesn't. The tell is whether you can say *why* it
+can no longer happen, rather than only that it stopped happening. Yesterday we
+could only say the second thing, and we reported it as though it were the first.

--- a/todo.d/20260810-mui6-drawer-backdrop-regression.md
+++ b/todo.d/20260810-mui6-drawer-backdrop-regression.md
@@ -1,0 +1,68 @@
+- [ ] 🔴 **MUI v6 leaves the Drawer backdrop visible — the same mechanism as the
+      2026-08-10 "invisible sheet" incident.** Blocks TODO-MUI-1 (5.14 → 6.5).
+      Measured 2026-08-10 by running the full e2e suite on both versions on the
+      same quiet machine.
+
+      | Spec | main (MUI 5.18.0) | branch (MUI 6.5.0) |
+      |---|---|---|
+      | `scan-import-organize.spec.ts:259` [chromium] | ✅ passes | ❌ **fails** |
+      | `batch-operations.spec.ts:100` [webkit] | ❌ fails | ❌ fails |
+      | totals | 555 passed / 1 failed / 8 skipped | 554 passed / 2 failed / 8 skipped |
+
+      So v6 introduces **exactly one** new failure, and it is this:
+
+          Error: expect(locator).toHaveCount(expected) failed
+          Locator: locator('.MuiDrawer-modal .MuiBackdrop-root').filter({ visible: true })
+          Expected: 0   Received: 1   Timeout: 15000ms
+            - 34 × locator resolved to 1 element
+
+      **Why this specific assertion matters.** It is the guard added in #2283
+      after a stuck MUI Drawer left an INVISIBLE full-viewport backdrop over the
+      page that swallowed every click until reload. The assertion is not
+      cosmetic test rot — it is the tripwire for a user-facing dead UI. Under v6
+      the backdrop stays visible for the full 15s timeout, so the drawer's close
+      transition is not completing (or is completing without removing/hiding the
+      backdrop). **Do NOT relax or delete this assertion to get v6 green.** That
+      is precisely the move the incident exists to prevent.
+
+      Note the failure is browser-specific: the SAME test passes on webkit
+      (5.8s) and fails on chromium (18.8s). And it passes when the two specs are
+      run in ISOLATION (32/32) — it only fails inside the full suite. Both facts
+      point at the close-transition timing rather than at logic, and both match
+      the original incident's profile, whose root cause ("why the transition
+      never completes") was documented as **still unexplained** and labelled so
+      in-code.
+
+      **Work:** find what changed in v6's Modal/Backdrop/Drawer close path —
+      v6 reworked transitions and the ripple. Candidates: the backdrop's
+      `transitionDuration` default, `keepMounted` behaviour, or the
+      `closeAfterTransition` semantics. Fix the product behaviour, then re-run
+      the full suite on both browsers. Only then land the v6 bump.
+
+      Branch with the full v6 upgrade (codemods applied, build clean, 448/448
+      vitest green) is `feat/mui-v6-upgrade` — everything except this one
+      failure is ready.
+
+- [ ] 🔴 **`main` is NOT green: `batch-operations.spec.ts:100` [webkit] fails on
+      main and nobody noticed.** Measured 2026-08-10 on `76269d57`:
+      **555 passed / 1 failed / 8 skipped**, not the 556/0/8 recorded after the
+      2026-08-10 repair.
+
+          Error: expect(locator).toBeChecked() failed
+          Locator: getByLabel('Select Test Book 1', { exact: true })
+          Timeout: 5000ms — element(s) not found
+
+      "Batch Operations › selection persists across page navigation" — a
+      checkbox that should stay checked across navigation is not merely
+      unchecked, its LABEL IS ABSENT, so the row is not rendering as expected at
+      all. Webkit only; chromium passes.
+
+      **Why it went unnoticed:** `e2e.yml` is `paths:`-filtered, so the e2e
+      suite does not run on most PRs — a regression here lands silently and the
+      only signal is someone running the suite locally. That filter is already
+      recorded as the blocker for an org-level required-check rule
+      (`todo.d/20260810-e2e-gate-not-required.md`); this is the first measured
+      instance of it actually costing something.
+
+      Do not conflate with the MUI v6 item above — this one is independent of
+      any upgrade and is present on plain `main` today.

--- a/todo.d/20260810-mui6-drawer-backdrop-regression.md
+++ b/todo.d/20260810-mui6-drawer-backdrop-regression.md
@@ -1,13 +1,15 @@
 - [ ] 🔴 **MUI v6 leaves the Drawer backdrop visible — the same mechanism as the
       2026-08-10 "invisible sheet" incident.** Blocks TODO-MUI-1 (5.14 → 6.5).
       Measured 2026-08-10 by running the full e2e suite on both versions on the
-      same quiet machine.
+      same quiet machine, **twice per side**.
 
-      | Spec | main (MUI 5.18.0) | branch (MUI 6.5.0) |
-      |---|---|---|
-      | `scan-import-organize.spec.ts:259` [chromium] | ✅ passes | ❌ **fails** |
-      | `batch-operations.spec.ts:100` [webkit] | ❌ fails | ❌ fails |
-      | totals | 555 passed / 1 failed / 8 skipped | 554 passed / 2 failed / 8 skipped |
+      | Spec | main (MUI 5.18.0) | branch (MUI 6.5.0) | Verdict |
+      |---|---|---|---|
+      | `scan-import-organize.spec.ts:259` [chromium] | ✅ 2/2 | ❌ **2/2** | **real v6 regression** |
+      | `batch-operations.spec.ts:100` [webkit] | ✅ 1, ❌ 1 | ✅ 1, ❌ 1 | flake, unrelated to v6 |
+
+      main: 556 passed / 0 failed / 8 skipped (run 2, exit 0).
+      branch: 555 passed / 1 failed / 8 skipped (run 2, exit 2).
 
       So v6 introduces **exactly one** new failure, and it is this:
 
@@ -43,26 +45,25 @@
       vitest green) is `feat/mui-v6-upgrade` — everything except this one
       failure is ready.
 
-- [ ] 🔴 **`main` is NOT green: `batch-operations.spec.ts:100` [webkit] fails on
-      main and nobody noticed.** Measured 2026-08-10 on `76269d57`:
-      **555 passed / 1 failed / 8 skipped**, not the 556/0/8 recorded after the
-      2026-08-10 repair.
+- [ ] 🟡 **`batch-operations.spec.ts:100` [webkit] is an intermittent flake —
+      find its mechanism.** Observed 2026-08-10 failing once on `main`
+      (`76269d57`) and once on the MUI v6 branch, and **passing** on a re-run of
+      each. `main` is green: 556 passed / 0 failed / 8 skipped, exit 0.
 
           Error: expect(locator).toBeChecked() failed
           Locator: getByLabel('Select Test Book 1', { exact: true })
           Timeout: 5000ms — element(s) not found
 
-      "Batch Operations › selection persists across page navigation" — a
-      checkbox that should stay checked across navigation is not merely
-      unchecked, its LABEL IS ABSENT, so the row is not rendering as expected at
-      all. Webkit only; chromium passes.
+      "Batch Operations › selection persists across page navigation". When it
+      does fail, the checkbox is not merely unchecked — its **label is absent**,
+      so the row is not rendering as the test expects at all. Webkit only. That
+      shape (row not rendered yet, rather than state lost) points at the
+      navigation completing before the list re-renders, which is a timing
+      mechanism worth finding rather than re-running past.
 
-      **Why it went unnoticed:** `e2e.yml` is `paths:`-filtered, so the e2e
-      suite does not run on most PRs — a regression here lands silently and the
-      only signal is someone running the suite locally. That filter is already
-      recorded as the blocker for an org-level required-check rule
-      (`todo.d/20260810-e2e-gate-not-required.md`); this is the first measured
-      instance of it actually costing something.
-
-      Do not conflate with the MUI v6 item above — this one is independent of
-      any upgrade and is present on plain `main` today.
+      🚨 **This entry previously claimed `main` was red.** That claim came from a
+      single run and was wrong; it was published in a PR body and a memory file
+      before being re-run. A failure seen once on a suite with known webkit
+      flake is not a measurement — re-run before recording it. Per
+      `feedback_fix_flaky_tests`, this still gets its mechanism found rather
+      than being ignored as noise.

--- a/todo.d/20260810-mui6-drawer-backdrop-regression.md
+++ b/todo.d/20260810-mui6-drawer-backdrop-regression.md
@@ -1,49 +1,58 @@
-- [ ] 🔴 **MUI v6 leaves the Drawer backdrop visible — the same mechanism as the
-      2026-08-10 "invisible sheet" incident.** Blocks TODO-MUI-1 (5.14 → 6.5).
-      Measured 2026-08-10 by running the full e2e suite on both versions on the
-      same quiet machine, **twice per side**.
+- [x] 🔴 **The Drawer's close transition can stall forever, leaving an invisible
+      full-viewport backdrop that swallows every click until reload.** FIXED
+      2026-08-11 in `web/src/theme.ts` — `MuiDrawer.defaultProps.slotProps
+      .transition = { exit: false }`. No longer blocks TODO-MUI-1 (5.14 → 6.5).
 
-      | Spec | main (MUI 5.18.0) | branch (MUI 6.5.0) | Verdict |
-      |---|---|---|---|
-      | `scan-import-organize.spec.ts:259` [chromium] | ✅ 2/2 | ❌ **2/2** | **real v6 regression** |
-      | `batch-operations.spec.ts:100` [webkit] | ✅ 1, ❌ 1 | ✅ 1, ❌ 1 | flake, unrelated to v6 |
+      🚨 **This entry's original verdict — "real v6 regression" — was WRONG, and
+      so was the 2026-08-10 fix it was chasing.** The defect is present on
+      `main` (MUI 5.18.0) too. v6 did not introduce it; v6 moved its timing
+      window onto the common path, which is why v6 failed 2/2 and v5 passed 2/2
+      in the original n=2 comparison. Two runs per side cannot tell a regression
+      apart from a shifted race.
 
-      main: 556 passed / 0 failed / 8 skipped (run 2, exit 0).
-      branch: 555 passed / 1 failed / 8 skipped (run 2, exit 2).
+      Measured 2026-08-11, chromium, `workers=1`, `--repeat-each=10`, n=10 per
+      cell. P1 = press Escape with nothing crossing the CDP boundary first;
+      P2 = identical but with one `page.evaluate()` immediately before the
+      Escape. (The pre-existing probe called `page.evaluate` before *every*
+      Escape, so its "closes 6/6" result had measured the instrumented world.)
 
-      So v6 introduces **exactly one** new failure, and it is this:
+      | build | P1 pass | P2 pass |
+      |---|---|---|
+      | v6.5.0, `exit: 0` only (as filed) | **0/10** | 10/10 |
+      | v5.18.0, `exit: 0` only (i.e. `main` today) | 9/10 | **1/10** |
+      | v6.5.0 + `exit: false` | 10/10 | 10/10 |
 
-          Error: expect(locator).toHaveCount(expected) failed
-          Locator: locator('.MuiDrawer-modal .MuiBackdrop-root').filter({ visible: true })
-          Expected: 0   Received: 1   Timeout: 15000ms
-            - 34 × locator resolved to 1 element
+      MECHANISM (in-page instrumentation + a patched react-transition-group):
+      Escape is delivered correctly and `onClose(_, 'escapeKeyDown')` fires —
+      focus, `isTopModal()` and the Select menu are all fine, so the four
+      theories in the original report are disproven. The Slide and the
+      Backdrop's Fade both enter `exiting`, RTG schedules completion with
+      `setTimeout`, **the timer fires**, and RTG calls `setState({status:
+      'exited'})` on an instance whose `updater.isMounted` is `true`. React
+      never applies that update: the same instance re-renders 4 ms later still
+      `exiting`, `componentDidUpdate` agrees at +9 ms, and a 300 ms probe still
+      reads `exiting`. So `onExited` never runs, `useModal`'s `exited` stays
+      false, `Modal` never returns null, and its `position: fixed; inset: 0`
+      backdrop stays hit-testable — `document.elementFromPoint(20, 300)`
+      returns it. `exit: false` makes RTG take the synchronous branch in
+      `performExit` instead, so the lost update is never scheduled.
 
-      **Why this specific assertion matters.** It is the guard added in #2283
-      after a stuck MUI Drawer left an INVISIBLE full-viewport backdrop over the
-      page that swallowed every click until reload. The assertion is not
-      cosmetic test rot — it is the tripwire for a user-facing dead UI. Under v6
-      the backdrop stays visible for the full 15s timeout, so the drawer's close
-      transition is not completing (or is completing without removing/hiding the
-      backdrop). **Do NOT relax or delete this assertion to get v6 green.** That
-      is precisely the move the incident exists to prevent.
-
-      Note the failure is browser-specific: the SAME test passes on webkit
-      (5.8s) and fails on chromium (18.8s). And it passes when the two specs are
-      run in ISOLATION (32/32) — it only fails inside the full suite. Both facts
-      point at the close-transition timing rather than at logic, and both match
-      the original incident's profile, whose root cause ("why the transition
-      never completes") was documented as **still unexplained** and labelled so
-      in-code.
-
-      **Work:** find what changed in v6's Modal/Backdrop/Drawer close path —
-      v6 reworked transitions and the ripple. Candidates: the backdrop's
-      `transitionDuration` default, `keepMounted` behaviour, or the
-      `closeAfterTransition` semantics. Fix the product behaviour, then re-run
-      the full suite on both browsers. Only then land the v6 bump.
-
-      Branch with the full v6 upgrade (codemods applied, build clean, 448/448
-      vitest green) is `feat/mui-v6-upgrade` — everything except this one
-      failure is ready.
+- [ ] 🟡 **Why does React silently drop a `setState` issued from a `setTimeout`
+      on a mounted class component inside a portal?** This is the residual
+      unknown under the Drawer fix above and under the 2026-08-10 "invisible
+      sheet" incident, and it is now the *only* part still unexplained. Ruled
+      out: duplicate React copies (single `react@18.3.1`, deduped), StrictMode
+      (dev-only in `web/src/main.tsx`), `flushSync`/`startTransition`/
+      `unstable_batchedUpdates` (absent from `web/src`), uncaught exceptions
+      (none observed), and unmounting (`componentWillUnmount` never runs,
+      `isMounted` stays true). Leading untested hypothesis: this is a
+      production-build React 18 concurrent-root update issued while the root is
+      mid-render, where the dev-only warning that would have named it does not
+      exist. `exit: false` sidesteps the question rather than answering it, so
+      any other component that keeps a timer-driven exit transition is still
+      exposed — `MuiMenu` currently is (its `exit: 0` measured 20/20 on
+      2026-08-10, but that is the same kind of evidence that `exit: 0` on the
+      Drawer produced before it failed 10/10 on v6).
 
 - [ ] 🟡 **`batch-operations.spec.ts:100` [webkit] is an intermittent flake —
       find its mechanism.** Observed 2026-08-10 failing once on `main`

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
-        "@mui/icons-material": "^5.14.19",
-        "@mui/material": "^5.14.20",
+        "@mui/icons-material": "^6.5.0",
+        "@mui/material": "^6.5.0",
         "esbuild": "0.28.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1210,30 +1210,30 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.18.0.tgz",
-      "integrity": "sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.5.0.tgz",
+      "integrity": "sha512-LGb8t8i6M2ZtS3Drn3GbTI1DVhDY6FJ9crEey2lZ0aN2EMZo8IZBZj9wRf4vqbZHaWjsYgtbOnJw5V8UWbmK2Q==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.18.0.tgz",
-      "integrity": "sha512-1s0vEZj5XFXDMmz3Arl/R7IncFqJ+WQ95LDp1roHWGDE2oCO3IS4/hmiOv1/8SD9r6B7tv9GLiqVZYHo+6PkTg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.5.0.tgz",
+      "integrity": "sha512-VPuPqXqbBPlcVSA0BmnoE4knW4/xG6Thazo8vCLWkOKusko6DtwFV6B665MMWJ9j0KFohTIf3yx2zYtYacvG1g==",
       "dependencies": {
-        "@babel/runtime": "^7.23.9"
+        "@babel/runtime": "^7.26.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@mui/material": "^5.0.0",
+        "@mui/material": "^6.5.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -1244,25 +1244,25 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
-      "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.5.0.tgz",
+      "integrity": "sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/core-downloads-tracker": "^5.18.0",
-        "@mui/system": "^5.18.0",
-        "@mui/types": "~7.2.15",
-        "@mui/utils": "^5.17.1",
+        "@babel/runtime": "^7.26.0",
+        "@mui/core-downloads-tracker": "^6.5.0",
+        "@mui/system": "^6.5.0",
+        "@mui/types": "~7.2.24",
+        "@mui/utils": "^6.4.9",
         "@popperjs/core": "^2.11.8",
-        "@types/react-transition-group": "^4.4.10",
-        "clsx": "^2.1.0",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
         "react-is": "^19.0.0",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1271,6 +1271,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^6.5.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1282,27 +1283,25 @@
         "@emotion/styled": {
           "optional": true
         },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
         "@types/react": {
           "optional": true
         }
       }
     },
-    "node_modules/@mui/material/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
-    },
     "node_modules/@mui/private-theming": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
-      "integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.9.tgz",
+      "integrity": "sha512-LktcVmI5X17/Q5SkwjCcdOLBzt1hXuc14jYa7NPShog0GBDCDvKtcnP0V7a2s6EiVRlv7BzbWEJzH6+l/zaCxw==",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/utils": "^5.17.1",
+        "@babel/runtime": "^7.26.0",
+        "@mui/utils": "^6.4.9",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1319,18 +1318,19 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.18.0.tgz",
-      "integrity": "sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.5.0.tgz",
+      "integrity": "sha512-8woC2zAqF4qUDSPIBZ8v3sakj+WgweolpyM/FXf8jAx6FMls+IE4Y8VDZc+zS805J7PRz31vz73n2SovKGaYgw==",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
+        "@babel/runtime": "^7.26.0",
         "@emotion/cache": "^11.13.5",
         "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1351,21 +1351,21 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
-      "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.5.0.tgz",
+      "integrity": "sha512-XcbBYxDS+h/lgsoGe78ExXFZXtuIlSBpn/KsZq8PtZcIkUNJInkuDqcLd2rVBQrDC1u+rvVovdaWPf2FHKJf3w==",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/private-theming": "^5.17.1",
-        "@mui/styled-engine": "^5.18.0",
-        "@mui/types": "~7.2.15",
-        "@mui/utils": "^5.17.1",
-        "clsx": "^2.1.0",
+        "@babel/runtime": "^7.26.0",
+        "@mui/private-theming": "^6.4.9",
+        "@mui/styled-engine": "^6.5.0",
+        "@mui/types": "~7.2.24",
+        "@mui/utils": "^6.4.9",
+        "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1403,19 +1403,19 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.17.1.tgz",
-      "integrity": "sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==",
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.9.tgz",
+      "integrity": "sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/types": "~7.2.15",
-        "@types/prop-types": "^15.7.12",
+        "@babel/runtime": "^7.26.0",
+        "@mui/types": "~7.2.24",
+        "@types/prop-types": "^15.7.14",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
         "react-is": "^19.0.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1430,11 +1430,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@mui/utils/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/@playwright/test": {
       "version": "1.62.1",
@@ -3764,11 +3759,6 @@
         "react-is": "^16.7.0"
       }
     },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -4880,12 +4870,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/pretty-format/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true
-    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -4895,11 +4879,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
@@ -4959,6 +4938,11 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",

--- a/web/package.json
+++ b/web/package.json
@@ -22,8 +22,8 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@mui/icons-material": "^5.14.19",
-    "@mui/material": "^5.14.20",
+    "@mui/icons-material": "^6.5.0",
+    "@mui/material": "^6.5.0",
     "esbuild": "0.28.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,8 +1,7 @@
 // file: web/src/App.tsx
-// version: 1.22.0
+// version: 1.23.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-07-13
-
+// last-edited: 2026-08-10
 import { useState, useEffect, useCallback, lazy, Suspense, useRef } from 'react';
 import { STORAGE_KEYS } from './lib/storageKeys';
 import { Routes, Route, Navigate } from 'react-router-dom';
@@ -208,7 +207,10 @@ function App() {
       {/* Shutdown/Restart Overlay */}
       <Backdrop
         open={serverShutdown}
-        sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 9999 }}
+        sx={theme => ({
+          color: '#fff',
+          zIndex: theme.zIndex.drawer + 9999
+        })}
       >
         <Stack spacing={3} alignItems="center">
           <CircularProgress color="inherit" size={60} />

--- a/web/src/components/AudioSampleCompare.tsx
+++ b/web/src/components/AudioSampleCompare.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/AudioSampleCompare.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
 
 import { useState, useRef, useCallback } from 'react';
@@ -95,17 +95,23 @@ function SamplePlayer({ book, src, label, selected, onSelect }: PlayerProps) {
   return (
     <Box
       onClick={onSelect}
-      sx={{
+      sx={[{
         flex: 1,
         border: 2,
-        borderColor: selected ? 'primary.main' : 'divider',
         borderRadius: 2,
         p: 2,
         cursor: 'pointer',
         transition: 'border-color 0.15s',
-        bgcolor: selected ? 'action.selected' : 'background.paper',
-        '&:hover': { borderColor: 'primary.light' },
-      }}
+        '&:hover': { borderColor: 'primary.light' }
+      }, selected ? {
+        borderColor: 'primary.main'
+      } : {
+        borderColor: 'divider'
+      }, selected ? {
+        bgcolor: 'action.selected'
+      } : {
+        bgcolor: 'background.paper'
+      }]}
     >
       <Stack spacing={1}>
         <Stack direction="row" alignItems="center" justifyContent="space-between">

--- a/web/src/components/BatchActivityEntry.tsx
+++ b/web/src/components/BatchActivityEntry.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/BatchActivityEntry.tsx
-// version: 1.1.1
+// version: 1.2.0
 // guid: 7e3a1f9c-4b82-4d5e-a6c8-2f0d8e7b3a91
 
 import React, { useState } from 'react';
@@ -141,7 +141,6 @@ export function BatchActivityEntry({ entry, tierColor }: BatchActivityEntryProps
             {entry.summary}
           </Typography>
         </TableCell>
-
         {/* 5. Item count chip + type info (desktop source column) */}
         <TableCell>
           <Chip
@@ -162,10 +161,13 @@ export function BatchActivityEntry({ entry, tierColor }: BatchActivityEntryProps
       <TableRow>
         <TableCell
           colSpan={7}
-          sx={{
-            py: 0,
-            borderBottom: expanded ? undefined : 'none',
-          }}
+          sx={[{
+            py: 0
+          }, expanded ? {
+            borderBottom: null
+          } : {
+            borderBottom: 'none'
+          }]}
         >
           <Collapse in={expanded} timeout="auto" unmountOnExit>
             <Box sx={{ py: 1, pl: 4 }}>

--- a/web/src/components/ChangeLog.tsx
+++ b/web/src/components/ChangeLog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/ChangeLog.tsx
-// version: 1.4.1
+// version: 1.5.0
 // guid: 00f575de-ecea-45b7-9aa5-d6dbbc3f21f6
 
 import { useCallback, useEffect, useState } from 'react';
@@ -135,17 +135,20 @@ export const ChangeLog = ({ bookId, refreshKey, onRevert, onCompareSnapshot }: C
       {entries.map((entry, idx) => (
         <Box
           key={`${entry.timestamp}-${idx}`}
-          sx={{
+          sx={[{
             display: 'flex',
             alignItems: 'flex-start',
             gap: 2,
             py: 1.5,
             px: 1,
-            borderBottom: idx < entries.length - 1 ? '1px solid' : 'none',
             borderColor: 'divider',
             cursor: (entry.type === 'metadata_apply' || entry.type === 'tag_write') ? 'pointer' : undefined,
-            '&:hover': { bgcolor: 'action.hover' },
-          }}
+            '&:hover': { bgcolor: 'action.hover' }
+          }, idx < entries.length - 1 ? {
+            borderBottom: '1px solid'
+          } : {
+            borderBottom: 'none'
+          }]}
           onClick={() => {
             if (entry.type === 'metadata_apply' || entry.type === 'tag_write') {
               onCompareSnapshot?.(entry.timestamp);

--- a/web/src/components/TagComparison.tsx
+++ b/web/src/components/TagComparison.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/TagComparison.tsx
-// version: 1.4.2
+// version: 1.5.0
 // guid: cfed2692-76f6-47b0-bc84-cc2a4075e554
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -236,11 +236,17 @@ export const TagComparison = ({ bookId, versions, refreshKey, snapshotTimestamp,
                   return next;
                 });
               }}
-              sx={{
-                fontSize: '0.7rem',
-                opacity: isVisible ? 0.6 : 1,
-                textDecoration: isVisible ? 'none' : 'none',
-              }}
+              sx={[{
+                fontSize: '0.7rem'
+              }, isVisible ? {
+                opacity: 0.6
+              } : {
+                opacity: 1
+              }, isVisible ? {
+                textDecoration: 'none'
+              } : {
+                textDecoration: 'none'
+              }]}
             />
           );
         })}
@@ -335,12 +341,11 @@ export const TagComparison = ({ bookId, versions, refreshKey, snapshotTimestamp,
                   {visibleTagEntries.map(([tagName], colIdx) => (
                     <TableCell
                       key={tagName}
-                      sx={{
+                      sx={[{
                         fontWeight: 'bold',
                         position: 'relative',
-                        minWidth: 80,
-                        ...(colWidths[colIdx] ? { width: colWidths[colIdx] } : {}),
-                      }}
+                        minWidth: 80
+                      }, (colWidths[colIdx] ? { width: colWidths[colIdx] } : {})]}
                     >
                       <Stack direction="row" alignItems="center" spacing={0.5}>
                         <span>{TAG_LABELS[tagName] || tagName}</span>
@@ -374,7 +379,6 @@ export const TagComparison = ({ bookId, versions, refreshKey, snapshotTimestamp,
                     );
                   })}
                 </TableRow>
-
                 {/* DB Value row */}
                 <TableRow>
                   <TableCell sx={{ fontWeight: 'bold', color: 'text.secondary', position: 'sticky', left: 0, bgcolor: 'background.paper', zIndex: 1 }}>
@@ -390,7 +394,6 @@ export const TagComparison = ({ bookId, versions, refreshKey, snapshotTimestamp,
                     );
                   })}
                 </TableRow>
-
                 {/* Comparison row (only when active) */}
                 {hasComparison && (
                   <TableRow>
@@ -413,7 +416,6 @@ export const TagComparison = ({ bookId, versions, refreshKey, snapshotTimestamp,
             </Table>
           </Box>
         )}
-
         {visibleTagEntries.length === 0 && !loading && tagEntries.length === 0 && (
           <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
             No tag data available.

--- a/web/src/components/audiobooks/AudiobookCard.tsx
+++ b/web/src/components/audiobooks/AudiobookCard.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/audiobooks/AudiobookCard.tsx
-// version: 1.13.0
+// version: 1.14.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
-// last-edited: 2026-07-13
-
+// last-edited: 2026-08-10
 import React from 'react';
 import {
   Card,
@@ -122,17 +121,32 @@ export const AudiobookCard: React.FC<AudiobookCardProps> = ({
 
   return (
     <Card
-      sx={{
+      sx={[{
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
-        cursor: onClick ? 'pointer' : 'default',
-        transition: 'transform 0.2s, box-shadow 0.2s',
+        transition: 'transform 0.2s, box-shadow 0.2s'
+      }, onClick ? {
+        cursor: 'pointer'
+      } : {
+        cursor: 'default'
+      }, onClick ? {
         '&:hover': {
-          transform: onClick ? 'translateY(-4px)' : 'none',
-          boxShadow: onClick ? 6 : 1,
-        },
-      }}
+          transform: 'translateY(-4px)'
+        }
+      } : {
+        '&:hover': {
+          transform: 'none'
+        }
+      }, onClick ? {
+        '&:hover': {
+          boxShadow: 6
+        }
+      } : {
+        '&:hover': {
+          boxShadow: 1
+        }
+      }]}
       onClick={handleCardClick}
     >
       <Box sx={{ position: 'relative' }}>

--- a/web/src/components/audiobooks/AudiobookList.tsx
+++ b/web/src/components/audiobooks/AudiobookList.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/audiobooks/AudiobookList.tsx
-// version: 2.8.0
+// version: 2.9.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-11
-
+// last-edited: 2026-08-10
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Table,
@@ -534,7 +533,14 @@ export const AudiobookList: React.FC<AudiobookListProps> = ({
                 <TableRow
                   hover
                   onClick={() => handleRowClick(audiobook)}
-                  sx={{ cursor: onClick ? 'pointer' : 'default', contentVisibility: 'auto', containIntrinsicSize: '1px 52px' }}
+                  sx={[{
+                    contentVisibility: 'auto',
+                    containIntrinsicSize: '1px 52px'
+                  }, onClick ? {
+                    cursor: 'pointer'
+                  } : {
+                    cursor: 'default'
+                  }]}
                 >
                   {/* Expand cell */}
                   <TableCell padding="checkbox" sx={{ width: 50 }}>
@@ -618,104 +624,104 @@ export const AudiobookList: React.FC<AudiobookListProps> = ({
               </TableCell>
             </TableRow>
 
-            {/* Expanded files rows */}
-            {isExpanded && (
-              <TableRow sx={{ bgcolor: 'background.default' }}>
-                <TableCell colSpan={hasSelection ? activeColumns.length + 3 : activeColumns.length + 2} sx={{ p: 0 }}>
-                  <Collapse in={isExpanded} timeout="auto" unmountOnExit>
-                    <Box sx={{ p: 2 }}>
-                      <Typography variant="subtitle2" sx={{ mb: 1.5, fontWeight: 600 }}>
-                        Files ({audiobook.total_file_count || 0})
-                      </Typography>
-
-                      {isLoadingFiles ? (
-                        <Box display="flex" justifyContent="center" p={2}>
-                          <CircularProgress size={24} />
-                        </Box>
-                      ) : fetchError ? (
-                        // Fix #6: show error UI with Retry button instead of silent spinner/empty list
-                        <Box display="flex" alignItems="center" gap={1} p={1}>
-                          <Typography variant="body2" color="error">
-                            Failed to load files: {fetchError}
+                {/* Expanded files rows */}
+                {isExpanded && (
+                  <TableRow sx={{ bgcolor: 'background.default' }}>
+                    <TableCell colSpan={hasSelection ? activeColumns.length + 3 : activeColumns.length + 2} sx={{ p: 0 }}>
+                      <Collapse in={isExpanded} timeout="auto" unmountOnExit>
+                        <Box sx={{ p: 2 }}>
+                          <Typography variant="subtitle2" sx={{ mb: 1.5, fontWeight: 600 }}>
+                            Files ({audiobook.total_file_count || 0})
                           </Typography>
-                          <Button size="small" variant="outlined" color="error" onClick={() => fetchFiles(audiobook.id)}>
-                            Retry
-                          </Button>
-                        </Box>
-                      ) : files.length === 0 ? (
-                        <Typography variant="body2" color="text.secondary">
-                          No files found
-                        </Typography>
-                      ) : (
-                        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-                          {files.map((file) => (
-                            <Box
-                              key={file.id}
-                              sx={{
-                                display: 'grid',
-                                gridTemplateColumns: '1fr auto',
-                                gap: 1,
-                                alignItems: 'center',
-                                p: 1.5,
-                                bgcolor: 'background.paper',
-                                borderRadius: 1,
-                                border: '1px solid',
-                                borderColor: 'divider',
-                              }}
-                            >
-                              <Box sx={{ minWidth: 0 }}>
-                                <Typography variant="body2" sx={{ fontWeight: 500, wordBreak: 'break-word' }}>
-                                  {file.original_filename || file.file_path.split('/').pop() || 'Unknown'}
-                                </Typography>
-                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', wordBreak: 'break-word' }}>
-                                  {file.file_path}
-                                </Typography>
-                              </Box>
 
-                              <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexShrink: 0 }}>
-                                <Chip
-                                  icon={getFingerprinterStatusIcon(file)}
-                                  label={hasFingerprint(file) ? '✓ Fingerprinted' : '✗ Not Fingerprinted'}
-                                  color={getFingerprinterStatusColor(file)}
-                                  variant="outlined"
-                                  size="small"
-                                />
-                                <FormControlLabel
-                                  control={
-                                    <Switch
-                                      size="small"
-                                      checked={!!file.skip_scan}
-                                      onChange={async (e) => {
-                                        const newValue = e.target.checked;
-                                        try {
-                                          const updated = await api.patchBookFile(audiobook.id, file.id, {
-                                            skip_scan: newValue,
-                                          });
-                                          handleFileUpdate(audiobook.id, updated);
-                                        } catch (err) {
-                                          console.error('Failed to update skip_scan:', err);
-                                        }
-                                      }}
-                                    />
-                                  }
-                                  label="Skip"
-                                  sx={{ ml: 0.5 }}
-                                />
-                                <Typography variant="caption" color="text.secondary" sx={{ minWidth: 80, textAlign: 'right' }}>
-                                  {formatFileSize(file.file_size)}
-                                </Typography>
-                              </Box>
+                          {isLoadingFiles ? (
+                            <Box display="flex" justifyContent="center" p={2}>
+                              <CircularProgress size={24} />
                             </Box>
-                          ))}
+                          ) : fetchError ? (
+                            // Fix #6: show error UI with Retry button instead of silent spinner/empty list
+                            <Box display="flex" alignItems="center" gap={1} p={1}>
+                              <Typography variant="body2" color="error">
+                                Failed to load files: {fetchError}
+                              </Typography>
+                              <Button size="small" variant="outlined" color="error" onClick={() => fetchFiles(audiobook.id)}>
+                                Retry
+                              </Button>
+                            </Box>
+                          ) : files.length === 0 ? (
+                            <Typography variant="body2" color="text.secondary">
+                              No files found
+                            </Typography>
+                          ) : (
+                            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                              {files.map((file) => (
+                                <Box
+                                  key={file.id}
+                                  sx={{
+                                    display: 'grid',
+                                    gridTemplateColumns: '1fr auto',
+                                    gap: 1,
+                                    alignItems: 'center',
+                                    p: 1.5,
+                                    bgcolor: 'background.paper',
+                                    borderRadius: 1,
+                                    border: '1px solid',
+                                    borderColor: 'divider',
+                                  }}
+                                >
+                                  <Box sx={{ minWidth: 0 }}>
+                                    <Typography variant="body2" sx={{ fontWeight: 500, wordBreak: 'break-word' }}>
+                                      {file.original_filename || file.file_path.split('/').pop() || 'Unknown'}
+                                    </Typography>
+                                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', wordBreak: 'break-word' }}>
+                                      {file.file_path}
+                                    </Typography>
+                                  </Box>
+
+                                  <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexShrink: 0 }}>
+                                    <Chip
+                                      icon={getFingerprinterStatusIcon(file)}
+                                      label={hasFingerprint(file) ? '✓ Fingerprinted' : '✗ Not Fingerprinted'}
+                                      color={getFingerprinterStatusColor(file)}
+                                      variant="outlined"
+                                      size="small"
+                                    />
+                                    <FormControlLabel
+                                      control={
+                                        <Switch
+                                          size="small"
+                                          checked={!!file.skip_scan}
+                                          onChange={async (e) => {
+                                            const newValue = e.target.checked;
+                                            try {
+                                              const updated = await api.patchBookFile(audiobook.id, file.id, {
+                                                skip_scan: newValue,
+                                              });
+                                              handleFileUpdate(audiobook.id, updated);
+                                            } catch (err) {
+                                              console.error('Failed to update skip_scan:', err);
+                                            }
+                                          }}
+                                        />
+                                      }
+                                      label="Skip"
+                                      sx={{ ml: 0.5 }}
+                                    />
+                                    <Typography variant="caption" color="text.secondary" sx={{ minWidth: 80, textAlign: 'right' }}>
+                                      {formatFileSize(file.file_size)}
+                                    </Typography>
+                                  </Box>
+                                </Box>
+                              ))}
+                            </Box>
+                          )}
                         </Box>
-                      )}
-                    </Box>
-                  </Collapse>
-                </TableCell>
-              </TableRow>
-            )}
-          </React.Fragment>
-          );
+                      </Collapse>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </React.Fragment>
+            );
           })}
         </TableBody>
       </Table>

--- a/web/src/components/audiobooks/MetadataEditDialog.tsx
+++ b/web/src/components/audiobooks/MetadataEditDialog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/MetadataEditDialog.tsx
-// version: 2.1.1
+// version: 2.2.0
 // guid: 4a5b6c7d-8e9f-0a1b-2c3d-4e5f6a7b8c9d
 
 import React, { useState, useEffect, useCallback } from 'react';
@@ -222,20 +222,31 @@ export const MetadataEditDialog: React.FC<MetadataEditDialogProps> = ({
               size="small"
               onClick={() => toggleLock(field)}
               aria-label={`${locked ? 'Unlock' : 'Lock'} ${label}`}
-              sx={{
+              sx={[{
                 mt: '10px',
                 mr: 0.5,
                 flexShrink: 0,
                 width: 32,
                 height: 32,
                 border: '1px solid',
-                borderColor: locked ? 'warning.main' : 'divider',
-                borderRadius: 1,
-                bgcolor: locked ? 'rgba(237, 108, 2, 0.08)' : 'transparent',
+                borderRadius: 1
+              }, locked ? {
+                borderColor: 'warning.main'
+              } : {
+                borderColor: 'divider'
+              }, locked ? {
+                bgcolor: 'rgba(237, 108, 2, 0.08)'
+              } : {
+                bgcolor: 'transparent'
+              }, locked ? {
                 '&:hover': {
-                  bgcolor: locked ? 'rgba(237, 108, 2, 0.16)' : 'action.hover',
-                },
-              }}
+                  bgcolor: 'rgba(237, 108, 2, 0.16)'
+                }
+              } : {
+                '&:hover': {
+                  bgcolor: 'action.hover'
+                }
+              }]}
             >
               {locked ? (
                 <LockIcon sx={{ fontSize: 16, color: 'warning.main' }} />
@@ -266,21 +277,28 @@ export const MetadataEditDialog: React.FC<MetadataEditDialogProps> = ({
               helperText={field === 'year' ? (yearError || undefined) : undefined}
               required={field === 'title'}
               size="small"
-              sx={{
+              sx={[isDirty ? {
                 '& .MuiOutlinedInput-root': {
-                  bgcolor: isDirty ? 'rgba(237, 108, 2, 0.04)' : 'transparent',
-                },
-              }}
+                  bgcolor: 'rgba(237, 108, 2, 0.04)'
+                }
+              } : {
+                '& .MuiOutlinedInput-root': {
+                  bgcolor: 'transparent'
+                }
+              }]}
             />
             {(sourceLabel || showFetched) && (
               <Stack direction="row" spacing={1} sx={{ mt: 0.25, ml: 0.5 }}>
                 {sourceLabel && (
                   <Typography
                     variant="caption"
-                    sx={{
-                      color: isDirty ? 'warning.main' : 'text.disabled',
-                      fontSize: '0.7rem',
-                    }}
+                    sx={[{
+                      fontSize: '0.7rem'
+                    }, isDirty ? {
+                      color: 'warning.main'
+                    } : {
+                      color: 'text.disabled'
+                    }]}
                   >
                     Source: {sourceLabel}
                   </Typography>

--- a/web/src/components/audiobooks/SearchBar.tsx
+++ b/web/src/components/audiobooks/SearchBar.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/SearchBar.tsx
-// version: 2.4.0
+// version: 2.5.0
 // guid: 1d2e3f4a-5b6c-7d8e-9f0a-1b2c3d4e5f6a
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -318,7 +318,6 @@ export const SearchBar: React.FC<SearchBarProps> = ({
               </Box>
             ))}
           </Box>
-
           <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5, mb: 0.5 }}>
             Available fields:
           </Typography>

--- a/web/src/components/bookdetail/BookDetailDialogs.tsx
+++ b/web/src/components/bookdetail/BookDetailDialogs.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/bookdetail/BookDetailDialogs.tsx
-// version: 1.0.1
+// version: 1.1.0
 // guid: b8c9d0e1-f2a3-4567-bcde-678901234567
-// last-edited: 2026-08-07
-
+// last-edited: 2026-08-10
 import {
   Alert,
   Box,
@@ -244,18 +243,30 @@ export const BookDetailDialogs = ({
               {organizePreview.steps.map((step, index) => (
                 <Box
                   key={index}
-                  sx={{
+                  sx={[{
                     display: 'flex',
                     alignItems: 'flex-start',
                     gap: 1.5,
                     mb: 2,
                     p: 1.5,
-                    borderRadius: 1,
-                    bgcolor: step.action === 'warning' ? 'warning.main' : 'action.hover',
-                    opacity: step.action === 'warning' ? 0.9 : 1,
-                  }}
+                    borderRadius: 1
+                  }, step.action === 'warning' ? {
+                    bgcolor: 'warning.main'
+                  } : {
+                    bgcolor: 'action.hover'
+                  }, step.action === 'warning' ? {
+                    opacity: 0.9
+                  } : {
+                    opacity: 1
+                  }]}
                 >
-                  <Box sx={{ mt: 0.25, color: step.action === 'warning' ? 'warning.contrastText' : 'primary.main' }}>
+                  <Box sx={[{
+                    mt: 0.25
+                  }, step.action === 'warning' ? {
+                    color: 'warning.contrastText'
+                  } : {
+                    color: 'primary.main'
+                  }]}>
                     {step.action === 'copy' && <FileCopyIcon />}
                     {step.action === 'rename' && <DriveFileRenameOutlineIcon />}
                     {step.action === 'write_tags' && <LabelIcon />}
@@ -265,9 +276,11 @@ export const BookDetailDialogs = ({
                   <Box sx={{ flex: 1, minWidth: 0 }}>
                     <Typography
                       variant="subtitle2"
-                      sx={{
-                        color: step.action === 'warning' ? 'warning.contrastText' : 'text.primary',
-                      }}
+                      sx={[step.action === 'warning' ? {
+                        color: 'warning.contrastText'
+                      } : {
+                        color: 'text.primary'
+                      }]}
                     >
                       {step.description}
                     </Typography>
@@ -421,7 +434,6 @@ export const BookDetailDialogs = ({
           </Button>
         </DialogActions>
       </Dialog>
-
       <Dialog open={purgeDialogOpen} onClose={onClosePurge}>
         <DialogTitle>Purge Audiobook</DialogTitle>
         <DialogContent dividers>

--- a/web/src/components/bookdetail/BookDetailVersionGroup.tsx
+++ b/web/src/components/bookdetail/BookDetailVersionGroup.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/bookdetail/BookDetailVersionGroup.tsx
-// version: 1.1.1
+// version: 1.2.0
 // guid: f6a7b8c9-d0e1-2345-fabc-456789012345
-// last-edited: 2026-08-07
-
+// last-edited: 2026-08-10
 import {
   Alert,
   Box,
@@ -173,17 +172,30 @@ export const BookDetailVersionGroup = ({
     <Paper key={groupId} sx={{ mb: 1, overflow: 'hidden' }} data-testid={`format-tray-${fmt.toLowerCase()}`}>
       {/* Format tray header */}
       <Box
-        sx={{
+        sx={[{
           display: 'flex',
           alignItems: 'center',
           px: 2,
           py: 1,
-          bgcolor: hasPrimary ? 'primary.dark' : 'background.paper',
           cursor: 'pointer',
-          '&:hover': { bgcolor: hasPrimary ? 'primary.dark' : 'action.hover' },
-          borderBottom: isExpanded ? '1px solid' : 'none',
-          borderColor: 'divider',
-        }}
+          borderColor: 'divider'
+        }, hasPrimary ? {
+          bgcolor: 'primary.dark'
+        } : {
+          bgcolor: 'background.paper'
+        }, hasPrimary ? {
+          '&:hover': {
+            bgcolor: 'primary.dark'
+          }
+        } : {
+          '&:hover': {
+            bgcolor: 'action.hover'
+          }
+        }, isExpanded ? {
+          borderBottom: '1px solid'
+        } : {
+          borderBottom: 'none'
+        }]}
         onClick={() => {
           for (const v of groupVersions) {
             onToggleVersionExpanded(v.id);
@@ -277,7 +289,16 @@ export const BookDetailVersionGroup = ({
             .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
 
           return (
-            <Box key={version.id} sx={{ p: 2, borderBottom: groupVersions.length > 1 ? '2px solid' : 'none', borderColor: 'divider', '&:not(:last-child)': { pb: 3 }, '&:not(:first-of-type)': { pt: 3 } }}>
+            <Box key={version.id} sx={[{
+              p: 2,
+              borderColor: 'divider',
+              '&:not(:last-child)': { pb: 3 },
+              '&:not(:first-of-type)': { pt: 3 }
+            }, groupVersions.length > 1 ? {
+              borderBottom: '2px solid'
+            } : {
+              borderBottom: 'none'
+            }]}>
               {/* Version action buttons */}
               <Stack direction="row" spacing={1} sx={{ mb: 2 }} flexWrap="wrap" useFlexGap>
                 {!isPrimary && versions.length > 1 && (
@@ -314,7 +335,6 @@ export const BookDetailVersionGroup = ({
                   </Button>
                 )}
               </Stack>
-
               {/* Path and codec info */}
               <Table size="small" sx={{ mb: 2 }}>
                 <TableBody>
@@ -336,7 +356,6 @@ export const BookDetailVersionGroup = ({
                   )}
                 </TableBody>
               </Table>
-
               {vSegs.length > 1 && metadataEntries.length > 0 && (
                 <Box
                   sx={{
@@ -492,8 +511,11 @@ export const BookDetailVersionGroup = ({
                           const isSelected = isCurrentBook && selectedSegmentIds.has(seg.id);
                           return (
                             <TableRow key={seg.id} hover selected={isSelected}
-                              sx={{ cursor: isCurrentBook ? 'pointer' : 'default',
-                                ...(isMissing && { bgcolor: 'error.50', '&:hover': { bgcolor: 'error.100' } }) }}
+                              sx={[isCurrentBook ? {
+                                cursor: 'pointer'
+                              } : {
+                                cursor: 'default'
+                              }, isMissing && { bgcolor: 'error.50', '&:hover': { bgcolor: 'error.100' } }]}
                               onClick={() => {
                                 if (!isCurrentBook) return;
                                 if (isMissing) { onSetRelocateSegment(seg); }
@@ -519,7 +541,10 @@ export const BookDetailVersionGroup = ({
                                   <span>{seg.track_number ?? '\u2014'}</span>
                                 </Stack>
                               </TableCell>
-                              <TableCell sx={{ wordBreak: 'break-all', fontSize: '0.8rem', ...(isMissing && { color: 'error.main' }) }}>
+                              <TableCell sx={[{
+                                wordBreak: 'break-all',
+                                fontSize: '0.8rem'
+                              }, isMissing && { color: 'error.main' }]}>
                                 <Tooltip title={seg.file_path}><span>{seg.file_path}</span></Tooltip>
                               </TableCell>
                               <TableCell>

--- a/web/src/components/bookdetail/WhisperIntroPanel.tsx
+++ b/web/src/components/bookdetail/WhisperIntroPanel.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/bookdetail/WhisperIntroPanel.tsx
-// version: 1.0.1
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f01234567890
-// last-edited: 2026-08-07
-
+// last-edited: 2026-08-10
 import { useState } from 'react';
 import {
   Accordion,
@@ -65,20 +64,27 @@ export function WhisperIntroPanel({ book }: Props) {
 
       <AccordionDetails>
         {book.intro_transcription && (
-          <Box sx={{ mb: hasExtracted ? 2 : 0 }}>
+          <Box sx={[hasExtracted ? {
+            mb: 2
+          } : {
+            mb: 0
+          }]}>
             <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5, textTransform: 'uppercase', letterSpacing: 0.5 }}>
               Raw Transcript
             </Typography>
             <Typography
               variant="body2"
-              sx={{
+              sx={[{
                 fontStyle: 'italic',
-                color: isShort ? 'warning.main' : 'text.primary',
                 bgcolor: 'action.hover',
                 borderRadius: 1,
                 p: 1.5,
-                whiteSpace: 'pre-wrap',
-              }}
+                whiteSpace: 'pre-wrap'
+              }, isShort ? {
+                color: 'warning.main'
+              } : {
+                color: 'text.primary'
+              }]}
             >
               {book.intro_transcription}
             </Typography>

--- a/web/src/components/dedup/CandidateCompareDrawer.tsx
+++ b/web/src/components/dedup/CandidateCompareDrawer.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/dedup/CandidateCompareDrawer.tsx
-// version: 1.4.0
+// version: 1.5.0
 // guid: a6f7b8c9-d0e1-2345-fabc-af6789012345
-// last-edited: 2026-06-28
-
+// last-edited: 2026-08-10
 // CandidateCompareDrawer is a right-side Drawer that shows a full side-by-side
 // comparison of the two books in a dedup candidate, plus the score breakdown.
 // It fetches the breakdown data on open via GET /api/v1/dedup/candidates/:id/breakdown.
@@ -114,16 +113,22 @@ function MetadataCompareRow({ id, label, left, right }: MetadataCompareRowProps)
     <Box
       data-testid={`metadata-row-${id}`}
       data-different={different ? 'true' : 'false'}
-      sx={{
+      sx={[{
         display: 'grid',
         gridTemplateColumns: { xs: '1fr', sm: '140px minmax(0, 1fr) minmax(0, 1fr)' },
         gap: { xs: 0.75, sm: 1 },
         alignItems: 'stretch',
         p: 1,
-        borderRadius: 1,
-        bgcolor: different ? 'warning.light' : 'transparent',
-        color: different ? 'warning.contrastText' : 'inherit',
-      }}
+        borderRadius: 1
+      }, different ? {
+        bgcolor: 'warning.light'
+      } : {
+        bgcolor: 'transparent'
+      }, different ? {
+        color: 'warning.contrastText'
+      } : {
+        color: 'inherit'
+      }]}
     >
       <Typography variant="caption" fontWeight={700} color={different ? 'inherit' : 'text.secondary'}>
         {label}

--- a/web/src/components/dedup/DedupAIReviewTab.tsx
+++ b/web/src/components/dedup/DedupAIReviewTab.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/dedup/DedupAIReviewTab.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-06-22
-
+// last-edited: 2026-08-10
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useAsyncAction } from '../../hooks/useAsyncAction';
@@ -309,7 +308,6 @@ function AIAuthorPipelinePage() {
               </CardContent>
             </Card>
           ))}
-
           {/* No results for this filter */}
           {filteredResults.length === 0 && (
             <Typography color="text.secondary" sx={{ p: 2, textAlign: 'center' }}>
@@ -318,7 +316,6 @@ function AIAuthorPipelinePage() {
           )}
         </Box>
       )}
-
       {/* Scan complete but no results */}
       {scan?.status === 'complete' && results.length === 0 && (
         <Paper sx={{ p: 4, mx: 2, textAlign: 'center' }}>
@@ -327,7 +324,6 @@ function AIAuthorPipelinePage() {
           </Typography>
         </Paper>
       )}
-
       {/* Scan History Drawer */}
       <Drawer anchor="right" open={historyOpen} onClose={() => setHistoryOpen(false)}>
         <Box sx={{ width: 400, p: 2 }}>
@@ -335,7 +331,18 @@ function AIAuthorPipelinePage() {
           {scans.map(s => (
             <Card
               key={s.id}
-              sx={{ mb: 1, cursor: 'pointer', border: scan?.id === s.id ? 2 : undefined, borderColor: scan?.id === s.id ? 'primary.main' : undefined }}
+              sx={[{
+                mb: 1,
+                cursor: 'pointer'
+              }, scan?.id === s.id ? {
+                border: 2
+              } : {
+                border: null
+              }, scan?.id === s.id ? {
+                borderColor: 'primary.main'
+              } : {
+                borderColor: null
+              }]}
               variant="outlined"
               onClick={() => { loadScan(s.id); setHistoryOpen(false); }}
             >
@@ -357,7 +364,6 @@ function AIAuthorPipelinePage() {
     </Box>
   );
 }
-
 // ---- AI Review Top-Level Tab ----
 export function AIReviewTab() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -367,14 +373,12 @@ export function AIReviewTab() {
     next.set('aisub', v);
     setSearchParams(next, { replace: true });
   };
-
   return (
     <Box>
       <Tabs value={aiSub} onChange={(_, v) => setAiSub(v)} sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}>
         <Tab value="authors" label="Authors" icon={<PersonIcon />} iconPosition="start" />
         <Tab value="books" label="Books" icon={<MenuBookIcon />} iconPosition="start" />
       </Tabs>
-
       {aiSub === 'authors' && <AIAuthorPipelinePage />}
       {aiSub === 'books' && (
         <Box sx={{ p: 4, textAlign: 'center' }}>

--- a/web/src/components/dedup/DedupAcousticTab.tsx
+++ b/web/src/components/dedup/DedupAcousticTab.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/dedup/DedupAcousticTab.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: c3d4e5f6-a7b8-9012-cdef-012345678902
-// last-edited: 2026-06-22
-
+// last-edited: 2026-08-10
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate, Link as RouterLink } from 'react-router-dom';
 import {
@@ -906,7 +905,11 @@ export function AcousticDedupTab() {
                     key={c.id}
                     hover
                     selected={selected}
-                    sx={{ opacity: busy ? 0.5 : 1 }}
+                    sx={[busy ? {
+                      opacity: 0.5
+                    } : {
+                      opacity: 1
+                    }]}
                   >
                     <TableCell padding="checkbox">
                       <Checkbox

--- a/web/src/components/dedup/DedupAdvancedScanTab.tsx
+++ b/web/src/components/dedup/DedupAdvancedScanTab.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/dedup/DedupAdvancedScanTab.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-05-11
-
+// last-edited: 2026-08-10
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   Box,
@@ -258,7 +257,6 @@ export function BookDedupScanTab() {
               </Card>
             ))}
           </Stack>
-
           <PaginationControls total={filteredGroups.length} page={pagination.page} rowsPerPage={pagination.rowsPerPage}
             onPageChange={pagination.setPage} onRowsPerPageChange={pagination.setRowsPerPage} />
         </>

--- a/web/src/components/dedup/DedupAuthorTab.tsx
+++ b/web/src/components/dedup/DedupAuthorTab.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/dedup/DedupAuthorTab.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
-// last-edited: 2026-05-11
-
+// last-edited: 2026-08-10
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -535,7 +534,11 @@ export function AuthorDedupTab() {
                                       setError(err instanceof Error ? err.message : 'Failed to rename author');
                                     }
                                   }}
-                                  sx={{ cursor: isSameAsCanonical ? 'default' : 'pointer' }} />
+                                  sx={[isSameAsCanonical ? {
+                                    cursor: 'default'
+                                  } : {
+                                    cursor: 'pointer'
+                                  }]} />
                               </Tooltip>
                               <Chip
                                 label={isNarrator ? 'Narrator' : 'Author'}
@@ -621,13 +624,11 @@ export function AuthorDedupTab() {
           onPageChange={pagination.setPage} onRowsPerPageChange={pagination.setRowsPerPage} />
         </>
       )}
-
       <AuthorBooksPopover
         anchorEl={popoverAnchor}
         onClose={() => { setPopoverAnchor(null); setPopoverAuthorIds([]); }}
         authorIds={popoverAuthorIds}
       />
-
       <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
         <DialogTitle>Confirm Merge All</DialogTitle>
         <DialogContent>

--- a/web/src/components/dedup/DedupEmbeddingTab.tsx
+++ b/web/src/components/dedup/DedupEmbeddingTab.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/dedup/DedupEmbeddingTab.tsx
-// version: 1.2.0
+// version: 1.3.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f01234567891
-// last-edited: 2026-06-29
-
+// last-edited: 2026-08-10
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -730,7 +729,13 @@ export function EmbeddingDedupTab() {
               alignItems="center"
               spacing={0.5}
               useFlexGap
-              sx={{ minWidth: 0, pr: isMultiWay ? 3 : 0 }} // leave room for the button
+              sx={[{
+                minWidth: 0
+              }, isMultiWay ? {
+                pr: 3
+              } : {
+                pr: 0
+              }]} // leave room for the button
             >
               <Typography
                 className="dedup-side-title"
@@ -802,14 +807,17 @@ export function EmbeddingDedupTab() {
                   handleMergeCluster(cluster, id);
                 }}
                 disabled={anyActionBusy}
-                sx={{
+                sx={[{
                   position: 'absolute',
                   top: -4,
-                  right: isMultiWay ? 22 : -4,
                   padding: '2px',
                   color: 'text.disabled',
-                  '&:hover': { color: 'warning.main' },
-                }}
+                  '&:hover': { color: 'warning.main' }
+                }, isMultiWay ? {
+                  right: 22
+                } : {
+                  right: -4
+                }]}
               >
                 {actionLoading === `${cluster.key}:primary:${id}` ? (
                   <CircularProgress size={14} />

--- a/web/src/components/dedup/DedupSeriesTab.tsx
+++ b/web/src/components/dedup/DedupSeriesTab.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/dedup/DedupSeriesTab.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: c3d4e5f6-a7b8-9012-cdef-012345678902
-// last-edited: 2026-05-11
-
+// last-edited: 2026-08-10
 import { useState, useEffect, useCallback } from 'react';
 import {
   Box,
@@ -442,7 +441,23 @@ export function SeriesDedupTab() {
                                   const isDup = (bookIdCounts.get(book.id) || 0) > 1;
                                   return (
                                     <Box key={book.id} sx={{ flexShrink: 0, width: 130, textAlign: 'center' }}>
-                                      <Box sx={{ width: 130, height: 195, borderRadius: 1, overflow: 'hidden', border: '1px solid', borderColor: isDup ? 'warning.main' : 'divider', bgcolor: 'action.hover', cursor: src ? 'pointer' : 'default', position: 'relative' }}
+                                      <Box sx={[{
+                                        width: 130,
+                                        height: 195,
+                                        borderRadius: 1,
+                                        overflow: 'hidden',
+                                        border: '1px solid',
+                                        bgcolor: 'action.hover',
+                                        position: 'relative'
+                                      }, isDup ? {
+                                        borderColor: 'warning.main'
+                                      } : {
+                                        borderColor: 'divider'
+                                      }, src ? {
+                                        cursor: 'pointer'
+                                      } : {
+                                        cursor: 'default'
+                                      }]}
                                         onClick={() => { if (src) setFloatingCovers((prev) => prev.some((c) => c.src === src) ? prev.filter((c) => c.src !== src) : [...prev, { src, title: cleanDisplayTitle(book.title), author: authorLabel }]); }}>
                                         {isDup && (
                                           <Chip label="dup" size="small" color="warning" sx={{ position: 'absolute', top: 4, right: 4, zIndex: 1, height: 18, fontSize: '0.6rem' }} />

--- a/web/src/components/dedup/DedupSplitBookTab.tsx
+++ b/web/src/components/dedup/DedupSplitBookTab.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/dedup/DedupSplitBookTab.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
-// last-edited: 2026-05-29
-
+// last-edited: 2026-08-10
 // Split-book backfill review tab (MAYDEPLOY-G3).
 //
 // Lists persisted split-book candidate clusters from
@@ -169,7 +168,6 @@ function CandidateRow({ candidate, expanded, onToggle, onMergeRequest, merging }
     </>
   );
 }
-
 export function DedupSplitBookTab() {
   const [candidates, setCandidates] = useState<SplitBookCandidate[]>([]);
   const [loading, setLoading] = useState(true);
@@ -183,7 +181,6 @@ export function DedupSplitBookTab() {
   const [confirmCandidate, setConfirmCandidate] = useState<SplitBookCandidate | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isUnmountedRef = useRef(false);
-
   const loadCandidates = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -196,11 +193,9 @@ export function DedupSplitBookTab() {
       setLoading(false);
     }
   }, []);
-
   useEffect(() => {
     loadCandidates();
   }, [loadCandidates]);
-
   useEffect(() => {
     return () => {
       isUnmountedRef.current = true;

--- a/web/src/components/dedup/FingerprintCanvas.tsx
+++ b/web/src/components/dedup/FingerprintCanvas.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/dedup/FingerprintCanvas.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: c7d8e9f0-a1b2-4c3d-8e4f-5a6b7c8d9e0f
-// last-edited: 2026-06-19
-
+// last-edited: 2026-08-10
 // FingerprintCanvas renders a chromaprint base64 fingerprint as a visual
 // bit-matrix heatmap. Each row = one time bucket (aggregated frames), each
 // column = one of the 32 bit positions. Cells are colored by bit value and
@@ -265,10 +264,13 @@ export function FingerprintPair({ hashA, hashB, width = 180, rows = 48 }: Finger
           Visual similarity:{' '}
           <Box
             component="span"
-            sx={{
-              fontWeight: 700,
-              color: simPct > 80 ? 'success.main' : simPct > 50 ? 'warning.main' : 'error.main',
-            }}
+            sx={[{
+              fontWeight: 700
+            }, simPct > 80 ? {
+              color: 'success.main'
+            } : {
+              color: simPct > 50 ? 'warning.main' : 'error.main'
+            }]}
           >
             {simPct}%
           </Box>

--- a/web/src/components/dedup/ScoreBreakdownPanel.tsx
+++ b/web/src/components/dedup/ScoreBreakdownPanel.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/dedup/ScoreBreakdownPanel.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: d3c4e5f6-a7b8-9012-cdef-dc3456789012
-// last-edited: 2026-06-10
-
+// last-edited: 2026-08-10
 // ScoreBreakdownPanel renders a stacked bar visualization of the per-signal
 // score contributions for a dedup candidate. Signal contributions are
 // computed client-side from the stored signal values and weights.
@@ -117,11 +116,14 @@ export function ScoreBreakdownPanel({ breakdown }: ScoreBreakdownPanelProps) {
           {withShares.map((s) => (
             <Box
               key={s.kind}
-              sx={{
+              sx={[{
                 width: `${s.share * 100}%`,
-                bgcolor: SIGNAL_COLORS[s.kind] ?? '#9e9e9e',
-                minWidth: s.share > 0 ? 2 : 0,
-              }}
+                bgcolor: SIGNAL_COLORS[s.kind] ?? '#9e9e9e'
+              }, s.share > 0 ? {
+                minWidth: 2
+              } : {
+                minWidth: 0
+              }]}
             />
           ))}
         </Box>

--- a/web/src/components/dedup/UnifiedDedupTab.tsx
+++ b/web/src/components/dedup/UnifiedDedupTab.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/dedup/UnifiedDedupTab.tsx
-// version: 1.8.0
+// version: 1.9.0
 // guid: c8b9d0e1-f2a3-4567-bcde-cb8901234567
-// last-edited: 2026-06-29
-
+// last-edited: 2026-08-10
 // UnifiedDedupTab is the T017 single surface that replaces the separate Books /
 // Advanced-Scan / Acoustic tabs. It shows a paginated candidate table filtered
 // by band (CERTAIN/HIGH/MEDIUM/REVIEW), with a side drawer for per-candidate
@@ -213,16 +212,22 @@ function renderBookCard(book: Book | null | undefined, id: string, opts: BookCar
               component={RouterLink}
               to={`/library/${id}`}
               underline="hover"
-              sx={{
-                color: isGarbageTitle ? 'warning.main' : 'primary.main',
+              sx={[{
                 fontWeight: 600,
                 fontSize: '1rem',
                 textTransform: 'none',
                 textAlign: 'left',
                 whiteSpace: 'normal',
-                wordBreak: 'break-word',
-                fontStyle: isGarbageTitle ? 'italic' : 'normal',
-              }}
+                wordBreak: 'break-word'
+              }, isGarbageTitle ? {
+                color: 'warning.main'
+              } : {
+                color: 'primary.main'
+              }, isGarbageTitle ? {
+                fontStyle: 'italic'
+              } : {
+                fontStyle: 'normal'
+              }]}
               onClick={(e: MouseEvent) => e.stopPropagation()}
             >
               {isGarbageTitle ? title || '(no title)' : title}
@@ -1035,19 +1040,25 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
                       onClick={(e) => handleRowClick(e, c.id, idx)}
                       data-testid={`dedup-candidate-row-${c.id}`}
                       aria-current={isFocused ? 'true' : undefined}
-                      sx={{
-                        opacity: busy ? 0.7 : 1,
+                      sx={[{
                         cursor: 'pointer',
-                        // Zebra stripe: odd rows get a subtle tint for easier reading
-                        bgcolor: isSelected
-                          ? undefined
-                          : idx % 2 === 1
-                            ? 'action.hover'
-                            : 'transparent',
-                        outline: isFocused ? 2 : 0,
                         outlineColor: 'primary.main',
-                        outlineOffset: -2,
-                      }}
+                        outlineOffset: -2
+                      }, busy ? {
+                        opacity: 0.7
+                      } : {
+                        opacity: 1
+                      }, isSelected ? {
+                        bgcolor: null
+                      } : {
+                        bgcolor: idx % 2 === 1
+                            ? 'action.hover'
+                            : 'transparent'
+                      }, isFocused ? {
+                        outline: 2
+                      } : {
+                        outline: 0
+                      }]}
                     >
                       {showMultiSelect && (
                         <TableCell padding="checkbox">

--- a/web/src/components/filemanager/DirectoryTree.tsx
+++ b/web/src/components/filemanager/DirectoryTree.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/filemanager/DirectoryTree.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6c7d8e9f-0a1b-2c3d-4e5f-6a7b8c9d0e1f
 
 import React, { useState } from 'react';
@@ -102,17 +102,20 @@ const TreeNode: React.FC<TreeNodeProps> = ({
   return (
     <Box>
       <Box
-        sx={{
+        sx={[{
           display: 'flex',
           alignItems: 'center',
           pl: level * 2,
           py: 0.5,
           cursor: node.is_dir ? 'pointer' : 'default',
-          bgcolor: isSelected ? 'action.selected' : 'transparent',
           '&:hover': {
             bgcolor: node.is_dir ? 'action.hover' : 'transparent',
-          },
-        }}
+          }
+        }, isSelected ? {
+          bgcolor: 'action.selected'
+        } : {
+          bgcolor: 'transparent'
+        }]}
         onClick={handleClick}
       >
         {node.is_dir && (

--- a/web/src/components/layout/MainLayout.tsx
+++ b/web/src/components/layout/MainLayout.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/layout/MainLayout.tsx
-// version: 1.4.0
+// version: 1.5.0
 // guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a
-// last-edited: 2026-07-13
-
+// last-edited: 2026-08-10
 import { useState, ReactNode } from 'react';
 import { Box } from '@mui/material';
 import { Sidebar } from './Sidebar';
@@ -43,21 +42,20 @@ export function MainLayout({ children }: MainLayoutProps) {
       />
       <Box
         component="main"
-        sx={{
+        sx={theme => ({
           flexGrow: 1,
           p: 3,
           width: { sm: `calc(100% - ${effectiveWidth}px)` },
           mt: 8,
           height: '100vh',
           overflow: 'auto',
-          transition: (theme) =>
-            theme.transitions.create(['width', 'margin'], {
-              easing: theme.transitions.easing.sharp,
-              duration: sidebarCollapsed
-                ? theme.transitions.duration.leavingScreen
-                : theme.transitions.duration.enteringScreen,
-            }),
-        }}
+          transition: theme.transitions.create(['width', 'margin'], {
+            easing: theme.transitions.easing.sharp,
+            duration: sidebarCollapsed
+              ? theme.transitions.duration.leavingScreen
+              : theme.transitions.duration.enteringScreen,
+          })
+        })}
       >
         <ReviewBanner />
         {children}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/layout/Sidebar.tsx
-// version: 1.17.0
+// version: 1.18.0
 // guid: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c
-// last-edited: 2026-08-08
-
+// last-edited: 2026-08-10
 import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
@@ -120,9 +119,17 @@ export function Sidebar({ open, onClose, drawerWidth, collapsed = false, onToggl
             <ListItemButton
               selected={location.pathname === '/dashboard'}
               onClick={() => handleNavigation('/dashboard')}
-              sx={{ justifyContent: isCollapsed ? 'center' : 'flex-start' }}
+              sx={[isCollapsed ? {
+                justifyContent: 'center'
+              } : {
+                justifyContent: 'flex-start'
+              }]}
             >
-              <ListItemIcon sx={{ minWidth: isCollapsed ? 0 : undefined }}>
+              <ListItemIcon sx={[isCollapsed ? {
+                minWidth: 0
+              } : {
+                minWidth: null
+              }]}>
                 <DashboardIcon />
               </ListItemIcon>
               {!isCollapsed && <ListItemText primary="Dashboard" />}
@@ -187,9 +194,17 @@ export function Sidebar({ open, onClose, drawerWidth, collapsed = false, onToggl
               <ListItemButton
                 selected={location.pathname === item.path}
                 onClick={() => handleNavigation(item.path)}
-                sx={{ justifyContent: isCollapsed ? 'center' : 'flex-start' }}
+                sx={[isCollapsed ? {
+                  justifyContent: 'center'
+                } : {
+                  justifyContent: 'flex-start'
+                }]}
               >
-                <ListItemIcon sx={{ minWidth: isCollapsed ? 0 : undefined }}>
+                <ListItemIcon sx={[isCollapsed ? {
+                  minWidth: 0
+                } : {
+                  minWidth: null
+                }]}>
                   {renderMenuIcon(item)}
                 </ListItemIcon>
                 {!isCollapsed && <ListItemText primary={item.text} />}
@@ -239,21 +254,20 @@ export function Sidebar({ open, onClose, drawerWidth, collapsed = false, onToggl
       {/* Permanent drawer — supports collapse to icon-only */}
       <Drawer
         variant="permanent"
-        sx={{
+        sx={theme => ({
           display: { xs: 'none', sm: 'block' },
           '& .MuiDrawer-paper': {
             boxSizing: 'border-box',
             width: drawerWidth,
             overflowX: 'hidden',
-            transition: (theme) =>
-              theme.transitions.create('width', {
-                easing: theme.transitions.easing.sharp,
-                duration: collapsed
-                  ? theme.transitions.duration.leavingScreen
-                  : theme.transitions.duration.enteringScreen,
-              }),
-          },
-        }}
+            transition: theme.transitions.create('width', {
+              easing: theme.transitions.easing.sharp,
+              duration: collapsed
+                ? theme.transitions.duration.leavingScreen
+                : theme.transitions.duration.enteringScreen,
+            }),
+          }
+        })}
         open
       >
         {buildContent(collapsed, true)}

--- a/web/src/components/layout/TopBar.tsx
+++ b/web/src/components/layout/TopBar.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/layout/TopBar.tsx
-// version: 1.6.2
+// version: 1.7.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 
 import { useEffect, useRef, useState } from 'react';
@@ -108,15 +108,14 @@ export function TopBar({ onMenuClick, drawerWidth }: TopBarProps) {
   return (
     <AppBar
       position="fixed"
-      sx={{
+      sx={theme => ({
         width: { sm: `calc(100% - ${drawerWidth}px)` },
         ml: { sm: `${drawerWidth}px` },
-        transition: (theme) =>
-          theme.transitions.create(['width', 'margin'], {
-            easing: theme.transitions.easing.sharp,
-            duration: theme.transitions.duration.leavingScreen,
-          }),
-      }}
+        transition: theme.transitions.create(['width', 'margin'], {
+          easing: theme.transitions.easing.sharp,
+          duration: theme.transitions.duration.leavingScreen,
+        })
+      })}
     >
       <Toolbar>
         <IconButton

--- a/web/src/components/library/LibraryDialogs.tsx
+++ b/web/src/components/library/LibraryDialogs.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/library/LibraryDialogs.tsx
-// version: 1.5.0
+// version: 1.6.0
 // guid: d4e5f6a7-b8c9-0123-def0-234567890123
-// last-edited: 2026-06-30
-
+// last-edited: 2026-08-10
 import React from 'react';
 import {
   Typography,
@@ -1225,10 +1224,13 @@ export const LibraryDialogs = ({
               }}
             >
               <ExpandMoreIcon
-                sx={{
-                  transform: importPathsExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
-                  transition: 'transform 0.3s',
-                }}
+                sx={[{
+                  transition: 'transform 0.3s'
+                }, importPathsExpanded ? {
+                  transform: 'rotate(180deg)'
+                } : {
+                  transform: 'rotate(0deg)'
+                }]}
               />
             </IconButton>
           </Stack>

--- a/web/src/components/library/LibrarySoftDeletedSection.tsx
+++ b/web/src/components/library/LibrarySoftDeletedSection.tsx
@@ -61,10 +61,13 @@ export function LibrarySoftDeletedSection({
       >
         <Stack direction="row" alignItems="center" spacing={1}>
           <ExpandMoreIcon
-            sx={{
-              transform: softDeletedExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
-              transition: 'transform 0.2s',
-            }}
+            sx={[{
+              transition: 'transform 0.2s'
+            }, softDeletedExpanded ? {
+              transform: 'rotate(180deg)'
+            } : {
+              transform: 'rotate(0deg)'
+            }]}
           />
           <Typography variant="h6">Soft-Deleted Books</Typography>
         </Stack>

--- a/web/src/components/library/TagCloud.tsx
+++ b/web/src/components/library/TagCloud.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/library/TagCloud.tsx
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7e6c9a1d-3f2b-4c8e-9a5d-1b6f8e2c4d9a
-// last-edited: 2026-08-08
-
+// last-edited: 2026-08-10
 import { useMemo, useState } from 'react';
 import { Box, Button, Chip, Collapse, IconButton, Stack, Typography } from '@mui/material';
 import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
@@ -124,9 +123,7 @@ export function TagCloud({ availableTags, selectedTags, onTagsChange }: TagCloud
       />
     );
   };
-
   const hiddenCount = sortedTags.length - previewTags.length;
-
   return (
     <Box sx={{ p: 1.5, border: 1, borderColor: 'divider', borderRadius: 1 }}>
       <Stack
@@ -148,10 +145,13 @@ export function TagCloud({ availableTags, selectedTags, onTagsChange }: TagCloud
           }}
         >
           <ExpandMoreIcon
-            sx={{
-              transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
-              transition: 'transform 0.2s',
-            }}
+            sx={[{
+              transition: 'transform 0.2s'
+            }, expanded ? {
+              transform: 'rotate(180deg)'
+            } : {
+              transform: 'rotate(0deg)'
+            }]}
           />
         </IconButton>
       </Stack>

--- a/web/src/components/settings/APIKeysTab.tsx
+++ b/web/src/components/settings/APIKeysTab.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/settings/APIKeysTab.tsx
-// version: 1.1.0
+// version: 1.2.0
 // guid: f6a7b8c9-d0e1-2345-fabc-456789012345
-// last-edited: 2026-06-22
-
+// last-edited: 2026-08-10
 import { useState, useEffect, useRef } from 'react';
 import {
   Box,
@@ -264,7 +263,11 @@ export function APIKeysTab() {
                   : false;
 
                 return (
-                  <TableRow key={k.id} sx={{ opacity: k.status === 'revoked' ? 0.5 : 1 }}>
+                  <TableRow key={k.id} sx={[k.status === 'revoked' ? {
+                    opacity: 0.5
+                  } : {
+                    opacity: 1
+                  }]}>
                     <TableCell>
                       <Tooltip title={k.description || ''} placement="top">
                         <Typography variant="body2" fontWeight={500}>{k.name}</Typography>
@@ -342,7 +345,6 @@ export function APIKeysTab() {
           </Table>
         </TableContainer>
       )}
-
       {/* Create API Key Dialog */}
       <Dialog open={createOpen} onClose={() => setCreateOpen(false)} maxWidth="sm" fullWidth>
         <DialogTitle>Create API Key</DialogTitle>
@@ -409,7 +411,6 @@ export function APIKeysTab() {
           </Button>
         </DialogActions>
       </Dialog>
-
       {/* One-time token display */}
       <Dialog open={!!createdToken} maxWidth="sm" fullWidth>
         <DialogTitle>API Key Created</DialogTitle>

--- a/web/src/components/settings/ITunesImport.tsx
+++ b/web/src/components/settings/ITunesImport.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/settings/ITunesImport.tsx
-// version: 1.19.2
+// version: 1.20.0
 // guid: 4eb9b74d-7192-497b-849a-092833ae63a4
-// last-edited: 2026-08-07
-
+// last-edited: 2026-08-10
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
@@ -1044,13 +1043,11 @@ export function ITunesImport() {
                 }
                 label="Create backup before writing"
               />
-
               <Tabs value={writeBackMode} onChange={(_e, v) => setWriteBackMode(v)} sx={{ borderBottom: 1, borderColor: 'divider' }}>
                 <Tab label="Enter IDs" />
                 <Tab label="Sync All" />
                 <Tab label="Browse & Select" />
               </Tabs>
-
               {/* Mode 0: Enter IDs manually */}
               {writeBackMode === 0 && (
                 <Stack spacing={2}>

--- a/web/src/components/settings/MetadataSettingsTab.tsx
+++ b/web/src/components/settings/MetadataSettingsTab.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/settings/MetadataSettingsTab.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9e0f1a2b-3c4d-5e6f-7a8b-9c0d1e2f3a4b
-// last-edited: 2026-05-01
-
+// last-edited: 2026-08-10
 import { Dispatch, SetStateAction } from 'react';
 import {
   Box,
@@ -306,13 +305,13 @@ export function MetadataSettingsTab(props: MetadataSettingsTabProps) {
                     sx={{ mr: 1 }}
                   >
                     <ExpandMoreIcon
-                      sx={{
-                        transform:
-                          expandedSource === source.id
-                            ? 'rotate(180deg)'
-                            : 'rotate(0deg)',
-                        transition: 'transform 0.3s',
-                      }}
+                      sx={[{
+                        transition: 'transform 0.3s'
+                      }, expandedSource === source.id ? {
+                        transform: 'rotate(180deg)'
+                      } : {
+                        transform: 'rotate(0deg)'
+                      }]}
                     />
                   </IconButton>
                 )}

--- a/web/src/components/system/MaintenanceTab.tsx
+++ b/web/src/components/system/MaintenanceTab.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/system/MaintenanceTab.tsx
-// version: 1.8.3
+// version: 1.9.0
 // guid: c3d4e5f6-a7b8-9012-cdef-345678901234
-// last-edited: 2026-08-07
-
+// last-edited: 2026-08-10
 import { useEffect, useState, useCallback, useRef } from 'react';
 import {
   Alert,
@@ -1107,15 +1106,17 @@ export function MaintenanceTab() {
                         {task.name}
                         {task.last_run && ` · Last run: ${new Date(task.last_run).toLocaleString()}`}
                       </Typography>
-
                       <Box
-                        sx={{
+                        sx={[{
                           display: 'flex',
                           flexWrap: 'wrap',
                           alignItems: 'center',
-                          gap: 1,
-                          mt: isMobile ? 1 : 0.5,
-                        }}
+                          gap: 1
+                        }, isMobile ? {
+                          mt: 1
+                        } : {
+                          mt: 0.5
+                        }]}
                       >
                         <FormControlLabel
                           control={

--- a/web/src/components/system/StorageTab.tsx
+++ b/web/src/components/system/StorageTab.tsx
@@ -1,8 +1,7 @@
 // file: web/src/components/system/StorageTab.tsx
-// version: 1.3.0
+// version: 1.4.0
 // guid: 9e0f1a2b-3c4d-5e6f-7a8b-9c0d1e2f3a4b
-// last-edited: 2026-04-30
-
+// last-edited: 2026-08-10
 import { useState, useEffect } from 'react';
 import {
   Box,
@@ -202,7 +201,11 @@ export function StorageTab() {
                 storage.folders.map((folder, index) => (
                   <Box
                     key={folder.id}
-                    sx={{ mb: index < storage.folders.length - 1 ? 2 : 0 }}
+                    sx={[index < storage.folders.length - 1 ? {
+                      mb: 2
+                    } : {
+                      mb: 0
+                    }]}
                   >
                     <Stack
                       direction="row"

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -1,8 +1,7 @@
 // file: web/src/pages/ActivityLog.tsx
-// version: 2.19.1
+// version: 2.20.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
-// last-edited: 2026-08-07
-
+// last-edited: 2026-08-10
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
@@ -611,17 +610,29 @@ export default function ActivityLog() {
         label={hideNoOp ? '\u2713 hide no-op' : 'show no-op'}
         onClick={() => setHideNoOp((v) => !v)}
         variant={hideNoOp ? 'filled' : 'outlined'}
-        sx={{
-          borderWidth: hideNoOp ? 2 : 1,
-          cursor: 'pointer',
-          opacity: hideNoOp ? 1 : 0.6,
-        }}
+        sx={[{
+          cursor: 'pointer'
+        }, hideNoOp ? {
+          borderWidth: 2
+        } : {
+          borderWidth: 1
+        }, hideNoOp ? {
+          opacity: 1
+        } : {
+          opacity: 0.6
+        }]}
       />
     </Stack>
   );
 
   const sourcesButton = (fullWidth?: boolean) => (
-    <Box sx={{ position: 'relative', width: fullWidth ? '100%' : undefined }} ref={sourcesDropdownRef}>
+    <Box sx={[{
+      position: 'relative'
+    }, fullWidth ? {
+      width: '100%'
+    } : {
+      width: null
+    }]} ref={sourcesDropdownRef}>
       <Button
         size="small"
         variant="outlined"
@@ -687,11 +698,17 @@ export default function ActivityLog() {
                   <input type="checkbox" checked={!isExcluded} readOnly style={{ pointerEvents: 'none' }} />
                   <Typography
                     variant="body2"
-                    sx={{
-                      textDecoration: isExcluded ? 'line-through' : 'none',
-                      opacity: isExcluded ? 0.5 : 1,
-                      flexGrow: 1,
-                    }}
+                    sx={[{
+                      flexGrow: 1
+                    }, isExcluded ? {
+                      textDecoration: 'line-through'
+                    } : {
+                      textDecoration: 'none'
+                    }, isExcluded ? {
+                      opacity: 0.5
+                    } : {
+                      opacity: 1
+                    }]}
                   >
                     {s.source}
                   </Typography>
@@ -883,14 +900,20 @@ export default function ActivityLog() {
                     <Paper
                       key={op.id}
                       variant="outlined"
-                      sx={{
+                      sx={[{
                         p: 1.5,
                         cursor: 'pointer',
-                        border: expandedOpId === op.id ? 2 : 1,
-                        borderColor: expandedOpId === op.id ? 'primary.main' : 'divider',
                         ml: indent,
-                        transition: 'all 0.2s ease',
-                      }}
+                        transition: 'all 0.2s ease'
+                      }, expandedOpId === op.id ? {
+                        border: 2
+                      } : {
+                        border: 1
+                      }, expandedOpId === op.id ? {
+                        borderColor: 'primary.main'
+                      } : {
+                        borderColor: 'divider'
+                      }]}
                       onClick={() => setExpandedOpId(expandedOpId === op.id ? null : op.id)}
                     >
                       <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 0.5 }}>
@@ -1201,7 +1224,9 @@ export default function ActivityLog() {
                           label={label}
                           size="small"
                           color={color}
-                          sx={{ cursor: 'pointer', ...(sx ?? {}) }}
+                          sx={[{
+                            cursor: 'pointer'
+                          }, sx ?? {}]}
                           variant={tagFilter.includes(tag) ? 'filled' : 'outlined'}
                           clickable
                           onClick={() => toggleTagFilter(tag)}
@@ -1224,7 +1249,9 @@ export default function ActivityLog() {
                           label={label}
                           size="small"
                           color={color}
-                          sx={{ cursor: 'pointer', ...(sx ?? {}) }}
+                          sx={[{
+                            cursor: 'pointer'
+                          }, sx ?? {}]}
                           variant={tagFilter.includes(tag) ? 'filled' : 'outlined'}
                           clickable
                           onClick={() => toggleTagFilter(tag)}
@@ -1275,7 +1302,6 @@ export default function ActivityLog() {
                     />
                   </MenuItem>
                 </Menu>
-
                 {/* Auto-refresh (moved here on mobile) */}
                 <Button
                   size="small"
@@ -1410,7 +1436,6 @@ export default function ActivityLog() {
                 </MenuItem>
               </Menu>
             </Stack>
-
             {/* Row 3: Active filter summary */}
             <Stack direction="row" spacing={1} alignItems="center">
               <Typography variant="caption" color="text.secondary">
@@ -1425,7 +1450,6 @@ export default function ActivityLog() {
           </Stack>
         )}
       </Paper>
-
       {/* Large-log warning banner */}
       {total > 1000 && (
         <Typography
@@ -1585,12 +1609,15 @@ export default function ActivityLog() {
                                   spacing={1}
                                   alignItems="center"
                                   flexWrap="wrap"
-                                  sx={{
+                                  sx={[{
                                     py: 0.5,
                                     borderBottom: '1px solid',
-                                    borderColor: 'divider',
-                                    color: item.type === 'error' ? 'error.main' : 'text.primary',
-                                  }}
+                                    borderColor: 'divider'
+                                  }, item.type === 'error' ? {
+                                    color: 'error.main'
+                                  } : {
+                                    color: 'text.primary'
+                                  }]}
                                 >
                                   {item.timestamp && (
                                     <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace', minWidth: 70 }}>
@@ -1648,7 +1675,10 @@ export default function ActivityLog() {
                                             size="small"
                                             label={label}
                                             color={color}
-                                            sx={{ cursor: 'pointer', fontSize: '0.65rem', ...(tagSx ?? {}) }}
+                                            sx={[{
+                                              cursor: 'pointer',
+                                              fontSize: '0.65rem'
+                                            }, tagSx ?? {}]}
                                             variant={tagFilter.includes(tag) ? 'filled' : 'outlined'}
                                             clickable
                                             onClick={(e: React.MouseEvent) => {
@@ -1680,10 +1710,13 @@ export default function ActivityLog() {
                   <TableRow
                     key={entry.id}
                     hover
-                    sx={{
-                      bgcolor: rowBgColor(entry),
-                      opacity: entry.tier === 'debug' ? 0.6 : 1,
-                    }}
+                    sx={[{
+                      bgcolor: rowBgColor(entry)
+                    }, entry.tier === 'debug' ? {
+                      opacity: 0.6
+                    } : {
+                      opacity: 1
+                    }]}
                   >
                     <TableCell sx={{ whiteSpace: 'nowrap', color: 'text.secondary', fontSize: '0.75rem' }}>
                       {isMobile ? formatTimestampCompact(entry.timestamp) : formatTimestamp(entry.timestamp)}
@@ -1734,7 +1767,9 @@ export default function ActivityLog() {
                                   size="small"
                                   label={label}
                                   color={color}
-                                  sx={{ cursor: 'pointer', ...(sx ?? {}) }}
+                                  sx={[{
+                                    cursor: 'pointer'
+                                  }, sx ?? {}]}
                                   variant={tagFilter.includes(tag) ? 'filled' : 'outlined'}
                                   clickable
                                   onClick={(e) => { e.stopPropagation(); toggleTagFilter(tag); }}

--- a/web/src/pages/Authors.tsx
+++ b/web/src/pages/Authors.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Authors.tsx
-// version: 1.4.0
+// version: 1.5.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -208,7 +208,13 @@ function AuthorRow({ author, selected, visibleColumns, columnWidths, onSelect, o
         </TableCell>
       </TableRow>
       <TableRow>
-        <TableCell colSpan={totalCols} sx={{ py: 0, borderBottom: open ? undefined : 'none' }}>
+        <TableCell colSpan={totalCols} sx={[{
+          py: 0
+        }, open ? {
+          borderBottom: null
+        } : {
+          borderBottom: 'none'
+        }]}>
           <Collapse in={open} timeout="auto" unmountOnExit>
             <Box sx={{ py: 1, pl: 4 }}>
               {loadingBooks ? (

--- a/web/src/pages/Diagnostics.tsx
+++ b/web/src/pages/Diagnostics.tsx
@@ -1,6 +1,6 @@
 // file: web/src/pages/Diagnostics.tsx
-// version: 1.3.1
-// last-edited: 2026-08-07
+// version: 1.4.0
+// last-edited: 2026-08-10
 // guid: f2323fc4-b3e7-4298-9ec5-759447cbd643
 
 import { useState, useCallback, useRef, useEffect } from 'react';
@@ -336,16 +336,24 @@ export function Diagnostics() {
           <Grid item xs={12} sm={6} key={cat.id}>
             <Card
               variant="outlined"
-              sx={{
-                border: selectedCategory === cat.id ? 2 : 1,
-                borderColor:
-                  selectedCategory === cat.id ? 'primary.main' : 'divider',
-              }}
+              sx={[selectedCategory === cat.id ? {
+                border: 2
+              } : {
+                border: 1
+              }, selectedCategory === cat.id ? {
+                borderColor: 'primary.main'
+              } : {
+                borderColor: 'divider'
+              }]}
             >
               <CardActionArea onClick={() => setSelectedCategory(cat.id)}>
                 <CardContent>
                   <Stack direction="row" spacing={2} alignItems="center">
-                    <Box sx={{ color: selectedCategory === cat.id ? 'primary.main' : 'text.secondary' }}>
+                    <Box sx={[selectedCategory === cat.id ? {
+                      color: 'primary.main'
+                    } : {
+                      color: 'text.secondary'
+                    }]}>
                       {cat.icon}
                     </Box>
                     <Box>
@@ -363,7 +371,6 @@ export function Diagnostics() {
           </Grid>
         ))}
       </Grid>
-
       {/* Description */}
       <TextField
         label="Description"
@@ -376,7 +383,6 @@ export function Diagnostics() {
         onChange={(e) => setDescription(e.target.value)}
         sx={{ mb: 3 }}
       />
-
       {/* Actions */}
       <Stack direction="row" spacing={2} sx={{ mb: 3 }}>
         <Button
@@ -396,7 +402,6 @@ export function Diagnostics() {
           Submit to AI
         </Button>
       </Stack>
-
       {/* Progress */}
       {isRunning && (
         <Box sx={{ mb: 3 }}>
@@ -412,7 +417,6 @@ export function Diagnostics() {
           />
         </Box>
       )}
-
       {/* AI Results Panel */}
       {aiResults && (
         <Box sx={{ mt: 2 }}>

--- a/web/src/pages/ReviewQueue.tsx
+++ b/web/src/pages/ReviewQueue.tsx
@@ -1,8 +1,7 @@
 // file: web/src/pages/ReviewQueue.tsx
-// version: 2.2.1
+// version: 2.3.0
 // guid: 4c8f2a17-5e93-4d60-a1b8-7f3c6d9e0a52
-// last-edited: 2026-08-07
-
+// last-edited: 2026-08-10
 import { useEffect, useMemo, useState } from 'react';
 import {
   Accordion,
@@ -334,7 +333,11 @@ function ItemActions({
           />
         )
       )}
-      <Stack direction="row" spacing={1} sx={{ mt: withSelector ? 0.5 : 0 }}>
+      <Stack direction="row" spacing={1} sx={[withSelector ? {
+        mt: 0.5
+      } : {
+        mt: 0
+      }]}>
         <Tooltip
           title={
             action
@@ -370,7 +373,6 @@ function ItemActions({
     </Stack>
   );
 }
-
 // MemberFilesDetail renders a review item's payload header plus a rich per-member
 // list. It fetches the member books lazily (it only mounts when the accordion is
 // expanded, via unmountOnExit) so opening the queue never fans out hundreds of
@@ -388,10 +390,8 @@ function MemberFilesDetail({ item }: { item: ReviewItem }) {
         : undefined;
   const entries = useMemo(() => memberEntries(payload), [payload]);
   const members = memberCount(payload);
-
   const [books, setBooks] = useState<Map<string, Book>>(new Map());
   const [loading, setLoading] = useState(false);
-
   useEffect(() => {
     const ids = entries.map((e) => e.bookId).filter((id): id is string => !!id);
     if (ids.length === 0) return;
@@ -406,7 +406,6 @@ function MemberFilesDetail({ item }: { item: ReviewItem }) {
       });
     return () => ctrl.abort();
   }, [entries]);
-
   return (
     <Box sx={{ pl: 1 }}>
       <Stack spacing={0.5} sx={{ mb: 1 }}>

--- a/web/src/pages/Series.tsx
+++ b/web/src/pages/Series.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Series.tsx
-// version: 1.4.1
+// version: 1.5.0
 // guid: 7d8e9f0a-1b2c-3d4e-5f6a-7b8c9d0e1f2a
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
@@ -167,7 +167,19 @@ function SeriesRow({ series, selected, expanded, visibleColumns, columnWidths, o
 
   return (
     <>
-      <TableRow hover sx={{ cursor: bookCount > 0 ? 'pointer' : 'default', '& > *': { borderBottom: isExpanded ? 'unset' : undefined } }} onClick={(e) => { if (bookCount > 0 && !(e.target as HTMLElement).closest('button, input, .MuiCheckbox-root')) onToggleExpand(); }}>
+      <TableRow hover sx={[bookCount > 0 ? {
+        cursor: 'pointer'
+      } : {
+        cursor: 'default'
+      }, isExpanded ? {
+        '& > *': {
+          borderBottom: 'unset'
+        }
+      } : {
+        '& > *': {
+          borderBottom: null
+        }
+      }]} onClick={(e) => { if (bookCount > 0 && !(e.target as HTMLElement).closest('button, input, .MuiCheckbox-root')) onToggleExpand(); }}>
         <TableCell padding="checkbox" sx={{ width: 42 }}>
           <Checkbox checked={selected} onChange={onToggleSelect} />
         </TableCell>

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -1,5 +1,5 @@
 // file: web/src/theme.ts
-// version: 1.4.0
+// version: 1.5.0
 // guid: 2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-08-11
 
@@ -67,22 +67,73 @@ export function createAppTheme(mode: PaletteMode = 'dark') {
         },
       },
       MuiDrawer: {
-        // exit: 0 for the same reason as MuiMenu below — see that comment for
-        // the mechanism and the measurements. This is the SECOND component hit
-        // by the same stuck-modal defect, and it was named alongside the Select
-        // menu in playwright.config.ts long before either was understood.
+        // ⚠️ 2026-08-11: the `exit: 0` below is NOT what stops the stuck-modal
+        // defect. That claim was in this comment from 2026-08-10 and it is
+        // WRONG — see "WHAT exit: 0 ACTUALLY DOES" further down. The line that
+        // does the work is `slotProps.transition.exit: false`.
         //
-        // Measured 2026-08-10 on current main (which already carries the
-        // MuiMenu fix), 20 copies of the scan-import-organize "complete
-        // workflow" e2e test across 12 workers: 17/20 FAILED with
-        // `.MuiDrawer-modal .MuiBackdrop-root` still visible after 15s.
+        // THE DEFECT (same one as MuiMenu below): close the right-hand filter
+        // Drawer with Escape and the Drawer's exit transition can stall
+        // forever. The paper animates away and the backdrop reaches opacity 0,
+        // so the UI LOOKS closed — but MUI's Modal only unmounts once the
+        // child transition reports `exited`, so a `position: fixed; inset: 0`
+        // backdrop stays in the DOM and swallows every click on the page until
+        // a reload. Confirmed by hit-test: `document.elementFromPoint(20, 300)`
+        // returns `.MuiBackdrop-root` whose parent is the Drawer's modal root.
         //
-        // Note Drawer already used NUMERIC durations (enteringScreen /
-        // leavingScreen), so this is direct evidence against the "a numeric
-        // duration restores react-transition-group's fallback timer and fixes
-        // it" theory — the Drawer had that fallback all along and stalls
-        // anyway. Only removing the exit window helps.
+        // MECHANISM, measured 2026-08-11 with in-page instrumentation
+        // (`SlideProps` lifecycle hooks + a patched copy of
+        // react-transition-group logging every state transition):
+        //   1. Escape is delivered correctly. `onClose(_, 'escapeKeyDown')`
+        //      fires, `open` goes false. Focus, `isTopModal()` and the Select
+        //      menu are all fine — the menu's Modal is already out of the
+        //      ModalManager by then. (The four theories in the original bug
+        //      report about focus and Escape routing are all disproven.)
+        //   2. The Drawer's Slide and the Backdrop's Fade both enter `exiting`
+        //      and RTG schedules completion with `setTimeout(cb, exitTimeout)`.
+        //   3. The timer FIRES. RTG calls `setState({status: 'exited'})` with
+        //      `updater.isMounted(this) === true`.
+        //   4. React NEVER APPLIES THAT UPDATE. The same instance re-renders
+        //      4ms later still reporting `exiting`, `componentDidUpdate` agrees
+        //      at +9ms, and a 300ms-later probe still reads `exiting` on a
+        //      mounted instance. Permanent.
+        //   5. `onExited` therefore never runs, `useModal`'s `exited` stays
+        //      false, and `Modal` never returns null. → step 1 of this comment.
+        //
+        // WHY `exit: false` FIXES IT: with `exit: false` react-transition-group
+        // takes the synchronous branch in `performExit` —
+        // `safeSetState({status: EXITED}, () => onExited())` called directly
+        // from `componentDidUpdate`, inside React's commit phase — instead of
+        // deferring to a timer. The update that gets lost is never scheduled.
+        // Visually this is identical to the `exit: 0` we already shipped: the
+        // drawer disappears immediately either way.
+        //
+        // WHAT `exit: 0` ACTUALLY DOES: it narrows the race, it does not close
+        // it. Measured on origin/main (MUI 5.18.0, i.e. WITH `exit: 0`
+        // shipped), n=10 per cell, chromium, workers=1: an Escape preceded by a
+        // CDP round-trip stalled 9/10. On the MUI 6.5.0 branch the same
+        // `exit: 0` build stalled 10/10 without the round-trip. v6 did not
+        // introduce this defect; it moved the timing window onto the common
+        // path. Treat any future "we fixed it by shortening the duration" claim
+        // with suspicion.
+        //
+        // STILL UNEXPLAINED: why React silently drops a setState issued from a
+        // setTimeout on a mounted class component inside a portal. Ruled out:
+        // duplicate React copies (single react@18.3.1, deduped), StrictMode
+        // (dev-only here), flushSync/startTransition (absent from web/src),
+        // uncaught exceptions (none), and unmount (componentWillUnmount never
+        // runs, isMounted stays true). `exit: false` sidesteps the question
+        // rather than answering it.
+        //
+        // Repro (P1 in the throwaway escape-focus probe, or the real gate):
+        //   CI=true npx playwright test --config=tests/e2e/playwright.config.ts \
+        //     --project=chromium -g "complete workflow" --repeat-each=10 --workers=1
         defaultProps: {
+          slotProps: { transition: { exit: false } },
+          // Kept for the enter animation. No Drawer call site passes its own
+          // `slotProps`/`SlideProps`, so the defaults above are not clobbered —
+          // MUI merges defaultProps shallowly, so adding one would silently
+          // drop `exit: false`.
           transitionDuration: { enter: 225, exit: 0 },
         },
         styleOverrides: {


### PR DESCRIPTION
MUI `5.14` → `6.5.0`. **Draft — one confirmed regression blocks it.**

## Correction to an earlier version of this PR body

This body previously stated that `main` was red at 555 passed / 1 failed / 8 skipped. **That was wrong and is retracted.** It rested on a single run. A re-run of the same SHA (`76269d57`) returned **556 passed / 0 failed / 8 skipped, exit 0**, with `batch-operations.spec.ts:100` [webkit] passing in 1.6s. **`main` is green.** That spec is an intermittent webkit flake, not a standing failure.

## Attribution, now n=2 per side

| Spec | main | this branch | Verdict |
|---|---|---|---|
| `scan-import-organize.spec.ts:259` [chromium] | ✅ 2/2 | ❌ **2/2** | **real v6 regression** |
| `batch-operations.spec.ts:100` [webkit] | ✅ 1, ❌ 1 | ✅ 1, ❌ 1 | flake, unrelated to v6 |

Same machine, quiet, full `make test-e2e` each time. Branch run 2: 555 passed / 1 failed / 8 skipped, exit 2.

## What is done and green

- `@mui/material` + `@mui/icons-material` at 6.5.0
- `v6.0.0/sx-prop` codemod — 40 files, 0 errors; `v6.0.0/theme-v6` needed no changes
- `npm run build` clean; **vitest 65 files / 448 tests pass**
- Emotion stays the engine; Pigment CSS deliberately not adopted

The predicted v6 ripple/`act()` churn never materialised, because the 2026-08-07 inventory holds: 0 `styled()`, 0 JSS, 0 theme augmentation, 0 deep imports, no `@mui/lab`, no `@mui/x-*`. All 1,726 `sx=` usages carry over.

## The blocker

`scan-import-organize.spec.ts:259` [chromium]:

```
expect(locator).toHaveCount(expected) failed
locator('.MuiDrawer-modal .MuiBackdrop-root').filter({ visible: true })
Expected: 0   Received: 1   Timeout: 15000ms
  - 34 × locator resolved to 1 element
```

That assertion is the tripwire added in #2283 after a stuck Drawer left an **invisible** full-viewport backdrop swallowing every click until reload. Under v6 the backdrop stays visible the full 15s — the close transition never completes.

**It will not be relaxed or deleted to get v6 green.** That is precisely the move the incident exists to prevent, and `toBeHidden()` cannot see an `opacity:0` element that still eats clicks.

Passes in isolation (32/32), fails only in the full suite — the same profile as the original incident, whose root cause was never explained and is labelled so in-code. v6 reworked Modal/Backdrop transitions; the candidates to investigate are the backdrop's `transitionDuration` default, `keepMounted`, and `closeAfterTransition`.