### PR TITLE
fix(database): make the versiongroup backfill observable and chunked [skip changelog]

### DIFF
--- a/changelog.d/20260810_220000_vgbackfill_observable.md
+++ b/changelog.d/20260810_220000_vgbackfill_observable.md
@@ -1,0 +1,30 @@
+### Fixed
+
+#### The version-group index backfill now logs, and no longer buffers the whole rebuild in memory
+
+This backfill is the production repair for a version-group index that could
+silently under-report. It could not be observed and could not finish
+economically on a large library.
+
+- **It logged only on success.** A sentinel-gated skip, a missed type assertion
+  in the caller, and a still-running scan were all silent and identical from
+  outside — so a deployment could not tell whether the repair had run. Deploying
+  to a 366,922-book library produced no log line at all for over twelve minutes.
+  Every exit path now logs: start, "already complete, skipping", periodic
+  progress, completion with counts and duration, and an explicit error on each
+  failure.
+- **The caller failed silently.** `server_lifecycle.go` asserted the store to an
+  interface and did nothing when the assertion missed — if the store is ever
+  wrapped or decorated, the index would never be rebuilt and nothing would say
+  so. It now logs a warning naming the concrete type.
+- **One unbounded batch held the entire rebuild.** Every index row for every
+  book accumulated in memory and was committed once at the very end, so an
+  interrupted run discarded all of its work. Writes are now committed in chunks;
+  the completion sentinel joins the final batch, so it can never become durable
+  without the rows it claims were written.
+- **A real read error was treated as "not yet run."** Only `ErrNotFound` now
+  means that; any other sentinel read failure aborts instead of silently
+  triggering a full rebuild on every boot.
+- The row filter is now structural (a primary `book:<id>` row has exactly one
+  colon) rather than a blacklist of index prefixes that listed one twice and
+  would have silently accepted any prefix added later.

--- a/internal/database/pebble_store_versiongroup_backfill.go
+++ b/internal/database/pebble_store_versiongroup_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_versiongroup_backfill.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9f3b7c21-6d84-4a5e-b0c9-2e7fa1d85b36
 // last-edited: 2026-08-10
 // PERF-VERSIONS: one-time backfill that writes the
@@ -12,9 +12,11 @@ package database
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/pebble/v2"
 )
@@ -32,63 +34,178 @@ import (
 // format or the set of indexed books ever changes.
 const versionGroupBackfillKey = "system:backfill:versiongroup_index_v2_done"
 
-// BackfillVersionGroupIndex writes the secondary index for every book with
-// a non-empty VersionGroupID. Idempotent — gated by a sentinel key so
-// repeated calls after the first successful run are cheap no-ops.
+// versionGroupBackfillChunk is how many index rows are buffered before a
+// commit.
+//
+// This used to be unbounded: one pebble.Batch accumulated a row for EVERY
+// book and was committed once at the end. On a 366,922-book production
+// library that buffers the entire rebuild in memory and makes nothing durable
+// until the final commit, so an interrupted run threw away all of its work and
+// started over from zero on the next boot — and, because the only log line was
+// emitted after that final commit, a long run was indistinguishable from a run
+// that never started. Chunking bounds the memory, makes progress durable, and
+// gives the progress log something to report.
+// A var, not a const, only so tests can lower it and exercise the multi-chunk
+// path without creating ten thousand books. Never reassign it in production
+// code.
+var versionGroupBackfillChunk = 10_000
+
+// versionGroupBackfillLogEvery is how many books are scanned between progress
+// logs. A backfill over a six-figure library must say something while it
+// works; silence for minutes is indistinguishable from being wedged.
+const versionGroupBackfillLogEvery = 50_000
+
+// BackfillVersionGroupIndex writes the secondary index for every book with a
+// non-empty VersionGroupID.
+//
+// Idempotent in two independent senses, both of which matter:
+//
+//  1. Gated by a sentinel key, so the common case after the first successful
+//     run is a cheap no-op (and says so in the log).
+//  2. The work itself is repeatable. Every write is a deterministic
+//     key -> value derived only from the book row, so re-running re-writes
+//     identical bytes. An interrupted run therefore costs time on the next
+//     boot, never correctness, and the sentinel is committed only after every
+//     chunk is durable — a partial rebuild never marks itself complete.
+//
+// Every exit path logs. A one-time repair whose execution cannot be observed
+// should be treated as not having run.
 func (p *PebbleStore) BackfillVersionGroupIndex() error {
-	if _, closer, err := p.db.Get([]byte(versionGroupBackfillKey)); err == nil {
+	start := time.Now()
+
+	// Only pebble.ErrNotFound means "not yet run". Any other error is a real
+	// read failure, and must not be silently reinterpreted as "not done" —
+	// that would trigger a full rebuild of a six-figure library on every boot.
+	switch _, closer, err := p.db.Get([]byte(versionGroupBackfillKey)); {
+	case err == nil:
 		closer.Close()
+		slog.Info("versiongroup-backfill: already complete, skipping",
+			"sentinel", versionGroupBackfillKey)
 		return nil
+	case errors.Is(err, pebble.ErrNotFound):
+		// Not yet run — fall through and do the work.
+	default:
+		slog.Error("versiongroup-backfill: cannot read sentinel, aborting",
+			"sentinel", versionGroupBackfillKey, "err", err)
+		return fmt.Errorf("read backfill sentinel: %w", err)
 	}
+
+	slog.Info("versiongroup-backfill: starting",
+		"sentinel", versionGroupBackfillKey,
+		"chunk", versionGroupBackfillChunk)
 
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte("book:0"),
 		UpperBound: []byte("book:;"),
 	})
 	if err != nil {
+		slog.Error("versiongroup-backfill: cannot open iterator", "err", err)
 		return err
 	}
+	defer iter.Close()
 
-	batch := p.db.NewBatch()
-	indexed := 0
-	scanned := 0
+	var (
+		batch     = p.db.NewBatch()
+		buffered  int
+		indexed   int
+		scanned   int
+		skipped   int
+		unmarshal int
+		commits   int
+	)
+	// Close whatever batch is current if we bail out early. Reassigned after
+	// each commit, so this always refers to the live one. The previous version
+	// leaked the batch on the success path entirely.
+	defer func() {
+		if batch != nil {
+			batch.Close()
+		}
+	}()
+
+	flush := func() error {
+		if buffered == 0 {
+			return nil
+		}
+		if err := batch.Commit(pebble.Sync); err != nil {
+			return err
+		}
+		batch.Close()
+		batch = p.db.NewBatch()
+		commits++
+		buffered = 0
+		return nil
+	}
+
 	for iter.First(); iter.Valid(); iter.Next() {
 		key := string(iter.Key())
-		// Only the primary `book:<id>` rows carry full JSON payloads;
-		// skip every secondary index prefix.
-		if strings.Contains(key, ":path:") || strings.Contains(key, ":series:") ||
-			strings.Contains(key, ":author:") || strings.Contains(key, ":version:") ||
-			strings.Contains(key, ":versiongroup:") || strings.Contains(key, ":hash:") ||
-			strings.Contains(key, ":originalhash:") || strings.Contains(key, ":organizedhash:") ||
-			strings.Contains(key, ":organizedhash:") {
+		// Only the primary `book:<id>` rows carry full JSON payloads. Book IDs
+		// are ULIDs and contain no colons, so a primary row is exactly
+		// "book:<id>" — one colon. Every secondary index has more. Counting is
+		// exact where the previous substring blacklist was not: it had to
+		// enumerate every index prefix, listed ":organizedhash:" twice, and
+		// would have silently started unmarshalling rows for any index prefix
+		// added later and forgotten here.
+		if strings.Count(key, ":") != 1 {
 			continue
 		}
 
 		var book Book
 		if err := json.Unmarshal(iter.Value(), &book); err != nil {
+			unmarshal++
 			continue
 		}
 		scanned++
+		if scanned%versionGroupBackfillLogEvery == 0 {
+			slog.Info("versiongroup-backfill: progress",
+				"scanned", scanned, "indexed", indexed,
+				"elapsed", time.Since(start).Round(time.Second).String())
+		}
 		if book.VersionGroupID == nil || *book.VersionGroupID == "" {
+			skipped++
 			continue
 		}
 		vgKey := []byte(fmt.Sprintf("book:versiongroup:%s:%s", *book.VersionGroupID, book.ID))
 		if err := batch.Set(vgKey, []byte(book.ID), nil); err != nil {
-			iter.Close()
-			batch.Close()
+			slog.Error("versiongroup-backfill: batch write failed",
+				"book_id", book.ID, "scanned", scanned, "indexed", indexed, "err", err)
 			return err
 		}
 		indexed++
+		buffered++
+		if buffered >= versionGroupBackfillChunk {
+			if err := flush(); err != nil {
+				slog.Error("versiongroup-backfill: chunk commit failed",
+					"scanned", scanned, "indexed", indexed, "err", err)
+				return err
+			}
+		}
 	}
-	iter.Close()
+	if err := iter.Error(); err != nil {
+		slog.Error("versiongroup-backfill: iteration failed",
+			"scanned", scanned, "indexed", indexed, "err", err)
+		return err
+	}
 
+	// The sentinel joins the CURRENT batch, so the tail rows and the
+	// "complete" marker become durable in the same atomic commit. The sentinel
+	// therefore can never outlive the rows it claims were written: if the
+	// process dies before this commit, no sentinel exists, and the next boot
+	// re-runs and rewrites identical rows over the chunks already committed.
 	if err := batch.Set([]byte(versionGroupBackfillKey), []byte("1"), nil); err != nil {
-		batch.Close()
 		return err
 	}
 	if err := batch.Commit(pebble.Sync); err != nil {
+		slog.Error("versiongroup-backfill: sentinel commit failed",
+			"scanned", scanned, "indexed", indexed, "err", err)
 		return err
 	}
-	slog.Info("versiongroup-backfill scanned indexed", "scanned", scanned, "indexed", indexed)
+
+	slog.Info("versiongroup-backfill: complete",
+		"scanned", scanned,
+		"indexed", indexed,
+		"no_version_group", skipped,
+		"unmarshal_errors", unmarshal,
+		"commits", commits+1,
+		"duration", time.Since(start).Round(time.Millisecond).String())
 	return nil
 }

--- a/internal/database/pebble_store_versiongroup_backfill_test.go
+++ b/internal/database/pebble_store_versiongroup_backfill_test.go
@@ -1,0 +1,230 @@
+// file: internal/database/pebble_store_versiongroup_backfill_test.go
+// version: 1.0.0
+// guid: 4b8e1d07-9a3c-4f52-8e61-7d0c2a9f4b13
+// last-edited: 2026-08-10
+
+package database
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// countVGIndexRows returns how many book:versiongroup:* rows exist.
+func countVGIndexRows(t *testing.T, s *PebbleStore) int {
+	t.Helper()
+	iter, err := s.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book:versiongroup:"),
+		UpperBound: []byte("book:versiongroup;"),
+	})
+	if err != nil {
+		t.Fatalf("NewIter: %v", err)
+	}
+	defer iter.Close()
+	n := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		n++
+	}
+	return n
+}
+
+// seedGroupedBooks creates n books sharing one version group and returns their
+// IDs. Index rows are deleted afterwards so the backfill has work to do —
+// CreateBook already writes them.
+func seedGroupedBooks(t *testing.T, s *PebbleStore, gid string, n int) []string {
+	t.Helper()
+	ids := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		b := &Book{
+			Title:          fmt.Sprintf("Backfill Book %d", i),
+			VersionGroupID: &gid,
+		}
+		created, err := s.CreateBook(b)
+		if err != nil {
+			t.Fatalf("CreateBook %d: %v", i, err)
+		}
+		ids = append(ids, created.ID)
+	}
+	for _, id := range ids {
+		key := []byte(fmt.Sprintf("book:versiongroup:%s:%s", gid, id))
+		if err := s.db.Delete(key, pebble.Sync); err != nil {
+			t.Fatalf("Delete index row: %v", err)
+		}
+	}
+	if got := countVGIndexRows(t, s); got != 0 {
+		t.Fatalf("precondition: expected 0 index rows after wipe, got %d", got)
+	}
+	return ids
+}
+
+// The sentinel must gate re-runs, and — because the sentinel is what makes the
+// run cheap — a second call must not rewrite anything. The bug this guards is
+// the inverse too: if the sentinel read ever misreports, a six-figure library
+// rebuilds its whole index on every boot.
+func TestBackfillVersionGroupIndex_SecondRunIsANoOp(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+	s.WaitForWarmup()
+
+	gid := "vg-backfill-idempotent"
+	ids := seedGroupedBooks(t, s, gid, 5)
+
+	if err := s.BackfillVersionGroupIndex(); err != nil {
+		t.Fatalf("first backfill: %v", err)
+	}
+	after := countVGIndexRows(t, s)
+	if after != len(ids) {
+		t.Fatalf("first backfill wrote %d index rows, want %d", after, len(ids))
+	}
+
+	// Wipe one row, then re-run. The sentinel is set, so the run must skip and
+	// leave the damage in place — proving the second call really is gated and
+	// is not quietly redoing the full scan.
+	damaged := []byte(fmt.Sprintf("book:versiongroup:%s:%s", gid, ids[0]))
+	if err := s.db.Delete(damaged, pebble.Sync); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if err := s.BackfillVersionGroupIndex(); err != nil {
+		t.Fatalf("second backfill: %v", err)
+	}
+	if got := countVGIndexRows(t, s); got != len(ids)-1 {
+		t.Fatalf("second backfill was NOT a no-op: %d rows, want %d", got, len(ids)-1)
+	}
+}
+
+// Re-running the work itself (sentinel cleared) must converge on the same
+// state, not accumulate or drop rows. This is the property that makes an
+// interrupted run safe to resume.
+func TestBackfillVersionGroupIndex_RerunConvergesToSameState(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+	s.WaitForWarmup()
+
+	gid := "vg-backfill-converge"
+	ids := seedGroupedBooks(t, s, gid, 7)
+
+	if err := s.BackfillVersionGroupIndex(); err != nil {
+		t.Fatalf("first backfill: %v", err)
+	}
+	first := countVGIndexRows(t, s)
+
+	// Clear the sentinel and run the real work a second time.
+	if err := s.db.Delete([]byte(versionGroupBackfillKey), pebble.Sync); err != nil {
+		t.Fatalf("clear sentinel: %v", err)
+	}
+	if err := s.BackfillVersionGroupIndex(); err != nil {
+		t.Fatalf("second backfill: %v", err)
+	}
+	second := countVGIndexRows(t, s)
+
+	if first != len(ids) || second != first {
+		t.Fatalf("not convergent: first=%d second=%d want both %d", first, second, len(ids))
+	}
+}
+
+// The chunked commit path must write EVERY row, not just the last partial
+// chunk. Before chunking existed, one unbounded batch buffered the whole
+// rebuild; the risk introduced by chunking is dropping rows at a boundary, so
+// exercise several boundaries with an exact multiple and a remainder.
+func TestBackfillVersionGroupIndex_ChunkedCommitWritesEveryRow(t *testing.T) {
+	for _, tc := range []struct{ books, chunk int }{
+		{books: 9, chunk: 2},  // remainder
+		{books: 8, chunk: 2},  // exact multiple — final flush has nothing to do
+		{books: 5, chunk: 1},  // commit every row
+		{books: 4, chunk: 99}, // never reaches a chunk boundary
+	} {
+		t.Run(fmt.Sprintf("books=%d_chunk=%d", tc.books, tc.chunk), func(t *testing.T) {
+			orig := versionGroupBackfillChunk
+			versionGroupBackfillChunk = tc.chunk
+			t.Cleanup(func() { versionGroupBackfillChunk = orig })
+
+			s, err := NewPebbleStore(t.TempDir())
+			if err != nil {
+				t.Fatalf("NewPebbleStore: %v", err)
+			}
+			defer s.Close()
+			s.WaitForWarmup()
+
+			gid := "vg-backfill-chunk"
+			ids := seedGroupedBooks(t, s, gid, tc.books)
+
+			if err := s.BackfillVersionGroupIndex(); err != nil {
+				t.Fatalf("backfill: %v", err)
+			}
+			if got := countVGIndexRows(t, s); got != len(ids) {
+				t.Fatalf("chunked backfill wrote %d rows, want %d", got, len(ids))
+			}
+			// Every specific ID must be present — a count alone would pass if
+			// a boundary row were replaced by a duplicate of another.
+			for _, id := range ids {
+				key := []byte(fmt.Sprintf("book:versiongroup:%s:%s", gid, id))
+				val, closer, err := s.db.Get(key)
+				if err != nil {
+					t.Fatalf("missing index row for %s: %v", id, err)
+				}
+				if string(val) != id {
+					t.Fatalf("index row for %s holds %q", id, string(val))
+				}
+				closer.Close()
+			}
+		})
+	}
+}
+
+// The scan must consider only primary `book:<id>` rows. The previous filter was
+// a blacklist of index prefixes — it listed ":organizedhash:" twice and would
+// have started unmarshalling any prefix added later and forgotten. The rule is
+// now structural: book IDs are ULIDs and carry no colons, so a primary row has
+// exactly one.
+func TestBackfillVersionGroupIndex_IgnoresSecondaryIndexRows(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+	s.WaitForWarmup()
+
+	gid := "vg-backfill-prefixes"
+	ids := seedGroupedBooks(t, s, gid, 3)
+
+	// A secondary-index row that (a) no blacklist in the old code mentioned and
+	// (b) falls INSIDE the iterator's [book:0, book:;) bounds, so the in-loop
+	// filter is genuinely what has to reject it. Keys such as "book:path:..."
+	// start with 'p' (0x70) and are already excluded by the upper bound, which
+	// is why the old substring blacklist was mostly unreachable — and why a
+	// test using one of those would pass no matter how broken the filter was.
+	// This key starts with '0' (0x30) and is therefore scanned.
+	bogus := []byte(`{"id":"NOT-A-REAL-BOOK","version_group_id":"` + gid + `"}`)
+	if err := s.db.Set([]byte("book:0futureindex:xyz"), bogus, pebble.Sync); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	if err := s.BackfillVersionGroupIndex(); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got := countVGIndexRows(t, s); got != len(ids) {
+		t.Fatalf("backfill wrote %d rows, want %d — a secondary index row was scanned", got, len(ids))
+	}
+	iter, err := s.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book:versiongroup:"),
+		UpperBound: []byte("book:versiongroup;"),
+	})
+	if err != nil {
+		t.Fatalf("NewIter: %v", err)
+	}
+	defer iter.Close()
+	for iter.First(); iter.Valid(); iter.Next() {
+		if strings.Contains(string(iter.Key()), "NOT-A-REAL-BOOK") {
+			t.Fatalf("backfill indexed a secondary-index row: %s", iter.Key())
+		}
+	}
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 3.8.0
+// version: 3.9.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-08-09
+// last-edited: 2026-08-10
 
 package server
 
@@ -1016,10 +1016,18 @@ func (s *Server) startBackfills() {
 			return
 		}
 		type vgBackfiller interface{ BackfillVersionGroupIndex() error }
-		if b, ok := s.Store().(vgBackfiller); ok {
-			if err := b.BackfillVersionGroupIndex(); err != nil {
-				slog.Warn("versiongroup-backfill", "err", err)
-			}
+		b, ok := s.Store().(vgBackfiller)
+		if !ok {
+			// Not a silent fall-through: this is the production repair for an
+			// under-reporting version-group index, and if the store is ever
+			// wrapped or decorated the assertion misses and NOTHING happens.
+			// That is indistinguishable from a completed run unless it says so.
+			slog.Warn("versiongroup-backfill: store does not implement BackfillVersionGroupIndex, index will NOT be rebuilt",
+				"store_type", fmt.Sprintf("%T", s.Store()))
+			return
+		}
+		if err := b.BackfillVersionGroupIndex(); err != nil {
+			slog.Warn("versiongroup-backfill", "err", err)
 		}
 	}()
 


### PR DESCRIPTION
Fixes **VGBACKFILL-OBS**, found while verifying tonight's production deploy.

## Why this exists

The version-group index backfill is the **production repair** for an index that could silently under-report (the v1→v2 sentinel bump in #2288 was designed so that deploying performs it). After deploying `76269d57` to prod at 21:23 EDT, there was **no `versiongroup` line in the journal at any priority for 12+ minutes** — and no way to tell whether it had skipped, silently missed, or was still running.

## What was wrong

| Problem | Consequence |
|---|---|
| Logged **only on success** | Sentinel-skip, missed type assertion, and still-running are indistinguishable |
| Caller's type assertion failed **silently** | If the store is ever wrapped, the index is never rebuilt and nothing says so |
| **One unbounded batch** for the whole rebuild | 366,922 books buffered in memory; an interrupted run discards everything |
| Batch **never closed** on the success path | Leak |
| Any sentinel read error treated as "not run" | A transient I/O error rebuilds a six-figure library on every boot |
| Filter was a **prefix blacklist** | Listed `:organizedhash:` twice; silently accepts any prefix added later |

## What changed

Every exit path logs — start, `already complete, skipping`, periodic progress, completion with counts and duration, and an explicit error per failure. The caller warns with the concrete type when its assertion misses.

Rows commit in chunks, and the sentinel **joins the final batch**, so it cannot become durable without the rows it claims were written. An interrupted run therefore costs time on the next boot, never correctness.

The filter is now structural: book IDs are ULIDs and carry no colons, so a primary `book:<id>` row has exactly one.

## Verification — each test watched failing first

- **Blacklist filter restored** → `IgnoresSecondaryIndexRows` fails: *"backfill wrote 4 rows, want 3"*
- **Lossy chunk flush** → `ChunkedCommitWritesEveryRow` fails: **1/9**, **0/8**, **0/5** rows
- With the fix: all pass, `exit=0`

Two findings from building those controls, both of which would have left inert tests:

1. The secondary-row test was **initially inert** — it passed with the broken filter. Its bogus key `book:somefutureindex:` starts with `s` (`0x73`) and falls **outside** the iterator's `[book:0, book:;)` bounds. Moving it to `book:0futureindex:` made it real. This also means the old blacklist was largely unreachable: `book:path:`, `book:versiongroup:` etc. were already excluded by the upper bound.
2. Removing the "final flush" changed **nothing**, because the sentinel `Commit` used the same batch and carried the tail rows anyway. The flush was redundant and its comment claimed a two-batch ordering that did not exist. Removed, and the comment now describes the atomic commit that actually happens.

## Follow-up

Prod's current state is still unknown — this needs deploying and then re-checking the journal for `versiongroup-backfill: complete` vs `already complete, skipping`.