### PR TITLE
fix(organize): already-organized books stayed in the backlog forever [skip changelog]

### DIFF
--- a/changelog.d/20260811_213000_fix_organize_library_state_stamp.md
+++ b/changelog.d/20260811_213000_fix_organize_library_state_stamp.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Organizing a book that was already in the right place no longer leaves it in
+  the "Needs Organizing" backlog forever. The organize stamp recorded *when* a
+  book was organized and *which operation* did it, but never updated the book's
+  library state — and that state is exactly what the dashboard counts. Because
+  already-correct books are diverted out of the organize path before reaching
+  the code that sets the state, re-running organize could never clear them. The
+  backlog was self-refilling and no amount of organizing would empty it.

--- a/internal/organizer/service.go
+++ b/internal/organizer/service.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/service.go
-// version: 1.13.0
+// version: 1.14.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
 // last-edited: 2026-08-11
 
@@ -744,10 +744,25 @@ func (orgSvc *Service) hydrateAndUpdateBook(bookID string, mutate func(*database
 }
 
 // stampOrganizeMetadata hydrates the full book row via GetBookByID and writes
-// the LastOrganizeOperationID/LastOrganizedAt stamp back onto that hydrated
-// struct. See hydrateAndUpdateBook for the rationale.
+// the LibraryState/LastOrganizeOperationID/LastOrganizedAt stamp back onto that
+// hydrated struct. See hydrateAndUpdateBook for the rationale.
+//
+// LibraryState MUST be set here, not just the two timestamps. All three callers
+// mean "this book is now sitting at its correct organized path": the
+// oldPath==newPath branch, the alreadyInRoot re-organize branch, and the bulk
+// alreadyCorrect stamp. Until 2026-08-11 this helper wrote only the two stamp
+// fields, so a book that was PERFECTLY organized kept library_state="imported"
+// forever — and the dashboard's "Needs Organizing" card counts exactly
+// library_state=="imported". Re-running organize could never clear it, because
+// FilterBooksNeedingOrganization diverts already-correct books into
+// alreadyCorrect BEFORE they can reach ReOrganizeInPlace, which does set the
+// state correctly (see the oldPath==targetPath branch). That asymmetry — one
+// path marking the state, its sibling silently not — is what produced a
+// permanent, self-refilling organize backlog.
 func (orgSvc *Service) stampOrganizeMetadata(bookID, operationID string, when time.Time) error {
+	organizedState := "organized"
 	return orgSvc.hydrateAndUpdateBook(bookID, func(b *database.Book) {
+		b.LibraryState = &organizedState
 		b.LastOrganizeOperationID = &operationID
 		b.LastOrganizedAt = &when
 	})

--- a/internal/organizer/stamp_library_state_test.go
+++ b/internal/organizer/stamp_library_state_test.go
@@ -1,0 +1,114 @@
+// file: internal/organizer/stamp_library_state_test.go
+// version: 1.0.0
+// guid: 6d2b8f04-3a71-4e59-b8c2-1f7a09e4d35c
+// last-edited: 2026-08-11
+
+package organizer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/database/mocks"
+	"github.com/stretchr/testify/mock"
+)
+
+// ---------------------------------------------------------------------------
+// Regression: stampOrganizeMetadata must write LibraryState, not only the two
+// timestamp/op-id fields.
+//
+// The dashboard's "Needs Organizing" card counts books where
+// library_state == "imported" (memdb_summaries.go). Before this fix the stamp
+// wrote LastOrganizeOperationID and LastOrganizedAt but left LibraryState
+// untouched, so a book that was PERFECTLY organized stayed "imported" forever
+// and the backlog could never be cleared — re-running organize did not help,
+// because FilterBooksNeedingOrganization diverts already-correct books into the
+// `alreadyCorrect` bucket BEFORE they can reach ReOrganizeInPlace, which is the
+// path that does set the state (see its oldPath == targetPath branch).
+//
+// All three callers of this helper mean "this book is now sitting at its
+// correct organized path", so the state belongs in the shared helper rather
+// than at each call site.
+// ---------------------------------------------------------------------------
+
+func TestStampOrganizeMetadata_SetsLibraryStateOrganized(t *testing.T) {
+	imported := "imported"
+	book := &database.Book{
+		ID:           "book-1",
+		Title:        "Already In The Right Place",
+		FilePath:     "/library/Author/Title",
+		LibraryState: &imported,
+	}
+
+	var captured *database.Book
+	mockStore := mocks.NewMockStore(t)
+	mockStore.On("GetBookByID", "book-1").Return(book, nil)
+	mockStore.On("UpdateBook", "book-1", mock.AnythingOfType("*database.Book")).
+		Run(func(args mock.Arguments) {
+			// Capture the row as it is actually written. Asserting on the
+			// in-memory `book` pointer instead would be a blind spot: the
+			// helper writes through a freshly hydrated struct, so the value
+			// the store receives is the only one that matters.
+			captured = args.Get(1).(*database.Book)
+		}).
+		Return(book, nil)
+
+	svc := NewService(mockStore)
+
+	when := time.Date(2026, 8, 11, 21, 0, 0, 0, time.UTC)
+	if err := svc.stampOrganizeMetadata("book-1", "op-organize-1", when); err != nil {
+		t.Fatalf("stampOrganizeMetadata returned error: %v", err)
+	}
+
+	if captured == nil {
+		t.Fatal("UpdateBook was never called — nothing was stamped")
+	}
+
+	if captured.LibraryState == nil {
+		t.Fatal("LibraryState was left nil — the book stays out of the organized count")
+	}
+	if got := *captured.LibraryState; got != "organized" {
+		t.Fatalf("LibraryState = %q, want %q — a correctly-organized book would stay in the "+
+			"\"Needs Organizing\" backlog forever", got, "organized")
+	}
+
+	// The pre-existing stamp fields must survive the change.
+	if captured.LastOrganizeOperationID == nil || *captured.LastOrganizeOperationID != "op-organize-1" {
+		t.Errorf("LastOrganizeOperationID not stamped: %v", captured.LastOrganizeOperationID)
+	}
+	if captured.LastOrganizedAt == nil || !captured.LastOrganizedAt.Equal(when) {
+		t.Errorf("LastOrganizedAt not stamped: %v", captured.LastOrganizedAt)
+	}
+}
+
+// Control: a book that is already marked "organized" must stay that way — the
+// helper must not flap the state or clear it. This exists so the test above
+// cannot pass merely because the field happened to be non-empty.
+func TestStampOrganizeMetadata_KeepsAlreadyOrganizedState(t *testing.T) {
+	organized := "organized"
+	book := &database.Book{
+		ID:           "book-2",
+		Title:        "Previously Organized",
+		FilePath:     "/library/Author/Title",
+		LibraryState: &organized,
+	}
+
+	var captured *database.Book
+	mockStore := mocks.NewMockStore(t)
+	mockStore.On("GetBookByID", "book-2").Return(book, nil)
+	mockStore.On("UpdateBook", "book-2", mock.AnythingOfType("*database.Book")).
+		Run(func(args mock.Arguments) {
+			captured = args.Get(1).(*database.Book)
+		}).
+		Return(book, nil)
+
+	svc := NewService(mockStore)
+
+	if err := svc.stampOrganizeMetadata("book-2", "op-organize-2", time.Now()); err != nil {
+		t.Fatalf("stampOrganizeMetadata returned error: %v", err)
+	}
+	if captured == nil || captured.LibraryState == nil || *captured.LibraryState != "organized" {
+		t.Fatalf("expected LibraryState to remain \"organized\", got %v", captured.LibraryState)
+	}
+}


### PR DESCRIPTION
## The bug

`stampOrganizeMetadata` wrote `LastOrganizeOperationID` and `LastOrganizedAt` but **never `LibraryState`**. The dashboard's "Needs Organizing" card counts `library_state == "imported"`, so a book sitting at its correct organized path counted as unorganized **forever**.

Re-running organize could not clear it. `FilterBooksNeedingOrganization` diverts already-correct books into the `alreadyCorrect` bucket *before* they can reach `ReOrganizeInPlace` — which is the sibling path that **does** set the state, on its `oldPath == targetPath` branch. One path marked the state; its sibling silently did not. The backlog was self-refilling.

## The fix

One line, in the shared helper. Verified all three callers (`oldPath == newPath`, the `alreadyInRoot` re-organize branch, and the bulk `alreadyCorrect` stamp) mean "this book is now at its correct organized path", so the state write belongs in the helper rather than at each call site.

## Verification

**Negative control — the test was watched going red before it was trusted:**

| State | Result |
|---|---|
| Fix applied | `--- PASS` both tests |
| **Fix reverted** | `--- FAIL: LibraryState = "imported", want "organized"` |
| Fix restored | `ok  internal/organizer  0.296s` |

Full package: `go test ./internal/organizer/ -short` → **exit 0**.

A control test also pins that an already-`organized` book keeps that state, so the primary test cannot pass merely because the field was non-empty.

## Not claimed

- Prod impact is **not** measured yet. Two other predicates independently inflate the same count and are **not** touched here: non-primary versions are counted (the primary filter only applies when `SortBy=="title"`), and iTunes-tree books are counted despite that tree being hands-off for writes.
- Existing rows are not backfilled — books already stuck at `imported` need an organize run (or a backfill) to pick up the correct state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp