### PR TITLE
docs(todo): iTunes listened/progress not propagated; UI still locks up [skip changelog]

### DIFF
--- a/changelog.d/20260811_215800_docs_todo_playback_and_ui_lockup.md
+++ b/changelog.d/20260811_215800_docs_todo_playback_and_ui_lockup.md
@@ -1,0 +1,7 @@
+### Changed
+
+- Recorded two outstanding user-facing gaps in the backlog: listened/in-progress
+  status is not being carried over from iTunes or from the files themselves, and
+  the web interface still locks up. The second entry documents the measurements
+  showing the lock-up may now be backend starvation rather than the DOM-volume
+  problem the earlier fix targeted.

--- a/todo.d/20260811-itunes-listened-progress-not-propagated.md
+++ b/todo.d/20260811-itunes-listened-progress-not-propagated.md
@@ -1,0 +1,37 @@
+- [ ] **PLAYBACK-IMPORT** Listened / in-progress status is not coming across from
+      iTunes (or from the files), so a book the owner has already finished still
+      shows as unplayed here, and a book they are part-way through shows no
+      progress. Reported 2026-08-11: *"I thought we were tracking listened status
+      and copying that over from iTunes... it feels like none of the stuff to
+      actually make the other features that need those were done."*
+
+      Investigate and report before changing anything — this is suspected to be
+      an **unwired pipeline**, the same shape as two other defects found the same
+      night (the iTunes playlist importer was never called; nothing ever
+      scheduled a folder scan). Confirm which of these is true rather than
+      assuming:
+
+      - Does the iTunes importer **read** the ITL/XML play-count, `Played`
+        flag, and bookmark/position fields at all? If it parses them, where do
+        they land?
+      - Is there a **write path** from those parsed values onto the book /
+        book_file rows (read status, progress position)? `internal/readstatus/`
+        and `internal/itunes/service/position_sync.go` both exist — are either
+        actually invoked on import, or only on the 2-way-sync path?
+      - Does the **file itself** carry progress (embedded chapter/position
+        metadata, `.m4b` bookmarks)? If so, is it read on scan?
+      - Does the **API expose** listened/progress to the UI, and does the UI
+        render it? A value that is stored but never surfaced looks identical to
+        one that was never stored.
+
+      ⚠️ Related known defect — do not repair progress data until it is fixed:
+      silent-failure **Wave 5** covers `internal/itunes/service/position_sync.go`
+      (lines 85, 118), where a *failed read* is indistinguishable from "no prior
+      state", so the iTunes bookmark **overwrites the user's real playback
+      position**. Backfilling progress through that path could destroy the very
+      data this task is meant to restore. Wave 5 lands first.
+
+      Also relevant: `internal/readstatus/readstatus.go:144` discards the
+      existing state and rebuilds a fresh one on a read error, and
+      `internal/database/pebble_store_playback.go:107` leaks a stale status index
+      entry so a book can appear under two statuses at once.

--- a/todo.d/20260811-web-ui-still-locks-up.md
+++ b/todo.d/20260811-web-ui-still-locks-up.md
@@ -1,0 +1,35 @@
+- [ ] **UI-LOCKUP-2** The web interface still locks up despite the virtualization
+      work and the earlier backend fixes. Reported 2026-08-11.
+
+      **Do not assume this is still a frontend/DOM-volume problem.** Measured on
+      prod the same night, the backend alone can account for a UI that appears
+      frozen:
+
+      - `GET /api/v1/audiobooks?library_state=imported&limit=1` took **36
+        seconds** — for one row.
+      - `GET /api/libraries/{id}/personalized` took **2m10s**.
+      - The server was OOM-killed **four times** in ninety minutes, and memdb
+        warmup takes **568 s (9.5 min)** during which the library is unusable —
+        `library list warm-up: memdb not ready after 5 min, skipping` fires
+        because warmup outlives its own waiter, so the list cache never warms.
+      - The activity-log query ignores client disconnect, so abandoned requests
+        keep scanning; 30 such goroutines were pinning 30 GB with zero clients
+        connected.
+
+      A frontend cannot render what it cannot fetch, and a browser tab whose
+      requests never return looks exactly like a frozen UI. So the first job is
+      to **separate the two**, not to add more virtualization:
+
+      1. Reproduce with DevTools Network open. Are requests **pending** (backend)
+        or returning fast while the page janks (frontend)?
+      2. If backend: which endpoint, and is it one of the known-unbounded ones?
+      3. If frontend: profile it. Is virtualization actually active on the list
+        that janks, or only on the one that was fixed before?
+      4. Check whether the lock-up correlates with server restarts / warmup
+        windows — if it only happens in the ~10 min after a restart, it is
+        startup sequencing, not the UI.
+
+      State which of the two it is, with evidence, before writing any fix. The
+      previous round of this task was closed against a DOM-volume hypothesis; if
+      that hypothesis was wrong, or was right then and is not the binding
+      constraint now, say so explicitly.


### PR DESCRIPTION
Two owner-reported gaps recorded as todo.d fragments.

**PLAYBACK-IMPORT** — finished books show unplayed, in-progress books show no progress. Suspected unwired pipeline (same shape as the iTunes playlist importer never being called, and nothing ever scheduling a folder scan). Flags that silent-failure **Wave 5 must land first**: `position_sync.go` cannot distinguish a failed read from "no prior state", so backfilling progress through it would overwrite the real playback position this task exists to restore.

**UI-LOCKUP-2** — explicitly warns against re-assuming a DOM-volume cause. Measured on prod tonight: `limit=1` took 36s, `/personalized` 2m10s, four OOM kills in ninety minutes, 568s memdb warmup. Separate backend from frontend with evidence before writing a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp