### PR TITLE
fix(organizer): stop writing the literal word "narrator" into filenames [skip changelog]

### DIFF
--- a/changelog.d/20260811_140000_fix_organizer_narrator_placeholder.md
+++ b/changelog.d/20260811_140000_fix_organizer_narrator_placeholder.md
@@ -1,0 +1,69 @@
+### Fixed
+
+#### The organizer wrote the literal word "narrator" into real filenames
+
+Books with no narrator were organized to paths like
+`.../Jerry Merritt/Time Pebbles/Time Pebbles/Time Pebbles - Jerry Merritt - read by narrator.mp3`.
+Measured on production 2026-08-11: of 3,194 books failing organize with
+`ErrTargetOccupied`, 2,611 (82%) had computed a path containing the literal
+string `read by narrator`.
+
+`internal/organizer/organizer.go` declared `defaultNarrator = "narrator"` and
+substituted it whenever `book.Narrator` was blank, so the value never reached
+the empty-placeholder handling that every other unset field goes through.
+
+Deleting that default is necessary but not sufficient. The default pattern is
+`{title} - {author} - read by {narrator}`, and the existing
+`removeEmptySegment` only knows four shapes — ` - {placeholder}`,
+`{placeholder} - `, `({placeholder}…)` and `(…{placeholder})`. Blanking the
+narrator alone left the connector words behind: `cleanupPattern` trims trailing
+` -/` characters but has no idea that "read by" is connective text. Measured
+with the default removed and nothing else changed:
+
+```
+{title} - {author} - read by {narrator}  ->  "Time Pebbles - Jerry Merritt - read by"
+```
+
+Mid-string it was worse than a cosmetic dangle. With the pattern
+`{title} - read by {narrator} - {author}`, the ` - {narrator}` rule consumed
+the *wrong* dash and glued the connector onto the next field, producing a
+filename that credits the author as the narrator:
+
+```
+{title} - read by {narrator} - {author}  ->  "Time Pebbles - read by Jerry Merritt"
+```
+
+The fix is a new `dropEmptyPatternSegments` pass that runs on the **raw**
+pattern, before any substitution, and removes each ` - `-delimited segment
+whose placeholders are *all* empty — connector words included. Three rules keep
+it from over-deleting:
+
+- A segment containing no placeholders is literal text the user asked for and
+  is always kept.
+- A segment where at least one placeholder has a value is kept, so
+  `{title} - {series} {series_number}` still renders `Title - Series Name`
+  for a book with a series but no series number.
+- A placeholder that is not a known field at all (a typo) is *not* treated as
+  empty, so it survives into the unresolved-placeholder check and a bad
+  pattern still errors loudly instead of silently swallowing its segment.
+
+Running before substitution is load-bearing: splitting on ` - ` after values
+are in would tear apart a book titled `Foundation - Part 1`. That case is
+pinned by a test.
+
+Because a pattern can now legitimately expand to nothing, `generateTargetPath`
+falls back to the book's own title (then `Unknown Title`) rather than emitting
+a bare `.m4b` dotfile that every narrator-less book would collide on.
+
+The config default is deliberately unchanged — deployed configs already contain
+`read by {narrator}`, so fixing the expansion engine is the only layer that
+helps them.
+
+**Scope, honestly:** this makes computed filenames correct. It does **not** by
+itself clear the 3,194 occupied-path organize failures, which are dominated by
+books with duplicated or swapped author+title metadata — roughly 250 distinct
+books compute one identical path. Note also that the next organize pass will
+*rename* previously-organized narrator-less files, since their computed target
+has changed. Known limitation: only ` - `-delimited and parenthesized segments
+are dropped, so a custom pattern using another connector (`{title} by
+{narrator}`) still leaves a dangling "by".

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -1,7 +1,7 @@
 // file: internal/organizer/organizer.go
-// version: 1.19.0
+// version: 1.20.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-07-17
+// last-edited: 2026-08-11
 
 package organizer
 
@@ -59,10 +59,22 @@ func (o *Organizer) SetStore(s database.Store) {
 }
 
 const (
-	defaultTitle    = "Unknown Title"
-	defaultNarrator = "narrator"
-	tempFileSuffix  = ".tmp"
+	defaultTitle   = "Unknown Title"
+	tempFileSuffix = ".tmp"
+
+	// patternSegmentSep is the delimiter that separates naming-pattern
+	// segments. A segment is the unit that gets dropped wholesale when every
+	// placeholder inside it is empty — see dropEmptyPatternSegments.
+	patternSegmentSep = " - "
 )
+
+// NOTE: there is deliberately no defaultNarrator constant. It used to be
+// "narrator", and expandPattern substituted it whenever a book had no narrator.
+// With the default pattern `{title} - {author} - read by {narrator}` that wrote
+// the literal word into real filenames: measured on production 2026-08-11,
+// 2,611 of 3,194 books failing organize with ErrTargetOccupied had computed a
+// path ending in "- read by narrator". Empty narrator now takes the
+// empty-placeholder path like every other unset field.
 
 var (
 	leftoverPlaceholderRegex  = regexp.MustCompile(`\{[^}]+\}`)
@@ -242,7 +254,19 @@ func (o *Organizer) generateTargetPath(book *database.Book) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("file pattern: %w", err)
 	}
-	fileName = sanitizeFilename(fileName) + ext
+	// A pattern can now legitimately expand to nothing — e.g. the (unusual)
+	// pattern "{narrator}" for a book with no narrator, which before this
+	// commit expanded to the literal word "narrator". An empty stem would make
+	// the target a bare dotfile (".m4b") that EVERY such book collides on, so
+	// fall back to the book's own title, and only then to defaultTitle.
+	stem := sanitizeFilename(fileName)
+	if strings.TrimSpace(stem) == "" {
+		stem = sanitizeFilename(strings.TrimSpace(book.Title))
+	}
+	if strings.TrimSpace(stem) == "" {
+		stem = sanitizeFilename(defaultTitle)
+	}
+	fileName = stem + ext
 
 	// When iTunes path trimming is enabled, shorten the filename stem so the
 	// Windows-equivalent path stays under MAX_PATH (260 chars). This uses
@@ -325,9 +349,6 @@ func (o *Organizer) expandPattern(pattern string, book *database.Book) (string, 
 	}
 
 	narrator := strings.TrimSpace(stringOrEmpty(book.Narrator))
-	if narrator == "" {
-		narrator = defaultNarrator
-	}
 
 	// Replacements map
 	replacements := map[string]string{
@@ -348,6 +369,24 @@ func (o *Organizer) expandPattern(pattern string, book *database.Book) (string, 
 		"{quality}":       stringOrEmpty(book.Quality),
 	}
 
+	// Drop whole segments whose placeholders are ALL empty, before any
+	// substitution happens. This has to run on the raw pattern: it is the only
+	// point at which the connector words around a placeholder are still
+	// identifiable as part of the pattern rather than as book metadata.
+	//
+	// Without it, `{title} - {author} - read by {narrator}` with no narrator
+	// leaves the literal "read by" behind — cleanupPattern trims " -/" but has
+	// no idea "read by" is connective text. Mid-string it is worse: the old
+	// ` - {narrator}` rule ate the wrong dash and produced
+	// "Time Pebbles - read by Jerry Merritt", crediting the AUTHOR as narrator.
+	empties := make(map[string]struct{}, len(replacements))
+	for placeholder, value := range replacements {
+		if strings.TrimSpace(value) == "" {
+			empties[placeholder] = struct{}{}
+		}
+	}
+	result = dropEmptyPatternSegments(result, empties)
+
 	// Perform replacements
 	for placeholder, value := range replacements {
 		if strings.TrimSpace(value) == "" {
@@ -364,6 +403,54 @@ func (o *Organizer) expandPattern(pattern string, book *database.Book) (string, 
 		return "", fmt.Errorf("naming pattern produced %q with unresolved placeholders %v — book is missing values for these fields, or the pattern references unknown placeholders", result, leftover)
 	}
 	return result, nil
+}
+
+// dropEmptyPatternSegments removes each " - "-delimited segment of a naming
+// pattern whose placeholders are ALL empty, including any literal connector
+// words the segment carries ("read by", "narrated by", "#", ...).
+//
+// It must be called on the RAW pattern, before any substitution: once values
+// are in, a title like "Foundation - Part 1" is indistinguishable from a
+// segment boundary and would be split apart.
+//
+// Rules, in order:
+//   - A segment with no placeholders at all is literal text the user asked
+//     for; it is always kept.
+//   - A segment where at least one placeholder has a value is kept, and the
+//     empty placeholders inside it are cleaned up downstream by
+//     removeEmptySegment / cleanupPattern. This is what stops
+//     `{title} - {series} {series_number}` from losing the series name just
+//     because the book has no series number.
+//   - Only a segment where every placeholder is empty is dropped.
+//
+// Placeholders that are not in the replacements map at all (typos, unknown
+// fields) are deliberately NOT treated as empty — they survive into the
+// leftover-placeholder check in expandPattern so a bad pattern errors loudly
+// instead of silently deleting the segment that referenced it.
+//
+// Path components are handled independently so an empty folder level collapses
+// on its own; cleanupPattern squashes the resulting "//".
+func dropEmptyPatternSegments(pattern string, empties map[string]struct{}) string {
+	components := strings.Split(pattern, "/")
+	for i, component := range components {
+		segments := strings.Split(component, patternSegmentSep)
+		kept := segments[:0:0]
+		for _, segment := range segments {
+			placeholders := leftoverPlaceholderRegex.FindAllString(segment, -1)
+			allEmpty := len(placeholders) > 0
+			for _, placeholder := range placeholders {
+				if _, empty := empties[placeholder]; !empty {
+					allEmpty = false
+					break
+				}
+			}
+			if !allEmpty {
+				kept = append(kept, segment)
+			}
+		}
+		components[i] = strings.Join(kept, patternSegmentSep)
+	}
+	return strings.Join(components, "/")
 }
 
 // removeEmptySegment removes segments containing empty placeholders

--- a/internal/organizer/organizer_test.go
+++ b/internal/organizer/organizer_test.go
@@ -1,6 +1,7 @@
 // file: internal/organizer/organizer_test.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
+// last-edited: 2026-08-11
 
 package organizer
 
@@ -588,6 +589,10 @@ func TestExpandPattern_EmptyTitle(t *testing.T) {
 	}
 }
 
+// TestExpandPattern_EmptyNarrator previously asserted that a blank narrator was
+// substituted with the literal string "narrator" (defaultNarrator). That default
+// was the production bug — it wrote the word "narrator" into real filenames — so
+// the test now pins the opposite: a blank narrator expands to nothing.
 func TestExpandPattern_EmptyNarrator(t *testing.T) {
 	org := &Organizer{config: &config.Config{}}
 
@@ -602,8 +607,213 @@ func TestExpandPattern_EmptyNarrator(t *testing.T) {
 		t.Fatalf("expand pattern failed: %v", err)
 	}
 
-	if result != defaultNarrator {
-		t.Errorf("expected %q, got %q", defaultNarrator, result)
+	if result != "" {
+		t.Errorf("expected an empty expansion, got %q", result)
+	}
+
+	// And in a realistic pattern the connector words go with it.
+	result, err = org.expandPattern("{title} - read by {narrator}", book)
+	if err != nil {
+		t.Fatalf("expand pattern failed: %v", err)
+	}
+	if result != "Book" {
+		t.Errorf("expected %q, got %q", "Book", result)
+	}
+}
+
+// TestExpandPattern_EmptySegmentDropsConnectorWords covers the production bug
+// where a book with no narrator was organized to a path containing the literal
+// word "narrator" (measured 2026-08-11: 2,611 of 3,194 occupied-path organize
+// failures contained "read by narrator").
+//
+// The requirement is stronger than "don't substitute a default": with the
+// default pattern `{title} - {author} - read by {narrator}`, blanking the
+// narrator alone leaves a dangling literal "read by". The whole " - "-delimited
+// segment has to go — but only when EVERY placeholder in that segment is empty.
+func TestExpandPattern_EmptySegmentDropsConnectorWords(t *testing.T) {
+	const defaultPattern = "{title} - {author} - read by {narrator}"
+
+	blank := "   "
+	tests := []struct {
+		name     string
+		pattern  string
+		book     *database.Book
+		expected string
+	}{
+		{
+			name:    "narrator present is kept with its connector words",
+			pattern: defaultPattern,
+			book: &database.Book{
+				Title:    "Time Pebbles",
+				Author:   &database.Author{Name: "Jerry Merritt"},
+				Narrator: stringPtr("Rob Inglis"),
+			},
+			expected: "Time Pebbles - Jerry Merritt - read by Rob Inglis",
+		},
+		{
+			name:    "narrator nil drops the whole read-by segment",
+			pattern: defaultPattern,
+			book: &database.Book{
+				Title:  "Time Pebbles",
+				Author: &database.Author{Name: "Jerry Merritt"},
+			},
+			expected: "Time Pebbles - Jerry Merritt",
+		},
+		{
+			name:    "narrator whitespace-only drops the whole read-by segment",
+			pattern: defaultPattern,
+			book: &database.Book{
+				Title:    "Reality Alternatives",
+				Author:   &database.Author{Name: "Lesley L. Smith"},
+				Narrator: &blank,
+			},
+			expected: "Reality Alternatives - Lesley L. Smith",
+		},
+		{
+			name:    "empty placeholder mid-string drops only that segment",
+			pattern: "{title} - read by {narrator} - {author}",
+			book: &database.Book{
+				Title:  "Time Pebbles",
+				Author: &database.Author{Name: "Jerry Merritt"},
+			},
+			expected: "Time Pebbles - Jerry Merritt",
+		},
+		{
+			name:    "segment with two placeholders keeps the segment when one is filled",
+			pattern: "{title} - {series} {series_number}",
+			book: &database.Book{
+				Title:  "Book Title",
+				Author: &database.Author{Name: "Author Name"},
+				Series: &database.Series{Name: "Series Name"},
+			},
+			expected: "Book Title - Series Name",
+		},
+		{
+			name:    "segment with two placeholders is dropped only when both are empty",
+			pattern: "{title} - {series} {series_number}",
+			book: &database.Book{
+				Title:  "Book Title",
+				Author: &database.Author{Name: "Author Name"},
+			},
+			expected: "Book Title",
+		},
+		{
+			name:    "literal-only segments are never dropped",
+			pattern: "{title} - Audiobook - read by {narrator}",
+			book: &database.Book{
+				Title: "Book Title",
+			},
+			expected: "Book Title - Audiobook",
+		},
+		{
+			name:    "empty placeholder in parentheses still drops the parens",
+			pattern: "{title} ({print_year}) - read by {narrator}",
+			book: &database.Book{
+				Title: "Book Title",
+			},
+			expected: "Book Title",
+		},
+		{
+			// The segment split runs on the RAW pattern, never on substituted
+			// text — otherwise a title containing " - " would be torn apart.
+			name:    "title containing the segment separator survives intact",
+			pattern: defaultPattern,
+			book: &database.Book{
+				Title:    "Foundation - Part 1",
+				Author:   &database.Author{Name: "Isaac Asimov"},
+				Narrator: stringPtr("Scott Brick"),
+			},
+			expected: "Foundation - Part 1 - Isaac Asimov - read by Scott Brick",
+		},
+		{
+			name:    "title containing the separator survives a dropped sibling segment",
+			pattern: defaultPattern,
+			book: &database.Book{
+				Title:  "Foundation - Part 1",
+				Author: &database.Author{Name: "Isaac Asimov"},
+			},
+			expected: "Foundation - Part 1 - Isaac Asimov",
+		},
+		{
+			name:    "folder pattern with empty series collapses the path component",
+			pattern: "{author}/{series}/{title}",
+			book: &database.Book{
+				Title:  "Book Title",
+				Author: &database.Author{Name: "Author Name"},
+			},
+			expected: "Author Name/Book Title",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			org := &Organizer{config: &config.Config{}}
+			result, err := org.expandPattern(tt.pattern, tt.book)
+			if err != nil {
+				t.Fatalf("expand pattern failed: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("pattern %q:\n  expected: %q\n  got:      %q", tt.pattern, tt.expected, result)
+			}
+			if strings.Contains(strings.ToLower(result), "read by") && tt.book.Narrator == nil {
+				t.Errorf("pattern %q leaked a dangling connector: %q", tt.pattern, result)
+			}
+		})
+	}
+}
+
+// TestExpandPattern_UnknownPlaceholderIsNotEmpty pins the discriminating case
+// for dropEmptyPatternSegments: an unknown placeholder must NOT be treated as
+// empty. If it were, a typo'd pattern would have its segment silently deleted
+// instead of raising the unresolved-placeholder error.
+func TestExpandPattern_UnknownPlaceholderIsNotEmpty(t *testing.T) {
+	org := &Organizer{config: &config.Config{}}
+	book := &database.Book{
+		Title:  "Book Title",
+		Author: &database.Author{Name: "Author Name"},
+	}
+
+	// {narrator} is empty and {unknown_field} is unknown — they share a
+	// segment, so the segment must survive and the error must still fire.
+	if _, err := org.expandPattern("{title} - read by {narrator} {unknown_field}", book); err == nil {
+		t.Fatal("expected an unresolved-placeholder error, got nil")
+	} else if !strings.Contains(err.Error(), "unresolved placeholders") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Same, with the unknown placeholder alone in its own segment.
+	if _, err := org.expandPattern("{title} - read by {narrator} - {unknown_field}", book); err == nil {
+		t.Fatal("expected an unresolved-placeholder error for a lone unknown placeholder, got nil")
+	}
+}
+
+// TestGenerateTargetPath_EmptyStemFallsBackToTitle covers the new failure mode
+// created by dropping empty segments: a pattern that expands to nothing would
+// otherwise produce a bare dotfile (".m4b") that every narrator-less book
+// collides on.
+func TestGenerateTargetPath_EmptyStemFallsBackToTitle(t *testing.T) {
+	tmpDir := t.TempDir()
+	org := &Organizer{
+		config: &config.Config{
+			RootDir:             tmpDir,
+			FolderNamingPattern: "{author}",
+			FileNamingPattern:   "read by {narrator}",
+		},
+	}
+
+	book := &database.Book{
+		Title:    "Time Pebbles",
+		Author:   &database.Author{Name: "Jerry Merritt"},
+		FilePath: "/source/time-pebbles.m4b",
+	}
+
+	got, err := org.generateTargetPath(book)
+	if err != nil {
+		t.Fatalf("generate target path: %v", err)
+	}
+	want := filepath.Join(tmpDir, "Jerry Merritt", "Time Pebbles.m4b")
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
 	}
 }
 

--- a/internal/organizer/pattern_test.go
+++ b/internal/organizer/pattern_test.go
@@ -1,6 +1,7 @@
 // file: internal/organizer/pattern_test.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 9a0b1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d
+// last-edited: 2026-08-11
 
 package organizer
 
@@ -204,7 +205,9 @@ func TestPatternExpansionWithRealData(t *testing.T) {
 			folderPattern:  "{author}/{series}",
 			filePattern:    "{title} - {narrator}",
 			expectedFolder: "Unknown Author",
-			expectedFile:   "Unknown Title - narrator.m4b",
+			// Title falls back to "Unknown Title", but an absent narrator is
+			// NOT defaulted to the word "narrator" — its segment is dropped.
+			expectedFile: "Unknown Title.m4b",
 		},
 	}
 
@@ -262,8 +265,9 @@ func TestEmptyFieldRemoval(t *testing.T) {
 				Title:  "Book Title",
 				Author: &database.Author{Name: "Jane Doe"},
 			},
-			pattern:  "{title} - {narrator}",
-			expected: "Book Title - narrator",
+			pattern: "{title} - {narrator}",
+			// Was "Book Title - narrator" — the defaultNarrator bug.
+			expected: "Book Title",
 		},
 		{
 			name: "keep filled narrator",


### PR DESCRIPTION
## The bug

The organizer wrote the literal word `narrator` into real filenames:

```
/mnt/bigdata/books/audiobook-organizer/Jerry Merritt/Time Pebbles/Time Pebbles/Time Pebbles - Jerry Merritt - read by narrator.mp3
/mnt/bigdata/books/audiobook-organizer/Lesley L. Smith/Reality Alternatives/Reality Alternatives/Reality Alternatives - Lesley L. Smith - read by narrator.mp3
```

Measured on production 2026-08-11: of 3,194 organize failures with
`ErrTargetOccupied`, **2,611 (82%)** had the literal string `read by narrator`
in the computed path.

`internal/organizer/organizer.go` declared `defaultNarrator = "narrator"` and
substituted it whenever `book.Narrator` was blank, so the value never reached
the empty-placeholder handling (`removeEmptySegment`) that every other unset
field goes through.

## Why deleting the default is not the fix

The default pattern is `{title} - {author} - read by {narrator}`.
`removeEmptySegment` only knows four shapes — ` - {placeholder}`,
`{placeholder} - `, `({placeholder}…)`, `(…{placeholder})` — and
`cleanupPattern` trims trailing ` -/` characters but has no idea that "read by"
is connective text.

I measured this rather than assuming it. With `defaultNarrator` removed and
**nothing else changed**:

```
{title} - {author} - read by {narrator}   ->  "Time Pebbles - Jerry Merritt - read by"
```

and, worse, mid-string the ` - {placeholder}` rule consumed the **wrong dash**
and glued the connector onto the next field — producing a filename that
credits the author as the narrator:

```
{title} - read by {narrator} - {author}   ->  "Time Pebbles - read by Jerry Merritt"
```

That second shape is a correctness bug, not a cosmetic one, and it is the
reason the fix has to operate on segments rather than on placeholders.

## The fix

New `dropEmptyPatternSegments` runs on the **raw** pattern, before any
substitution, and drops each ` - `-delimited segment whose placeholders are
*all* empty — connector words included. Four rules govern it, three of which
exist to stop it over-deleting:

| Case | Behaviour |
|---|---|
| Segment with no placeholders (`Audiobook`) | always kept — it is literal text the user asked for |
| Segment where at least one placeholder is filled (`{series} {series_number}`, series set, number empty) | kept; the empty placeholder is cleaned up downstream as before |
| Segment where every placeholder is empty (`read by {narrator}`) | dropped whole |
| Placeholder that is not a known field (`{unknown_field}`) | **not** treated as empty — survives into the unresolved-placeholder error so a typo'd pattern still fails loudly |

Running before substitution is load-bearing: splitting on ` - ` *after* values
are in would tear apart a book titled `Foundation - Part 1`. There is a test
pinning exactly that.

`removeEmptySegment` is unchanged and still handles the parenthesised shapes.
It cannot over-delete after this pass, because any empty placeholder that
survives is by construction in a mixed segment.

Because a pattern can now legitimately expand to nothing, `generateTargetPath`
falls back to the book's own title (then `Unknown Title`) instead of emitting a
bare `.m4b` dotfile that every narrator-less book would collide on. That guard
was verified by disabling it and watching the test go red — with both fallback
branches short-circuited, the computed target really is
`.../Jerry Merritt/.m4b`.

**Config defaults are deliberately untouched.** Deployed configs already
contain `read by {narrator}`, so fixing the expansion engine is the only layer
that helps them; changing the default would also break `config_test.go:55`
and `:433` for no gain.

## Tests

Red first. Against unmodified `main`:

```
--- FAIL: TestExpandPattern_EmptySegmentDropsConnectorWords/narrator_nil_drops_the_whole_read-by_segment
    expected: "Time Pebbles - Jerry Merritt"
    got:      "Time Pebbles - Jerry Merritt - read by narrator"
--- FAIL: .../empty_placeholder_mid-string_drops_only_that_segment
    expected: "Time Pebbles - Jerry Merritt"
    got:      "Time Pebbles - read by narrator - Jerry Merritt"
```

Green after:

```
--- PASS: TestExpandPattern_EmptySegmentDropsConnectorWords (11 subtests)
--- PASS: TestExpandPattern_UnknownPlaceholderIsNotEmpty
--- PASS: TestGenerateTargetPath_EmptyStemFallsBackToTitle
ok  	github.com/falkcorp/audiobook-organizer/internal/organizer
```

Coverage: narrator present; narrator nil; narrator whitespace-only;
`{narrator}` mid-string; a segment with two placeholders where only one is
empty; the same segment with both empty; literal-only segment; parenthesised
empty placeholder; folder-pattern path component; title containing ` - `
(with and without a dropped sibling segment); unknown placeholder still errors.

Two existing tests **encoded the bug** and were updated, not deleted:
`organizer_test.go` `TestExpandPattern_EmptyNarrator` (asserted the literal
`"narrator"`) and `pattern_test.go` (`"Unknown Title - narrator.m4b"` and
`"Book Title - narrator"`).

## Scope — what this does NOT fix

- **This does not unblock the 3,194 occupied-path organize failures.** Those
  are dominated by books with duplicated or swapped author+title metadata —
  roughly 250 distinct books compute one identical target path. This PR makes
  the computed filename correct; it does not deduplicate that metadata.
- **The next organize pass will rename** previously-organized narrator-less
  files, because their computed target has changed. Desirable, but it is a
  mass-rename event and should be expected.
- **Known limitation:** only ` - `-delimited and parenthesised segments are
  dropped. A custom pattern using a different connector (`{title} by
  {narrator}`) will still leave a dangling "by".

## Verification

- `go build ./...` — exit 0
- `go test ./internal/organizer/...` — exit 0
- `go vet ./internal/organizer/` — exit 0
- `gofmt -l` clean on all three changed Go files (two pre-existing unformatted
  files in the package, `path_format.go` and `path_format_test.go`, were not
  touched)

Not verified: no run against production data, and no E2E/frontend run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp
