### PR TITLE
feat(itunes): read smart playlists from the XML export [skip changelog]

### DIFF
--- a/changelog.d/20260810_222000_itunes_playlist_xml_source.md
+++ b/changelog.d/20260810_222000_itunes_playlist_xml_source.md
@@ -1,0 +1,28 @@
+### Added
+
+#### iTunes smart playlists now import from the XML export
+
+The importer previously read only the binary `iTunes Library.itl`, which
+extracts **zero** smart playlists from real iTunes 12.13.10.3 libraries. The XML
+export of the *same* library carries **292**, each with an intact Smart Criteria
+blob. iTunes maintains both files, so this reads the one that is legible.
+
+`maintenance.itunes-playlist-import` now takes `libraryPath` and picks the
+reader by extension, defaulting to the configured `itunes.library_read_path`
+(usually the XML). The old `itlPath` parameter still works. Reading the binary
+`.itl` now logs a warning pointing at the XML.
+
+Measured on the live 153 MB export: **351 playlists, 292 smart**, parsed in
+under four seconds.
+
+### Fixed
+
+#### An import will no longer create hundreds of silently-empty playlists
+
+The Smart Criteria translator currently yields empty queries, because
+`ParseSmartCriteria` misreads the format and returns rules with no field,
+operator or operands *without* erroring. The op now always evaluates a dry run
+first and **refuses to apply** when playlists would be created with an empty
+query, naming how many. `allowEmptyQueries=true` overrides it — the raw criteria
+blob is stored on every imported row, so shells imported that way can be
+re-translated once the parser is fixed.

--- a/internal/itunes/xml_library.go
+++ b/internal/itunes/xml_library.go
@@ -1,0 +1,124 @@
+// file: internal/itunes/xml_library.go
+// version: 1.0.0
+// guid: 8a2f4c17-3e69-4d05-9b3a-6c1e7f0d24b8
+// last-edited: 2026-08-10
+// Reads playlists out of an `iTunes Library.xml` export into the same
+// *ITLLibrary shape the binary .itl parser produces, so every consumer
+// (notably service.MigrateSmartPlaylists) works against either source
+// unchanged.
+
+package itunes
+
+import (
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"howett.net/plist"
+)
+
+// Why this exists: the binary .itl parser extracts ZERO smart playlists from
+// real 12.13.10.3 libraries, while the XML export of the SAME library carries
+// 292 of them, each with an intact Smart Criteria blob. The XML is the working
+// source for reading playlists. iTunes writes both files, so this is not a
+// workaround for missing data — it is reading the copy that is legible.
+//
+// Read-only: this opens the export for reading and never writes to the iTunes
+// tree.
+
+// xmlPlaylist mirrors one entry of the top-level `Playlists` array.
+type xmlPlaylist struct {
+	Name          string `plist:"Name"`
+	PersistentID  string `plist:"Playlist Persistent ID"`
+	Folder        bool   `plist:"Folder"`
+	SmartInfo     []byte `plist:"Smart Info"`
+	SmartCriteria []byte `plist:"Smart Criteria"`
+	Items         []struct {
+		TrackID int `plist:"Track ID"`
+	} `plist:"Playlist Items"`
+}
+
+type xmlLibrary struct {
+	ApplicationVersion string        `plist:"Application Version"`
+	Playlists          []xmlPlaylist `plist:"Playlists"`
+}
+
+// ParseXMLLibraryPlaylists reads the playlist section of an iTunes XML export.
+//
+// Only playlists are populated on the returned library — tracks are not read,
+// because the sole consumer needs `Playlists` and decoding a six-figure track
+// array would cost memory for nothing. Callers that need tracks must keep using
+// the .itl parser.
+func ParseXMLLibraryPlaylists(path string) (*ITLLibrary, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open iTunes XML: %w", err)
+	}
+	defer f.Close()
+
+	var raw xmlLibrary
+	dec := plist.NewDecoder(f)
+	if err := dec.Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decode iTunes XML plist: %w", err)
+	}
+
+	lib := &ITLLibrary{Version: raw.ApplicationVersion}
+	var badPID int
+	for _, p := range raw.Playlists {
+		// A playlist is smart exactly when it carries a criteria blob. The .itl
+		// path has a separate IsSmart flag it must infer; here the presence of
+		// the blob IS the evidence, so the two cannot disagree.
+		pl := ITLPlaylist{
+			Title:         p.Name,
+			IsFolder:      p.Folder,
+			IsSmart:       len(p.SmartCriteria) > 0,
+			SmartInfo:     p.SmartInfo,
+			SmartCriteria: p.SmartCriteria,
+		}
+		if pid, ok := decodePersistentID(p.PersistentID); ok {
+			pl.PersistentID = pid
+		} else if p.PersistentID != "" {
+			// Do not silently import a playlist under a zero PID: the importer
+			// keys idempotency on it, so every such playlist would collide with
+			// every other one and all but the first would look "already
+			// imported".
+			badPID++
+			continue
+		}
+		for _, it := range p.Items {
+			pl.Items = append(pl.Items, it.TrackID)
+		}
+		lib.Playlists = append(lib.Playlists, pl)
+	}
+	if badPID > 0 {
+		slog.Warn("itunes-xml: skipped playlists with an undecodable persistent ID",
+			"skipped", badPID, "path", path)
+	}
+
+	smart := 0
+	for _, p := range lib.Playlists {
+		if p.IsSmart {
+			smart++
+		}
+	}
+	slog.Info("itunes-xml: parsed playlists",
+		"path", path, "playlists", len(lib.Playlists), "smart", smart,
+		"app_version", raw.ApplicationVersion)
+	return lib, nil
+}
+
+// decodePersistentID converts iTunes' 16-hex-char persistent ID into the
+// 8-byte array the ITL types use. Returns ok=false for anything else.
+func decodePersistentID(s string) ([8]byte, bool) {
+	var out [8]byte
+	if len(s) != 16 {
+		return out, false
+	}
+	b, err := hex.DecodeString(s)
+	if err != nil || len(b) != 8 {
+		return out, false
+	}
+	copy(out[:], b)
+	return out, true
+}

--- a/internal/itunes/xml_library_test.go
+++ b/internal/itunes/xml_library_test.go
@@ -1,0 +1,132 @@
+// file: internal/itunes/xml_library_test.go
+// version: 1.0.0
+// guid: 5d1a9e64-27bf-4c38-a0e5-93b6c8f21a70
+// last-edited: 2026-08-10
+
+package itunes
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const miniXML = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Application Version</key><string>12.13.10.3</string>
+  <key>Playlists</key>
+  <array>
+    <dict>
+      <key>Name</key><string>Smart One</string>
+      <key>Playlist Persistent ID</key><string>A1B2C3D4E5F60718</string>
+      <key>Smart Info</key><data>AQID</data>
+      <key>Smart Criteria</key><data>U0xzdAABAAE=</data>
+      <key>Playlist Items</key>
+      <array><dict><key>Track ID</key><integer>11</integer></dict>
+             <dict><key>Track ID</key><integer>22</integer></dict></array>
+    </dict>
+    <dict>
+      <key>Name</key><string>Plain One</string>
+      <key>Playlist Persistent ID</key><string>0011223344556677</string>
+    </dict>
+    <dict>
+      <key>Name</key><string>A Folder</string>
+      <key>Playlist Persistent ID</key><string>8899AABBCCDDEEFF</string>
+      <key>Folder</key><true/>
+    </dict>
+    <dict>
+      <key>Name</key><string>Bad PID</string>
+      <key>Playlist Persistent ID</key><string>NOTHEX</string>
+      <key>Smart Criteria</key><data>U0xzdA==</data>
+    </dict>
+  </array>
+</dict></plist>`
+
+func writeTemp(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "iTunes Library.xml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return p
+}
+
+func TestParseXMLLibraryPlaylists_ReadsSmartCriteriaAndPID(t *testing.T) {
+	lib, err := ParseXMLLibraryPlaylists(writeTemp(t, miniXML))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if lib.Version != "12.13.10.3" {
+		t.Errorf("version = %q", lib.Version)
+	}
+	// "Bad PID" must be dropped, not imported under a zero PID — the importer
+	// keys idempotency on the PID, so a zero would make every such playlist
+	// collide and all but the first report "already imported".
+	if len(lib.Playlists) != 3 {
+		t.Fatalf("got %d playlists, want 3 (Bad PID must be skipped)", len(lib.Playlists))
+	}
+
+	var smart *ITLPlaylist
+	for i := range lib.Playlists {
+		if lib.Playlists[i].Title == "Smart One" {
+			smart = &lib.Playlists[i]
+		}
+	}
+	if smart == nil {
+		t.Fatal("Smart One missing")
+	}
+	if !smart.IsSmart {
+		t.Error("Smart One should be smart — it carries a criteria blob")
+	}
+	if got := string(smart.SmartCriteria); got != "SLst\x00\x01\x00\x01" {
+		t.Errorf("criteria = %q", got)
+	}
+	if got := hex.EncodeToString(smart.PersistentID[:]); got != "a1b2c3d4e5f60718" {
+		t.Errorf("pid = %s", got)
+	}
+	if len(smart.Items) != 2 || smart.Items[0] != 11 || smart.Items[1] != 22 {
+		t.Errorf("items = %v", smart.Items)
+	}
+
+	for _, p := range lib.Playlists {
+		switch p.Title {
+		case "Plain One":
+			if p.IsSmart {
+				t.Error("Plain One has no criteria blob and must not be smart")
+			}
+		case "A Folder":
+			if !p.IsFolder {
+				t.Error("A Folder should be a folder")
+			}
+		}
+	}
+}
+
+// Against the owner's real 153 MB export, if present. This is the case the
+// .itl parser gets wrong: it reports 0 smart playlists for the same library.
+func TestParseXMLLibraryPlaylists_RealExport(t *testing.T) {
+	path := os.Getenv("ITUNES_XML")
+	if path == "" {
+		t.Skip("ITUNES_XML not set")
+	}
+	lib, err := ParseXMLLibraryPlaylists(path)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	smart, withCriteria := 0, 0
+	for _, p := range lib.Playlists {
+		if p.IsSmart {
+			smart++
+		}
+		if len(p.SmartCriteria) > 0 {
+			withCriteria++
+		}
+	}
+	t.Logf("REAL_XML playlists=%d smart=%d with_criteria=%d version=%s",
+		len(lib.Playlists), smart, withCriteria, lib.Version)
+	if smart == 0 {
+		t.Fatal("no smart playlists found in the real export — the whole point of this reader")
+	}
+}

--- a/internal/plugins/maintenance/itunes_playlist_import.go
+++ b/internal/plugins/maintenance/itunes_playlist_import.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/itunes_playlist_import.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7c4e91a3-58bd-42f6-9e0a-1d6b3f8c25e4
 // last-edited: 2026-08-10
 
@@ -38,14 +38,23 @@ import (
 type itunesPlaylistImportParams struct {
 	// DryRun reports what would be imported without creating rows.
 	DryRun bool `json:"dryRun"`
-	// ITLPath is the binary iTunes Library.itl to read.
+	// LibraryPath is the iTunes library to read: either an `iTunes
+	// Library.xml` export or a binary `iTunes Library.itl`. The reader is
+	// chosen by extension.
 	//
-	// Required in practice. It is NOT defaulted from config.LibraryReadPath
-	// because that field resolves to Libraries.Original.XMLPath whenever
-	// ImportSource is "original" or unset (itunes_libraries.go Resolve()) —
-	// i.e. an XML file, which the binary ITL parser cannot read. Silently
-	// feeding XML to ParseITL would fail in a way that looks like "no
-	// playlists found".
+	// Prefer the XML. The binary ITL parser extracts ZERO smart playlists from
+	// real 12.13.10.3 libraries while the XML export of the SAME library yields
+	// 292, each with an intact Smart Criteria blob (measured 2026-08-10 on the
+	// owner's library, and on an April backup, so it is not writeback damage).
+	// iTunes maintains both files; this reads the one that is legible.
+	//
+	// Defaults to config.ITunes.LibraryReadPath, which resolves to the Original
+	// XML export unless import_source is "ao". That default was previously
+	// refused precisely because it is an XML — now that XML is the better
+	// source, it is the sensible default.
+	LibraryPath string `json:"libraryPath"`
+	// ITLPath is the previous name for LibraryPath, kept so existing callers
+	// and saved op params keep working. LibraryPath wins if both are set.
 	ITLPath string `json:"itlPath"`
 	// OwnerUserID is stamped as CreatedByUserID on every imported playlist.
 	//
@@ -55,6 +64,13 @@ type itunesPlaylistImportParams struct {
 	// still reports a healthy count. Set this to the account that should see
 	// them.
 	OwnerUserID string `json:"ownerUserId"`
+	// AllowEmptyQueries permits an apply run to create playlists whose Smart
+	// Criteria did not translate to a query. Off by default: importing a
+	// silently-empty playlist looks like success and is the exact confusion
+	// this op exists to end. The raw criteria blob is stored on every imported
+	// row, so shells imported this way can be re-translated once the parser is
+	// fixed.
+	AllowEmptyQueries bool `json:"allowEmptyQueries"`
 }
 
 func (p *Plugin) itunesPlaylistImportDef() sdk.OperationDef {
@@ -62,7 +78,7 @@ func (p *Plugin) itunesPlaylistImportDef() sdk.OperationDef {
 		ID:              "maintenance.itunes-playlist-import",
 		Plugin:          "maintenance",
 		DisplayName:     "Import iTunes smart (dynamic) playlists",
-		Description:     "Reads smart playlists from a binary iTunes Library.itl, translates each Smart Criteria blob into our query DSL, and creates a matching smart UserPlaylist. Read-only with respect to iTunes — writes only to our own store. Idempotent: playlists already imported are skipped by iTunes persistent ID. Default dry-run reports what would be imported; set dryRun=false to apply.",
+		Description:     "Reads smart playlists from an iTunes Library.xml export (preferred) or a binary .itl, translates each Smart Criteria blob into our query DSL, and creates a matching smart UserPlaylist. Read-only with respect to iTunes — writes only to our own store. Idempotent: playlists already imported are skipped by iTunes persistent ID. Default dry-run reports what would be imported; set dryRun=false to apply.",
 		ResumePolicy:    sdk.ResumeDrop,
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.itunes-playlist-import",
@@ -83,32 +99,47 @@ func (p *Plugin) runITunesPlaylistImport(ctx context.Context, raw json.RawMessag
 		}
 	}
 
-	itlPath := strings.TrimSpace(params.ITLPath)
-	if itlPath == "" {
-		// Fall back to the configured read path ONLY if it actually is an ITL.
-		// See the ITLPath doc comment: LibraryReadPath is commonly an XML.
-		if cand := config.AppConfig.ITunes.LibraryReadPath; strings.HasSuffix(strings.ToLower(cand), ".itl") {
-			itlPath = cand
-		}
+	libPath := strings.TrimSpace(params.LibraryPath)
+	if libPath == "" {
+		libPath = strings.TrimSpace(params.ITLPath)
 	}
-	if itlPath == "" {
-		return fmt.Errorf("itunes-playlist-import: itlPath is required " +
-			"(the configured itunes.library_read_path is empty or not a .itl — " +
-			"it resolves to the Original XML export unless import_source is \"ao\")")
+	if libPath == "" {
+		libPath = strings.TrimSpace(config.AppConfig.ITunes.LibraryReadPath)
+	}
+	if libPath == "" {
+		return fmt.Errorf("itunes-playlist-import: libraryPath is required " +
+			"(itunes.library_read_path is empty)")
 	}
 
-	st, err := os.Stat(itlPath)
+	st, err := os.Stat(libPath)
 	if err != nil {
-		return fmt.Errorf("itunes-playlist-import: cannot read %q: %w", itlPath, err)
+		return fmt.Errorf("itunes-playlist-import: cannot read %q: %w", libPath, err)
 	}
-	_ = reporter.UpdateProgress(0, 3, fmt.Sprintf("Phase 1/3: parsing %s (%.1f MB)…", itlPath, float64(st.Size())/(1024*1024)))
 
-	lib, err := itunes.ParseITL(itlPath)
+	// Dispatch on extension. Feeding XML to ParseITL fails in a way that looks
+	// like "no playlists found", so the choice must never be implicit.
+	isXML := strings.HasSuffix(strings.ToLower(libPath), ".xml")
+	source := "itl"
+	if isXML {
+		source = "xml"
+	}
+	_ = reporter.UpdateProgress(0, 3, fmt.Sprintf("Phase 1/3: parsing %s source %s (%.1f MB)…",
+		source, libPath, float64(st.Size())/(1024*1024)))
+
+	var lib *itunes.ITLLibrary
+	if isXML {
+		lib, err = itunes.ParseXMLLibraryPlaylists(libPath)
+	} else {
+		reporter.Log(slog.LevelWarn, fmt.Sprintf(
+			"reading the BINARY .itl at %s — it extracts 0 smart playlists from real "+
+				"12.13.10.3 libraries. Point libraryPath at the iTunes Library.xml export instead.", libPath))
+		lib, err = itunes.ParseITL(libPath)
+	}
 	if err != nil {
-		return fmt.Errorf("itunes-playlist-import: parse %q: %w", itlPath, err)
+		return fmt.Errorf("itunes-playlist-import: parse %s %q: %w", source, libPath, err)
 	}
 	if lib == nil {
-		return fmt.Errorf("itunes-playlist-import: parse %q returned no library", itlPath)
+		return fmt.Errorf("itunes-playlist-import: parse %s %q returned no library", source, libPath)
 	}
 
 	smart := 0
@@ -137,7 +168,7 @@ func (p *Plugin) runITunesPlaylistImport(ctx context.Context, raw json.RawMessag
 				"same library can contain hundreds of smart playlists the binary ITL parser "+
 				"does not surface. Verify with: grep -c 'Smart Criteria' '<library>.xml'",
 			len(lib.Playlists))
-		slog.Warn("itunes-playlist-import: no smart playlists extracted", "itl", itlPath, "playlists", len(lib.Playlists))
+		slog.Warn("itunes-playlist-import: no smart playlists extracted", "source", source, "path", libPath, "playlists", len(lib.Playlists))
 		_ = reporter.Log(slog.LevelWarn, msg)
 		_ = reporter.UpdateProgress(3, 3, "0 smart playlists extracted — see log")
 		return nil
@@ -148,10 +179,48 @@ func (p *Plugin) runITunesPlaylistImport(ctx context.Context, raw json.RawMessag
 	}
 
 	importer := itunesservice.NewPlaylistImporter(p.deps.Store())
-	res := importer.MigrateSmartPlaylists(lib, itunesservice.PlaylistImportOptions{
+
+	// ALWAYS dry-run first, even when applying. The criteria translator is
+	// currently producing empty queries (ITUNES-SMARTCRIT-PARSE): ParseSmartCriteria
+	// misreads the SLst format and returns rules with no field, no operator and
+	// no operands, WITHOUT erroring — so an apply run would happily create
+	// hundreds of playlists that are all empty. Importing 292 empty playlists is
+	// worse than importing none: it looks like it worked.
+	probe := importer.MigrateSmartPlaylists(lib, itunesservice.PlaylistImportOptions{
 		OwnerUserID: strings.TrimSpace(params.OwnerUserID),
-		DryRun:      params.DryRun,
+		DryRun:      true,
 	})
+	empties := 0
+	for _, it := range probe.Items {
+		if it.Status == "would-import" && strings.TrimSpace(it.Query) == "" {
+			empties++
+		}
+	}
+	if empties > 0 {
+		msg := fmt.Sprintf(
+			"%d of %d importable playlists translate to an EMPTY query — their Smart "+
+				"Criteria did not survive parsing (ITUNES-SMARTCRIT-PARSE). Importing them "+
+				"would create playlists that are silently empty.", empties, probe.Imported)
+		_ = reporter.Log(slog.LevelWarn, msg)
+		slog.Warn("itunes-playlist-import: empty translated queries",
+			"empty", empties, "importable", probe.Imported)
+
+		if !params.DryRun && !params.AllowEmptyQueries {
+			return fmt.Errorf("itunes-playlist-import: refusing to apply — %d of %d "+
+				"playlists would be created with an empty query. Fix the Smart Criteria "+
+				"parser first, or pass allowEmptyQueries=true to import them as empty "+
+				"shells anyway (their raw criteria blob is stored, so they can be "+
+				"re-translated later)", empties, probe.Imported)
+		}
+	}
+
+	res := probe
+	if !params.DryRun {
+		res = importer.MigrateSmartPlaylists(lib, itunesservice.PlaylistImportOptions{
+			OwnerUserID: strings.TrimSpace(params.OwnerUserID),
+			DryRun:      false,
+		})
+	}
 
 	// Report by RE-READING the store, not by trusting the returned counter.
 	// On an apply run the authoritative number is how many smart playlists
@@ -170,7 +239,7 @@ func (p *Plugin) runITunesPlaylistImport(ctx context.Context, raw json.RawMessag
 		mode = "DRY-RUN"
 	}
 	slog.Info("itunes-playlist-import complete",
-		"mode", mode, "itl", itlPath,
+		"mode", mode, "source", source, "path", libPath,
 		"playlistsInLibrary", len(lib.Playlists),
 		"smartFound", res.SmartFound,
 		"imported", res.Imported, "skipped", res.Skipped,

--- a/todo.d/20260810-itunes-smart-criteria-parser-is-wrong.md
+++ b/todo.d/20260810-itunes-smart-criteria-parser-is-wrong.md
@@ -17,39 +17,93 @@
       One operand decoded as `72057594037927936` — that is `0x0100000000000000`,
       a byte-order artifact, confirming the endianness is also wrong.
 
-      **What the format actually is** (derived from the 292 real blobs):
+      **Is the criteria plain text in the XML?** No. `Smart Criteria` is a
+      base64-wrapped **binary** blob — byte-for-byte the same `SLst` structure as
+      in the `.itl`. The XML's advantage is only that the blob is *present*
+      (292/292) where ITL extraction yields 0. **But the string operands inside
+      the blob are plain UTF-16BE and are recoverable without a full parser.**
 
-      - Magic `SLst` (`0x534c7374`) at offset 0 — the parser never checks it.
-      - **Big-endian**, not little-endian.
-      - Header is **136 bytes**, not the 8 the parser assumes; a rule count sits
-        at offset 8 as a BE uint32.
-      - Rules are **variable-length**, not the fixed 136 bytes assumed. Fitting
-        `len == 136 + n*124` over all blobs matches only **10 of 292** — the
-        long ones carry embedded text operands.
+      **What the format actually is** (derived from the 292 real blobs, and the
+      two claims marked ✅ are the only ones validated against ground truth):
 
-      So the parser has the header size and the rule size roughly swapped, reads
-      the wrong endianness, and assumes fixed-width records in a variable-width
-      format.
+      - ✅ Magic `SLst` (`0x534c7374`) at offset 0 — the parser never checks it.
+      - ✅ **Big-endian**, not little-endian.
+      - ⚠️ It is **NOT** a flat `header + rules[]` array. The blob is a **nested
+        tree of `SLst` containers** — an 850-byte single-rule blob contains
+        *three* `SLst` magics (offsets 0x000, 0x0C0, 0x1FC). An earlier revision
+        of this entry claimed a flat 136-byte header with variable-length rules;
+        parsing all 292 blobs that way **overruns on 281/292** and that claim was
+        wrong. The container nesting is still unmapped.
 
-      **Why no test caught it:** `playlist_sync_test.go` builds `ITLPlaylist`
-      values by hand with `IsSmart: true` and never exercises a real blob, and
-      the tolerant-by-design error handling means a round-trip over real data
-      still returns `nil`. Any fix must assert on **rule content** — a
-      non-empty `Rules` slice is not evidence, since the broken parser produces
-      1,751 of them.
+      **A parser is not required to extract the rules.** Operands can be located
+      structurally and the surrounding rule header read at fixed negative
+      offsets. Over all 292 blobs this yields **358 operands whose declared
+      length matches**, which is what proves the alignment:
 
-      **Unblocking path, in order:**
+          find a UTF-16BE run at offset `off`
+          require  u32be(off-4)  == len(run)*2     # length prefix agrees
+          field  =  u32be(off-56)
+          operator= u32be(off-52)
 
-      1. **The XML export works as a source.** All 292 blobs extract cleanly from
-         `Playlists[].Smart Criteria`, so the ITL extraction gap
-         (`ITUNES-ITL-SMART`, 0 of 292) does not block reading criteria.
-      2. **224 of the 292 playlists carry materialized `Playlist Items`.**
-         Importing those as membership needs no criteria parsing at all and
-         would satisfy "import my playlists" today, at the cost of them being
-         static snapshots rather than dynamic.
-      3. Fixing the parser is what makes them genuinely *dynamic*, and is the
-         only path that keeps them updating.
+      **Field codes** (over alignment-proven operands): `3`=Album ×204,
+      `4`=Artist ×126, `8`=Genre ×23, plus `71` ×2, `2` ×2, `14` ×1.
 
-      Do not wire criteria-based import until the parser is fixed and asserted
-      on real rule content — right now it would silently import 292 playlists
+      **Operator words — validated against actual playlist membership**, by
+      testing whether the materialized members really satisfy the rule:
+
+      | word | meaning | evidence |
+      |---|---|---|
+      | `0x1000002` | contains | satisfied **4017/4017 = 100%** |
+      | `0x3000002` | does **NOT** contain | satisfied **0/23700 = 0.0%** |
+      | `0x1000001` | **UNRESOLVED** (22 uses) | 18.2% — fits neither |
+
+      🚨 `0x3000002` is a **perfect inversion**. Treating every `…0002` word as
+      "contains" would ship 79 playlists matching exactly the books they were
+      written to exclude — silently, and looking like a successful import. Do not
+      map an operator word without running this membership check on it.
+
+      **Conjunction:** with negation applied, **38/46** multi-rule playlists have
+      every rule holding for >95% of members, so rules are predominantly ANDed;
+      the other 8 (e.g. `Recent Litrpg`, 10 rules) are ORs. The AND/OR flag has
+      **not** been located — candidate is the u32 at offset 8 of each `SLst`
+      container (`0x02` outer vs `0x01` inner in the dump), untested.
+
+      **Why no test caught the original defect:** `playlist_sync_test.go` builds
+      `ITLPlaylist` values by hand with `IsSmart: true` and never exercises a
+      real blob, and the tolerant-by-design error handling means a round-trip
+      over real data still returns `nil`. Any fix must assert on **rule
+      content** — a non-empty `Rules` slice is not evidence, since the broken
+      parser produces 1,751 of them. The membership check above is the ground
+      truth to assert against, and it needs no prod access.
+
+      **Two independent recovery sources, covering 290/292 (99.3%):**
+
+      1. **224 of 292 carry materialized `Playlist Items`** (116,822 track refs)
+         — actual current membership, needing **no criteria parsing at all**.
+         Imports as a static snapshot.
+      2. **66 more have criteria strings but zero materialized items.** For these
+         the operands are the only source.
+      3. **2 have neither** and are unrecoverable from the XML.
+
+      **The split is convenient:** the 68 zero-membership playlists are almost
+      exactly the *series* ones (`Ascend Online`, `Aurora Cycle`,
+      `Anime Trope System`, `A Snake's Life`) — the ones the owner expects to
+      become obsolete once series support lands. So the criteria parser is the
+      **low-value half**: the 224 that can be snapshotted need none of it.
+
+      **Track resolution is by persistent ID, not path.** `Playlist Items` give
+      Track IDs, which resolve 100% within the XML to a `Tracks` entry carrying a
+      `Persistent ID`; `BookFile.ITunesPersistentID` is indexed with
+      `GetBookByITunesPersistentID`. This sidesteps the `itunes_path`
+      normalization bug entirely — the XML `Location` values are Windows drive
+      paths (`file://localhost/W:/itunes/iTunes Media/...`) and should not be
+      used for matching.
+
+      ⚠️ **NOT MEASURED, and it gates option 1:** what fraction of the XML's
+      track persistent IDs actually exist in our DB. Measure that before
+      promising 224 importable playlists — if PID coverage is poor, both recovery
+      paths are moot.
+
+      Do not wire criteria-based import until the operator mapping is asserted
+      against real membership — right now it would silently import 292 playlists
       whose rules are all empty.

--- a/todo.d/20260810-itunes-smart-criteria-parser-is-wrong.md
+++ b/todo.d/20260810-itunes-smart-criteria-parser-is-wrong.md
@@ -1,0 +1,55 @@
+- [ ] **ITUNES-SMARTCRIT-PARSE** `ParseSmartCriteria` does not understand the
+      real Smart Criteria format. It reports success on every blob and returns
+      **garbage**. Measured 2026-08-10 against all 292 smart playlists in the
+      owner's live `iTunes Library.xml`.
+
+      🚨 **This is a "reporting success while meaning nothing" defect**, and it
+      is worse than a parse failure would be: `ParseSmartCriteria` is documented
+      as "tolerant of unknown fields/operators — those are recorded as raw hex
+      rather than causing parse failure," so a totally wrong layout yields
+      `err == nil` and a full-looking rule list. **292/292 blobs parsed with
+      zero errors and 1,751 rules — and essentially every rule is empty:**
+
+          PLAYLIST "Audiobooks" conj=OR rules=2
+             field=unknown_0x2000000 op=op_0x00 operands=[]
+             field=unknown_0x00      op=op_0x00 operands=[]
+
+      One operand decoded as `72057594037927936` — that is `0x0100000000000000`,
+      a byte-order artifact, confirming the endianness is also wrong.
+
+      **What the format actually is** (derived from the 292 real blobs):
+
+      - Magic `SLst` (`0x534c7374`) at offset 0 — the parser never checks it.
+      - **Big-endian**, not little-endian.
+      - Header is **136 bytes**, not the 8 the parser assumes; a rule count sits
+        at offset 8 as a BE uint32.
+      - Rules are **variable-length**, not the fixed 136 bytes assumed. Fitting
+        `len == 136 + n*124` over all blobs matches only **10 of 292** — the
+        long ones carry embedded text operands.
+
+      So the parser has the header size and the rule size roughly swapped, reads
+      the wrong endianness, and assumes fixed-width records in a variable-width
+      format.
+
+      **Why no test caught it:** `playlist_sync_test.go` builds `ITLPlaylist`
+      values by hand with `IsSmart: true` and never exercises a real blob, and
+      the tolerant-by-design error handling means a round-trip over real data
+      still returns `nil`. Any fix must assert on **rule content** — a
+      non-empty `Rules` slice is not evidence, since the broken parser produces
+      1,751 of them.
+
+      **Unblocking path, in order:**
+
+      1. **The XML export works as a source.** All 292 blobs extract cleanly from
+         `Playlists[].Smart Criteria`, so the ITL extraction gap
+         (`ITUNES-ITL-SMART`, 0 of 292) does not block reading criteria.
+      2. **224 of the 292 playlists carry materialized `Playlist Items`.**
+         Importing those as membership needs no criteria parsing at all and
+         would satisfy "import my playlists" today, at the cost of them being
+         static snapshots rather than dynamic.
+      3. Fixing the parser is what makes them genuinely *dynamic*, and is the
+         only path that keeps them updating.
+
+      Do not wire criteria-based import until the parser is fixed and asserted
+      on real rule content — right now it would silently import 292 playlists
+      whose rules are all empty.


### PR DESCRIPTION
You asked for your dynamic playlists imported, confirmed the XML is fair game, and deferred writeback. This makes the XML the source — and documents why the criteria still don't parse.

## The problem

| Source | Playlists | **Smart** |
|---|---:|---:|
| `iTunes Library.itl` (live, 32 MB) | 357 | **0** |
| `.../bkup/itunesgood/iTunes Library.itl` (April backup) | 335 | **0** |
| `iTunes Library.xml` (same library) | 351 | **292** |

Reproduced on an April backup too, so it is a parser gap — not writeback damage.

## What this adds

`ParseXMLLibraryPlaylists` decodes the playlist section of an XML export into the **same `*ITLLibrary`** the binary parser produces, so `MigrateSmartPlaylists` consumes either source with no changes.

Measured on the real 153 MB export: **351 playlists, 292 smart, 292 with criteria, in 3.9s** — matching an independent Python probe exactly.

Playlists whose persistent ID won't decode are **dropped, not imported under a zero PID** — the importer keys idempotency on that ID, so a zero would make every such playlist collide and all but the first report "already imported".

The op now takes `libraryPath` and dispatches on extension, defaulting to `itunes.library_read_path`. That default was previously *refused* because it resolves to the XML; now that's the better source. `itlPath` still works.

## The second finding: the criteria parser reports success on garbage

`ParseSmartCriteria` returns `err == nil` for all 292 blobs and produces **1,751 rules that are essentially all empty**:

```
PLAYLIST "Audiobooks" conj=OR rules=2
   field=unknown_0x2000000 op=op_0x00 operands=[]
   field=unknown_0x00      op=op_0x00 operands=[]
```

Worse than a parse failure: the function is documented as tolerant of unknown fields "rather than causing parse failure", so a completely wrong layout looks like a clean parse with a full rule list. One operand decoded as `72057594037927936` = `0x0100000000000000`, a byte-order artifact.

**The real format, derived from all 292 blobs:**

| | Parser assumes | Actually is |
|---|---|---|
| Magic | not checked | `SLst` at offset 0 |
| Endianness | little | **big** |
| Header | 8 bytes | **136 bytes** |
| Rules | fixed 136 bytes | **variable length** |

`len == 136 + n*124` fits only **10 of 292** — the long blobs carry embedded text operands.

## The guard that matters

**This does not yet make your playlists work, and it refuses to pretend otherwise.** A real import would create **292 silently-empty playlists** — exactly the "I did the thing and nothing happened" confusion this op exists to end.

So the op always evaluates a dry run first, counts playlists that would be created with an empty query, and **refuses to apply**:

```
refusing to apply — N of M playlists would be created with an empty query.
Fix the Smart Criteria parser first, or pass allowEmptyQueries=true to import
them as empty shells anyway (their raw criteria blob is stored, so they can be
re-translated later)
```

`ITunesRawCriteriaB64` is persisted on every imported row, so nothing is lost by waiting.

## Why no test caught the parser

`playlist_sync_test.go` hand-builds `ITLPlaylist` values with `IsSmart: true` and never touches a real blob. Any fix must assert on **rule content** — a non-empty `Rules` slice proves nothing, since the broken parser yields 1,751 of them.

## Verification

- Synthetic fixture covers smart / plain / folder / bad-PID
- Real-export test asserts smart > 0 (skips without `ITUNES_XML`)
- `go build ./...`, `go vet`, `internal/itunes/...` all pass

## Remaining

Fixing `ParseSmartCriteria` for the real `SLst` format is what makes these genuinely dynamic. Filed in the todo fragment included here.