### PR TITLE
fix(organize): post-scan auto-organize routed every multi-file book to the single-file path [skip changelog]

### DIFF
--- a/changelog.d/20260811_083000_fix_post_scan_organize_multifile.md
+++ b/changelog.d/20260811_083000_fix_post_scan_organize_multifile.md
@@ -1,0 +1,39 @@
+### Fixed
+
+#### Auto-organize after a scan failed on every multi-file book
+
+Organizing a book takes one of three routes, and picking the wrong one fails
+outright rather than degrading: a book already under the library root is
+re-organized in place, a book whose `file_path` is a *directory* goes through
+the multi-file path, and anything else goes through the single-file path.
+
+That three-way decision existed only inside the organize worker loop. The
+post-scan auto-organize hook — the pass that runs automatically at the end of
+a library scan — called the single-file organizer directly, for everything.
+Every multi-file book it touched therefore failed with
+
+> `cannot organize "…": file_path … is a directory but single-file organize was requested — use organizeDirectoryBook for multi-file books`
+
+Production logged **588 failures of exactly that shape in one post-scan run**
+on 2026-08-11. Multi-file books are most of the library, so in practice the
+automatic pass after a scan was organizing almost nothing.
+
+The decision now lives in one place, `Service.OrganizeOneBook`, and both call
+sites use it. A third caller cannot reintroduce the same omission by copying
+the wrong half.
+
+#### "Auto-organize complete: 0 organized" now says why it was zero
+
+The same hook reported a single number, so an operator seeing zero could not
+tell whether nothing needed organizing, everything failed, or the books were
+not in the database at all. It also collapsed a DB *lookup error* and a book
+that genuinely has no row into one bare `continue`, hiding both.
+
+The completion line now reports organized / failed / not-in-DB / lookup-error
+counts against the number scanned, and the first ten lookup errors are logged
+individually.
+
+Covered by four tests in `internal/organizer/organize_one_book_test.go`, which
+assert on which *path* was taken rather than on whether an artifact was
+produced. Two of them fail with the verbatim production error string when the
+directory branch is removed.

--- a/internal/organizer/organize_one_book_test.go
+++ b/internal/organizer/organize_one_book_test.go
@@ -1,0 +1,192 @@
+// file: internal/organizer/organize_one_book_test.go
+// version: 1.0.0
+// guid: 6e2a91d4-3c58-4b7f-8a06-1d94f2e7b350
+// last-edited: 2026-08-11
+
+package organizer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/database/mocks"
+	"github.com/falkcorp/audiobook-organizer/internal/logger"
+)
+
+// ---------------------------------------------------------------------------
+// Regression: the post-scan auto-organize hook (server.AutoOrganizeFn) called
+// Organizer.OrganizeBook — the SINGLE-FILE path — for every book it touched.
+// Any book whose file_path is a directory therefore failed outright with
+// "…is a directory but single-file organize was requested". Production logged
+// 588 failures of exactly that shape in one post-scan run on 2026-08-11.
+//
+// The fix hoists the three-way decision into Service.OrganizeOneBook so both
+// the worker loop and the post-scan hook share it. These tests assert on which
+// PATH was taken, not on whether an artifact was produced — a directory book
+// routed to the directory path fails for a *different, recognisable* reason
+// when its book_files rows are missing, and that difference is the signal.
+// ---------------------------------------------------------------------------
+
+const singleFileOrganizeErr = "single-file organize was requested"
+
+// directoryBookFixture builds a book whose file_path is a real directory
+// living OUTSIDE RootDir, so OrganizeOneBook cannot route it to
+// ReOrganizeInPlace and must choose between the single-file and directory
+// paths on its own.
+func directoryBookFixture(t *testing.T) *database.Book {
+	t.Helper()
+
+	rootDir := t.TempDir()
+	srcParent := t.TempDir()
+	config.AppConfig = config.Config{
+		RootDir:              rootDir,
+		FolderNamingPattern:  "{author}/{title}",
+		FileNamingPattern:    "{title}",
+		OrganizationStrategy: "copy",
+	}
+	if strings.HasPrefix(srcParent, rootDir) {
+		t.Fatalf("fixture invalid: source %s is under RootDir %s", srcParent, rootDir)
+	}
+
+	bookDir := filepath.Join(srcParent, "Multi Part Book")
+	if err := os.MkdirAll(bookDir, 0o775); err != nil {
+		t.Fatalf("setup: mkdir book dir: %v", err)
+	}
+	for _, name := range []string{"part1.mp3", "part2.mp3"} {
+		if err := os.WriteFile(filepath.Join(bookDir, name), []byte("audio"), 0o644); err != nil {
+			t.Fatalf("setup: write %s: %v", name, err)
+		}
+	}
+
+	return &database.Book{
+		ID:       "book-dir-1",
+		Title:    "Multi Part Book",
+		FilePath: bookDir,
+		Author:   &database.Author{Name: "Some Author"},
+	}
+}
+
+// TestOrganizeBook_RejectsDirectory is the negative control, and it is the
+// behaviour the old post-scan hook was walking into on every multi-file book.
+// It is asserted here rather than described in a comment so that a change to
+// Organizer.OrganizeBook's contract breaks this file loudly instead of quietly
+// invalidating the test below.
+func TestOrganizeBook_RejectsDirectory(t *testing.T) {
+	book := directoryBookFixture(t)
+	org := NewOrganizer(&config.AppConfig)
+
+	_, _, err := org.OrganizeBook(book)
+	if err == nil {
+		t.Fatal("negative control broken: OrganizeBook accepted a directory; the routing bug this file guards can no longer occur, so rewrite these tests rather than deleting them")
+	}
+	if !strings.Contains(err.Error(), singleFileOrganizeErr) {
+		t.Fatalf("negative control broken: expected error containing %q, got: %v", singleFileOrganizeErr, err)
+	}
+}
+
+// TestOrganizeOneBook_DirectoryBook_TakesDirectoryPath fails against the old
+// code: routing a directory book through Organizer.OrganizeBook produces the
+// single-file error, and this asserts that error is NOT what comes back.
+//
+// The book deliberately has zero book_files rows, so the directory path fails
+// with its own distinctive "no segments tracked" message. That is the point —
+// it proves which branch ran without depending on a successful copy.
+func TestOrganizeOneBook_DirectoryBook_TakesDirectoryPath(t *testing.T) {
+	book := directoryBookFixture(t)
+
+	mockStore := mocks.NewMockStore(t)
+	mockStore.On("GetBookFiles", "book-dir-1").Return([]database.BookFile{}, nil)
+
+	svc := NewService(mockStore)
+	org := NewOrganizer(&config.AppConfig)
+
+	_, err := svc.OrganizeOneBook(org, book, logger.New("test"))
+	if err == nil {
+		t.Fatal("expected the directory path to reject a book with no tracked segments")
+	}
+	if strings.Contains(err.Error(), singleFileOrganizeErr) {
+		t.Fatalf("OrganizeOneBook routed a directory book to the SINGLE-FILE path — this is the 2026-08-11 production defect: %v", err)
+	}
+	if !strings.Contains(err.Error(), "no segments tracked") {
+		t.Fatalf("expected the directory path's own error, got: %v", err)
+	}
+	mockStore.AssertExpectations(t)
+}
+
+// TestOrganizeOneBook_DirectoryBook_OrganizesSegments covers the happy path:
+// with book_files present the directory branch actually moves the segments.
+func TestOrganizeOneBook_DirectoryBook_OrganizesSegments(t *testing.T) {
+	book := directoryBookFixture(t)
+
+	mockStore := mocks.NewMockStore(t)
+	mockStore.On("GetBookFiles", "book-dir-1").Return([]database.BookFile{
+		{ID: "bf-1", FilePath: filepath.Join(book.FilePath, "part1.mp3")},
+		{ID: "bf-2", FilePath: filepath.Join(book.FilePath, "part2.mp3")},
+	}, nil)
+
+	svc := NewService(mockStore)
+	org := NewOrganizer(&config.AppConfig)
+
+	targetDir, err := svc.OrganizeOneBook(org, book, logger.New("test"))
+	if err != nil {
+		t.Fatalf("OrganizeOneBook on a multi-file book: %v", err)
+	}
+	if !strings.HasPrefix(targetDir, config.AppConfig.RootDir) {
+		t.Fatalf("expected target %s under RootDir %s", targetDir, config.AppConfig.RootDir)
+	}
+	entries, err := os.ReadDir(targetDir)
+	if err != nil {
+		t.Fatalf("read target dir: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 organized segments in %s, got %d", targetDir, len(entries))
+	}
+}
+
+// TestOrganizeOneBook_SingleFileBook_TakesSingleFilePath guards the other
+// direction: the shared method must not send an ordinary one-file book down
+// the directory branch, which would fail on its (absent) book_files rows.
+func TestOrganizeOneBook_SingleFileBook_TakesSingleFilePath(t *testing.T) {
+	rootDir := t.TempDir()
+	srcParent := t.TempDir()
+	config.AppConfig = config.Config{
+		RootDir:              rootDir,
+		FolderNamingPattern:  "{author}/{title}",
+		FileNamingPattern:    "{title}",
+		OrganizationStrategy: "copy",
+	}
+
+	srcFile := filepath.Join(srcParent, "solo.mp3")
+	if err := os.WriteFile(srcFile, []byte("audio"), 0o644); err != nil {
+		t.Fatalf("setup: write source file: %v", err)
+	}
+
+	book := &database.Book{
+		ID:       "book-file-1",
+		Title:    "Solo Book",
+		FilePath: srcFile,
+		Format:   "mp3",
+		Author:   &database.Author{Name: "Some Author"},
+	}
+
+	// No GetBookFiles expectation: if the directory branch were taken this
+	// mock would fail the test on an unexpected call.
+	mockStore := mocks.NewMockStore(t)
+	svc := NewService(mockStore)
+	org := NewOrganizer(&config.AppConfig)
+
+	newPath, err := svc.OrganizeOneBook(org, book, logger.New("test"))
+	if err != nil {
+		t.Fatalf("OrganizeOneBook on a single-file book: %v", err)
+	}
+	if !strings.HasPrefix(newPath, rootDir) {
+		t.Fatalf("expected organized path %s under RootDir %s", newPath, rootDir)
+	}
+	if _, statErr := os.Stat(newPath); statErr != nil {
+		t.Fatalf("organized file missing at %s: %v", newPath, statErr)
+	}
+}

--- a/internal/organizer/service.go
+++ b/internal/organizer/service.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/service.go
-// version: 1.11.0
+// version: 1.12.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
 // last-edited: 2026-08-11
 
@@ -724,13 +724,11 @@ func (orgSvc *Service) organizeBooks(ctx context.Context, booksToOrganize []data
 				var newPath string
 				var err error
 
-				if alreadyInRoot {
-					newPath, err = orgSvc.ReOrganizeInPlace(&book, log)
-				} else if isDir {
-					newPath, err = orgSvc.OrganizeDirectoryBook(workerOrg, &book, log)
-				} else {
-					newPath, _, err = workerOrg.OrganizeBook(&book)
-				}
+				// Same decision as the post-scan auto-organize hook, via one
+				// shared method — see OrganizeOneBook for why that matters.
+				// isDir/alreadyInRoot are still computed above because the
+				// DB-update step below branches on them too.
+				newPath, err = orgSvc.OrganizeOneBook(workerOrg, &book, log)
 
 				// --- Step 2: DB operations ---
 				if err != nil {
@@ -892,6 +890,42 @@ func (orgSvc *Service) organizeBooks(ctx context.Context, booksToOrganize []data
 	}
 
 	return stats
+}
+
+// OrganizeOneBook applies the correct organize strategy for one book and
+// returns its new path.
+//
+// There are three, and picking the wrong one fails outright rather than
+// degrading:
+//
+//	already under RootDir -> ReOrganizeInPlace
+//	file_path is a dir    -> OrganizeDirectoryBook (multi-file book)
+//	otherwise             -> Organizer.OrganizeBook (single file)
+//
+// WHY THIS IS A METHOD AND NOT AN INLINE `if`: this branch used to live only
+// inside organizeBooks' worker loop. The post-scan auto-organize hook in
+// package server called Organizer.OrganizeBook directly, so every multi-file
+// book it touched failed with
+//
+//	cannot organize %q: file_path %s is a directory but single-file organize
+//	was requested — use organizeDirectoryBook for multi-file books
+//
+// Measured on production 2026-08-11: 588 failures of exactly that shape in a
+// single post-scan run. Both call sites now share one decision, so a third
+// caller cannot reintroduce the same omission by copying the wrong half.
+func (orgSvc *Service) OrganizeOneBook(org *Organizer, book *database.Book, log logger.Logger) (string, error) {
+	if book == nil {
+		return "", fmt.Errorf("cannot organize: book is nil")
+	}
+	oldPath := book.FilePath
+	if config.AppConfig.RootDir != "" && strings.HasPrefix(oldPath, config.AppConfig.RootDir) {
+		return orgSvc.ReOrganizeInPlace(book, log)
+	}
+	if info, err := os.Stat(oldPath); err == nil && info.IsDir() {
+		return orgSvc.OrganizeDirectoryBook(org, book, log)
+	}
+	newPath, _, err := org.OrganizeBook(book)
+	return newPath, err
 }
 
 // OrganizeDirectoryBook handles organizing a multi-file book where file_path is a directory.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 2.36.0
+// version: 2.37.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-08-09
+// last-edited: 2026-08-11
 
 package server
 
@@ -814,17 +814,38 @@ func NewServer(store database.Store) *Server {
 		org := organizer.NewOrganizer(&config.AppConfig)
 		org.SetStore(server.Store())
 		organized := 0
+		// Counted, not just skipped. "Auto-organize complete: 0 organized" told
+		// an operator nothing about WHY zero — on 2026-08-11 it hid 588
+		// multi-file routing failures and 3,194 occupied-target collisions.
+		var failed, lookupErrors, notInDB int
 		for i := range books {
 			if l.IsCanceled() {
 				break
 			}
 			dbBook, err := server.store.GetBookByFilePath(books[i].FilePath)
-			if err != nil || dbBook == nil {
+			if err != nil {
+				// A lookup ERROR and a book that genuinely is not in the DB are
+				// different things, and collapsing them into one bare `continue`
+				// hid both. Count and log them separately.
+				lookupErrors++
+				if lookupErrors <= 10 {
+					l.Warn("Auto-organize: DB lookup failed for %s: %v", books[i].FilePath, err)
+				}
 				continue
 			}
-			newPath, _, err := org.OrganizeBook(dbBook)
+			if dbBook == nil {
+				notInDB++
+				continue
+			}
+			// OrganizeOneBook, not Organizer.OrganizeBook: the latter is the
+			// SINGLE-FILE path and returns an error for any book whose
+			// file_path is a directory. This hook called it unconditionally, so
+			// every multi-file book failed here — 588 of them in one production
+			// run on 2026-08-11.
+			newPath, err := server.organizeService.OrganizeOneBook(org, dbBook, l)
 			if err != nil {
 				l.Warn("Organize failed for %s: %v", dbBook.Title, err)
+				failed++
 				continue
 			}
 			if newPath != dbBook.FilePath {
@@ -841,7 +862,8 @@ func NewServer(store database.Store) *Server {
 				}
 			}
 		}
-		l.Info("Auto-organize complete: %d organized", organized)
+		l.Info("Auto-organize complete: %d organized, %d failed, %d not in DB, %d lookup errors (of %d scanned)",
+			organized, failed, notInDB, lookupErrors, len(books))
 	}
 
 	// Note: the search index is opened in Start(), not here, so


### PR DESCRIPTION
## The defect

Organizing one book takes one of three routes, and picking the wrong one fails outright rather than degrading:

| condition | route |
|---|---|
| already under `RootDir` | `ReOrganizeInPlace` |
| `file_path` is a **directory** | `OrganizeDirectoryBook` (multi-file) |
| otherwise | `Organizer.OrganizeBook` (single file) |

That decision existed **only** inside `organizeBooks`' worker loop. The post-scan auto-organize hook (`AutoOrganizeFn` in `internal/server/server.go`) called `Organizer.OrganizeBook` directly, for everything — so every book whose `file_path` is a directory failed with:

```
cannot organize "…" (id=…): file_path … is a directory but single-file
organize was requested — use organizeDirectoryBook for multi-file books
```

**588 failures of exactly that shape in one production post-scan run on 2026-08-11.** Multi-file books are most of the library, so the automatic pass after a scan was organizing almost nothing.

## The fix

Hoist the decision into `Service.OrganizeOneBook` and call it from **both** sites. A third caller cannot now reintroduce the omission by copying the wrong half.

## Second fix: the hook's own reporting

`Auto-organize complete: 0 organized` told an operator nothing about *why* zero. The hook also collapsed a DB **lookup error** and a book that genuinely has no DB row into a single bare `continue`, hiding both. It now counts and reports organized / failed / not-in-DB / lookup-errors against the number scanned, and logs the first ten lookup errors individually.

## Verification

`internal/organizer/organize_one_book_test.go` — 4 tests, asserting on **which path ran**, not on whether an artifact was produced. The directory-book test deliberately has zero `book_files` rows so the directory branch fails with its own distinctive `no segments tracked` error; that difference *is* the signal.

**Negative control** — directory branch deleted from `OrganizeOneBook`, suite re-run:

```
--- PASS: TestOrganizeBook_RejectsDirectory
--- FAIL: TestOrganizeOneBook_DirectoryBook_TakesDirectoryPath
        OrganizeOneBook routed a directory book to the SINGLE-FILE path —
        this is the 2026-08-11 production defect: cannot organize
        "Multi Part Book": file_path … is a directory but single-file
        organize was requested — use organizeDirectoryBook for multi-file books
--- FAIL: TestOrganizeOneBook_DirectoryBook_OrganizesSegments
--- PASS: TestOrganizeOneBook_SingleFileBook_TakesSingleFilePath
FAIL  exit 1
```

Two go red carrying the **verbatim production error string**. The single-file test correctly stays green — it guards the opposite direction.

With the fix restored: **4/4 PASS**, and the full package is `ok github.com/falkcorp/audiobook-organizer/internal/organizer 2.783s`, **exit 0, 0 failures**.

## Not claimed

- This does **not** address the 3,194 books failing on an occupied target path — a separate defect, tracked separately.
- It does not make the post-scan loop concurrent (it is still sequential over the scanned set); that is also tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp