### PR TITLE
fix(docs): correct the inflated book count and the sort-index decision it distorted [skip changelog]

### DIFF
--- a/changelog.d/20260811_110000_fix_inflated_book_count_refs.md
+++ b/changelog.d/20260811_110000_fix_inflated_book_count_refs.md
@@ -1,0 +1,51 @@
+### Fixed
+
+#### Corrected a book count that was ~7.5× too high, and the decision it distorted
+
+A number had been circulating through this codebase for months — written
+variously as 392,962, 366,922, 366,916, "392K-book", "393K", "367K-book" — as
+the size of the production library. It was never a book count. It was the
+number of PebbleDB *keys* under the `book:` prefix, and that prefix is shared
+with roughly seven secondary-index families (`book:path:`, `book:hash:`,
+`book:versiongroup:`, `book:work:` and others), so it ran about 7.5 keys per
+actual row.
+
+The real figure is **~48,900 books**, from the organizer's own complete paging
+enumeration, and independently consistent with system-status readings of 46,221
+and 54,734.
+
+**Why this was worth chasing down rather than quietly editing.** One decision
+had already been made on the inflated number. The memory cost of the nine
+optional sort indexes was measured properly — 3,750 bytes per book, benchmarked
+at 100,000 books — and that measurement was and remains correct. But it was
+then multiplied by 366,916 instead of ~48,900:
+
+| | as recorded | corrected |
+|---|---|---|
+| all nine sort keys | +1,312 MB | **~+175 MB** |
+| per sort key | ~146 MB | **~19 MB** |
+
+"+1.3 GB on a server already holding 1.25 GB" reads as prohibitive. "+175 MB"
+does not. The indexes shipped switched off on the strength of the first
+reading; whether to turn some on is worth revisiting against the second. That
+is an owner decision, and it is flagged in the code rather than decided here.
+
+**How it spread, since the pattern is the point.** The error survived three
+chances to be caught. A design document noticed that 392K disagreed with the
+~44,888 books a person actually sees, correctly flagged the discrepancy, and
+then resolved it the wrong way — trusting the bigger number and inventing
+"non-primary versions" to account for the gap. A later pass "corrected" 392K to
+366,916, propagating the error while looking like a fix. And a backfill audit
+concluded the version-group scan covered only 13.3% of the library by dividing
+a genuine scan count by the inflated one.
+
+Every affected comment and document is now corrected or annotated in place —
+kept and struck through rather than deleted, so nobody re-derives the same
+conclusion from the same evidence. The per-row analysis in the May heap audit
+is unaffected: it comes from the Go struct layout, not from the population, so
+it needs re-multiplying, not re-deriving.
+
+Row counts for the other tables (`book_files`, `works`, `book_authors`,
+`series`, `authors`) came from the same counter but sit under different
+prefixes with different index families, so they are **not** assumed wrong and
+**not** assumed right. Re-verifying them is tracked as `ROWCOUNT-REVERIFY`.

--- a/docs/design/2026-08-09-search-backend-options.md
+++ b/docs/design/2026-08-09-search-backend-options.md
@@ -1,7 +1,7 @@
 <!-- file: docs/design/2026-08-09-search-backend-options.md -->
-<!-- version: 4.1.0 -->
+<!-- version: 4.1.1 -->
 <!-- guid: 4f1c8a72-6d93-4e05-b8a1-9c72e0f45d38 -->
-<!-- last-edited: 2026-08-09 -->
+<!-- last-edited: 2026-08-11 -->
 
 # Search, querying and sorting — the design we are going to build
 
@@ -56,8 +56,23 @@ The code carried three different numbers. They measure different things, and two
 | narrators | 922 | — |
 | author_aliases | 30 | — |
 
-- **"392K-book"** (`memdb_strip.go:14`) was **books**, now 366,916. Not tracks — tracks are
-  330,180 and are the *second* largest table.
+- 🚨 **RETRACTED 2026-08-11.** ~~**"392K-book"** (`memdb_strip.go:14`) was **books**, now
+  366,916. Not tracks — tracks are 330,180 and are the *second* largest table.~~
+  366,916 was **not a book count**. It was the number of Pebble KEYS under the `book:`
+  prefix, which is shared with roughly seven secondary-index families (`book:path:`,
+  `book:hash:`, `book:versiongroup:`, `book:work:`, …) — about 7.5 keys per row. The row
+  count is ~48,900 ("Fetched 48896 total books from database", the organizer's own full
+  paging enumeration, 2026-08-11), consistent with system-status readings of 46,221 and
+  54,734. Pinned by `TestWarmupCounts_CountRowsNotPebbleKeys`.
+
+  Kept rather than deleted because this entry is *how the error propagated*: it found a
+  discrepancy between 392K and the user-facing ~44,888, correctly flagged it, and then
+  resolved it in the wrong direction — treating the larger number as authoritative and
+  inventing "non-primary versions" to explain the gap. The gap was index keys.
+
+  The other rows in the table above have **not** been re-verified. They came from the same
+  warmup counter, but each prefix has its own index families (or none), so they may or may
+  not be inflated. Do not assume they are wrong, and do not assume they are right.
 - **"~68K unfiltered"** (`pebble_store.go:689`) and **"~38K primary"**
   (`memdb_summaries.go:18`) are **older figures for filtered subsets** at the time those
   comments were written. Neither describes the table.
@@ -65,8 +80,17 @@ The code carried three different numbers. They measure different things, and two
   Aug 8 summary) is the **primary-version** count — what a person means by "my library".
   366,916 is every row including non-primary versions.
 
-**Consequence:** an index over *books* is a 366K-entry structure, not a 44K one. That is the
-number to size against. Memdb warmup takes **107.9 seconds**.
+**Consequence:** 🚨 ~~an index over *books* is a 366K-entry structure, not a 44K one. That is
+the number to size against.~~ **Reversed by the retraction above.** An index over *books* is
+an ~49K-entry structure. Every sizing estimate in this document that multiplied by 366K is
+overstated by roughly 7.5x — including, materially, the sort-index memory cost, which drops
+from "+1.3 GB, roughly doubles memdb" to "~+175 MB" (see
+`internal/database/memdb_sort_index_cost_test.go`). That was an open decision and the
+correction changes its answer.
+
+Memdb warmup takes **107.9 seconds** — that figure is an observation, not an extrapolation,
+and stands. Note it is also not contradicted by the smaller book count: warmup loads every
+table, and `book_files` is several hundred thousand rows on its own.
 
 ### 1.2 The engine that already exists
 

--- a/docs/perf-audit-2026-05-29-heap-breakdown.md
+++ b/docs/perf-audit-2026-05-29-heap-breakdown.md
@@ -1,5 +1,5 @@
 <!-- file: docs/perf-audit-2026-05-29-heap-breakdown.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.0.1 -->
 <!-- guid: a1b2c3d4-perf-d4-2026-05-29-heap-breakdown -->
 
 # Heap breakdown audit — post-#1152 strip (MAYDEPLOY-D4)
@@ -30,6 +30,26 @@ stripped `Description`, `BookSigV1`, `BookSigV1Mask`, `BookSigSegments`,
   books 392,962 • authors 17,562 • series 43,124 • book_files 308,857 •
   book_authors 193,059 • book_narrators 3,368 • narrators 922 • works
   211,774.
+
+  > 🚨 **`books 392,962` is not a book count (noted 2026-08-11).** The
+  > equivalent figure from the same source was later shown to be Pebble KEYS
+  > under the `book:` prefix — a prefix shared with ~7 secondary-index
+  > families, so ~7.5 keys per row. The row count is **~48,900** (the
+  > organizer's own full paging enumeration, 2026-08-11; system status
+  > independently read 46,221 and 54,734). See
+  > `internal/database/memdb_sort_index_cost_test.go` and
+  > `TestWarmupCounts_CountRowsNotPebbleKeys`.
+  >
+  > **Every books-multiplied total in this document is therefore ~8x too
+  > high.** The per-row struct analysis below is unaffected — it is derived
+  > from the struct shape, not from the population — so the fix is to
+  > re-multiply, not to re-derive. The other row counts in this list have
+  > NOT been re-verified either way.
+  >
+  > The document is annotated rather than recomputed because its conclusions
+  > (strip heavy fields; do not hydrate) were directional and survive a
+  > smaller library. Anyone quoting an absolute megabyte figure from it must
+  > re-multiply first.
 
 > **Confidence:** medium. Per-row sizes are precise from the struct shape;
 > the string-content estimates rely on observed averages from prior pprof

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,7 @@
 // file: internal/config/config.go
-// version: 1.75.0
+// version: 1.75.1
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
-// last-edited: 2026-08-07
+// last-edited: 2026-08-11
 
 package config
 
@@ -777,17 +777,23 @@ type Config struct {
 	// ⚠️ DEFAULT IS EMPTY, AND THAT IS DELIBERATE. Each index costs real
 	// memory, measured rather than estimated at 100,000 books:
 	//
-	//	all nine enabled: 6,395 B/book vs 2,645 B/book — +142%
-	//	extrapolated to prod's 366,916 books: +1,312 MB
+	//	all nine enabled: 6,395 B/book vs 2,645 B/book — +142% (+3,750 B)
+	//	extrapolated to ~48,900 books: ~+175 MB
 	//	insert throughput: 2.8x slower
 	//
-	// That is ~146 MB per sort key, against a design-doc estimate of "tens
-	// of MB per field" — optimistic by roughly an order of magnitude,
-	// because go-memdb's radix tree is immutable and path-copies nodes on
-	// every insert, so cost tracks node count rather than key length.
+	// That is ~19 MB per sort key. go-memdb's radix tree is immutable and
+	// path-copies nodes on every insert, so cost tracks node count rather
+	// than key length — short keys do not make it cheap.
 	//
-	// memdb is already ~1.25 GB resident with a 107.9s warmup, so enabling
-	// all nine roughly doubles it. Enable the fields that are actually
+	// 🚨 This comment previously said "+1,312 MB" and "~146 MB per sort key",
+	// extrapolating to 366,916 books. That was never a book count — it was
+	// Pebble KEYS under the `book:` prefix, ~7.5 per row. The per-book
+	// measurement was always right; only the multiplier was wrong. See
+	// memdb_sort_index_cost_test.go for the full correction. It matters
+	// because it changes the answer: +175 MB is a very different proposition
+	// from +1.3 GB.
+	//
+	// Enable the fields that are actually
 	// sorted by, and measure warmup afterwards.
 	//
 	// Empty (the default) reproduces today's behaviour exactly: only title

--- a/internal/database/memdb_sort_index_cost_test.go
+++ b/internal/database/memdb_sort_index_cost_test.go
@@ -1,13 +1,12 @@
 // file: internal/database/memdb_sort_index_cost_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 6d0b3e57-41ac-4928-b3f6-8e17c2a95d10
-// last-edited: 2026-08-09
+// last-edited: 2026-08-11
 //
 // Measures what the sorted secondary indexes cost, because "tens of MB per
 // field" was an estimate in the design doc and estimates are not measurements.
 //
-// Prod is 366,916 books with memdb warmup at 107.9s and ~1.25GB resident.
-// Adding nine indexes to that structure is a production-affecting change, so
+// Adding nine indexes to the books table is a production-affecting change, so
 // the insert cost and the resident cost get measured on the same shape of
 // data before it ships, not after someone notices a slower boot.
 //
@@ -20,12 +19,8 @@
 // ⚠️ MEASURED RESULT, 2026-08-09 (100,000 books, same fixture both sides):
 //
 //	                    without      with 9 indexes    delta
-//	  heap per book     2,645 B      6,395 B           +142%
-//	  at 366,916 books  925.6 MB     2,237.8 MB        +1,312 MB
+//	  heap per book     2,645 B      6,395 B           +142%  (+3,750 B)
 //	  insert 100K       335 ms       935 ms            2.8x slower
-//
-// That is ~146 MB per sort key. The design doc estimated "tens of MB per
-// sort field" and was optimistic by roughly an order of magnitude.
 //
 // The reason is that go-memdb is an IMMUTABLE radix tree: every insert
 // path-copies nodes from root to leaf, so the per-index cost is dominated by
@@ -36,9 +31,42 @@
 // for nearly every row. A library with populated author/series data pays
 // more.
 //
-// Consequence: memdb is already ~1.25 GB resident with a 107.9s warmup.
-// Enabling all nine would push it past ~2.5 GB. That is a decision to take
-// with the number in hand, not on the estimate.
+// 🚨 EXTRAPOLATION CORRECTED 2026-08-11 — READ BEFORE QUOTING A TOTAL.
+//
+// The per-book delta above is a real measurement and is unchanged. What was
+// wrong was the population it got multiplied by. This header used to read:
+//
+//	at 366,916 books  925.6 MB  2,237.8 MB  +1,312 MB
+//	... ~146 MB per sort key ... enabling all nine would push memdb past 2.5 GB
+//
+// 366,916 was never a book count. It was the number of Pebble KEYS under the
+// `book:` prefix, which is shared with roughly seven secondary-index families
+// (book:path:, book:hash:, book:versiongroup:, book:work:, …) — about 7.5
+// keys per actual row. See memdb_warmup.go and
+// TestWarmupCounts_CountRowsNotPebbleKeys.
+//
+// The best current row count is ~48,900, from the organizer's own full paging
+// enumeration on 2026-08-11 ("Fetched 48896 total books from database"),
+// consistent with system status readings of 46,221 and 54,734.
+//
+// Re-extrapolated at 48,900 books:
+//
+//	                    without      with 9 indexes    delta
+//	  books table       ~123 MB      ~298 MB           ~+175 MB
+//
+// So all nine sort keys cost roughly **175 MB, not 1.3 GB** — about 19 MB per
+// key rather than 146 MB. The earlier figure overstated the cost by ~7.5x.
+//
+// This CHANGES THE DECISION it was gathered for, so it is flagged rather than
+// quietly edited: "+1.3 GB on a box already at 1.25 GB" reads as prohibitive,
+// while "+175 MB" does not. The owner's call either way — but on this number.
+//
+// Two things NOT claimed: the ~1.25 GB resident memdb figure is a real
+// observation and is not contradicted here (memdb holds every table, and
+// book_files alone is several hundred thousand rows — the books table is not
+// the bulk of it); and 48,900 is the best available count, not a verified one.
+// The definitive number comes from the row/key-separated warmup counter once
+// it is deployed.
 
 package database
 
@@ -49,9 +77,16 @@ import (
 	"time"
 )
 
-// costBookCount is deliberately below prod's 366,916 so the test stays
-// usable in CI; the per-book cost is what extrapolates.
+// costBookCount is deliberately ABOVE the production book count (~48,900) so
+// the per-book figure is measured on a tree at least as deep as the real one;
+// the per-book cost is what extrapolates.
 const costBookCount = 100_000
+
+// prodBookCount is the best available production row count — the organizer's
+// own full paging enumeration on 2026-08-11. NOT the 366,916 this file used
+// to extrapolate to: that was Pebble keys under the `book:` prefix, ~7.5 per
+// row. See the header for the full correction.
+const prodBookCount = 48_900
 
 func TestSortIndexCost(t *testing.T) {
 	enableAllSortIndexes(t)
@@ -126,9 +161,10 @@ func TestSortIndexCost(t *testing.T) {
 		float64(costBookCount)/insertTook.Seconds())
 	t.Logf("heap delta:          %.1f MB", float64(heapDelta)/(1024*1024))
 	t.Logf("heap per book:       %.0f bytes", perBook)
-	t.Logf("extrapolated to prod (366,916 books): %.1f MB, insert %.1fs",
-		perBook*366916/(1024*1024),
-		insertTook.Seconds()*366916/float64(costBookCount))
+	t.Logf("extrapolated to prod (%d books): %.1f MB, insert %.1fs",
+		prodBookCount,
+		perBook*prodBookCount/(1024*1024),
+		insertTook.Seconds()*prodBookCount/float64(costBookCount))
 
 	// Sanity, not a threshold: a wildly wrong number means the measurement
 	// is broken rather than that the indexes are bad.

--- a/internal/database/memdb_sort_indexers.go
+++ b/internal/database/memdb_sort_indexers.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_sort_indexers.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 5e7d1b94-08c6-4a32-bf51-9d2e6c0a374b
-// last-edited: 2026-08-09
+// last-edited: 2026-08-11
 //
 // Sorted secondary indexes for the library list.
 //
@@ -14,9 +14,13 @@
 //
 // That is deliberate — a sort applied after pagination only orders the rows
 // you already fetched, so it chose slow over wrong. But "slow" here means
-// materialising and sorting all 366,916 books to return 50 of them, on every
-// page load. memdb_reads.go:585 records the same shape costing 340MB of
-// allocations per call at 68K rows; at 366K it is worse.
+// materialising and sorting the WHOLE book table to return 50 of them, on
+// every page load. memdb_reads.go:585 records the same shape costing 340MB of
+// allocations per call at 68K rows.
+//
+// (This used to say "all 366,916 books". 366,916 was Pebble KEYS under the
+// `book:` prefix, not rows — see memdb_sort_index_cost_test.go. The argument
+// is unchanged; sorting the full table to return a page is wrong at any size.)
 //
 // Title escapes this because it has a sorted index (memIdxTitle) that memdb
 // can walk in order, stopping at limit+offset. These indexers give the same

--- a/internal/database/pebble_store_versiongroup_backfill.go
+++ b/internal/database/pebble_store_versiongroup_backfill.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_versiongroup_backfill.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: 9f3b7c21-6d84-4a5e-b0c9-2e7fa1d85b36
-// last-edited: 2026-08-10
+// last-edited: 2026-08-11
 // PERF-VERSIONS: one-time backfill that writes the
 // book:versiongroup:<gid>:<id> secondary index for every existing book
 // that has a VersionGroupID. Without this, /audiobooks/:id/versions
@@ -38,7 +38,7 @@ const versionGroupBackfillKey = "system:backfill:versiongroup_index_v2_done"
 // commit.
 //
 // This used to be unbounded: one pebble.Batch accumulated a row for EVERY
-// book and was committed once at the end. On a 366,922-book production
+// book and was committed once at the end. On a production-scale
 // library that buffers the entire rebuild in memory and makes nothing durable
 // until the final commit, so an interrupted run threw away all of its work and
 // started over from zero on the next boot — and, because the only log line was

--- a/internal/dedup/lifecycle.go
+++ b/internal/dedup/lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/lifecycle.go
-// version: 1.4.0
+// version: 1.4.1
 // guid: 3e4f5a6b-7c8d-9e0f-a1b2-c3d4e5f60718
-// last-edited: 2026-06-18
+// last-edited: 2026-08-11
 
 // Lifecycle methods on *dedup.Engine that the serviceregistry container
 // picks up via interface satisfaction. PostInit subscribes to lifecycle
@@ -39,7 +39,7 @@ const defaultHydrationStopTimeout = 5 * time.Second
 // FindSimilar in engine.go falls back to the SQLite linear-scan path
 // (EmbeddingStore.FindSimilar at internal/database/embedding_store.go).
 //
-// Tradeoff: skipping hydrate saves ~6GB heap on the 392K-book / 42K-
+// Tradeoff: skipping hydrate saves ~6GB heap on the full-library / 42K-
 // embedding production library, but each dedup FindSimilar goes from
 // chromem ANN (<10ms) to SQLite full-scan + cosine (~50-200ms). Dedup
 // queries are rare (operator-triggered scans, dedup-on-import), so the

--- a/internal/search/bleve_translator.go
+++ b/internal/search/bleve_translator.go
@@ -1,5 +1,5 @@
 // file: internal/search/bleve_translator.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: 9c2a4f1d-5b3e-4f70-a7d6-2e8c0f1b9a47
 // last-edited: 2026-08-11
 //
@@ -141,7 +141,7 @@ func isStopwordOnly(term string) bool {
 //
 // The guard matters as much as the fix. A nil query from Translate becomes
 // MatchAll, so unconditionally dropping stopwords would make a search for "of"
-// return the entire 367K-book library. Requiring a surviving non-stopword term
+// return the entire library. Requiring a surviving non-stopword term
 // means this only ever fires on the broken case; an all-stopword query keeps its
 // current behaviour exactly.
 //

--- a/internal/server/library_list_warmer.go
+++ b/internal/server/library_list_warmer.go
@@ -1,7 +1,7 @@
 // file: internal/server/library_list_warmer.go
-// version: 2.2.0
+// version: 2.2.1
 // guid: 7e8d9a0b-1c2d-3e4f-5a6b-7c8d9e0f1a2b
-// last-edited: 2026-07-03
+// last-edited: 2026-08-11
 
 // Pre-warms svc.audiobookService.listCache by firing the queries the UI
 // is most likely to hit on first load — library page (first few pages,
@@ -37,7 +37,7 @@ func readHeapAllocMB() uint64 {
 }
 
 // warmerMemoryDeltaMB is how many MB above the post-eager baseline the
-// trickle is allowed to grow heap by. Production measurement (392K-book
+// trickle is allowed to grow heap by. Production measurement (full-library
 // library, ~13GB baseline): a single trickle query allocates ~1.8GB
 // transient before GC. Default 4096 (4GB) gives one-query headroom +
 // GC reclaim buffer. Tunable via LIST_WARMER_HEAP_DELTA_MB.

--- a/todo.d/20260811-reverify-library-row-counts.md
+++ b/todo.d/20260811-reverify-library-row-counts.md
@@ -1,0 +1,61 @@
+- [ ] **ROWCOUNT-REVERIFY** Re-measure every production table row count once the
+      row/key-separated warmup counter is deployed, and correct what it moves.
+
+      **Why this is open rather than done.** The `books` figure that appears
+      throughout this repo (392,962 → 366,922 → 366,916, depending on vintage)
+      was never a book count. It was the number of Pebble KEYS under the
+      `book:` prefix, which is shared with roughly seven secondary-index
+      families — `book:path:`, `book:hash:`, `book:originalhash:`,
+      `book:organizedhash:`, `book:versiongroup:`, `book:work:`,
+      `book:asin:`/`book:isbn13:` — at about 7.5 keys per row. The warmup now
+      reports rows and keys separately, pinned by
+      `TestWarmupCounts_CountRowsNotPebbleKeys`, but production has not yet
+      run the fixed counter.
+
+      **Best current number: ~48,900 books.** From the organizer's own full
+      paging enumeration on 2026-08-11 (`Fetched 48896 total books from
+      database`), corroborated by system-status readings of 46,221 and 54,734.
+      This is the strongest available evidence, not a verified count.
+
+      **What has already been corrected** (2026-08-11): the inflated figure was
+      removed or annotated in `memdb_sort_index_cost_test.go`, `config.go`,
+      `memdb_sort_indexers.go`, `pebble_store_versiongroup_backfill.go`,
+      `library_list_warmer.go`, `bleve_translator.go`, `dedup/lifecycle.go`,
+      `web/src/pages/Library.tsx`, `docs/design/2026-08-09-search-backend-options.md`
+      and `docs/perf-audit-2026-05-29-heap-breakdown.md`.
+
+      **The one that changed an answer, and needs an owner decision:** the sort
+      index memory cost. The per-book measurement (+3,750 B/book for all nine
+      indexes, measured at 100,000 books) was always correct; only the
+      population it was multiplied by was wrong. Re-extrapolated:
+
+      | | old (366,916) | corrected (~48,900) |
+      |---|---|---|
+      | all nine sort keys | +1,312 MB | **~+175 MB** |
+      | per sort key | ~146 MB | **~19 MB** |
+
+      "+1.3 GB on a box already at 1.25 GB resident" reads as prohibitive.
+      "+175 MB" does not. The sort indexes shipped default-off on the strength
+      of the larger number; whether to enable some or all of them is worth
+      re-deciding on the corrected one.
+
+      **Still to do:**
+      1. After the next deploy, capture the warmup line and record rows AND
+         keys for every table, not just books.
+      2. Re-verify `book_files`, `works`, `book_authors`, `series`, `authors`.
+         These came from the same counter, but each prefix has its own index
+         families (or none), so they may or may not be inflated. **Do not
+         assume they are wrong and do not assume they are right** — that
+         assume-by-analogy step is what produced the original error.
+      3. Re-multiply the absolute totals in
+         `docs/perf-audit-2026-05-29-heap-breakdown.md`. Its per-row struct
+         analysis is derived from struct shape and is unaffected.
+
+      **The recurrence to avoid.** This number survived three separate
+      opportunities to catch it: the design doc noticed the 392K-vs-44,888
+      discrepancy and resolved it in the wrong direction by inventing
+      "non-primary versions" to explain the gap; a later pass "corrected" 392K
+      to 366,916, propagating the error while appearing to fix it; and a
+      backfill audit reached "13.3% under-scan" by dividing a real scan count
+      by the inflated one. Two numerators agreeing tells you nothing about the
+      denominator they share.

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.tsx
-// version: 1.83.0
+// version: 1.83.1
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
 // last-edited: 2026-08-11
 
@@ -167,7 +167,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
   // which reads `searchParams.get('limit') || '20'` and has no localStorage
   // fallback of its own. So the restore path has been dead for as long as that
   // effect has existed. Its only surviving effect is one wasted 1000-row query
-  // against a 366,922-book library on every single library load, superseded
+  // against the full library on every single library load, superseded
   // before a card of it is ever painted.
   //
   // Dropping the localStorage read therefore changes no rendered output at all;


### PR DESCRIPTION
## The number

`392,962` / `366,922` / `366,916` / `"392K-book"` / `"393K"` / `"367K-book"` have been circulating as the size of the production library. **None of them is a book count.** They are PebbleDB *keys* under the `book:` prefix, which is shared with roughly seven secondary-index families (`book:path:`, `book:hash:`, `book:originalhash:`, `book:organizedhash:`, `book:versiongroup:`, `book:work:`, `book:asin:`/`book:isbn13:`) — about **7.5 keys per row**.

The real figure is **~48,900 books** — the organizer's own complete paging enumeration (`Fetched 48896 total books from database`), independently consistent with system-status readings of 46,221 and 54,734.

## The part that changed an answer

The nine optional sort indexes. Their memory cost was **measured properly**: 3,750 B/book, benchmarked at 100,000 books, with `runtime.KeepAlive` guards. That measurement was and is correct. It was then multiplied by the wrong population.

| | as recorded | corrected |
|---|---|---|
| all nine sort keys | +1,312 MB | **~+175 MB** |
| per sort key | ~146 MB | **~19 MB** |

Live confirmation from the corrected test:

```
heap per book:       6398 bytes
extrapolated to prod (48900 books): 298.4 MB, insert 0.5s
--- PASS: TestSortIndexCost (1.10s)   exit 0
```

**"+1.3 GB on a box already at 1.25 GB" reads as prohibitive. "+175 MB" does not.** The indexes shipped default-off on the strength of the first reading. Whether to enable any of them is **your call** — flagged in-code, not decided here.

## How it spread

Three chances to catch it, three misses — worth recording because the shape recurs:

1. The search-backend design doc **noticed** that 392K disagreed with the ~44,888 books a person actually sees, correctly flagged it, then resolved it in the **wrong direction** — trusting the larger number and inventing "non-primary versions" to explain the gap. The gap was index keys.
2. A later pass "corrected" 392K → 366,916 — propagating the error while looking like a fix.
3. A backfill audit concluded a 13.3% under-scan by dividing a genuine scan count by the inflated one.

Every site is corrected **or annotated in place, struck through rather than deleted** — item 1 is *how the error propagated*, so removing it would let someone re-derive the same conclusion from the same evidence.

## Explicitly not claimed

- **The other tables are not re-verified.** `book_files`, `works`, `book_authors`, `series`, `authors` came from the same counter but sit under different prefixes with different index families. They are **not assumed wrong and not assumed right** — assuming by analogy is the exact step that produced the original error. Tracked as `ROWCOUNT-REVERIFY`.
- **~48,900 is the best available count, not a verified one.** The definitive number comes from the row/key-separated warmup counter (#2301) once it is deployed.
- **The ~1.25 GB resident memdb figure is not contradicted.** It is an observation, and memdb holds every table — `book_files` alone is several hundred thousand rows, so the books table was never the bulk of it.
- **The May heap audit's per-row analysis is unaffected.** It derives from the Go struct layout, not the population, so it needs re-multiplying rather than re-deriving. Annotated accordingly.

## Verification

`go build ./...` exit 0. `go vet` on database/config/search/dedup/server exit 0. `TestSortIndexCost` passes with the corrected extrapolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp