### PR TITLE
fix(fileops,itunes): silent-failure wave 1 — failed recoveries reported success [skip changelog]

### DIFF
--- a/changelog.d/20260811_130000_silent_failure_wave1_dataloss.md
+++ b/changelog.d/20260811_130000_silent_failure_wave1_dataloss.md
@@ -1,0 +1,45 @@
+### Fixed
+
+#### Four places where a failed recovery reported success
+
+Wave 1 of the silent-failure sweep: the sites where a discarded error could
+lose or corrupt a file without saying so.
+
+**A failed rollback now says it failed.** When copying a file into place fails
+partway, the code restores the original from its backup — but the restore's own
+error was thrown away. Since the target has already been partially overwritten
+by that point, a failed restore left a **truncated audiobook** on disk while the
+returned error read `failed to copy file`, which sounds like nothing happened.
+The caller moved on, and the only intact copy sat in the backup directory with
+nothing pointing at it. The error now names both the damaged file and where the
+good copy is.
+
+**The same fix after a checksum mismatch**, where it is worse: that branch is
+reached having *just proven* the target is corrupt. It attempted a restore,
+ignored whether the restore worked, and returned `operation failed integrity
+check` — which reads as "we refused to do it", not "there is a known-bad file on
+disk right now".
+
+**The iTunes library restore no longer claims something it didn't check.** After
+a failed atomic rename, the code restores the original `.itl` from its backup.
+The restore result was discarded while the returned error ended in `(restored
+original)` — a false statement in the error string itself. If that restore
+fails, the live iTunes library is not at its expected path at all; it is sitting
+under a `.bak-<timestamp>` name nothing looks for. The error now reports the
+restore honestly and tells you where the library actually is.
+
+**The iTunes conflict guard now fails closed.** It exists to refuse a write when
+the library may have changed underneath us. If it could not stat the file it
+returned "no conflict" — turning *cannot verify* into *verified safe*, the one
+answer it is not entitled to give. It now refuses.
+
+**Import checkpoints report failures.** Five resume-state writes discarded their
+errors. They are deliberately non-fatal — a checkpoint failure should not abort
+an otherwise-healthy import — but non-fatal is not the same as invisible. If
+they all fail, the import still reports success while its resume state points at
+an earlier phase, and a later crash silently redoes work.
+
+Covered by three tests that force the **rollback itself** to fail, which is the
+only way to exercise these branches; a test that merely makes the copy fail
+passes with or without the fix. With the discards restored, two of the three go
+red carrying the original misleading messages.

--- a/internal/fileops/rollback_failure_test.go
+++ b/internal/fileops/rollback_failure_test.go
@@ -1,0 +1,205 @@
+// file: internal/fileops/rollback_failure_test.go
+// version: 1.0.0
+// guid: c81f5a30-7d64-4e2b-96a1-40b7c5e93d18
+// last-edited: 2026-08-11
+
+package fileops
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// A discarded rollback error is worse than no rollback at all: the error the
+// caller receives then describes a different world than the one on disk.
+//
+// Both sites guarded here used to read `_ = copyFile(op.backupPath,
+// op.targetPath)`. In each, execution has already modified targetPath by the
+// time the rollback runs, so a failed rollback means a damaged file is left
+// behind — while Execute() returns "failed to copy file" or "operation failed
+// integrity check", both of which read as "nothing happened".
+//
+// These tests force the rollback itself to fail, which is the only way to
+// exercise the branch. A test that merely makes the *copy* fail passes with or
+// without the fix.
+// ---------------------------------------------------------------------------
+
+// skipIfRoot bails out when permission bits cannot be used to force failure.
+func skipIfRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("runs as root: mode bits do not deny access, so the failure cannot be forced")
+	}
+}
+
+// newOpWithUnreadableBackup builds a real FileOperation whose backup file
+// exists but cannot be read, so any rollback attempt fails at os.Open.
+func newOpWithUnreadableBackup(t *testing.T, cfg OperationConfig) (*FileOperation, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	srcPath := filepath.Join(root, "source.mp3")
+	if err := os.WriteFile(srcPath, []byte("original audio payload"), 0o644); err != nil {
+		t.Fatalf("setup: write source: %v", err)
+	}
+
+	// targetDir is read-only, so creating a NEW file inside it fails — that is
+	// what makes the forward copy fail without touching the source.
+	targetDir := filepath.Join(root, "target")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("setup: mkdir targetDir: %v", err)
+	}
+	targetPath := filepath.Join(targetDir, "out.mp3")
+
+	cfg.BackupDir = filepath.Join(root, "backups")
+	op, err := NewFileOperation(srcPath, targetPath, cfg)
+	if err != nil {
+		t.Fatalf("setup: NewFileOperation: %v", err)
+	}
+
+	// The backup must EXIST (Execute stats it before rolling back) but be
+	// unreadable, so copyFile fails at os.Open rather than being skipped.
+	if err := os.WriteFile(op.backupPath, []byte("the only intact copy"), 0o644); err != nil {
+		t.Fatalf("setup: write backup: %v", err)
+	}
+	if err := os.Chmod(op.backupPath, 0o000); err != nil {
+		t.Fatalf("setup: chmod backup: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(op.backupPath, 0o644) })
+
+	if err := os.Chmod(targetDir, 0o500); err != nil {
+		t.Fatalf("setup: chmod targetDir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(targetDir, 0o755) })
+
+	return op, targetPath
+}
+
+func TestExecute_CopyFails_AndRollbackFails_SaysSo(t *testing.T) {
+	skipIfRoot(t)
+
+	op, _ := newOpWithUnreadableBackup(t, OperationConfig{VerifyChecksums: false, MaxBackups: 5})
+
+	err := op.Execute()
+	if err == nil {
+		t.Fatal("expected Execute to fail")
+	}
+
+	// The old behaviour: exactly "failed to copy file: ..." and nothing about
+	// the rollback, so the caller cannot know the target may be damaged.
+	if !strings.Contains(err.Error(), "ROLLBACK ALSO FAILED") {
+		t.Fatalf("a failed rollback was swallowed — the error does not mention it: %v", err)
+	}
+	if !strings.Contains(err.Error(), op.backupPath) {
+		t.Errorf("the error must name where the intact copy is (%s), got: %v", op.backupPath, err)
+	}
+}
+
+func TestExecute_ChecksumMismatch_AndRollbackFails_SaysSo(t *testing.T) {
+	skipIfRoot(t)
+
+	root := t.TempDir()
+	srcPath := filepath.Join(root, "source.mp3")
+	if err := os.WriteFile(srcPath, []byte("original audio payload"), 0o644); err != nil {
+		t.Fatalf("setup: write source: %v", err)
+	}
+	targetPath := filepath.Join(root, "out.mp3")
+
+	op, err := NewFileOperation(srcPath, targetPath, OperationConfig{
+		VerifyChecksums: true,
+		BackupDir:       filepath.Join(root, "backups"),
+		MaxBackups:      5,
+	})
+	if err != nil {
+		t.Fatalf("setup: NewFileOperation: %v", err)
+	}
+
+	// Force the mismatch branch: the copy will succeed and hash correctly, so
+	// the recorded "original" hash is what has to disagree. This reaches the
+	// branch that has just PROVEN the target is corrupt.
+	op.originalHash = "0000000000000000000000000000000000000000000000000000000000000000"
+
+	if err := os.WriteFile(op.backupPath, []byte("the only intact copy"), 0o644); err != nil {
+		t.Fatalf("setup: write backup: %v", err)
+	}
+	if err := os.Chmod(op.backupPath, 0o000); err != nil {
+		t.Fatalf("setup: chmod backup: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(op.backupPath, 0o644) })
+
+	err = op.Execute()
+	if err == nil {
+		t.Fatal("expected Execute to fail on checksum mismatch")
+	}
+	if !strings.Contains(err.Error(), "ROLLBACK ALSO FAILED") {
+		t.Fatalf("the restore after a PROVEN-corrupt target failed and was swallowed: %v", err)
+	}
+	if !strings.Contains(err.Error(), "known-corrupt") {
+		t.Errorf("the error must say a known-bad file was left in place, got: %v", err)
+	}
+}
+
+// Control: when the rollback SUCCEEDS the error must stay clean. Without this,
+// the tests above would pass against an implementation that shouted about a
+// failed rollback on every error.
+//
+// Note the fixture shape, which the first draft of this test got wrong: the
+// forward copy has to fail on its SOURCE (unreadable original), not on its
+// destination. Denying writes to the target directory makes the forward copy
+// fail — but it makes the rollback fail too, for exactly the same reason, so
+// "rollback succeeds" becomes unreachable and the control proves nothing.
+func TestExecute_CopyFails_RollbackSucceeds_ErrorStaysClean(t *testing.T) {
+	skipIfRoot(t)
+
+	root := t.TempDir()
+	srcPath := filepath.Join(root, "source.mp3")
+	if err := os.WriteFile(srcPath, []byte("original audio payload"), 0o644); err != nil {
+		t.Fatalf("setup: write source: %v", err)
+	}
+	targetPath := filepath.Join(root, "out.mp3")
+
+	op, err := NewFileOperation(srcPath, targetPath, OperationConfig{
+		VerifyChecksums: false,
+		BackupDir:       filepath.Join(root, "backups"),
+		MaxBackups:      5,
+	})
+	if err != nil {
+		t.Fatalf("setup: NewFileOperation: %v", err)
+	}
+
+	// Readable backup this time, so the rollback can succeed.
+	backupContent := []byte("the only intact copy")
+	if err := os.WriteFile(op.backupPath, backupContent, 0o644); err != nil {
+		t.Fatalf("setup: write backup: %v", err)
+	}
+
+	// Source unreadable: the forward copy fails at os.Open(src) while the
+	// target directory stays writable, so the rollback can complete.
+	if err := os.Chmod(srcPath, 0o000); err != nil {
+		t.Fatalf("setup: chmod source: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(srcPath, 0o644) })
+
+	err = op.Execute()
+	if err == nil {
+		t.Fatal("expected Execute to fail")
+	}
+	if strings.Contains(err.Error(), "ROLLBACK ALSO FAILED") {
+		t.Fatalf("rollback succeeded but the error claims it failed: %v", err)
+	}
+	if !strings.Contains(err.Error(), "failed to copy file") {
+		t.Errorf("expected the original copy error, got: %v", err)
+	}
+
+	// And the rollback actually restored the backup, not just returned nil.
+	got, readErr := os.ReadFile(targetPath)
+	if readErr != nil {
+		t.Fatalf("target missing after a supposedly successful rollback: %v", readErr)
+	}
+	if string(got) != string(backupContent) {
+		t.Errorf("target content = %q, want the restored backup %q", got, backupContent)
+	}
+}

--- a/internal/fileops/safe_operations.go
+++ b/internal/fileops/safe_operations.go
@@ -1,7 +1,7 @@
 // file: internal/fileops/safe_operations.go
-// version: 1.0.2
+// version: 1.1.0
 // guid: 8f7e6d5c-4b3a-2918-7f6e-5d4c3b2a1908
-// last-edited: 2026-05-15
+// last-edited: 2026-08-11
 
 package fileops
 
@@ -108,9 +108,25 @@ func (op *FileOperation) Execute() error {
 
 	// Step 2: Copy source to target
 	if err := copyFile(op.originalPath, op.targetPath); err != nil {
-		// Rollback: restore from backup if it exists
+		// Rollback: restore from backup if it exists.
+		//
+		// A discarded rollback error is WORSE than no rollback, because the
+		// error we return then tells the caller a different story than what is
+		// on disk. By this point copyFile has already begun writing
+		// op.targetPath, so on failure the target is partially overwritten. If
+		// the restore ALSO fails and we swallow it, the caller (organizer,
+		// iTunes importer) reads "failed to copy file" — which sounds like
+		// nothing happened — and moves on, leaving a truncated audiobook at
+		// targetPath and the user's only intact copy orphaned at backupPath
+		// with nothing pointing at it.
 		if _, statErr := os.Stat(op.backupPath); statErr == nil {
-			_ = copyFile(op.backupPath, op.targetPath)
+			if rbErr := copyFile(op.backupPath, op.targetPath); rbErr != nil {
+				slog.Error("ROLLBACK FAILED: target may be corrupt and the only intact copy is the backup",
+					"target", op.targetPath, "backup", op.backupPath,
+					"copy_error", err, "rollback_error", rbErr)
+				return fmt.Errorf("failed to copy file: %w; ROLLBACK ALSO FAILED: %s may be corrupt — the intact copy is at %s: %w",
+					err, op.targetPath, op.backupPath, rbErr)
+			}
 		}
 		return fmt.Errorf("failed to copy file: %w", err)
 	}
@@ -131,9 +147,22 @@ func (op *FileOperation) Execute() error {
 		op.targetHash = targetHash
 
 		if op.originalHash != op.targetHash {
-			// Rollback: restore from backup
+			// Rollback: restore from backup.
+			//
+			// This branch is reached having just PROVEN the target is corrupt.
+			// Discarding the restore error here meant the code could establish
+			// corruption, attempt recovery, ignore whether recovery worked, and
+			// then return "operation failed integrity check" — which reads as
+			// "we refused to do it", not "there is a known-bad file on disk".
 			if _, statErr := os.Stat(op.backupPath); statErr == nil {
-				_ = copyFile(op.backupPath, op.targetPath)
+				if rbErr := copyFile(op.backupPath, op.targetPath); rbErr != nil {
+					slog.Error("ROLLBACK FAILED after checksum mismatch: a known-corrupt file is left in place",
+						"target", op.targetPath, "backup", op.backupPath,
+						"original_hash", op.originalHash, "target_hash", op.targetHash,
+						"rollback_error", rbErr)
+					return fmt.Errorf("checksum mismatch: operation failed integrity check; ROLLBACK ALSO FAILED: %s is known-corrupt and was NOT restored — the intact copy is at %s: %w",
+						op.targetPath, op.backupPath, rbErr)
+				}
 			}
 			return fmt.Errorf("checksum mismatch: operation failed integrity check")
 		}

--- a/internal/itunes/itl_safe_write.go
+++ b/internal/itunes/itl_safe_write.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/itl_safe_write.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-03
+// last-edited: 2026-08-11
 //
 // SafeWriteITL — the single atomic iTunes-library writeback chokepoint
 // (fable5 TASK-004). Implements SPEC 2 §3 (the 8-step atomic write protocol,
@@ -282,9 +282,32 @@ func SafeWriteITL(path string, mutate func(before []byte) (after []byte, err err
 	}
 	if err := os.Rename(newPath, path); err != nil {
 		// Restore original from backup; original is otherwise lost.
-		_ = os.Rename(backupPath, path)
+		//
+		// 🔴 The restore result is CHECKED, and the error message no longer
+		// claims a restore that may not have happened. This block previously
+		// read `_ = os.Rename(backupPath, path)` while returning an error
+		// ending in "(restored original)" — a statement the code had not
+		// verified and could not know to be true.
+		//
+		// If this restore fails, the live iTunes library does not exist at
+		// `path` AT ALL: it is sitting at `path + ".bak-<timestamp>"`, under a
+		// name nothing else looks for. Reporting that as "restored original"
+		// is how a recoverable situation becomes an unnoticed loss — and
+		// `books/itunes/**` is hands-off, so nothing else is going to repair
+		// it. See the 2026-07-05 iTunes corruption incident.
+		if rErr := os.Rename(backupPath, path); rErr != nil {
+			_ = os.Remove(newPath)
+			slog.Error("SafeWriteITL: RESTORE FAILED — the iTunes library is not at its expected path",
+				"op", "itl-safe-write", "component", "itl-safe-write",
+				"expected_path", path, "actual_location", backupPath,
+				"rename_error", err, "restore_error", rErr)
+			return nil, fmt.Errorf("SafeWriteITL: atomic rename %s → %s failed (%w) AND RESTORE FAILED (%w) — "+
+				"the iTunes library is NOT at %s; the original is at %s and must be moved back by hand",
+				newPath, path, err, rErr, path, backupPath)
+		}
 		_ = os.Remove(newPath)
-		return nil, fmt.Errorf("SafeWriteITL: atomic rename %s → %s (restored original): %w", newPath, path, err)
+		return nil, fmt.Errorf("SafeWriteITL: atomic rename %s → %s (original restored to %s): %w",
+			newPath, path, path, err)
 	}
 	if err := syncDir(dir); err != nil {
 		// The rename already landed; a failed dir fsync is logged but not fatal

--- a/internal/itunes/service/importer.go
+++ b/internal/itunes/service/importer.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/importer.go
-// version: 1.13.1
+// version: 1.14.0
 // guid: 2b8e5f1a-4c7d-4e9f-b3a0-6d8c2e7a4f1b
-// last-edited: 2026-07-18
+// last-edited: 2026-08-11
 
 package itunesservice
 
@@ -44,6 +44,30 @@ func RecordITLReadTime() {
 	itlState.mu.Unlock()
 }
 
+// logCheckpointErr records a failed resume-state write.
+//
+// These are deliberately NOT fatal — a checkpoint failure must not abort an
+// import that is otherwise succeeding. But they were `_ =` discards, and that
+// is a different thing from "non-fatal": if every checkpoint write fails, the
+// import still reports success while its resume state says it never got past
+// the phase it last managed to record. A crash then resumes from the wrong
+// phase, re-running work that already happened, and nothing anywhere said the
+// checkpoint was not being written.
+//
+// Logged rather than counted: unlike a per-item loop, there are five of these
+// on distinct phase boundaries, so the phase name is the useful signal.
+//
+// (Wave 0 of the silent-failure plan introduces a shared helper for this shape.
+// This is local to the file on purpose so Wave 1 does not pre-empt that design;
+// fold it in when Wave 0 lands.)
+func logCheckpointErr(err error, opID, phase string) {
+	if err == nil {
+		return
+	}
+	slog.Warn("itunes import: checkpoint write failed; resume will restart from an earlier phase",
+		"op_id", opID, "phase", phase, "err", err)
+}
+
 // CheckITLConflict returns an error if the ITL file at path has been
 // externally modified since the last recorded read.
 func CheckITLConflict(itlPath string) error {
@@ -56,7 +80,21 @@ func CheckITLConflict(itlPath string) error {
 	}
 	stat, err := os.Stat(itlPath)
 	if err != nil {
-		return nil
+		// FAIL CLOSED. This guard exists to refuse a write when the ITL has
+		// changed underneath us. A stat error means "cannot verify", and
+		// returning nil turned that into "verified safe" — the one answer we
+		// are certainly not entitled to give.
+		//
+		// The write this gates is to books/itunes/**, which is hands-off and
+		// where an overwrite is not recoverable from anything the app owns.
+		// Refusing a legitimate write is a nuisance; permitting a conflicting
+		// one is the 2026-07-05 corruption incident.
+		//
+		// os.IsNotExist is deliberately NOT special-cased: if the ITL has
+		// vanished since we read it, that is the strongest possible signal
+		// something else is moving it around.
+		return fmt.Errorf("ITL conflict check failed: cannot stat %s to verify it is unchanged since our last read (%v): %w — refusing to write",
+			itlPath, lastRead, err)
 	}
 	if stat.ModTime().After(lastRead.Add(2 * time.Second)) {
 		return fmt.Errorf("ITL conflict: file modified at %v (our last read: %v) — re-sync before writing",
@@ -404,7 +442,7 @@ func (imp *Importer) Execute(ctx context.Context, opID string, req ImportRequest
 		updateImportProgress(log, status, processed, totalGroups, book.Title)
 
 		if processed%10 == 0 {
-			_ = operations.SaveCheckpoint(imp.store, opID, "itunes_import", "importing", processed, totalGroups)
+			logCheckpointErr(operations.SaveCheckpoint(imp.store, opID, "itunes_import", "importing", processed, totalGroups), opID, "importing")
 		}
 	}
 
@@ -414,7 +452,7 @@ func (imp *Importer) Execute(ctx context.Context, opID string, req ImportRequest
 
 	// Phase 3: Hash validation
 	if len(newBookIDs) > 0 && req.SkipDuplicates {
-		_ = operations.SaveCheckpoint(imp.store, opID, "itunes_import", "hash_validation", 0, len(newBookIDs))
+		logCheckpointErr(operations.SaveCheckpoint(imp.store, opID, "itunes_import", "hash_validation", 0, len(newBookIDs)), opID, "hash_validation")
 		log.UpdateProgress(totalGroups, totalGroups, fmt.Sprintf("Hash validation: checking %d new books...", len(newBookIDs)))
 		log.Info("Starting hash validation for %d new books...", len(newBookIDs))
 
@@ -494,19 +532,19 @@ func (imp *Importer) Execute(ctx context.Context, opID string, req ImportRequest
 
 	// Phase 4: Metadata enrichment
 	if req.FetchMetadata {
-		_ = operations.SaveCheckpoint(imp.store, opID, "itunes_import", "enriching", 0, 0)
+		logCheckpointErr(operations.SaveCheckpoint(imp.store, opID, "itunes_import", "enriching", 0, 0), opID, "enriching")
 		log.Info("Starting metadata enrichment phase...")
 		imp.enrichImportedBooks(ctx, status, log)
 	}
 
 	// Phase 5: Organize
 	if importMode == itunes.ImportModeOrganize && !req.PreserveLocation {
-		_ = operations.SaveCheckpoint(imp.store, opID, "itunes_import", "organizing", 0, 0)
+		logCheckpointErr(operations.SaveCheckpoint(imp.store, opID, "itunes_import", "organizing", 0, 0), opID, "organizing")
 		log.Info("Starting organize phase...")
 		imp.organizeImportedBooks(ctx, status, log)
 	}
 
-	_ = operations.ClearState(imp.store, opID)
+	logCheckpointErr(operations.ClearState(imp.store, opID), opID, "clear-state")
 
 	if fp, err := itunes.ComputeFingerprint(req.LibraryPath); err == nil {
 		_ = imp.store.SaveLibraryFingerprint(fp.Path, fp.Size, fp.ModTime, fp.CRC32)

--- a/internal/itunes/service/importer_execute_test.go
+++ b/internal/itunes/service/importer_execute_test.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/importer_execute_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
-// last-edited: 2026-07-13
+// last-edited: 2026-08-11
 
 package itunesservice
 
@@ -49,14 +49,35 @@ func TestCheckITLConflict_ZeroLastRead(t *testing.T) {
 	assert.NoError(t, err, "should be nil when lastRead is zero")
 }
 
-func TestCheckITLConflict_NoFile(t *testing.T) {
+// TestCheckITLConflict_UnstatableFailsClosed replaces a test that asserted the
+// OPPOSITE, and the replacement is deliberate rather than test rot.
+//
+// The old test read:
+//
+//	// File doesn't exist — stat fails → no conflict (returns nil)
+//	assert.NoError(t, err, "missing file should not be flagged as conflict")
+//
+// It was pinning the defect. CheckITLConflict exists to REFUSE a write when the
+// ITL may have changed underneath us; a stat error means "cannot verify", and
+// answering nil converts that into "verified safe" — the one answer the
+// function is not entitled to give. The write it gates lands in
+// books/itunes/**, which is hands-off, and an overwrite there is not
+// recoverable from anything the app owns.
+//
+// The only caller (server/handlers/itunes.go) already stats the path itself and
+// returns 400 if it is missing, so this branch is not the ordinary
+// "no library configured" path — it means the file went away, or became
+// unreadable, between that check and this one. That is precisely when refusing
+// is right.
+func TestCheckITLConflict_UnstatableFailsClosed(t *testing.T) {
 	itlState.mu.Lock()
 	itlState.lastRead = time.Now()
 	itlState.mu.Unlock()
 
-	// File doesn't exist — stat fails → no conflict (returns nil)
 	err := CheckITLConflict("/nonexistent/path.itl")
-	assert.NoError(t, err, "missing file should not be flagged as conflict")
+	assert.Error(t, err, "an unstatable ITL must fail CLOSED — 'cannot verify' is not 'no conflict'")
+	assert.Contains(t, err.Error(), "refusing to write",
+		"the error must say what was refused, not just that stat failed")
 }
 
 func TestCheckITLConflict_NoConflict(t *testing.T) {


### PR DESCRIPTION
Wave 1 of the plan in #2307: the discards that can lose or corrupt a file without saying so.

## The four

**`safe_operations.go:113`** — rollback after a failed copy. The target is **already partially overwritten** when this runs, so a swallowed restore error left a truncated audiobook on disk while the returned error read `failed to copy file` — which sounds like nothing happened. The caller moved on; the only intact copy sat in the backup directory with nothing pointing at it.

**`safe_operations.go:136`** — the same restore after a **checksum mismatch**, and worse in intent: that branch is reached having *just proven* the target is corrupt. It attempted recovery, ignored whether recovery worked, and returned `operation failed integrity check` — which reads as "we refused to do it", not "there is a known-bad file on disk right now".

**`itl_safe_write.go:285`** — restoring the original `.itl` after a failed atomic rename. The restore result was discarded while the returned error ended in `(restored original)` — **a claim the code had not verified.** If that restore fails, the live iTunes library is not at `path` at all; it is under a `.bak-<timestamp>` name nothing looks for, and `books/itunes/**` is hands-off so nothing else repairs it. See the 2026-07-05 corruption incident.

**`importer.go:57`** — `CheckITLConflict` failed **open**. A stat error returned `nil`: *cannot verify* answered as *verified safe*. Now refuses.

Plus five checkpoint / `ClearState` discards in `importer.go`. Deliberately non-fatal — but non-fatal is not invisible. If they all fail, the import reports success while its resume state points at an earlier phase.

## Verification

Three tests that force the **rollback itself** to fail. That distinction is the whole point: a test that merely makes the *copy* fail passes with or without the fix.

**Negative control**, discards restored:

```
--- FAIL: TestExecute_CopyFails_AndRollbackFails_SaysSo
    a failed rollback was swallowed — the error does not mention it:
    failed to copy file: open .../out.mp3: permission denied
--- FAIL: TestExecute_ChecksumMismatch_AndRollbackFails_SaysSo
    the restore after a PROVEN-corrupt target failed and was swallowed:
    checksum mismatch: operation failed integrity check
--- PASS: TestExecute_CopyFails_RollbackSucceeds_ErrorStaysClean
exit 1
```

Both red messages are the *real* misleading errors, quoted back. The third correctly stays green — it is the control against an implementation that shouts about a failed rollback on every error.

Worth recording: **the control caught a bug in my own fixture.** The first draft made the forward copy fail by denying writes to the target directory — which fails the rollback for the identical reason, making "rollback succeeds" unreachable. The failure has to be on the *source* side.

With the fix: `ok internal/fileops`, `ok internal/itunes`, `ok internal/itunes/service` — **exit 0, 0 failures.** `go build ./...` and `go vet` on fileops/itunes/server exit 0.

## One test was replaced, not deleted — flagging it explicitly

`TestCheckITLConflict_NoFile` asserted the **old fail-open behaviour**:

```go
// File doesn't exist — stat fails → no conflict (returns nil)
assert.NoError(t, err, "missing file should not be flagged as conflict")
```

It was pinning the defect. This is not "changing a test to match broken behaviour" — it is the inverse, and I want it visible rather than buried in a diff. The replacement, `TestCheckITLConflict_UnstatableFailsClosed`, records what the old one said and why it was wrong.

The behaviour change is safe for the one caller: `server/handlers/itunes.go:509` already stats the path itself and returns 400 if missing, so this branch is not the ordinary "no library configured" path — it means the file moved or became unreadable *between* those two checks, which is exactly when refusing is right.

## Not in scope

Wave 0 (shared helper + `errcheck` exemption list) still lands separately and first. `logCheckpointErr` here is file-local **on purpose** so Wave 1 does not pre-empt that design; fold it in when Wave 0 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp