### PR TITLE
fix(server): the versiongroup backfill never ran in production [skip changelog]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- file: CLAUDE.md -->
-<!-- version: 4.12.0 -->
+<!-- version: 4.13.0 -->
 <!-- guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f -->
 <!-- last-edited: 2026-08-10 -->
 
@@ -65,14 +65,19 @@ resolves it:
 
 ```bash
 cd ../<repo>-<feature>
-go work init .        # gopls: worktrees are SIBLINGS of the main checkout, so a
-                      # language server rooted there reports every file as
-                      # "not included in your workspace". go.work is gitignored.
-                      # A shared parent go.work is NOT an option — every worktree
-                      # declares the same module path, so it fails as a duplicate.
 npm ci --prefix web   # Playwright must come from the worktree, not an orphan
                       # ~/node_modules with a different pinned version.
 ```
+
+> **Do NOT run `go work init .` in a worktree.** It was recommended here briefly
+> on 2026-08-10 to quiet gopls "file not included in your workspace" noise, and it
+> **breaks the build**: workspace mode changes module-graph resolution and
+> re-admits the pre-split monolithic `google.golang.org/genproto` alongside the
+> split `genproto/googleapis/{api,rpc}` modules, so `go build ./...` fails with
+> `ambiguous import` on grpc, grpc-gateway and otel. Measured in a clean worktree:
+> without `go.work` exit 0, with it exit 1. A shared parent `go.work` is not an
+> option either — every worktree declares the same module path and it fails as a
+> duplicate. Accept the gopls noise; verify with real `go build` / `go vet`.
 
 **After merging:** always remove the worktree immediately after the PR merges:
 ```bash

--- a/changelog.d/20260810_231500_vgbackfill_unwrap.md
+++ b/changelog.d/20260810_231500_vgbackfill_unwrap.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- The version-group index backfill had **never run in production**. `Server.Start`
+  resolved it with a bare type assertion on `s.Store()`, but the store is wrapped
+  by the `indexedStore` search decorator, which embeds the `database.Store`
+  *interface* and so does not promote `BackfillVersionGroupIndex`. The assertion
+  missed on every boot where the Bleve index opened — which is every boot in
+  production. Caught 2026-08-10 23:07:40 by the warning added hours earlier in the
+  same area; before that it was completely silent. This is the likely origin of the
+  under-reporting version-group index, which was never built rather than corrupted.
+  Now resolved with `database.AsCapability`, which walks the `Unwrap` chain.

--- a/internal/server/indexed_store_capability_test.go
+++ b/internal/server/indexed_store_capability_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/indexed_store_capability_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2c7f4b18-6e93-4a52-9d81-5f0a3b6c8e27
-// last-edited: 2026-07-31
+// last-edited: 2026-08-10
 
 package server
 
@@ -147,5 +147,81 @@ func TestWipeFixupsReachPebbleThroughDecorator(t *testing.T) {
 	}
 	if _, err := wipeExternalIDs(ms, true); err != nil {
 		t.Errorf("wipeExternalIDs(dryRun) through the decorator: %v", err)
+	}
+}
+
+// TestIndexedStoreExposesVersionGroupBackfill is the THIRD instance of the bug
+// this file exists to prevent, and the first one caught in production by its own
+// log line rather than by a failing job.
+//
+// server_lifecycle.go used a bare `s.Store().(vgBackfiller)` type assertion.
+// BackfillVersionGroupIndex is a *PebbleStore method that deliberately lives
+// outside database.Store, so it is not promoted through the embedded interface
+// and the assertion missed on every boot where the Bleve index opened — i.e.
+// always, in production. MEASURED 2026-08-10 23:07:40 on the prod host:
+//
+//	versiongroup-backfill: store does not implement BackfillVersionGroupIndex,
+//	index will NOT be rebuilt   store_type=*server.indexedStore
+//
+// So the "one-time production repair" for the under-reporting version-group
+// index had never run once. The fix is database.AsCapability, which walks the
+// Unwrap chain.
+//
+// SCOPE: this asserts the capability RESOLVES and EXECUTES through the
+// decorator. It does not re-prove that the backfill writes correct index rows —
+// chunk boundaries, row contents and idempotency are covered by
+// pebble_store_versiongroup_backfill_test.go in package database, which can
+// reach the raw keys.
+func TestIndexedStoreExposesVersionGroupBackfill(t *testing.T) {
+	inner, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = inner.Close() })
+	inner.WaitForWarmup()
+
+	var wrapped database.Store = &indexedStore{Store: inner, server: nil}
+
+	// The shape of the original bug: a bare assertion cannot see it. If this
+	// ever starts succeeding, the decorator has changed and the guard below
+	// stops testing anything — so assert it rather than imply it.
+	if _, ok := wrapped.(vgBackfiller); ok {
+		t.Fatal("a bare type assertion now resolves vgBackfiller through the " +
+			"decorator; this test no longer reproduces the production bug")
+	}
+
+	// The PRODUCTION resolver, not database.AsCapability directly. Calling the
+	// helper here would prove only that the helper works, which says nothing
+	// about whether server_lifecycle.go uses it — the same distinction
+	// TestWipeFixupsReachPebbleThroughDecorator above is built around. Reverting
+	// resolveVGBackfiller to a bare assertion must turn this red.
+	b, ok := resolveVGBackfiller(wrapped)
+	if !ok {
+		t.Fatal("resolveVGBackfiller through indexedStore failed; the " +
+			"version-group index backfill would silently never run")
+	}
+
+	// Seed through the INNER store. Going through the decorator would call
+	// s.server.enqueueIndex on a nil *Server and panic — the same reason every
+	// other test in this file stays read-only. The read below still goes through
+	// the decorator, which is the direction that matters here.
+	gid := "vg-decorator-writethrough"
+	created, err := inner.CreateBook(&database.Book{
+		Title:          "Decorator Backfill Book",
+		VersionGroupID: &gid,
+	})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	if err := b.BackfillVersionGroupIndex(); err != nil {
+		t.Fatalf("BackfillVersionGroupIndex through the decorator: %v", err)
+	}
+	got, err := wrapped.GetBooksByVersionGroup(gid)
+	if err != nil {
+		t.Fatalf("GetBooksByVersionGroup: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != created.ID {
+		t.Fatalf("version group lookup after backfill: got %d books, want 1 (%s)",
+			len(got), created.ID)
 	}
 }

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 3.9.0
+// version: 3.10.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-08-10
 
@@ -1009,14 +1009,18 @@ func (s *Server) startBackfills() {
 	// PERF-VERSIONS: write the book:versiongroup:<gid>:<id> secondary
 	// index for every existing book once so /audiobooks/:id/versions
 	// stops full-scanning. Idempotent and gated by a sentinel key.
+	//
+	// Resolution is deliberately in resolveVGBackfiller (below) rather than
+	// inline here: a test can call that, but it cannot call the body of this
+	// goroutine, and a guard that cannot reach the real call site does not
+	// guard it.
 	s.bgWG.Add("versiongroup-backfill")
 	go func() {
 		defer s.bgWG.Done("versiongroup-backfill")
 		if err := s.bgCtx.Err(); err != nil {
 			return
 		}
-		type vgBackfiller interface{ BackfillVersionGroupIndex() error }
-		b, ok := s.Store().(vgBackfiller)
+		b, ok := resolveVGBackfiller(s.Store())
 		if !ok {
 			// Not a silent fall-through: this is the production repair for an
 			// under-reporting version-group index, and if the store is ever
@@ -1585,4 +1589,38 @@ func GetDefaultServerConfig() ServerConfig {
 		WriteTimeout: 0,                 // Disable write timeout so SSE streams stay open
 		IdleTimeout:  120 * time.Second, // 2 minute idle timeout
 	}
+}
+
+// vgBackfiller is the version-group index repair, which lives on *PebbleStore
+// and deliberately outside database.Store.
+type vgBackfiller interface{ BackfillVersionGroupIndex() error }
+
+// resolveVGBackfiller finds the version-group backfill on the running store.
+//
+// It uses database.AsCapability, NOT a bare type assertion. s.Store() is the
+// *server.indexedStore decorator whenever the Bleve index opened — i.e. always,
+// in production. That decorator embeds the database.Store INTERFACE, so it
+// promotes only that interface's method set and BackfillVersionGroupIndex is
+// invisible through it. AsCapability walks the Unwrap chain and finds it on the
+// inner store.
+//
+// MEASURED IN PRODUCTION 2026-08-10 23:07:40, hours after the caller's warning
+// shipped and minutes after it was first deployed:
+//
+//	versiongroup-backfill: store does not implement BackfillVersionGroupIndex,
+//	index will NOT be rebuilt   store_type=*server.indexedStore
+//
+// The bare assertion had been missing on every boot since the decorator was
+// installed, so this "one-time production repair" had NEVER ONCE RUN, silently.
+// That is the likely origin of the under-reporting version-group index
+// reproduced in #2277: the index was never built, rather than built and then
+// corrupted.
+//
+// This is the THIRD capability lost to the same decorator (after the
+// sync-identity/bookmark set on 2026-07-30 and the maintenance wipe fixups), so
+// it is a function rather than an inline assertion purely so
+// TestIndexedStoreExposesVersionGroupBackfill can execute the real resolution
+// path. A guard that cannot reach the production call site does not guard it.
+func resolveVGBackfiller(s database.Store) (vgBackfiller, bool) {
+	return database.AsCapability[vgBackfiller](s)
 }


### PR DESCRIPTION
## The version-group index backfill has never run in production

`Server.Start` resolved it with a bare type assertion on `s.Store()`. The store is wrapped by the `indexedStore` search decorator, which embeds the `database.Store` **interface** — so it promotes only that interface's method set, and `BackfillVersionGroupIndex` (a `*PebbleStore` method deliberately outside `database.Store`) is invisible through it.

The assertion missed on every boot where the Bleve index opened. That is every boot in production.

### How it surfaced

The warning shipped in #2293 a few hours ago. It fired the first time that code reached prod:

```
2026-08-10 23:07:40  WARN  versiongroup-backfill: store does not implement
BackfillVersionGroupIndex, index will NOT be rebuilt  store_type=*server.indexedStore
```

Before that line existed this was completely silent — indistinguishable from a completed run. This is the likely origin of the under-reporting version-group index reproduced in #2277: **the index was never built, rather than built and then corrupted.**

### Fix

`database.AsCapability`, which walks the `Unwrap` chain. This is the **third** capability lost to this same decorator, after the sync-identity/bookmark set (2026-07-30) and the maintenance wipe fixups.

### The test actually guards the call site

Resolution is extracted into `resolveVGBackfiller` so the test can execute the real path. A test calling `database.AsCapability` directly would stay green after a revert — it would prove the helper works, not that `server_lifecycle.go` uses it. That distinction is the one `TestWipeFixupsReachPebbleThroughDecorator` was already built around.

Verified as an instrument, negative control generated by editing the committed resolver:

| resolver | result |
|---|---|
| `database.AsCapability[vgBackfiller](s)` | exit 0 — PASS |
| reverted to `s.(vgBackfiller)` | exit 1 — **FAIL** |

`go build ./...` 0 · `go vet` 0 · `TestIndexedStore*` 4/4 pass

### Also: reverts the `go work init` guidance from #2292

I added it earlier today to quiet gopls noise. **It breaks the build.** Workspace mode re-admits the pre-split monolithic `google.golang.org/genproto` alongside `genproto/googleapis/{api,rpc}`, so `go build ./...` fails with `ambiguous import` on grpc, grpc-gateway and otel. Measured in a clean worktree: without `go.work` exit 0, with it exit 1. The gopls noise is cosmetic; the build breakage is not.

### Not claimed

Whether the rebuilt index stays complete. `UpdateBook` now writes unconditionally, but that is not measured here, and prod's index state after this deploys is still unknown until the `complete` line appears in the journal.
