### PR TITLE
fix(search): a stopword in a multi-word query returned zero results [skip changelog]

### DIFF
--- a/changelog.d/20260811_015500_search_stopword_conjunction.md
+++ b/changelog.d/20260811_015500_search_stopword_conjunction.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- Multi-word searches containing a common word ("of", "the", "a", "in") returned
+  **no results**. The query parser treats whitespace as AND, so `shards of
+  oblivion` became a conjunction of three match queries — but the English
+  analyzer strips stopwords at index time, so `of` exists in no document's term
+  dictionary and made the whole conjunction unsatisfiable. Single-word searches
+  worked, which made this look like "search breaks when there are spaces". A
+  large share of book titles were unfindable by their own name. Stopword-only
+  conjuncts are now dropped, but only when a real term survives, so searching for
+  `of` alone keeps its previous behaviour instead of returning the whole library.

--- a/internal/search/bleve_translator.go
+++ b/internal/search/bleve_translator.go
@@ -1,7 +1,7 @@
 // file: internal/search/bleve_translator.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9c2a4f1d-5b3e-4f70-a7d6-2e8c0f1b9a47
-// last-edited: 2026-07-10
+// last-edited: 2026-08-11
 //
 // AST → Bleve query translator (spec DES-1 v1.1). Walks the AST
 // produced by ParseQuery and emits a bleve/v2 query.Query suitable
@@ -19,6 +19,9 @@ import (
 	"strconv"
 
 	"github.com/blevesearch/bleve/v2"
+	"github.com/blevesearch/bleve/v2/analysis"
+	"github.com/blevesearch/bleve/v2/analysis/lang/en"
+	"github.com/blevesearch/bleve/v2/registry"
 	"github.com/blevesearch/bleve/v2/search/query"
 )
 
@@ -82,7 +85,7 @@ func translateNode(n Node, perUser *[]PerUserFilter, negated bool) (query.Query,
 
 func translateAnd(n *AndNode, perUser *[]PerUserFilter, negated bool) (query.Query, error) {
 	var children []query.Query
-	for _, c := range n.Children {
+	for _, c := range dropStopwordOnlyConjuncts(n.Children) {
 		q, err := translateNode(c, perUser, negated)
 		if err != nil {
 			return nil, err
@@ -98,6 +101,67 @@ func translateAnd(n *AndNode, perUser *[]PerUserFilter, negated bool) (query.Que
 		return children[0], nil
 	}
 	return bleve.NewConjunctionQuery(children...), nil
+}
+
+// freeTextAnalyzer is the analyzer the index applies to free-text fields
+// (bleve_index.go sets im.DefaultAnalyzer = en.AnalyzerName). It is resolved
+// from the same registry Bleve itself uses, so it cannot drift from the index's
+// notion of a stopword the way a hand-maintained word list would.
+//
+// nil if the registry lookup ever fails; every caller treats nil as "cannot
+// tell", which degrades to the old behaviour rather than to a wrong answer.
+var freeTextAnalyzer = func() analysis.Analyzer {
+	a, err := registry.NewCache().AnalyzerNamed(en.AnalyzerName)
+	if err != nil {
+		return nil
+	}
+	return a
+}()
+
+// isStopwordOnly reports whether a term survives analysis. The English analyzer
+// strips stopwords, so "of" produces zero tokens and therefore appears in no
+// document's term dictionary.
+func isStopwordOnly(term string) bool {
+	if freeTextAnalyzer == nil || term == "" {
+		return false
+	}
+	return len(freeTextAnalyzer.Analyze([]byte(term))) == 0
+}
+
+// dropStopwordOnlyConjuncts removes free-text conjuncts that analyze to nothing,
+// but ONLY when a real term remains.
+//
+// THE BUG (reported 2026-08-11, "shards of oblivion" finds nothing): the parser
+// treats whitespace as AND, so a three-word query becomes a conjunction of three
+// match queries. "of" is an English stopword, so the indexer never wrote it to
+// any document's term dictionary — the conjunct can never be satisfied and takes
+// the entire query down with it. Every multi-word title containing of/the/a/in
+// was unfindable, which is a large share of book titles. Single-word searches
+// worked, which is why this read as "spaces break search".
+//
+// The guard matters as much as the fix. A nil query from Translate becomes
+// MatchAll, so unconditionally dropping stopwords would make a search for "of"
+// return the entire 367K-book library. Requiring a surviving non-stopword term
+// means this only ever fires on the broken case; an all-stopword query keeps its
+// current behaviour exactly.
+//
+// Conjunction only. In a disjunction a stopword child contributes no hits and
+// harms nothing, so OR is deliberately left alone.
+func dropStopwordOnlyConjuncts(children []Node) []Node {
+	kept := make([]Node, 0, len(children))
+	dropped := 0
+	for _, c := range children {
+		if ft, ok := c.(*FreeTextNode); ok && !ft.Quoted && !ft.Prefix && !ft.Fuzzy &&
+			isStopwordOnly(ft.Value) {
+			dropped++
+			continue
+		}
+		kept = append(kept, c)
+	}
+	if dropped == 0 || len(kept) == 0 {
+		return children
+	}
+	return kept
 }
 
 func translateOr(n *OrNode, perUser *[]PerUserFilter, negated bool) (query.Query, error) {

--- a/internal/search/multiword_repro_test.go
+++ b/internal/search/multiword_repro_test.go
@@ -1,0 +1,80 @@
+// file: internal/search/multiword_repro_test.go
+// version: 1.0.0
+// guid: 6f2b9d41-8c05-4e37-a1d9-3b7e0c5a824f
+// last-edited: 2026-08-11
+
+package search
+
+import "testing"
+
+// Reported 2026-08-11: "when there are spaces in the word search doesn't find
+// them. In the app or in the web interface."
+//
+// Exercises the exact path the API uses for a library search box query:
+// ParseQuery -> Translate -> SearchNative. The parser documents whitespace as
+// AND, so a two-word query should require both terms and still match a book
+// whose title contains both.
+func TestMultiWordFreeTextFindsTheBook(t *testing.T) {
+	idx := openTestIndex(t)
+
+	docs := []BookDocument{
+		{BookID: "ascend", Title: "Ascend Online", Author: "Luke Chmilenko"},
+		{BookID: "other", Title: "Completely Different", Author: "Nobody"},
+		{BookID: "shards", Title: "Shards of Oblivion", Author: "Some Author"},
+	}
+	for _, d := range docs {
+		if err := idx.IndexBook(d); err != nil {
+			t.Fatalf("index %s: %v", d.BookID, err)
+		}
+	}
+
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{"single word", "Ascend", "ascend"},
+		{"two words", "Ascend Online", "ascend"},
+		{"two words lowercase", "ascend online", "ascend"},
+		{"title field two words", "title:Ascend Online", "ascend"},
+		{"quoted phrase", `"Ascend Online"`, "ascend"},
+		{"author two words", "Luke Chmilenko", "ascend"},
+		// Owner's actual failing example, 2026-08-11. "of" is an English
+		// stopword: if the index analyzer drops it but the parser still ANDs a
+		// match query for it, the conjunction can never be satisfied and the
+		// whole search returns nothing.
+		{"stopword in the middle", "shards of oblivion", "shards"},
+		{"stopword capitalized", "Shards of Oblivion", "shards"},
+		{"same query without the stopword", "shards oblivion", "shards"},
+		{"trailing space", "shards of oblivion ", "shards"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ast, err := ParseQuery(tc.query)
+			if err != nil {
+				t.Fatalf("parse %q: %v", tc.query, err)
+			}
+			bq, _, err := Translate(ast)
+			if err != nil {
+				t.Fatalf("translate %q: %v", tc.query, err)
+			}
+			hits, total, err := idx.SearchNative(bq, 0, 10)
+			if err != nil {
+				t.Fatalf("search %q: %v", tc.query, err)
+			}
+			if total == 0 {
+				t.Fatalf("query %q returned NO results; want to find %q", tc.query, tc.want)
+			}
+			found := false
+			for _, h := range hits {
+				if h.BookID == tc.want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("query %q did not return %q; got %v (total=%d)",
+					tc.query, tc.want, hitIDs(hits), total)
+			}
+		})
+	}
+}

--- a/todo.d/20260811-cache-search-results.md
+++ b/todo.d/20260811-cache-search-results.md
@@ -1,0 +1,44 @@
+- [ ] **SEARCH-CACHE** Search results are not cached anywhere on the server.
+      Every keystroke-debounced query re-runs the full Bleve search plus the
+      book hydration behind it.
+
+      **Measured by reading the code 2026-08-11:** `AudiobookService` already
+      owns a `listCache`, but it is consulted only on the **non-search** branch
+      of `GetAudiobooks` (`internal/audiobooks/service_query.go`, cache key
+      `all:<limit>:<offset>:p=…:sb=…:asc=…:noq=…`). The `if search != ""` branch
+      goes straight to `searchWithBleve` / `store.SearchBooks` and never touches
+      a cache on the way in or out.
+
+      The frontend has `web/src/stores/useLibraryCache.ts` (50 entries, LRU-ish
+      eviction), so a repeated query from the *same* browser tab may be served
+      client-side — but nothing is shared between users, tabs, or the mobile
+      app, and a cold tab always pays full cost.
+
+      **Why it is worth doing:** the per-user post-filter path fetches a
+      `searchPostFilterWindow`-sized candidate set from Bleve and narrows it in
+      Go, so a search is markedly more expensive than a plain list page. That is
+      also the reason the cache key cannot be the query string alone.
+
+      **Cache key must include, or it will serve wrong results:**
+
+      - the query string,
+      - `limit`/`offset`,
+      - `UserID` whenever per-user filters are active (`PerUserFilters` +
+        `UserID`) — per-user narrowing happens AFTER Bleve returns, so two users
+        running the same query legitimately get different sets,
+      - sort field and direction,
+      - every `ListFilters` value that participates in post-filtering
+        (`LibraryState`, `Tag`/`Tags`, `FieldFilters`, `IsPrimaryVersion`,
+        fingerprint status/coverage bounds).
+
+      ⚠️ **Invalidation is the hard part, and it is the same gap as
+      [MERGE-CACHE-EVICT].** A cached search that outlives an edit, merge or
+      delete shows books that no longer exist, which is exactly the "I merged
+      these and still see two copies" confusion. Prefer wiring it to the
+      existing search-index dirty-set/reconciler
+      (`internal/server/search_reconciler.go`) rather than a bare TTL — or use a
+      short TTL (30–60s) as an explicit, documented first cut and say so in the
+      log.
+
+      Do NOT cache before deciding invalidation. A stale search result is worse
+      than a slow one.


### PR DESCRIPTION
## `shards of oblivion` found nothing

Reported as *"when there are spaces in the word search doesn't find them. In the app or in the web interface."*

It isn't spaces — it's **stopwords**. The parser treats whitespace as AND, so the query became a conjunction of three match queries. The index uses the English analyzer, which strips stopwords, so `of` was never written to any document's term dictionary. Its conjunct could never be satisfied and took the entire query down with it.

Single-word searches worked, which is exactly why this presented as a spaces problem.

### Reproduced first, through the real path

`ParseQuery → Translate → SearchNative`, same as the API:

| query | before | after |
|---|---|---|
| `shards of oblivion` | **no results** | found |
| `Shards of Oblivion` | **no results** | found |
| `shards of oblivion ` (trailing space) | **no results** | found |
| `shards oblivion` | found | found |
| `"shards of oblivion"` (quoted) | found | found |

Any multi-word title containing of/the/a/in was unfindable by its own name — a large share of a book library.

### The guard is as important as the fix

A nil query from `Translate` becomes **MatchAll**. Dropping stopwords unconditionally would make a search for `of` return all 367K books — trading one bad answer for another. Stopword conjuncts are dropped **only when a real term survives**, so an all-stopword query keeps its exact current behaviour.

Conjunctions only. In a disjunction a stopword child contributes no hits and harms nothing, so OR is deliberately untouched.

The stopword test uses the analyzer resolved from Bleve's own registry, not a hand-maintained list, so it cannot drift from what the index actually does. If the lookup ever fails it returns nil and every caller degrades to the old behaviour.

`go build` 0 · `internal/search` ok 4.4s · `internal/audiobooks` ok 43.0s