### PR TITLE
fix(organize): checkpoint-based pre-organize backup, progress, freshness skip [skip changelog]

### DIFF
--- a/changelog.d/20260811_070000_organize_autobackup.md
+++ b/changelog.d/20260811_070000_organize_autobackup.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- Every library organize spent 20-25 minutes on a pre-organize database backup
+  that then failed, so from the UI the operation appeared never to start. The
+  backup archived the **live** PebbleDB directory, so compaction deleted `.sst`
+  and `.log` files between the directory walk enumerating them and the archiver
+  reading them — measured twice on a 14 GB production database (20m28s and
+  24m31s, both ending in `lstat .../536537.sst: no such file or directory`).
+  Meanwhile the phase reported no progress at all, so the operations registry
+  logged `strike recorded ... kind=stuck` against an operation that was working.
+  The backup now uses PebbleDB's `Checkpoint` (flush + hard-link, consistent by
+  construction), announces itself through the progress channel, and is skipped
+  when a successful backup is already less than six hours old.
+- The system backup handler resolved `Checkpointable` with a bare type
+  assertion, which the search-index store decorator silently defeated — so the
+  manual "create backup" button had quietly been taking the same racy
+  live-directory archive. It now resolves the capability through the decorator
+  chain and logs loudly when it cannot.

--- a/internal/organizer/auto_backup_test.go
+++ b/internal/organizer/auto_backup_test.go
@@ -1,0 +1,142 @@
+// file: internal/organizer/auto_backup_test.go
+// version: 1.0.0
+// guid: 4b7e2d18-9c53-4a06-8f21-6d5e3a90c471
+// last-edited: 2026-08-11
+
+package organizer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/logger"
+)
+
+// These tests pin the two defects measured on production 2026-08-11, where every
+// organize run spent 20-25 minutes on a pre-organize backup that then failed:
+//
+//	01:54:14 organize starting -> 02:14:42 "Auto-backup failed: failed to add
+//	  files to archive: lstat .../audiobooks.pebble/536537.sst: no such file or
+//	  directory"                                                      (20m28s)
+//	06:31:29 organize starting -> 06:56:00 same failure on 548621.log (24m31s)
+//	06:36:36 "registry: strike recorded ... kind=stuck  no progress for 5m8s"
+//
+// NOTE ON WHAT IS AND IS NOT BEING TESTED. The compaction race itself does not
+// reproduce on a small test database: the live-directory walk succeeds here.
+// So a test asserting "a backup file was produced" would pass with OR without
+// the fix and would be worthless. These tests assert on the METHOD CHOSEN,
+// which is what actually regresses.
+
+// storeDecorator wraps a Store the way the production search-index decorator
+// does: it satisfies Store by embedding it, exposes Unwrap for
+// database.AsCapability, and — crucially — does NOT itself implement
+// backup.Checkpointable. A bare `orgSvc.db.(backup.Checkpointable)` therefore
+// fails against this type, which is exactly the production bug.
+type storeDecorator struct {
+	Store
+	inner database.Store
+}
+
+func (d *storeDecorator) Unwrap() database.Store { return d.inner }
+
+// withBackupEnv points config.AppConfig at a temp database and backup dir, and
+// restores the previous globals afterwards.
+func withBackupEnv(t *testing.T, dbPath string) string {
+	t.Helper()
+	prevPath, prevType := config.AppConfig.DatabasePath, config.AppConfig.DatabaseType
+	t.Cleanup(func() {
+		config.AppConfig.DatabasePath, config.AppConfig.DatabaseType = prevPath, prevType
+	})
+	config.AppConfig.DatabasePath = dbPath
+	config.AppConfig.DatabaseType = "pebble"
+	return filepath.Join(filepath.Dir(dbPath), "backups")
+}
+
+func TestAutoBackup_UsesCheckpointThroughADecorator(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "audiobooks.pebble")
+	pebbleStore, err := database.NewPebbleStore(dbPath)
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = pebbleStore.Close() })
+
+	withBackupEnv(t, dbPath)
+
+	wrapped := &storeDecorator{Store: pebbleStore, inner: pebbleStore}
+
+	// Guard: if a bare assertion starts resolving through the decorator, this
+	// test has stopped reproducing the production shape and must be rewritten
+	// rather than trusted.
+	if _, ok := interface{}(wrapped).(interface{ Checkpoint(string) error }); ok {
+		t.Fatal("a bare type assertion now resolves Checkpoint through the decorator; " +
+			"this test no longer reproduces the production bug")
+	}
+
+	svc := NewService(wrapped)
+	got := svc.autoBackup(logger.New("test"))
+
+	if got != backupCheckpoint {
+		t.Fatalf("autoBackup took the %q path, want %q — the checkpoint capability "+
+			"was not resolved through the decorator, so the backup archives the "+
+			"LIVE Pebble directory and races compaction", got, backupCheckpoint)
+	}
+}
+
+func TestAutoBackup_SkipsWhenARecentBackupExists(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "audiobooks.pebble")
+	pebbleStore, err := database.NewPebbleStore(dbPath)
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = pebbleStore.Close() })
+
+	backupDir := withBackupEnv(t, dbPath)
+	if mkErr := os.MkdirAll(backupDir, 0o775); mkErr != nil {
+		t.Fatalf("mkdir backups: %v", mkErr)
+	}
+	recent := filepath.Join(backupDir, "audiobooks_pebble_20260811_000000.tar.gz")
+	if wErr := os.WriteFile(recent, []byte("not a real archive"), 0o644); wErr != nil {
+		t.Fatalf("seed backup: %v", wErr)
+	}
+
+	svc := NewService(pebbleStore)
+	if got := svc.autoBackup(logger.New("test")); got != backupSkippedRecent {
+		t.Fatalf("autoBackup took the %q path, want %q — a fresh backup already "+
+			"existed, so re-archiving 14 GB before every organize is pure delay",
+			got, backupSkippedRecent)
+	}
+}
+
+func TestAutoBackup_StillBacksUpWhenTheOnlyBackupIsStale(t *testing.T) {
+	// The skip must not become "never back up again". This is the negative
+	// control for the test above.
+	dbPath := filepath.Join(t.TempDir(), "audiobooks.pebble")
+	pebbleStore, err := database.NewPebbleStore(dbPath)
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = pebbleStore.Close() })
+
+	backupDir := withBackupEnv(t, dbPath)
+	if mkErr := os.MkdirAll(backupDir, 0o775); mkErr != nil {
+		t.Fatalf("mkdir backups: %v", mkErr)
+	}
+	stale := filepath.Join(backupDir, "audiobooks_pebble_20260810_000000.tar.gz")
+	if wErr := os.WriteFile(stale, []byte("not a real archive"), 0o644); wErr != nil {
+		t.Fatalf("seed backup: %v", wErr)
+	}
+	old := time.Now().Add(-2 * autoBackupMinInterval)
+	if cErr := os.Chtimes(stale, old, old); cErr != nil {
+		t.Fatalf("chtimes: %v", cErr)
+	}
+
+	svc := NewService(pebbleStore)
+	if got := svc.autoBackup(logger.New("test")); got == backupSkippedRecent {
+		t.Fatalf("autoBackup skipped on a backup %s old; the %s freshness window "+
+			"must not suppress backups indefinitely", 2*autoBackupMinInterval, autoBackupMinInterval)
+	}
+}

--- a/internal/organizer/service.go
+++ b/internal/organizer/service.go
@@ -1,7 +1,7 @@
 // file: internal/organizer/service.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
-// last-edited: 2026-07-17
+// last-edited: 2026-08-11
 
 package organizer
 
@@ -243,12 +243,74 @@ func (orgSvc *Service) PerformOrganize(ctx context.Context, req *Request, log lo
 	return nil
 }
 
-func (orgSvc *Service) autoBackup(log logger.Logger) {
+// autoBackupMinInterval is how recent a successful backup must be for
+// PerformOrganize to skip taking another one.
+//
+// WHY THIS EXISTS: the pre-organize backup archives the whole database, and on
+// production that is 14 GB at gzip.BestCompression. Measured on prod
+// 2026-08-11, two consecutive organize runs:
+//
+//	01:54:14 organize starting -> 02:14:42 backup failed   (20m28s)
+//	06:31:29 organize starting -> 06:56:00 backup failed   (24m31s)
+//
+// Every organize paid 20-25 minutes before touching a single book. From the
+// user's side the operation simply never started, and at 06:36:36 the ops
+// registry logged `strike recorded ... kind=stuck  no progress for 5m8s`
+// against an operation that was in fact working the whole time.
+//
+// Backing up before a destructive file-moving operation is right, so this does
+// not remove the backup — it stops re-taking one that is still fresh.
+const autoBackupMinInterval = 6 * time.Hour
+
+// newestBackupAge returns the age and filename of the most recent .tar.gz in
+// backupDir. Deliberately NOT backup.ListBackups: that checksums every archive
+// it finds, which on 14 GB files costs more than the check is worth.
+func newestBackupAge(backupDir string) (time.Duration, string, bool) {
+	entries, err := os.ReadDir(backupDir)
+	if err != nil {
+		return 0, "", false
+	}
+	var newest time.Time
+	var name string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".tar.gz") {
+			continue
+		}
+		info, statErr := e.Info()
+		if statErr != nil {
+			continue
+		}
+		if info.ModTime().After(newest) {
+			newest, name = info.ModTime(), e.Name()
+		}
+	}
+	if name == "" {
+		return 0, "", false
+	}
+	return time.Since(newest), name, true
+}
+
+// backupMethod records which path autoBackup took. It exists to make the
+// choice TESTABLE: the compaction race that motivates the checkpoint path does
+// not reproduce on a small test database, so asserting "a backup was created"
+// would pass whether or not the fix is present. Asserting on the method that
+// was chosen is what actually goes red on a regression.
+type backupMethod string
+
+const (
+	backupSkippedRecent backupMethod = "skipped-recent"
+	backupNoPath        backupMethod = "skipped-no-path"
+	backupCheckpoint    backupMethod = "checkpoint"
+	backupLiveWalk      backupMethod = "live-walk"
+	backupFailed        backupMethod = "failed"
+)
+
+func (orgSvc *Service) autoBackup(log logger.Logger) backupMethod {
 	dbPath := config.AppConfig.DatabasePath
 	dbType := config.AppConfig.DatabaseType
 	if dbPath == "" {
 		log.Warn("Skipping auto-backup: no database path configured")
-		return
+		return backupNoPath
 	}
 
 	backupConfig := backup.DefaultBackupConfig()
@@ -256,12 +318,57 @@ func (orgSvc *Service) autoBackup(log logger.Logger) {
 		backupConfig.BackupDir = filepath.Join(filepath.Dir(dbPath), backupConfig.BackupDir)
 	}
 
-	info, err := backup.CreateBackup(dbPath, dbType, backupConfig)
-	if err != nil {
-		log.Warn("Auto-backup failed: %s", err.Error())
-		return
+	if age, name, ok := newestBackupAge(backupConfig.BackupDir); ok && age < autoBackupMinInterval {
+		log.Info("Skipping auto-backup: %s is %s old (under the %s threshold)",
+			name, age.Truncate(time.Second), autoBackupMinInterval)
+		return backupSkippedRecent
 	}
-	log.Info("Auto-backup created: %s (%d bytes)", info.Filename, info.Size)
+
+	// Announce the phase and keep the progress channel alive. Without this the
+	// operation looks hung for the entire archive and the registry marks it
+	// stuck — see autoBackupMinInterval above.
+	start := time.Now()
+	log.UpdateProgress(0, 1, "Backing up database before organize (this can take several minutes)")
+	log.Info("Auto-backup starting: %s", dbPath)
+
+	var (
+		info   *backup.BackupInfo
+		err    error
+		method backupMethod
+	)
+	// Prefer the Pebble checkpoint path. CreateBackup walks the LIVE database
+	// directory, so Pebble compaction deletes .sst/.log files between the walk
+	// enumerating them and the archiver reading them — which is exactly how
+	// both prod runs died:
+	//
+	//	Auto-backup failed: failed to add files to archive:
+	//	  lstat /var/lib/audiobook-organizer/audiobooks.pebble/536537.sst: no such file or directory
+	//
+	// Checkpoint flushes and hard-links the SSTs into a private directory
+	// first, so the archive is consistent by construction.
+	//
+	// Resolved with database.AsCapability rather than a bare type assertion:
+	// the production store is wrapped by the search-index decorator, and a
+	// bare `orgSvc.db.(backup.Checkpointable)` sees only the decorator's own
+	// method set and silently falls back to the racy path. That exact shape
+	// was a live bug in the version-group backfill (PR #2295).
+	if cp, ok := database.AsCapability[backup.Checkpointable](orgSvc.db); ok && dbType == "pebble" {
+		method = backupCheckpoint
+		info, err = backup.CreateBackupWithCheckpoint(cp, dbPath, dbType, backupConfig)
+	} else {
+		method = backupLiveWalk
+		if dbType == "pebble" {
+			log.Warn("Auto-backup: store %T does not expose Checkpoint; falling back to a live-directory archive, which races Pebble compaction", orgSvc.db)
+		}
+		info, err = backup.CreateBackup(dbPath, dbType, backupConfig)
+	}
+	if err != nil {
+		log.Warn("Auto-backup failed after %s: %s", time.Since(start).Truncate(time.Second), err.Error())
+		return backupFailed
+	}
+	log.Info("Auto-backup created: %s (%d bytes) in %s via %s",
+		info.Filename, info.Size, time.Since(start).Truncate(time.Second), method)
+	return method
 }
 
 func (orgSvc *Service) syncITunesBeforeOrganize(ctx context.Context, log logger.Logger) {

--- a/internal/server/handlers/system/handler.go
+++ b/internal/server/handlers/system/handler.go
@@ -530,9 +530,16 @@ func (h *Handler) CreateBackup(c *gin.Context) {
 	// file-copy path so the source-path existence check runs and returns an
 	// appropriate error when the DB file is missing.
 	if store := h.resolveStore(); store != nil && dbType == "pebble" {
-		if cp, ok := store.(backup.Checkpointable); ok {
+		// database.AsCapability, NOT a bare `store.(backup.Checkpointable)`.
+		// The production store is wrapped by the search-index decorator, whose
+		// method set does not include Checkpoint, so a bare assertion fails and
+		// silently drops to the live-directory walk that races Pebble
+		// compaction. Same shape as the version-group backfill bug (PR #2295).
+		if cp, ok := database.AsCapability[backup.Checkpointable](store); ok {
 			info, err = backup.CreateBackupWithCheckpoint(cp, dbPath, dbType, backupConfig)
 		} else {
+			slog.Warn("backup: store does not expose Checkpoint, falling back to a live-directory archive",
+				"store_type", fmt.Sprintf("%T", store))
 			info, err = backup.CreateBackup(dbPath, dbType, backupConfig)
 		}
 	} else {


### PR DESCRIPTION
## The symptom

Reported by the owner: *"why is the library scan and the organize taking forever and never actually gets started"*.

## What was measured on production, 2026-08-11

```
01:54:14  library organize starting
02:14:42  Auto-backup failed: failed to add files to archive:
          lstat /var/lib/audiobook-organizer/audiobooks.pebble/536537.sst: no such file or directory   ← 20m28s
02:14:51  Fetched 48896 total books from database

06:31:29  library organize starting
06:36:36  registry: strike recorded  def_id=library.organize  kind=stuck  "no progress for 5m8s"
06:56:00  Auto-backup failed: ... lstat .../548621.log: no such file or directory                      ← 24m31s
```

Production database: **14 GB**, archived at `gzip.BestCompression`.

So every organize paid 20–25 minutes before touching a single book, produced no backup, reported no progress, and got the operation flagged `stuck` — then proceeded anyway with an unprotected database.

## Three defects in one code path

1. **The backup could never succeed.** `backup.CreateBackup` walks the *live* Pebble directory. Compaction deletes `.sst`/`.log` files between the walk enumerating them and the archiver reading them. `CreateBackupWithCheckpoint` already existed and already solved this (flush + hard-link into a private dir, consistent by construction) — organize just wasn't using it.

2. **The capability was resolved with a bare type assertion.** The production store is wrapped by the search-index decorator, whose method set excludes `Checkpoint`, so `store.(backup.Checkpointable)` fails and silently drops to the racy path. This is the same shape as the version-group backfill bug fixed in #2295. It was present in **two** places — organize, and the system "create backup" handler, which means the manual backup button has quietly been taking the racy archive too. Both now use `database.AsCapability`, and the fallback logs the concrete store type instead of going quiet.

3. **No progress was reported during the phase**, so a working operation looked hung to both the UI and the registry.

Additionally: the backup is now **skipped when a successful one is under six hours old**, so repeat organizes start immediately rather than re-archiving 14 GB.

## Deliberately NOT done

The backup is not removed. It guards a destructive file-moving operation, and dropping it is the owner's call, not this PR's. Nor is the checkpoint artifact substituted for the `.tar.gz`: retention (`cleanupOldBackups`, `ListBackups`) only recognises `.tar.gz`, so a checkpoint-directory artifact would be invisible to cleanup and grow without bound.

## On the tests

The compaction race does **not** reproduce on a small test database — the live-directory walk succeeds there. A test asserting "a backup file was produced" would therefore pass with or without this fix and would be worthless. The tests assert on **which path was chosen**, which is what actually regresses.

Verified by negative control — fix removed, both tests go red with their intended diagnostics:

```
--- FAIL: TestAutoBackup_UsesCheckpointThroughADecorator
    autoBackup took the "live-walk" path, want "checkpoint"
--- FAIL: TestAutoBackup_SkipsWhenARecentBackupExists
    autoBackup took the "checkpoint" path, want "skipped-recent"
```

Fix restored: 3/3 pass. `TestAutoBackup_StillBacksUpWhenTheOnlyBackupIsStale` is the negative control for the freshness window and passes in both states, as it should.

## Verification

- `go build ./...` → exit 0
- `go vet ./internal/organizer/ ./internal/server/handlers/system/` → exit 0
- `go test ./internal/organizer/ ./internal/server/handlers/system/ ./internal/backup/ -count=1` → exit 0

## NOT verified

- No production run of the new path. The 20–25 minute figures are measured; the post-fix duration is **not**.
- Checkpoint disk cost against a 14 GB live database is not measured. Hard-links are cheap initially, but the checkpoint pins SSTs against compaction for the duration of the archive.
- Six hours is a chosen default, not a measured one.

## Related, still open

This does not address the other organize findings from the same investigation: whole-library iteration returning only 13.3% of books, 3,194 books blocked by occupied target paths, 588 multi-file books routed into the single-file organize path, or the literal `read by narrator` in 2,611 computed filenames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp