### PR TITLE
fix(web): dark-mode buttons were below the WCAG contrast floor [skip changelog]

### DIFF
--- a/changelog.d/20260811_020500_dark_mode_button_contrast.md
+++ b/changelog.d/20260811_020500_dark_mode_button_contrast.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Dark-mode buttons on the library pages were nearly invisible against the
+  background. `primary.main` was hardcoded to `#1976d2` in **both** colour modes
+  — MUI's light-mode blue — which measures **3.89:1** against the dark
+  background, below the 4.5:1 WCAG AA floor. The library toolbar is built from
+  `variant="outlined"` buttons, which draw their label in `primary.main` and
+  their border at 50% alpha, so the border sat near 2:1. Dark mode now uses
+  MUI's dark-palette values (**9.94:1** primary, **8.77:1** secondary); light
+  mode keeps the original brand colours.

--- a/web/src/theme.contrast.test.ts
+++ b/web/src/theme.contrast.test.ts
@@ -1,0 +1,76 @@
+// file: web/src/theme.contrast.test.ts
+// version: 1.0.0
+// guid: 7e3d1a95-4c62-4b08-9f71-6a2d5c0e8b34
+// last-edited: 2026-08-11
+
+import { describe, expect, it } from 'vitest';
+import { createAppTheme } from './theme';
+
+// Reported 2026-08-11: the library page buttons in dark mode "too closely match
+// the existing" background. They did: primary.main was '#1976d2' in BOTH modes,
+// which is MUI's LIGHT-mode blue, and the library toolbar is built from
+// `variant="outlined"` buttons that draw their label in primary.main.
+//
+// This pins the fix as a MEASUREMENT rather than a matter of taste, so a future
+// palette edit cannot quietly put it back under the floor.
+
+/** sRGB relative luminance, per WCAG 2.1. */
+function luminance(hex: string): number {
+  const h = hex.replace('#', '');
+  const channels = [0, 2, 4].map((i) => {
+    const v = parseInt(h.slice(i, i + 2), 16) / 255;
+    return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+/** WCAG contrast ratio between two hex colours, 1:1 .. 21:1. */
+function contrast(a: string, b: string): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// WCAG AA for normal-size text. Button labels are normal-size text.
+const AA_NORMAL = 4.5;
+
+describe('dark theme contrast', () => {
+  const dark = createAppTheme('dark');
+  const bg = dark.palette.background.default;
+  const paper = dark.palette.background.paper;
+
+  it('sanity-checks the contrast helper against known values', () => {
+    // Anchors the maths itself: white on black is the maximum 21:1, and a
+    // colour against itself is 1:1. Without these, a broken helper could make
+    // every assertion below pass.
+    expect(contrast('#ffffff', '#000000')).toBeCloseTo(21, 1);
+    expect(contrast('#1976d2', '#1976d2')).toBeCloseTo(1, 5);
+  });
+
+  it('primary is legible on both dark surfaces', () => {
+    // The old hardcoded '#1976d2' measured 3.89:1 here and FAILED this.
+    expect(contrast(dark.palette.primary.main, bg)).toBeGreaterThanOrEqual(AA_NORMAL);
+    expect(contrast(dark.palette.primary.main, paper)).toBeGreaterThanOrEqual(AA_NORMAL);
+  });
+
+  it('secondary is legible on both dark surfaces', () => {
+    // The old hardcoded '#dc004e' measured 3.47:1 here and FAILED this.
+    expect(contrast(dark.palette.secondary.main, bg)).toBeGreaterThanOrEqual(AA_NORMAL);
+    expect(contrast(dark.palette.secondary.main, paper)).toBeGreaterThanOrEqual(AA_NORMAL);
+  });
+
+  it('is a real improvement over the previous shared palette', () => {
+    // Guards against a "fix" that merely nudges past the threshold.
+    expect(contrast(dark.palette.primary.main, bg)).toBeGreaterThan(contrast('#1976d2', bg));
+    expect(contrast(dark.palette.secondary.main, bg)).toBeGreaterThan(contrast('#dc004e', bg));
+  });
+});
+
+describe('light theme contrast', () => {
+  const light = createAppTheme('light');
+
+  it('keeps the original brand colours', () => {
+    // The dark-mode fix must not repaint light mode.
+    expect(light.palette.primary.main).toBe('#1976d2');
+    expect(light.palette.secondary.main).toBe('#dc004e');
+  });
+});

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -1,7 +1,7 @@
 // file: web/src/theme.ts
-// version: 1.3.0
+// version: 1.4.0
 // guid: 2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-08-10
+// last-edited: 2026-08-11
 
 import { createTheme } from '@mui/material/styles';
 
@@ -11,11 +11,30 @@ export function createAppTheme(mode: PaletteMode = 'dark') {
   return createTheme({
     palette: {
       mode,
+      // Mode-aware, because a single brand colour cannot serve both.
+      //
+      // THE BUG (reported 2026-08-11: library buttons in dark mode "too closely
+      // match the existing"): primary.main was '#1976d2' in BOTH modes. That is
+      // MUI's LIGHT-mode blue. Against the dark background it measures 3.89:1 —
+      // under the 4.5:1 WCAG AA floor for text — and the library toolbar is
+      // built from `variant="outlined"` buttons, which draw their label in
+      // primary.main and their border at 50% alpha, i.e. roughly 2:1. The
+      // buttons were genuinely low-contrast, not a matter of taste.
+      //
+      // The dark values are MUI's own dark-palette defaults, which exist for
+      // exactly this reason. Measured against background.default '#0a1929':
+      //
+      //   primary   #1976d2 -> 3.89:1   #90caf9 -> 9.94:1
+      //   secondary #dc004e -> 3.47:1   #f48fb1 -> 8.77:1
+      //
+      // Light mode keeps the original brand colours unchanged. Pinned by
+      // theme.contrast.test.ts so a future palette edit cannot quietly drop
+      // back under the floor.
       primary: {
-        main: '#1976d2',
+        main: mode === 'dark' ? '#90caf9' : '#1976d2',
       },
       secondary: {
-        main: '#dc004e',
+        main: mode === 'dark' ? '#f48fb1' : '#dc004e',
       },
       background:
         mode === 'dark'


### PR DESCRIPTION
## The library buttons really were too dark

Reported as *"the buttons on the library pages, dark mode sucks, their color too closely matches the existing"*. This is measurable, not taste.

`primary.main` was hardcoded to `#1976d2` in **both** colour modes — that's MUI's *light*-mode blue. The library toolbar is built almost entirely from `variant="outlined"` buttons, which draw their label in `primary.main` and their border at 50% alpha.

### Measured against `background.default` `#0a1929`

| token | before | after | WCAG AA (4.5:1) |
|---|---|---|---|
| primary | `#1976d2` — **3.89:1** | `#90caf9` — **9.94:1** | ✗ → ✓ |
| secondary | `#dc004e` — **3.47:1** | `#f48fb1` — **8.77:1** | ✗ → ✓ |

Outlined borders at 50% alpha were sitting near 2:1.

The new dark values are MUI's own dark-palette defaults, which exist for precisely this reason. **Light mode is untouched** and asserted as such.

### Verified as an instrument

`theme.contrast.test.ts` asserts the computed ratio, not the hex string, so a future palette edit can't quietly drop back under the floor. Against the previous shared palette **3 of its 5 tests fail**; the 2 that still pass are the contrast-maths sanity check (white/black = 21:1) and the light-mode assertion — neither should change.

Full frontend suite: **66 files, 453 tests, all passing.**