### PR TITLE
fix(database): warmup counts rows inserted, not Pebble keys scanned [skip changelog]

### DIFF
--- a/changelog.d/20260811_074500_warmup_row_counts.md
+++ b/changelog.d/20260811_074500_warmup_row_counts.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- The memdb warmup reported **Pebble key counts as book counts**. `warmIter`
+  returned the number of keys it visited under the `book:` prefix, but that
+  prefix is shared with roughly seven secondary-index families
+  (`book:path:`, `book:hash:`, `book:versiongroup:`, …) which the row callback
+  skips and yet were still counted. Production logged `books=366922` for a
+  library of roughly 49,000 books — about 7.5 keys per row. The same inflation
+  applied to `authors`, `book_files` and the other shared-prefix tables.
+  Warmup now reports rows actually inserted into memdb, and reports keys
+  scanned separately under its own name so the two cannot be confused.
+- **Retracts a bug that never existed.** Whole-library iterators were measured
+  against that inflated number and appeared to be returning 13.3% of the
+  library — first the version-group backfill (`scanned=48874`), then the
+  organizer (`Fetched 48896 total books`). Both scans were complete. Two
+  numerators agreeing said nothing, because they shared one unverified
+  denominator.

--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_reads.go
-// version: 1.14.0
+// version: 1.15.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000006
-// last-edited: 2026-07-11
+// last-edited: 2026-08-11
 
 package database
 
@@ -692,7 +692,7 @@ func (m *MemStore) ListBookIDs() ([]string, error) {
 // ListSoftDeletedBooks returns books with MarkedForDeletion=true, with optional
 // age filter (olderThan: only books whose MarkedForDeletionAt is on/before this
 // time). Uses the marked_for_deletion index so cost is O(deleted_count), not
-// O(total_books) — the soft-deleted set is typically tiny relative to 393K
+// O(total_books) — the soft-deleted set is typically tiny relative to the
 // total books, so this is orders of magnitude faster than the Pebble full-scan.
 func (m *MemStore) ListSoftDeletedBooks(limit, offset int, olderThan *time.Time) ([]Book, error) {
 	txn := m.db.Txn(false)
@@ -732,7 +732,7 @@ func (m *MemStore) ListSoftDeletedBooks(limit, offset int, olderThan *time.Time)
 // CountBooksByPathPrefix returns the number of (non-deleted) books whose
 // SourceImportPath (or FilePath, if SourceImportPath is nil) starts with prefix.
 // Falls back to a full memdb scan — no path-prefix index exists — but a memdb
-// scan over 393K rows is still ~200× faster than the equivalent Pebble scan
+// scan over the full book table is still ~200× faster than the equivalent Pebble scan
 // because the books are in RAM and don't need JSON unmarshal.
 func (m *MemStore) CountBooksByPathPrefix(prefix string) (int, error) {
 	if prefix == "" {

--- a/internal/database/memdb_store.go
+++ b/internal/database/memdb_store.go
@@ -1,11 +1,13 @@
 // file: internal/database/memdb_store.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000003
+// last-edited: 2026-08-11
 
 package database
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/hashicorp/go-memdb"
 )
@@ -19,6 +21,33 @@ import (
 // block readers.
 type MemStore struct {
 	db *memdb.MemDB
+
+	// lastWarmCounts records the per-table row counts published by the most
+	// recent WarmFromPebble. These are ROW counts (rows actually inserted into
+	// memdb), not Pebble key counts — see warmIter for why the distinction
+	// matters and what it cost when the two were conflated.
+	warmCountsMu    sync.RWMutex
+	lastWarmCounts  map[string]int
+	lastWarmScanned map[string]int
+}
+
+// LastWarmupCounts returns the per-table row counts from the most recent
+// WarmFromPebble, and the per-table count of Pebble keys scanned to produce
+// them. For prefixes shared with secondary indexes (book:, author:,
+// book_file:) the two differ by a large factor: on production, the book:
+// prefix holds ~7.5 keys per book row.
+func (m *MemStore) LastWarmupCounts() (rows, scanned map[string]int) {
+	m.warmCountsMu.RLock()
+	defer m.warmCountsMu.RUnlock()
+	rows = make(map[string]int, len(m.lastWarmCounts))
+	for k, v := range m.lastWarmCounts {
+		rows[k] = v
+	}
+	scanned = make(map[string]int, len(m.lastWarmScanned))
+	for k, v := range m.lastWarmScanned {
+		scanned[k] = v
+	}
+	return rows, scanned
 }
 
 // NewMemStore allocates an empty MemStore with the full schema applied.

--- a/internal/database/memdb_strip.go
+++ b/internal/database/memdb_strip.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_strip.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-stripbook0001
-// last-edited: 2026-08-06
+// last-edited: 2026-08-11
 
 package database
 
@@ -11,7 +11,7 @@ package database
 // Callers that need the full Book (UI enrichment, write paths) fetch it
 // from Pebble via GetBookByID, which is the canonical source.
 //
-// Memory math (392K-book production library):
+// Memory math (production library):
 //
 //	Description avg ~500-2000 chars  → ~400MB-1.5GB across all books
 //	BookSigV1 base64 4096 uint32s    → ~22KB per fingerprinted book

--- a/internal/database/memdb_warmup.go
+++ b/internal/database/memdb_warmup.go
@@ -1,6 +1,7 @@
 // file: internal/database/memdb_warmup.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000004
+// last-edited: 2026-08-11
 
 package database
 
@@ -9,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strings"
 	"time"
 
@@ -36,6 +38,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	defer txn.Abort()
 
 	counts := map[string]int{}
+	scanned := map[string]int{}
 	skips := map[string]int{}
 
 	// safeInsert tries to insert an object, logging+counting failures rather
@@ -224,6 +227,11 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	// GetAllWorks at scan start, which is the only meaningful caller.
 
 	txn.Commit()
+
+	m.warmCountsMu.Lock()
+	m.lastWarmCounts = maps.Clone(counts)
+	m.lastWarmScanned = maps.Clone(scanned)
+	m.warmCountsMu.Unlock()
 
 	slog.Info("memdb warmup complete",
 		"duration_ms", time.Since(started).Milliseconds(),

--- a/internal/database/memdb_warmup.go
+++ b/internal/database/memdb_warmup.go
@@ -1,5 +1,5 @@
 // file: internal/database/memdb_warmup.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000004
 // last-edited: 2026-08-11
 
@@ -42,8 +42,9 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	skips := map[string]int{}
 
 	// safeInsert tries to insert an object, logging+counting failures rather
-	// than aborting the warmup. Returns nil so warmIter keeps going.
-	safeInsert := func(table string, obj interface{}, keyForLog string) error {
+	// than aborting the warmup. Returns whether the row actually landed in
+	// memdb (never an error, so warmIter keeps going).
+	safeInsert := func(table string, obj interface{}, keyForLog string) (bool, error) {
 		if err := txn.Insert(table, obj); err != nil {
 			skips[table]++
 			// Don't spam: log first 10 per table, then drop to debug.
@@ -54,169 +55,190 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 				slog.Warn("memdb warmup: further skips muted",
 					"table", table, "muting_after", 10)
 			}
+			return false, nil
 		}
-		return nil
+		return true, nil
 	}
 
-	// Books: book:<id> where id has no further colons.
+	// Books: book:<id> where id has no further colons. The "book:" prefix is
+	// shared with ~7 secondary-index families, so `scanned` here runs about
+	// 7.5x `rows` on production — see warmIter.
 	// Strip heavy fields (Description, BookSigV1, etc.) before insertion
-	// — see memdb_strip.go. Cuts radix-tree footprint from ~10GB to
-	// ~2GB on the 392K-book production library.
-	if n, err := warmIter(ctx, p.db, "book:", func(key string, val []byte) error {
+	// — see memdb_strip.go. Cuts radix-tree footprint from ~10GB to ~2GB
+	// on the production library.
+	if n, keys, err := warmIter(ctx, p.db, "book:", func(key string, val []byte) (bool, error) {
 		if strings.Count(key, ":") != 1 {
-			return nil
+			return false, nil
 		}
 		var b Book
 		if err := json.Unmarshal(val, &b); err != nil {
-			return nil
+			return false, nil
 		}
 		return safeInsert(memTableBooks, stripBookForMemdb(&b), key)
 	}); err != nil {
 		return fmt.Errorf("warmup books: %w", err)
 	} else {
 		counts[memTableBooks] = n
+		scanned[memTableBooks] = keys
 	}
 
 	// Authors: author:<id> (skip author:name:* index)
-	if n, err := warmIter(ctx, p.db, "author:", func(key string, val []byte) error {
+	if n, keys, err := warmIter(ctx, p.db, "author:", func(key string, val []byte) (bool, error) {
 		if strings.Contains(key, ":name:") {
-			return nil
+			return false, nil
 		}
 		if strings.Count(key, ":") != 1 {
-			return nil
+			return false, nil
 		}
 		var a Author
 		if err := json.Unmarshal(val, &a); err != nil {
-			return nil
+			return false, nil
 		}
 		return safeInsert(memTableAuthors, &a, key)
 	}); err != nil {
 		return fmt.Errorf("warmup authors: %w", err)
 	} else {
 		counts[memTableAuthors] = n
+		scanned[memTableAuthors] = keys
 	}
 
 	// Series: series:<id>
-	if n, err := warmIter(ctx, p.db, "series:", func(key string, val []byte) error {
+	if n, keys, err := warmIter(ctx, p.db, "series:", func(key string, val []byte) (bool, error) {
 		if strings.Count(key, ":") != 1 {
-			return nil
+			return false, nil
 		}
 		var s Series
 		if err := json.Unmarshal(val, &s); err != nil {
-			return nil
+			return false, nil
 		}
 		return safeInsert(memTableSeries, &s, key)
 	}); err != nil {
 		return fmt.Errorf("warmup series: %w", err)
 	} else {
 		counts[memTableSeries] = n
+		scanned[memTableSeries] = keys
 	}
 
 	// BookFiles: book_file:<bookID>:<fileID>
 	// Strip AcoustIDSeg1..6 and fingerprint-diagnostic fields before
 	// insertion — see memdb_strip.go. Cuts ~70MB heap across 308K rows.
-	if n, err := warmIter(ctx, p.db, "book_file:", func(key string, val []byte) error {
+	if n, keys, err := warmIter(ctx, p.db, "book_file:", func(key string, val []byte) (bool, error) {
 		if strings.Count(key, ":") != 2 {
-			return nil
+			return false, nil
 		}
 		var bf BookFile
 		if err := json.Unmarshal(val, &bf); err != nil {
-			return nil
+			return false, nil
 		}
 		return safeInsert(memTableBookFiles, stripBookFileForMemdb(&bf), key)
 	}); err != nil {
 		return fmt.Errorf("warmup book_files: %w", err)
 	} else {
 		counts[memTableBookFiles] = n
+		scanned[memTableBookFiles] = keys
 	}
 
 	// BookAuthors: book_authors:<bookID> contains []BookAuthor; flatten.
-	if n, err := warmIter(ctx, p.db, "book_authors:", func(key string, val []byte) error {
+	// One key yields many rows, so track the row count directly rather than
+	// letting warmIter infer it from the per-key admitted flag.
+	bookAuthorRows := 0
+	if _, keys, err := warmIter(ctx, p.db, "book_authors:", func(key string, val []byte) (bool, error) {
 		var list []BookAuthor
 		if err := json.Unmarshal(val, &list); err != nil {
-			return nil
+			return false, nil
 		}
 		for i := range list {
 			ba := list[i]
-			_ = safeInsert(memTableBookAuthors, &ba, key)
+			if ok, _ := safeInsert(memTableBookAuthors, &ba, key); ok {
+				bookAuthorRows++
+			}
 		}
-		return nil
+		return false, nil
 	}); err != nil {
 		return fmt.Errorf("warmup book_authors: %w", err)
 	} else {
-		counts[memTableBookAuthors] = n
+		counts[memTableBookAuthors] = bookAuthorRows
+		scanned[memTableBookAuthors] = keys
 	}
 
 	// BookNarrators: book_narrators:<bookID> contains []BookNarrator; flatten.
-	if n, err := warmIter(ctx, p.db, "book_narrators:", func(key string, val []byte) error {
+	bookNarratorRows := 0
+	if _, keys, err := warmIter(ctx, p.db, "book_narrators:", func(key string, val []byte) (bool, error) {
 		var list []BookNarrator
 		if err := json.Unmarshal(val, &list); err != nil {
-			return nil
+			return false, nil
 		}
 		for i := range list {
 			bn := list[i]
-			_ = safeInsert(memTableBookNarrators, &bn, key)
+			if ok, _ := safeInsert(memTableBookNarrators, &bn, key); ok {
+				bookNarratorRows++
+			}
 		}
-		return nil
+		return false, nil
 	}); err != nil {
 		return fmt.Errorf("warmup book_narrators: %w", err)
 	} else {
-		counts[memTableBookNarrators] = n
+		counts[memTableBookNarrators] = bookNarratorRows
+		scanned[memTableBookNarrators] = keys
 	}
 
 	// Narrators: narrator:<id>
-	if n, err := warmIter(ctx, p.db, "narrator:", func(key string, val []byte) error {
+	if n, keys, err := warmIter(ctx, p.db, "narrator:", func(key string, val []byte) (bool, error) {
 		var nrt Narrator
 		if err := json.Unmarshal(val, &nrt); err != nil {
-			return nil
+			return false, nil
 		}
 		return safeInsert(memTableNarrators, &nrt, key)
 	}); err != nil {
 		return fmt.Errorf("warmup narrators: %w", err)
 	} else {
 		counts[memTableNarrators] = n
+		scanned[memTableNarrators] = keys
 	}
 
 	// ImportPaths: import_path:<id> (skip import_path:path:* index)
-	if n, err := warmIter(ctx, p.db, "import_path:", func(key string, val []byte) error {
+	if n, keys, err := warmIter(ctx, p.db, "import_path:", func(key string, val []byte) (bool, error) {
 		if strings.Contains(key, ":path:") {
-			return nil
+			return false, nil
 		}
 		var ip ImportPath
 		if err := json.Unmarshal(val, &ip); err != nil {
-			return nil
+			return false, nil
 		}
 		return safeInsert(memTableImportPaths, &ip, key)
 	}); err != nil {
 		return fmt.Errorf("warmup import_paths: %w", err)
 	} else {
 		counts[memTableImportPaths] = n
+		scanned[memTableImportPaths] = keys
 	}
 
 	// AuthorAliases: author_alias:<id>
-	if n, err := warmIter(ctx, p.db, "author_alias:", func(key string, val []byte) error {
+	if n, keys, err := warmIter(ctx, p.db, "author_alias:", func(key string, val []byte) (bool, error) {
 		var aa AuthorAlias
 		if err := json.Unmarshal(val, &aa); err != nil {
-			return nil
+			return false, nil
 		}
 		return safeInsert(memTableAuthorAliases, &aa, key)
 	}); err != nil {
 		return fmt.Errorf("warmup author_aliases: %w", err)
 	} else {
 		counts[memTableAuthorAliases] = n
+		scanned[memTableAuthorAliases] = keys
 	}
 
 	// BlockedHashes: blocked:hash:<hash>
-	if n, err := warmIter(ctx, p.db, "blocked:hash:", func(key string, val []byte) error {
+	if n, keys, err := warmIter(ctx, p.db, "blocked:hash:", func(key string, val []byte) (bool, error) {
 		var bh DoNotImport
 		if err := json.Unmarshal(val, &bh); err != nil {
-			return nil
+			return false, nil
 		}
 		return safeInsert(memTableBlockedHashes, &bh, key)
 	}); err != nil {
 		return fmt.Errorf("warmup blocked_hashes: %w", err)
 	} else {
 		counts[memTableBlockedHashes] = n
+		scanned[memTableBlockedHashes] = keys
 	}
 
 	// Works: intentionally NOT warmed into memdb. Works are queried in
@@ -362,14 +384,30 @@ func emitMemdbSizeTelemetry(ctx context.Context, m *MemStore, counts map[string]
 }
 
 // warmIter iterates every key under a given prefix and invokes the callback.
-// Returns the number of times the callback was invoked. Stops early if ctx
-// is cancelled or the callback returns an error.
-func warmIter(ctx context.Context, db *pebble.DB, prefix string, fn func(key string, val []byte) error) (int, error) {
+//
+// Returns TWO numbers, and the distinction is load-bearing:
+//
+//	rows    — times the callback reported it admitted a row into memdb
+//	scanned — Pebble keys visited under the prefix
+//
+// These are wildly different for any prefix shared with secondary indexes.
+// "book:" also holds book:path:, book:hash:, book:originalhash:,
+// book:organizedhash:, book:versiongroup:, book:work:, book:asin: and
+// book:isbn13: — roughly 6.5 index keys per book row on production. "author:"
+// also holds author:name:, about 1 index key per author row.
+//
+// warmIter previously returned only `scanned` and WarmFromPebble published it
+// under the label "books". Production therefore logged books=366922 for a
+// library of ~49,000 books. Every whole-library iterator was subsequently
+// measured against that inflated denominator and appeared to be returning
+// 13.3% of the library; a P0 "silent data loss" investigation followed. The
+// iterators were correct the whole time. Never conflate the two counts again.
+func warmIter(ctx context.Context, db *pebble.DB, prefix string, fn func(key string, val []byte) (bool, error)) (rows int, scanned int, err error) {
 	// Bail before creating an iterator if the warmup was canceled (Close). This
 	// keeps cancellation prompt and avoids calling NewIter on a DB that is about
 	// to be closed.
 	if err := ctx.Err(); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	upper := append([]byte(nil), []byte(prefix)...)
 	// Replace trailing ':' with ';' so the upper bound sorts immediately past
@@ -384,19 +422,27 @@ func warmIter(ctx context.Context, db *pebble.DB, prefix string, fn func(key str
 		UpperBound: upper,
 	})
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	defer iter.Close()
 
-	count := 0
 	for iter.First(); iter.Valid(); iter.Next() {
 		if ctx.Err() != nil {
-			return count, ctx.Err()
+			return rows, scanned, ctx.Err()
 		}
-		if err := fn(string(iter.Key()), iter.Value()); err != nil {
-			return count, err
+		scanned++
+		admitted, err := fn(string(iter.Key()), iter.Value())
+		if err != nil {
+			return rows, scanned, err
 		}
-		count++
+		if admitted {
+			rows++
+		}
 	}
-	return count, nil
+	// An iterator that stops short must say so rather than returning a partial
+	// set that reads as complete.
+	if err := iter.Error(); err != nil {
+		return rows, scanned, fmt.Errorf("warmup scan of %q failed after %d keys: %w", prefix, scanned, err)
+	}
+	return rows, scanned, nil
 }

--- a/internal/database/memdb_warmup_counts_test.go
+++ b/internal/database/memdb_warmup_counts_test.go
@@ -1,0 +1,70 @@
+// file: internal/database/memdb_warmup_counts_test.go
+// version: 1.0.0
+// guid: 7b1e4c92-5d3a-4f18-9e26-1a0c8b7d4f35
+// last-edited: 2026-08-11
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWarmupCounts_CountRowsNotPebbleKeys is a regression test for the
+// mislabeled warmup metric that triggered a false P0.
+//
+// warmIter walks a Pebble key PREFIX and returns the number of keys it
+// visited. WarmFromPebble then published that number under the label
+// "books" (and "authors", "book_files", ...). But the "book:" prefix is
+// shared by ~7 secondary index families — book:path:, book:hash:,
+// book:originalhash:, book:organizedhash:, book:versiongroup:, book:work:,
+// book:asin:/book:isbn13: — all of which the row callback deliberately
+// SKIPS via `strings.Count(key, ":") != 1`. Skipped keys were still counted.
+//
+// On production this reported `books=366922` while the library actually held
+// ~49,000 books (~7.5 keys per book). Every whole-library iterator was then
+// measured against that inflated denominator and looked like it was
+// returning 13.3% of the library, which is what this bug was first reported
+// as. The iterators were correct; the denominator was not.
+//
+// The count must be rows INSERTED INTO MEMDB, not keys scanned.
+func TestWarmupCounts_CountRowsNotPebbleKeys(t *testing.T) {
+	store := setupTestPebbleStore(t)
+	store.WaitForWarmup()
+
+	const totalBooks = 4
+	for i := 0; i < totalBooks; i++ {
+		hash := fmt.Sprintf("hash%03d", i)
+		orig := fmt.Sprintf("orighash%03d", i)
+		organized := fmt.Sprintf("orghash%03d", i)
+		_, err := store.CreateBook(&Book{
+			Title:             fmt.Sprintf("Book %03d", i),
+			FilePath:          fmt.Sprintf("/tmp/warmcount_%03d.m4b", i),
+			FileHash:          &hash,
+			OriginalFileHash:  &orig,
+			OrganizedFileHash: &organized,
+		})
+		require.NoError(t, err)
+	}
+
+	// Each CreateBook above writes 1 record key plus 4 secondary-index keys
+	// (path, hash, originalhash, organizedhash), so the "book:" prefix holds
+	// 5*totalBooks keys but only totalBooks book rows.
+	mem, err := NewMemStore()
+	require.NoError(t, err)
+	require.NoError(t, mem.WarmFromPebble(context.Background(), store))
+
+	rows, scanned := mem.LastWarmupCounts()
+
+	require.Equal(t, totalBooks, rows[memTableBooks],
+		"warmup must report the number of BOOK ROWS inserted into memdb, "+
+			"not the number of Pebble keys under the shared \"book:\" prefix")
+
+	// The scanned-keys number is still useful telemetry, but it must be
+	// reported under its own name so it can never be mistaken for a row count.
+	require.Greater(t, scanned[memTableBooks], rows[memTableBooks],
+		"secondary-index keys should make scanned strictly exceed rows")
+}

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.121.0
+// version: 1.122.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-08-10
+// last-edited: 2026-08-11
 
 package database
 
@@ -2661,7 +2661,7 @@ func (p *PebbleStore) GetDistinctLanguages() ([]string, error) {
 func (p *PebbleStore) ListSoftDeletedBooks(limit, offset int, olderThan *time.Time) ([]Book, error) {
 	// Fast path: memdb has a marked_for_deletion index, so this is O(deleted)
 	// instead of O(total) — typically the soft-deleted set is tiny relative
-	// to 393K total books, so this turns a 20s Pebble scan into <50ms.
+	// to the full book count, so this turns a 20s Pebble scan into <50ms.
 	if mem := p.mem(); mem != nil {
 		return mem.ListSoftDeletedBooks(limit, offset, olderThan)
 	}

--- a/todo.d/20260810-vgbackfill-scans-only-13pct-of-books.md
+++ b/todo.d/20260810-vgbackfill-scans-only-13pct-of-books.md
@@ -1,56 +1,56 @@
-- [ ] **VGBACKFILL-SCAN-BOUNDS** The version-group backfill scans only ~13% of
-      the library. Its Pebble iterator bounds exclude most book rows, and the
-      run reports a clean `complete` regardless — so it looks like a full
-      rebuild.
+- [x] ~~**VGBACKFILL-SCAN-BOUNDS** The version-group backfill scans only ~13% of
+      the library.~~ **RETRACTED 2026-08-11 — there was no under-scan.** Kept
+      rather than deleted so nobody re-derives the same wrong conclusion from
+      the same logs.
 
-      **Measured on prod 2026-08-10, one boot, same process:**
+      **What was claimed:** `scanned=48874` against `books=366922` from the same
+      boot = 13.3%, therefore the backfill's Pebble iterator bounds
+      (`book:0` .. `book:;`, admitting only digit-leading IDs) were excluding
+      ~318k rows.
 
-          memdb warmup complete    books=366922 ...
-          versiongroup-backfill: complete  scanned=48874 indexed=37377
-              no_version_group=11497 unmarshal_errors=0 commits=4
-              duration=12.943s
+      **What is actually true:** `books=366922` was never a book count. The
+      memdb warmup's `warmIter` returned the number of Pebble KEYS it visited
+      under the `book:` prefix, and that prefix is shared with roughly seven
+      secondary-index families — `book:path:`, `book:hash:`,
+      `book:originalhash:`, `book:organizedhash:`, `book:versiongroup:`,
+      `book:work:`, `book:asin:`/`book:isbn13:`. The row callback skips those
+      via `strings.Count(key, ":") != 1`, but the skipped keys were still
+      counted and then published under the label `books`. About 7.5 keys per
+      book row on production.
 
-      48,874 / 366,922 = **13.3%**. The backfill declared success and set its
-      sentinel, so it will not re-run: the remaining ~86.7% of books stay
-      unindexed until the sentinel key is bumped again.
+      The real library is **~46k–55k books**, corroborated three ways in the
+      same logs: `total_books=46221` and `total_books=54734` from system
+      status, and the organizer's own `Fetched 48896 total books from
+      database`. So `scanned=48874` was a **complete** scan, and the digit-only
+      iterator bounds — while genuinely fragile — were not excluding anything,
+      because production book IDs are ULIDs and a ULID minted this century
+      starts with `0`.
 
-      **Suspected cause — iterator bounds, NOT the row filter.** The scan uses:
+      **How the error was made, because the shape recurs:** the original entry
+      explicitly listed this explanation ("the two numbers could also disagree
+      because `books=366922` counts something the `book:<id>` keyspace does
+      not") and marked the whole thing NOT YET CONFIRMED. It was then upgraded
+      to CONFIRMED on 2026-08-11 when a *second* subsystem — the organizer's
+      `GetAllBooksCore` paging loop — reported 48,896 against the same
+      `books=366922`. Two independent readings agreeing looked like
+      corroboration. They were not independent: both were compared against the
+      **same unverified denominator**. Agreement between two numerators says
+      nothing about the denominator they share.
 
-          LowerBound: []byte("book:0")
-          UpperBound: []byte("book:;")
+      **Fixed in the same PR as this retraction:** warmup now reports rows
+      inserted into memdb, and reports keys scanned separately under its own
+      name so the two can never be confused again. Pinned by
+      `TestWarmupCounts_CountRowsNotPebbleKeys`, which fails with
+      `expected: 4, actual: 20` against the old counting.
 
-      `'0'` is `0x30` and `';'` is `0x3B`, so the range admits only IDs whose
-      first byte is `0x30`–`0x3A` — the ten digits (plus `:`). Any book ID
-      beginning with a letter is outside the range and is never visited.
-
-      New books get ULIDs (`CreateBook` → `newULID()`), and a ULID minted this
-      century starts with `'0'`, so ULID-keyed books ARE in range. But
-      `CreateBook` only mints an ID `if book.ID == ""` — a caller may supply its
-      own, and importers do. That is the likely source of the ~318k invisible
-      rows.
-
-      ⚠️ **NOT YET CONFIRMED**, and it must be before any fix: nobody has
-      sampled real prod book IDs. The two numbers could also disagree because
-      `books=366922` counts something the `book:<id>` keyspace does not
-      (memdb rows built from a different source, tombstoned rows, etc.). Get
-      actual key samples first — the `.api-token` at repo root is stale (401),
-      so this needs a fresh credential.
-
-      **This is pre-existing, not a regression from #2295.** The bounds are
-      unchanged from the original implementation; #2293 replaced a substring
-      blacklist with a `strings.Count(key, ":") != 1` structural filter and
-      #2295 fixed the decorator so the backfill runs at all. Both are why the
-      numbers are now visible: before tonight this code had never executed in
-      production, so it under-scanned silently and invisibly.
-
-      **Fix sketch (after confirming):** drop the bounds to a prefix scan over
-      `book:` → `book;` and let the existing one-colon structural filter reject
-      secondary indexes, which is what it was written to do. Then bump
-      `versionGroupBackfillKey` to `_v3_done` so every deployment rebuilds.
-      Assert on scanned-vs-total, not just on absence of error — a `complete`
-      line that under-scans by 87% is the same class of defect as the parse that
-      "succeeds" on garbage.
-
-      Related: the under-reporting version-group index reproduced in #2277 is
-      only partly explained by the never-running backfill if this holds — most
-      books were never candidates for indexing in the first place.
+- [ ] **VGBACKFILL-BOUNDS-FRAGILE** Separately, and still worth doing: the
+      version-group backfill's iterator bounds `book:0` .. `book:;` admit only
+      IDs whose first byte is `0x30`–`0x3A`. That is correct today only because
+      every production book ID happens to be a ULID starting with `0`. It is
+      not enforced anywhere — `CreateBook` mints a ULID only `if book.ID == ""`,
+      so a caller supplying a letter-leading ID would become permanently
+      invisible to this scan with no error. Replace the bounds with a prefix
+      scan over `book:` → `book;` and let the existing one-colon structural
+      filter reject the secondary indexes, which is what it was written for.
+      This is a latent-correctness fix, **not** the cause of any observed
+      under-scan.


### PR DESCRIPTION
## Summary

`warmIter` returned the number of Pebble **keys** it visited under a prefix, and `WarmFromPebble` published that number as the table's **row** count. The `book:` prefix is shared with ~7 secondary-index families — `book:path:`, `book:hash:`, `book:originalhash:`, `book:organizedhash:`, `book:versiongroup:`, `book:work:`, `book:asin:`/`book:isbn13:` — which the row callback deliberately skips via `strings.Count(key, ":") != 1`. Skipped keys were still counted.

Production logged `books=366922` for a library of roughly **49,000** books, about 7.5 keys per row. The same inflation applied to `authors`, `book_files`, and every other shared-prefix table.

## This retracts a bug that never existed

That inflated number became the denominator for whole-library iterator checks, and made two *correct* scans look broken:

| subsystem | reported | looked like |
|---|---|---|
| version-group backfill | `scanned=48874` | 13.3% of the library |
| organizer `GetAllBooksCore` | `Fetched 48896 total books` | 13.3% of the library |

Both scans were **complete**. Corroborated three ways from the same logs: `total_books=46221` and `total_books=54734` from system status, and the organizer's own fetch.

The reasoning error is worth naming because the shape recurs: the second observation was treated as independent corroboration of the first. It wasn't — both numerators were compared against the **same unverified denominator**. Agreement between two numerators says nothing about the denominator they share. `todo.d/20260810-vgbackfill-scans-only-13pct-of-books.md` is rewritten as an explicit retraction rather than deleted, so the conclusion cannot be re-derived from the same logs.

## What changed

- `warmIter`'s callback now returns whether the row actually landed in memdb; `warmIter` returns `(rows, keysScanned, err)`.
- `MemStore.LastWarmupCounts()` exposes both, so the distinction is assertable.
- The `memdb warmup complete` log line now carries true row counts, with scanned-keys reported separately under its own name.
- Corrected the `392K`/`393K` library-size figures in `memdb_reads.go`, `memdb_strip.go` and `pebble_store.go` comments — they came from this same bad metric.

## Verification

Negative control, fix reverted:

```
--- FAIL: TestWarmupCounts_CountRowsNotPebbleKeys
    expected: 4
    actual  : 20
    warmup must report the number of BOOK ROWS inserted into memdb,
    not the number of Pebble keys under the shared "book:" prefix
```

4 books × 5 keys each (record + path + hash + originalhash + organizedhash). Fix restored:

- `go build ./...` → exit 0
- `go test ./internal/database/ -count=1` → exit 0 (332s, full package)
- `gofmt -l` clean on all six changed files

## NOT verified

- **No production run of the corrected warmup.** The ~49K figure is inferred from three existing log signals, not from a direct row count — I have no working prod credential (`.api-token` returns `{"error":"invalid session","code":"UNAUTHORIZED"}`). The first restart after deploy will print the real number and should be checked.
- Only `books` inflation was measured (~7.5×). `authors`, `book_files`, `book_authors` etc. share the same defect but their per-row key ratios were not measured.
- Whether any sizing/perf decision made against the inflated number needs revisiting — memdb residency, sort-index memory, HNSW sizing. Tracked separately; conclusions may survive, but their stated basis does not.

## Follow-ups filed

- Sweep every remaining reference to the inflated count (CHANGELOG history, `docs/design/2026-08-09-search-backend-options.md`, `docs/perf-audit-*`, `library_list_warmer.go`, `dedup/lifecycle.go`, `bleve_translator.go`).
- `VGBACKFILL-BOUNDS-FRAGILE`: the backfill's `book:0`..`book:;` bounds admit only digit-leading IDs. Correct today only because production IDs are ULIDs starting with `0`, and nothing enforces that. Latent-correctness fix, **not** the cause of any observed under-scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp