### PR TITLE
fix(scan): nothing ever scanned for new books — wire a periodic library scan [skip changelog]

### DIFF
--- a/changelog.d/20260811_220000_fix_periodic_library_scan.md
+++ b/changelog.d/20260811_220000_fix_periodic_library_scan.md
@@ -1,0 +1,57 @@
+### Fixed
+
+#### Newly added books were never discovered — nothing scanned automatically
+
+Copying audiobooks into a watched folder did nothing until somebody opened the
+UI and pressed **Scan**. This was not a broken feature; automatic discovery had
+simply never been wired up. Four separate gaps produced the one symptom.
+
+**The scheduled scan could not tick.** `library_scan` was a registered
+scheduler task, but its `GetInterval` returned a hard-coded `0`. The scheduler
+only starts a ticker when `IsEnabled() && GetInterval() > 0`, so no ticker was
+ever created for it. `IsEnabled` and `RunOnStart` both read `scan_on_startup`,
+which defaults off, so the task was inert on every axis. There is now a
+`scheduled.library_scan` config family (`enabled` / `interval` / `on_startup`)
+that ships **enabled with a 6-hour interval** — the only member of that family
+that defaults on, because it is the only unattended discovery path. The legacy
+`scan_on_startup` flag still enables the task and still triggers a startup
+scan, so nobody loses behaviour they had configured.
+
+**The maintenance-window toggle was dead config.** `maintenance.library_scan`
+existed in the settings UI and in the config struct, but the maintenance-window
+operation only ever iterates `MaintenanceOrder()`, and `library_scan` was
+missing from that list. Flipping the toggle did nothing at all. It is now in
+the list, placed **last**: the window operation stops running tasks the moment
+the window closes, so a full library walk at the front would have starved
+dedup, purge and optimize on the same night.
+
+**File watchers only ever saw the import paths that existed at boot.** The
+auto-scan watchers were started from a single startup snapshot of the import
+paths, so a folder added later got no watcher until the process was restarted.
+Watchers are now managed by a supervisor that re-reads the desired set every
+five minutes: a path added, enabled, disabled or removed at runtime is picked
+up without a restart, and the watcher for a removed path is stopped rather than
+leaked. (These watchers remain the low-latency path only — fsnotify does not
+see writes made by remote NFS/SMB clients and can exhaust the kernel watch
+limit on a large tree, so the timed scan is the guaranteed catch-all.)
+
+**A failed import-path read started zero watchers in silence.** The startup
+code was `if err == nil && len(importPaths) > 0 { ... }` — a database read
+failure fell straight through the condition with no log line, leaving auto-scan
+apparently enabled but completely blind. Enumeration failures are now logged
+and pushed to the activity log, and a transient failure leaves the existing
+watchers running instead of tearing them down.
+
+A repeated scan can no longer pile up: the scheduled task skips a tick while
+the previous scan it enqueued is still queued or running, which matters because
+the operation dispatcher serializes a duplicate rather than rejecting it.
+
+One deliberate limit, now recorded in the code rather than left as an accident:
+a default scan still does **not** walk the organized library root. That
+directory is the destination the organizer writes into (and on this deployment
+the hands-off iTunes tree sits underneath it), so folding it into a scan that
+now runs every six hours would feed already-organized books back through the
+organize path on a loop. A folder dropped straight into the library root is
+therefore still not auto-discovered — add it as an import path, or run a scan
+with `force_update`. The scan log now says so out loud instead of staying
+quiet about it.

--- a/changelog.d/20260811_220000_fix_periodic_library_scan.md
+++ b/changelog.d/20260811_220000_fix_periodic_library_scan.md
@@ -48,10 +48,12 @@ the operation dispatcher serializes a duplicate rather than rejecting it.
 
 One deliberate limit, now recorded in the code rather than left as an accident:
 a default scan still does **not** walk the organized library root. That
-directory is the destination the organizer writes into (and on this deployment
-the hands-off iTunes tree sits underneath it), so folding it into a scan that
-now runs every six hours would feed already-organized books back through the
-organize path on a loop. A folder dropped straight into the library root is
+directory is the destination the organizer writes into, so folding it into a
+scan that now runs every six hours would feed already-organized books back
+through the organize path on a loop — and because the library root is an
+operator-set path that may sit above unrelated media or a hands-off iTunes
+tree, the timed path stays conservative. A folder dropped straight into the
+library root is
 therefore still not auto-discovered — add it as an import path, or run a scan
 with `force_update`. The scan log now says so out loud instead of staying
 quiet about it.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.75.1
+// version: 1.76.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-08-11
 
@@ -450,6 +450,11 @@ type AutoUpdateConfig struct {
 
 // ScheduledTasksConfig holds settings for all background scheduled tasks.
 type ScheduledTasksConfig struct {
+	// LibraryScan drives the periodic incremental library scan. Unlike the rest
+	// of this family it ships ENABLED with a non-zero interval: without it
+	// nothing in the process ever discovers a newly added book on its own
+	// (the fsnotify watcher is opt-in and best-effort).
+	LibraryScan              ScheduledTaskConfig `json:"library_scan"                mapstructure:"library_scan"`
 	DedupRefresh             ScheduledTaskConfig `json:"dedup_refresh"               mapstructure:"dedup_refresh"`
 	LabelRefinement          ScheduledTaskConfig `json:"label_refinement"            mapstructure:"label_refinement"`
 	AuthorSplit              ScheduledTaskConfig `json:"author_split"                mapstructure:"author_split"`
@@ -1082,6 +1087,19 @@ func InitConfig() {
 	viper.SetDefault("enable_json_logging", false)
 
 	// Scheduled task defaults (nested under "scheduled.*.*")
+	// library_scan ships ENABLED at a 6-hour interval. Every other member of
+	// this family defaults off, but this one is the ONLY thing that discovers
+	// newly added books unattended: before it existed the library_scan task's
+	// GetInterval returned a hard-coded 0, so scheduler.Start never created a
+	// ticker for it and a book copied into an import path stayed invisible
+	// until someone pressed Scan by hand. 360 min bounds worst-case discovery
+	// latency at 6h while keeping the walk cost modest on a large library
+	// (the scan is incremental — unchanged files are skipped via the scan
+	// cache). auto_scan_enabled's fsnotify watchers are the low-latency path
+	// on top of this, not a replacement for it.
+	viper.SetDefault("scheduled.library_scan.enabled", true)
+	viper.SetDefault("scheduled.library_scan.interval", 360)
+	viper.SetDefault("scheduled.library_scan.on_startup", false)
 	viper.SetDefault("scheduled.dedup_refresh.enabled", false)
 	viper.SetDefault("scheduled.dedup_refresh.interval", 360)
 	viper.SetDefault("scheduled.dedup_refresh.on_startup", false)
@@ -1112,6 +1130,9 @@ func InitConfig() {
 	viper.SetDefault("scheduled.reconcile.interval", 0)
 	viper.SetDefault("scheduled.reconcile.on_startup", false)
 	// BindEnv maps env vars so SCHEDULED_* overrides work even without AutomaticEnv.
+	viper.BindEnv("scheduled.library_scan.enabled", "SCHEDULED_LIBRARY_SCAN_ENABLED")                               //nolint:errcheck
+	viper.BindEnv("scheduled.library_scan.interval", "SCHEDULED_LIBRARY_SCAN_INTERVAL")                             //nolint:errcheck
+	viper.BindEnv("scheduled.library_scan.on_startup", "SCHEDULED_LIBRARY_SCAN_ON_STARTUP")                         //nolint:errcheck
 	viper.BindEnv("scheduled.dedup_refresh.enabled", "SCHEDULED_DEDUP_REFRESH_ENABLED")                             //nolint:errcheck
 	viper.BindEnv("scheduled.dedup_refresh.interval", "SCHEDULED_DEDUP_REFRESH_INTERVAL")                           //nolint:errcheck
 	viper.BindEnv("scheduled.dedup_refresh.on_startup", "SCHEDULED_DEDUP_REFRESH_ON_STARTUP")                       //nolint:errcheck
@@ -1629,6 +1650,11 @@ func InitConfig() {
 
 			// Scheduled background tasks (nested sub-struct)
 			Scheduled: ScheduledTasksConfig{
+				LibraryScan: ScheduledTaskConfig{
+					Enabled:   viper.GetBool("scheduled.library_scan.enabled"),
+					Interval:  viper.GetInt("scheduled.library_scan.interval"),
+					OnStartup: viper.GetBool("scheduled.library_scan.on_startup"),
+				},
 				DedupRefresh: ScheduledTaskConfig{
 					Enabled:   viper.GetBool("scheduled.dedup_refresh.enabled"),
 					Interval:  viper.GetInt("scheduled.dedup_refresh.interval"),
@@ -2128,6 +2154,21 @@ func ResetToDefaults() {
 				// via setting + env key.
 				AcoustIDOnlineLookup: false,
 				AcoustIDNightlyLimit: 5000,
+			},
+
+			// Scheduled background tasks. Only library_scan is listed: it is
+			// the one member of the family that defaults ON, so leaving the
+			// whole sub-struct at its zero value here would silently turn the
+			// periodic scan OFF on a factory reset while viper's defaults say
+			// it is on. The other scheduled tasks all default enabled=false,
+			// so their zero value is inert here and they stay omitted (this
+			// literal has never carried their intervals either).
+			Scheduled: ScheduledTasksConfig{
+				LibraryScan: ScheduledTaskConfig{
+					Enabled:   true,
+					Interval:  360,
+					OnStartup: false,
+				},
 			},
 
 			// iTunes sync (nested sub-struct)

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -1,7 +1,7 @@
 // file: internal/config/persistence.go
-// version: 1.30.0
+// version: 1.31.0
 // guid: 9c8d7e6f-5a4b-3c2d-1e0f-9a8b7c6d5e4f
-// last-edited: 2026-07-27
+// last-edited: 2026-08-11
 
 package config
 
@@ -1218,6 +1218,27 @@ func applySetting(key, value, typ string) error {
 			}
 
 		// Scheduled maintenance tasks
+		// library_scan is the periodic library scan — the only unattended
+		// discovery path for newly added books. Unlike its siblings it ships
+		// ENABLED (scheduled.library_scan.* defaults: true / 360 min), so an
+		// absent stored setting must leave the viper default alone. That holds
+		// here because applySetting is a per-leaf-key switch: a key that was
+		// never stored is simply never seen, so nothing zeroes the sub-struct.
+		// NOTE: the scheduler snapshots IsEnabled()/GetInterval() once in
+		// Start(), same as all ~20 other tasks, so a change here takes effect
+		// on the next restart.
+		case "scheduled_library_scan_enabled":
+			if b, err := strconv.ParseBool(value); err == nil {
+				c.Scheduled.LibraryScan.Enabled = b
+			}
+		case "scheduled_library_scan_interval":
+			if i, err := strconv.Atoi(value); err == nil {
+				c.Scheduled.LibraryScan.Interval = i
+			}
+		case "scheduled_library_scan_on_startup":
+			if b, err := strconv.ParseBool(value); err == nil {
+				c.Scheduled.LibraryScan.OnStartup = b
+			}
 		case "scheduled_dedup_refresh_enabled":
 			if b, err := strconv.ParseBool(value); err == nil {
 				c.Scheduled.DedupRefresh.Enabled = b

--- a/internal/config/scheduled_library_scan_test.go
+++ b/internal/config/scheduled_library_scan_test.go
@@ -1,0 +1,92 @@
+// file: internal/config/scheduled_library_scan_test.go
+// version: 1.0.0
+// guid: 0f6a3c81-4b52-4e97-8d10-9c74be23a5df
+// last-edited: 2026-08-11
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStoredSettingsDoNotDisableTheScheduledLibraryScan is the guard against
+// the shape of bug that ResetToDefaults() already had: scheduled.library_scan
+// is the ONE member of the scheduled.* family that ships enabled, so any code
+// path that rebuilds the Scheduled sub-struct without carrying it silently
+// turns automatic book discovery back off.
+//
+// Every deployment that predates this key has no stored setting for it. This
+// pins that applySetting's per-leaf-key switch leaves the shipped default
+// alone rather than decoding an absent key into a zero-valued
+// ScheduledTaskConfig (Enabled=false, Interval=0 → no ticker).
+func TestStoredSettingsDoNotDisableTheScheduledLibraryScan(t *testing.T) {
+	restore := Snapshot()
+	t.Cleanup(func() { AppConfig = restore })
+
+	ResetToDefaults()
+	require.True(t, AppConfig.Scheduled.LibraryScan.Enabled, "precondition: default should be enabled")
+	require.Equal(t, 360, AppConfig.Scheduled.LibraryScan.Interval, "precondition: default should be 360 min")
+
+	// Replay the kind of settings an existing install has stored — a mix of
+	// scheduled.* siblings and unrelated keys, none of which is library_scan.
+	stored := []struct{ key, value, typ string }{
+		{"scheduled_dedup_refresh_enabled", "true", "bool"},
+		{"scheduled_dedup_refresh_interval", "720", "int"},
+		{"scheduled_db_optimize_enabled", "true", "bool"},
+		{"scheduled_series_prune_enabled", "true", "bool"},
+		{"scan_on_startup", "false", "bool"},
+		{"auto_scan_enabled", "false", "bool"},
+		{"maintenance_window_library_scan", "false", "bool"},
+	}
+	for _, s := range stored {
+		require.NoError(t, applySetting(s.key, s.value, s.typ), "applySetting(%s)", s.key)
+	}
+
+	assert.True(t, AppConfig.Scheduled.LibraryScan.Enabled,
+		"replaying a pre-existing settings blob must not disable the periodic library scan")
+	assert.Equal(t, 360, AppConfig.Scheduled.LibraryScan.Interval,
+		"replaying a pre-existing settings blob must not zero the periodic scan interval")
+	// Sanity: the siblings that WERE stored did get applied, so the test is
+	// exercising a live code path rather than a no-op.
+	assert.True(t, AppConfig.Scheduled.DedupRefresh.Enabled)
+	assert.Equal(t, 720, AppConfig.Scheduled.DedupRefresh.Interval)
+}
+
+// TestScheduledLibraryScanSettingsAreApplicable pins that the new keys are
+// operable the same way their eight siblings are — an operator can turn the
+// periodic scan off or retune the interval through the settings path instead
+// of only through the config file or environment.
+func TestScheduledLibraryScanSettingsAreApplicable(t *testing.T) {
+	restore := Snapshot()
+	t.Cleanup(func() { AppConfig = restore })
+
+	ResetToDefaults()
+
+	require.NoError(t, applySetting("scheduled_library_scan_interval", "30", "int"))
+	assert.Equal(t, 30, AppConfig.Scheduled.LibraryScan.Interval)
+
+	require.NoError(t, applySetting("scheduled_library_scan_on_startup", "true", "bool"))
+	assert.True(t, AppConfig.Scheduled.LibraryScan.OnStartup)
+
+	require.NoError(t, applySetting("scheduled_library_scan_enabled", "false", "bool"))
+	assert.False(t, AppConfig.Scheduled.LibraryScan.Enabled)
+}
+
+// TestResetToDefaultsKeepsPeriodicScanOn pins the ResetToDefaults() literal,
+// which builds a whole Config from scratch: omitting the Scheduled sub-struct
+// there would leave a factory-reset install with automatic discovery off while
+// viper's defaults claimed it was on.
+func TestResetToDefaultsKeepsPeriodicScanOn(t *testing.T) {
+	restore := Snapshot()
+	t.Cleanup(func() { AppConfig = restore })
+
+	AppConfig.Scheduled.LibraryScan = ScheduledTaskConfig{Enabled: false, Interval: 0, OnStartup: true}
+	ResetToDefaults()
+
+	assert.True(t, AppConfig.Scheduled.LibraryScan.Enabled, "factory reset must leave the periodic scan enabled")
+	assert.Equal(t, 360, AppConfig.Scheduled.LibraryScan.Interval, "factory reset must restore the 6h interval")
+	assert.False(t, AppConfig.Scheduled.LibraryScan.OnStartup)
+}

--- a/internal/scanner/service.go
+++ b/internal/scanner/service.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/service.go
-// version: 1.10.1
+// version: 1.11.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-// last-edited: 2026-07-18
+// last-edited: 2026-08-11
 package scanner
 
 import (
@@ -211,7 +211,26 @@ func (ss *ScanService) determineFoldersToScan(folderPath *string, forceUpdate bo
 		foldersToScan = []string{*folderPath}
 		log.Info("Starting scan of folder: %s", *folderPath)
 	} else {
-		// Full scan: include RootDir if force_update enabled, then all import paths
+		// DECISION (2026-08-11): a DEFAULT scan deliberately does NOT walk
+		// RootDir; only force_update does. Now that library.scan runs on a
+		// timer (scheduled.library_scan, default every 6h) this is a standing
+		// choice rather than an accident, so the reasoning is recorded here:
+		//
+		//  1. RootDir is organize's DESTINATION, not a source. scanFolder
+		//     invokes AutoOrganizeFn on the books it processes, so folding the
+		//     destination into every timed scan would feed already-organized
+		//     books back into the organize path on a loop.
+		//  2. On this deployment the iTunes tree lives UNDER the books root
+		//     (/mnt/bigdata/books/itunes), and that tree is hands-off — a
+		//     default RootDir walk would drag it in every 6 hours.
+		//  3. The consequence is bounded and known: a folder dropped straight
+		//     into the organized library root is NOT auto-discovered. The
+		//     remedy is to add it as an import path (which the watcher
+		//     supervisor now picks up without a restart) or to run a scan with
+		//     force_update=true.
+		//
+		// The log line below states the exclusion out loud so this is a
+		// visible behaviour, not a silent one.
 		if forceUpdate && config.AppConfig.RootDir != "" {
 			foldersToScan = append(foldersToScan, config.AppConfig.RootDir)
 			log.Info("Full rescan: including library path %s", config.AppConfig.RootDir)
@@ -228,6 +247,10 @@ func (ss *ScanService) determineFoldersToScan(folderPath *string, forceUpdate bo
 			}
 		}
 		log.Info("Scanning %d total folders (%d import paths)", len(foldersToScan), len(folders))
+		if !forceUpdate && config.AppConfig.RootDir != "" {
+			log.Info("Library root %s excluded from this incremental scan (organize destination); "+
+				"use force_update=true to include it", config.AppConfig.RootDir)
+		}
 	}
 
 	return foldersToScan, nil

--- a/internal/scanner/service.go
+++ b/internal/scanner/service.go
@@ -220,9 +220,13 @@ func (ss *ScanService) determineFoldersToScan(folderPath *string, forceUpdate bo
 		//     invokes AutoOrganizeFn on the books it processes, so folding the
 		//     destination into every timed scan would feed already-organized
 		//     books back into the organize path on a loop.
-		//  2. On this deployment the iTunes tree lives UNDER the books root
-		//     (/mnt/bigdata/books/itunes), and that tree is hands-off — a
-		//     default RootDir walk would drag it in every 6 hours.
+		//  2. RootDir is operator-set and unconstrained, so its blast radius is
+		//     unknown at this layer. On the reference deployment the books
+		//     tree holds a hands-off iTunes subtree alongside PDFs, archives
+		//     and unrelated media; a RootDir pointed at or above that level
+		//     would be re-walked every 6 hours. (NOT asserting that is where
+		//     RootDir currently points — it is a DB setting this code cannot
+		//     see, which is exactly why the timed path stays conservative.)
 		//  3. The consequence is bounded and known: a folder dropped straight
 		//     into the organized library root is NOT auto-discovered. The
 		//     remedy is to add it as an import path (which the watcher

--- a/internal/scheduler/periodic_library_scan_test.go
+++ b/internal/scheduler/periodic_library_scan_test.go
@@ -1,0 +1,213 @@
+// file: internal/scheduler/periodic_library_scan_test.go
+// version: 1.0.0
+// guid: 8c5b1e74-2d06-4f39-a7b8-0e93c5d18a42
+// last-edited: 2026-08-11
+
+package scheduler
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLibraryScanIsScheduledUnderDefaultConfig is the regression test for
+// "nothing scans automatically". Out of the box, library_scan's GetInterval
+// returned a hard-coded 0, so Start's `IsEnabled() && GetInterval() > 0` gate
+// never created a ticker and a book copied into an import path stayed invisible
+// until somebody pressed Scan by hand.
+//
+// This asserts the exact gate Start uses, against the shipped default config.
+func TestLibraryScanIsScheduledUnderDefaultConfig(t *testing.T) {
+	restore := config.Snapshot()
+	t.Cleanup(func() { config.AppConfig = restore })
+
+	config.ResetToDefaults()
+
+	// Guard rail: the fix must not be sneaking through the legacy flags. Under
+	// defaults both of these are off, which is precisely why the old code was
+	// inert.
+	require.False(t, config.AppConfig.ScanOnStartup, "default config should still have scan_on_startup off")
+	require.False(t, config.AppConfig.AutoScanEnabled, "default config should still have auto_scan_enabled off")
+
+	ts := NewTaskScheduler(testDeps())
+	task, ok := ts.GetTask("library_scan")
+	require.True(t, ok, "library_scan should be registered")
+
+	assert.True(t, task.IsEnabled(), "library_scan must be enabled under default config")
+	interval := task.GetInterval()
+	assert.Greater(t, interval, time.Duration(0),
+		"library_scan must report a non-zero interval, otherwise Start never creates a ticker for it")
+	assert.Equal(t, 6*time.Hour, interval, "default periodic scan interval should be 6h (360 min)")
+}
+
+// TestLibraryScanIntervalIsConfigurable proves the interval is read from
+// config rather than being another hard-coded constant, including the two
+// ways an operator can turn the periodic scan back off.
+func TestLibraryScanIntervalIsConfigurable(t *testing.T) {
+	restore := config.Snapshot()
+	t.Cleanup(func() { config.AppConfig = restore })
+
+	ts := NewTaskScheduler(testDeps())
+	task, ok := ts.GetTask("library_scan")
+	require.True(t, ok)
+
+	cases := []struct {
+		name     string
+		enabled  bool
+		interval int
+		want     time.Duration
+	}{
+		{"custom interval honoured", true, 15, 15 * time.Minute},
+		{"hourly", true, 60, time.Hour},
+		{"disabled task means no ticker", false, 360, 0},
+		{"zero interval means no ticker", true, 0, 0},
+		{"negative interval means no ticker", true, -5, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			config.AppConfig.Scheduled.LibraryScan = config.ScheduledTaskConfig{
+				Enabled:  tc.enabled,
+				Interval: tc.interval,
+			}
+			assert.Equal(t, tc.want, task.GetInterval())
+		})
+	}
+}
+
+// TestLibraryScanEnabledPreservesLegacyScanOnStartup pins the compatibility
+// path: IsEnabled gates the startup run as well as the ticker, so a user who
+// only ever set scan_on_startup must not lose their startup scan just because
+// the new scheduled.library_scan key is off.
+func TestLibraryScanEnabledPreservesLegacyScanOnStartup(t *testing.T) {
+	restore := config.Snapshot()
+	t.Cleanup(func() { config.AppConfig = restore })
+
+	ts := NewTaskScheduler(testDeps())
+	task, ok := ts.GetTask("library_scan")
+	require.True(t, ok)
+
+	config.AppConfig.Scheduled.LibraryScan = config.ScheduledTaskConfig{Enabled: false, Interval: 0}
+	config.AppConfig.ScanOnStartup = true
+
+	assert.True(t, task.IsEnabled(), "legacy scan_on_startup must still enable the task")
+	assert.True(t, task.RunOnStart(), "legacy scan_on_startup must still trigger a startup scan")
+	assert.Equal(t, time.Duration(0), task.GetInterval(),
+		"legacy flag alone must NOT start a periodic ticker")
+}
+
+// TestLibraryScanIsReachableFromMaintenanceWindow pins the dead-config fix:
+// the maintenance-window op only ever iterates MaintenanceOrder(), so a task
+// absent from that list can never be run by the window no matter what
+// maintenance.library_scan is set to.
+func TestLibraryScanIsReachableFromMaintenanceWindow(t *testing.T) {
+	ts := NewTaskScheduler(testDeps())
+
+	found := false
+	for _, name := range ts.MaintenanceOrder() {
+		if name == "library_scan" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"library_scan must be in MaintenanceOrder(), otherwise the maintenance.library_scan setting is unreachable")
+}
+
+// TestStartCreatesTickerForNonZeroInterval pins the mechanic the fix above
+// depends on: Start must actually create a running ticker for an enabled task
+// whose GetInterval is > 0. Without this, TestLibraryScanIsScheduledUnder-
+// DefaultConfig would pass on a scheduler that never ticks.
+//
+// A bare TaskScheduler is used rather than NewTaskScheduler so only the probe
+// task is registered and the real tasks' startup runs stay out of the way.
+func TestStartCreatesTickerForNonZeroInterval(t *testing.T) {
+	restore := config.Snapshot()
+	t.Cleanup(func() { config.AppConfig = restore })
+	// Keep the maintenance-window goroutine out of this test.
+	config.AppConfig.Maintenance.Enabled = false
+
+	ts := &TaskScheduler{
+		deps:    testDeps(),
+		tasks:   make(map[string]*TaskDefinition),
+		lastRun: make(map[string]time.Time),
+	}
+
+	var fired atomic.Int32
+	ts.RegisterTask(TaskDefinition{
+		Name:     "ticker_probe",
+		Category: "test",
+		TriggerFn: func(string) (*database.Operation, error) {
+			fired.Add(1)
+			return nil, nil
+		},
+		IsEnabled:              func() bool { return true },
+		GetInterval:            func() time.Duration { return 5 * time.Millisecond },
+		RunOnStart:             func() bool { return false },
+		RunInMaintenanceWindow: func() bool { return false },
+	})
+
+	shutdown := make(chan struct{})
+	var wg sync.WaitGroup
+	ts.Start(shutdown, &wg)
+	defer func() {
+		close(shutdown)
+		wg.Wait()
+	}()
+
+	deadline := time.After(3 * time.Second)
+	for {
+		if fired.Load() > 0 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("Start never fired the ticker for an enabled task with a non-zero interval")
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+// TestStartCreatesNoTickerForZeroInterval is the paired negative: a task with
+// interval 0 stays manual-only. This is the behaviour every other task in
+// tasks.go relies on, so the library_scan fix must not have loosened it.
+func TestStartCreatesNoTickerForZeroInterval(t *testing.T) {
+	restore := config.Snapshot()
+	t.Cleanup(func() { config.AppConfig = restore })
+	config.AppConfig.Maintenance.Enabled = false
+
+	ts := &TaskScheduler{
+		deps:    testDeps(),
+		tasks:   make(map[string]*TaskDefinition),
+		lastRun: make(map[string]time.Time),
+	}
+
+	var fired atomic.Int32
+	ts.RegisterTask(TaskDefinition{
+		Name:     "manual_only_probe",
+		Category: "test",
+		TriggerFn: func(string) (*database.Operation, error) {
+			fired.Add(1)
+			return nil, nil
+		},
+		IsEnabled:              func() bool { return true },
+		GetInterval:            func() time.Duration { return 0 },
+		RunOnStart:             func() bool { return false },
+		RunInMaintenanceWindow: func() bool { return false },
+	})
+
+	shutdown := make(chan struct{})
+	var wg sync.WaitGroup
+	ts.Start(shutdown, &wg)
+	time.Sleep(50 * time.Millisecond)
+	close(shutdown)
+	wg.Wait()
+
+	assert.Equal(t, int32(0), fired.Load(), "a zero-interval task must never be ticked")
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,7 +1,7 @@
 // file: internal/scheduler/scheduler.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: 3f7a9c21-b4d8-4e05-a6f2-8c1d0e3b7a94
-// last-edited: 2026-07-03
+// last-edited: 2026-08-11
 
 // Package scheduler implements the unified task scheduling system.
 // TaskScheduler manages all registered tasks, their schedules, and manual
@@ -90,6 +90,29 @@ type TaskScheduler struct {
 	shutdown           chan struct{}
 	maintenanceOrder   []string
 	lastMaintenanceRun time.Time
+	// previousRun maps a task name to the v2 operation id it last enqueued.
+	// Only tasks that need to skip a tick while their own previous run is
+	// still queued/running use it (currently library_scan, whose full walk can
+	// outlast its interval on a large library). Guarded by mu.
+	previousRun map[string]string
+}
+
+// previousRunID returns the v2 operation id this task last enqueued, or "" if
+// it has not enqueued one since process start.
+func (ts *TaskScheduler) previousRunID(name string) string {
+	ts.mu.RLock()
+	defer ts.mu.RUnlock()
+	return ts.previousRun[name]
+}
+
+// setPreviousRunID records the v2 operation id a task just enqueued.
+func (ts *TaskScheduler) setPreviousRunID(name, opID string) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	if ts.previousRun == nil {
+		ts.previousRun = make(map[string]string)
+	}
+	ts.previousRun[name] = opID
 }
 
 // NewTaskScheduler creates a scheduler and registers all known tasks.
@@ -115,6 +138,17 @@ func NewTaskScheduler(deps SchedulerDeps) *TaskScheduler {
 		"cleanup_old_backups",
 		"library_size_refresh",
 		"db_optimize",
+		// library_scan is LAST on purpose. It was missing from this list
+		// entirely, which made maintenance.library_scan unreachable dead
+		// config: the window op iterates MaintenanceOrder(), so a user who
+		// flipped the toggle got nothing. It goes at the end rather than the
+		// front because the window op breaks out of the loop the moment the
+		// window closes — a full library walk parked in front of everything
+		// else would starve dedup/purge/optimize on the same night. The
+		// interval ticker (scheduled.library_scan) is the primary discovery
+		// mechanism now; this entry exists so the toggle actually does
+		// something for anyone who prefers scans confined to the window.
+		"library_scan",
 	}
 	return ts
 }

--- a/internal/scheduler/tasks.go
+++ b/internal/scheduler/tasks.go
@@ -1,7 +1,7 @@
 // file: internal/scheduler/tasks.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 9b4c7e21-a5f3-4d08-b2e6-3c8d1f7a0e54
-// last-edited: 2026-07-12
+// last-edited: 2026-08-11
 
 // Package scheduler — task registrations.
 // All 22 registered tasks are defined here. Each task's TriggerFn and
@@ -66,6 +66,15 @@ type labelRefinementCalibrateParams struct{}
 func (ts *TaskScheduler) registerAllTasks() {
 	// --- Library tasks ---
 
+	// library_scan is the ONLY unattended discovery path for new books, so it
+	// is the one task in this file that ships with a real, default-on interval.
+	//
+	// It used to be completely inert: GetInterval returned a hard-coded 0 (so
+	// scheduler.Start's `IsEnabled() && GetInterval() > 0` guard never created
+	// a ticker), IsEnabled/RunOnStart both read scan_on_startup which defaults
+	// false, and maintenance.library_scan was unreachable because "library_scan"
+	// was missing from maintenanceOrder. Net effect: a book copied into an
+	// import path was never noticed until somebody pressed Scan by hand.
 	ts.registerTask(TaskDefinition{
 		Name:        "library_scan",
 		Description: "Scan library for new/changed audiobooks (incremental by default, use force_update for full rescan)",
@@ -75,19 +84,55 @@ func (ts *TaskScheduler) registerAllTasks() {
 			if store == nil {
 				return nil, fmt.Errorf("database not initialized")
 			}
+			// Skip this tick if the previous scan we enqueued has not finished.
+			// library.scan's ConcurrencyKey makes the dispatcher SERIALIZE a
+			// duplicate rather than reject it (registry/dispatcher.go: "the op
+			// stays QUEUED"), so a scan that outruns the interval would other-
+			// wise pile up one queued op — plus one orphan legacy operation
+			// row — on every tick. Guarding here rather than in the generic
+			// ticker keeps the behaviour of the seven other interval tasks
+			// unchanged.
+			if prev := ts.previousRunID("library_scan"); prev != "" {
+				if row, err := store.GetOperationV2(prev); err == nil && row != nil {
+					if row.Status == "queued" || row.Status == "running" {
+						slog.Info("library_scan: previous scan still active, skipping this tick",
+							"op", prev, "status", row.Status, "source", source)
+						return nil, nil
+					}
+				}
+			}
 			opID := ulid.Make().String()
 			op, err := store.CreateOperation(opID, "scan", nil)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create operation: %w", err)
 			}
-			if _, enqErr := ts.deps.OpRegistry.EnqueueOp(context.Background(), "library.scan", libraryScanParams{}); enqErr != nil {
+			v2ID, enqErr := ts.deps.OpRegistry.EnqueueOp(context.Background(), "library.scan", libraryScanParams{})
+			if enqErr != nil {
 				return nil, fmt.Errorf("failed to enqueue library.scan: %w", enqErr)
 			}
+			ts.setPreviousRunID("library_scan", v2ID)
 			return op, nil
 		},
-		IsEnabled:              func() bool { return config.AppConfig.ScanOnStartup },
-		GetInterval:            func() time.Duration { return 0 },
-		RunOnStart:             func() bool { return config.AppConfig.ScanOnStartup },
+		IsEnabled: func() bool {
+			// IsEnabled gates the ticker, the startup run AND maintenance-window
+			// eligibility, so it must stay true for anyone who only ever set the
+			// legacy scan_on_startup flag — otherwise flipping to the new key
+			// would silently take away their startup scan.
+			return config.AppConfig.Scheduled.LibraryScan.Enabled || config.AppConfig.ScanOnStartup
+		},
+		GetInterval: func() time.Duration {
+			if !config.AppConfig.Scheduled.LibraryScan.Enabled {
+				return 0
+			}
+			mins := config.AppConfig.Scheduled.LibraryScan.Interval
+			if mins <= 0 {
+				return 0
+			}
+			return time.Duration(mins) * time.Minute
+		},
+		RunOnStart: func() bool {
+			return config.AppConfig.Scheduled.LibraryScan.OnStartup || config.AppConfig.ScanOnStartup
+		},
 		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.LibraryScan },
 	})
 

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 3.10.0
+// version: 3.11.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-08-10
+// last-edited: 2026-08-11
 
 package server
 
@@ -431,53 +431,72 @@ func (s *Server) Start(cfg ServerConfig) error {
 	// import path — previously only the first enabled path was watched,
 	// so users with multiple import locations had silent blind spots on
 	// every path after the first.
-	var fileWatchers []*watcher.Watcher
+	//
+	// Enumeration used to happen exactly ONCE here, from a boot-time snapshot,
+	// so an import path added later got no watcher until the process was
+	// restarted; and the read was `if err == nil && len(importPaths) > 0`,
+	// which turned a failed GetAllImportPaths into zero watchers with no log
+	// line at all. Both are now handled by watcher.Supervisor, which re-reads
+	// the desired set on a ticker and reports every failure.
+	//
+	// These watchers remain the LOW-LATENCY path only. The guaranteed
+	// catch-all is the periodic scheduled scan (scheduled.library_scan):
+	// fsnotify does not see writes made by remote NFS/SMB clients and can
+	// exhaust the inotify watch limit on a large tree, so it must never be
+	// the only discovery mechanism.
+	var watcherSupervisor *watcher.Supervisor
 	if config.AppConfig.AutoScanEnabled && s.Store() != nil {
-		importPaths, err := s.Store().GetAllImportPaths()
-		if err == nil && len(importPaths) > 0 {
-			var watchPaths []string
-			for _, ip := range importPaths {
-				if ip.Enabled {
-					watchPaths = append(watchPaths, ip.Path)
-				}
+		debounce := 5 * time.Second
+		if config.AppConfig.AutoScanDebounceSeconds > 0 {
+			debounce = time.Duration(config.AppConfig.AutoScanDebounceSeconds) * time.Second
+		}
+		watchLog := logger.NewWithActivityLog("auto-scan", s.Store())
+		// The same callback is reused across watchers because each watcher
+		// invokes it with its own root path, so the scan target is correct
+		// per event.
+		cb := func(path string) {
+			watchLog.Info("Auto-scan triggered for: %s", path)
+			if s.hub != nil {
+				s.hub.Broadcast(&realtime.Event{
+					Type: "scan.auto_triggered",
+					Data: map[string]any{"path": path},
+				})
 			}
-			if len(watchPaths) > 0 {
-				debounce := 5 * time.Second
-				if config.AppConfig.AutoScanDebounceSeconds > 0 {
-					debounce = time.Duration(config.AppConfig.AutoScanDebounceSeconds) * time.Second
-				}
-				watchLog := logger.NewWithActivityLog("auto-scan", s.Store())
-				// The same callback is reused across watchers because
-				// each watcher invokes it with its own root path, so
-				// the scan target is correct per event.
-				cb := func(path string) {
-					watchLog.Info("Auto-scan triggered for: %s", path)
-					if s.hub != nil {
-						s.hub.Broadcast(&realtime.Event{
-							Type: "scan.auto_triggered",
-							Data: map[string]any{"path": path},
-						})
+			if s.scanService != nil && s.opRegistry != nil {
+				go func() {
+					scanPath := path
+					if _, enqErr := s.opRegistry.EnqueueOp(context.Background(), "library.scan", libraryScanParams{FolderPath: &scanPath}); enqErr != nil {
+						watchLog.Error("Auto-scan: failed to enqueue: %v", enqErr)
 					}
-					if s.scanService != nil && s.opRegistry != nil {
-						go func() {
-							scanPath := path
-							if _, enqErr := s.opRegistry.EnqueueOp(context.Background(), "library.scan", libraryScanParams{FolderPath: &scanPath}); enqErr != nil {
-								watchLog.Error("Auto-scan: failed to enqueue: %v", enqErr)
-							}
-						}()
-					}
-				}
-				for _, wp := range watchPaths {
-					fw := watcher.New(cb, debounce)
-					if startErr := fw.Start(wp); startErr != nil {
-						watchLog.Warn("Failed to start file watcher for %s: %v", wp, startErr)
-						continue
-					}
-					fileWatchers = append(fileWatchers, fw)
-					watchLog.Info("Auto-scan file watcher started for %s", wp)
-				}
+				}()
 			}
 		}
+		// Re-read on every reconcile, not once: this is what makes a path
+		// added through the UI get a watcher without a restart.
+		paths := func() ([]string, error) {
+			importPaths, err := s.Store().GetAllImportPaths()
+			if err != nil {
+				return nil, fmt.Errorf("GetAllImportPaths: %w", err)
+			}
+			var enabled []string
+			for _, ip := range importPaths {
+				if ip.Enabled {
+					enabled = append(enabled, ip.Path)
+				}
+			}
+			return enabled, nil
+		}
+		watcherSupervisor = watcher.NewSupervisor(paths, cb, debounce, 0)
+		watcherSupervisor.SetErrorHook(func(err error) {
+			// Surfaced in the activity log too, so an operator sees it in the
+			// UI rather than only in journalctl.
+			watchLog.Error("Auto-scan watcher problem: %v", err)
+		})
+		backgroundWG.Add(1)
+		go func() {
+			defer backgroundWG.Done()
+			watcherSupervisor.Run(shutdown)
+		}()
 	}
 
 	// Periodic cleanup of expired/revoked auth sessions.
@@ -647,12 +666,15 @@ func (s *Server) Start(cfg ServerConfig) error {
 		}
 	}
 
-	// Stop every file watcher (one per import path).
-	for _, fw := range fileWatchers {
-		fw.Stop()
-	}
-	if len(fileWatchers) > 0 {
-		slog.Info("File watchers stopped ()", "fileWatchers_count", len(fileWatchers))
+	// Stop every file watcher (one per import path). The supervisor goroutine
+	// has already returned via `shutdown`; this only tears down the live
+	// watchers it left running.
+	if watcherSupervisor != nil {
+		stopped := len(watcherSupervisor.WatchedPaths())
+		watcherSupervisor.StopAll()
+		if stopped > 0 {
+			slog.Info("File watchers stopped", "fileWatchers_count", stopped)
+		}
 	}
 
 	// Persist HNSW snapshot for fast next-boot startup (before embedding store

--- a/internal/watcher/supervisor.go
+++ b/internal/watcher/supervisor.go
@@ -1,0 +1,192 @@
+// file: internal/watcher/supervisor.go
+// version: 1.0.0
+// guid: 6d1f4a08-5c93-4b27-9e10-72a8c4f3bd15
+// last-edited: 2026-08-11
+
+package watcher
+
+import (
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+)
+
+// DefaultReconcileInterval is how often the Supervisor re-reads the desired
+// watch set. It is deliberately short relative to the periodic library scan:
+// the scan is the guaranteed catch-all, the watchers are the low-latency path,
+// and a path added through the UI should start being watched within minutes
+// rather than at the next process restart.
+const DefaultReconcileInterval = 5 * time.Minute
+
+// managedWatcher is the slice of *Watcher that Supervisor drives. It exists so
+// the reconcile logic can be unit-tested against a fake instead of real
+// fsnotify handles (which need real directories and fire on real disk events).
+type managedWatcher interface {
+	Start(rootDir string) error
+	Stop()
+}
+
+// PathsProvider returns the set of directories that SHOULD be watched right
+// now. It is called on every reconcile tick — NOT once at boot — so that an
+// import path added, enabled, disabled or removed at runtime is picked up
+// without restarting the process.
+//
+// An error return is a hard "I don't know what the desired set is". The
+// Supervisor treats that as transient and keeps the watchers it already has,
+// because tearing down live watchers on a momentary DB read failure would
+// silently convert a blip into a permanent blind spot.
+type PathsProvider func() ([]string, error)
+
+// Supervisor keeps one Watcher running per desired path, reconciling the live
+// set against the desired set on a ticker.
+//
+// Before this existed, internal/server/server_lifecycle.go enumerated import
+// paths exactly once at boot and started watchers from that snapshot, so:
+//   - an import path added after boot was never watched, and
+//   - a failed enumeration (`if err == nil && len(...) > 0`) silently started
+//     zero watchers with no log line at all.
+//
+// Both of those are handled here instead.
+type Supervisor struct {
+	paths      PathsProvider
+	newWatcher func() managedWatcher
+	interval   time.Duration
+
+	// onError, when non-nil, is called with every provider/start failure in
+	// addition to the slog line. The server wires this to the activity log so
+	// the failure is visible in the UI and not only in journalctl.
+	onError func(error)
+
+	mu     sync.Mutex
+	active map[string]managedWatcher
+}
+
+// NewSupervisor builds a Supervisor that creates real fsnotify-backed Watchers.
+// Pass 0 for debounce to use DefaultDebounce, and 0 for interval to use
+// DefaultReconcileInterval.
+func NewSupervisor(paths PathsProvider, cb Callback, debounce, interval time.Duration) *Supervisor {
+	return newSupervisorWithFactory(paths, func() managedWatcher { return New(cb, debounce) }, interval)
+}
+
+// newSupervisorWithFactory is the injectable constructor used by tests.
+func newSupervisorWithFactory(paths PathsProvider, factory func() managedWatcher, interval time.Duration) *Supervisor {
+	if interval <= 0 {
+		interval = DefaultReconcileInterval
+	}
+	return &Supervisor{
+		paths:      paths,
+		newWatcher: factory,
+		interval:   interval,
+		active:     make(map[string]managedWatcher),
+	}
+}
+
+// SetErrorHook installs a callback invoked on every provider/start failure.
+// Must be called before Run.
+func (s *Supervisor) SetErrorHook(fn func(error)) { s.onError = fn }
+
+// Run reconciles once immediately, then on every interval tick, until shutdown
+// is closed. It does NOT stop the watchers on exit — call StopAll from the
+// process shutdown path so ordering stays under the caller's control.
+//
+// Intended to be run in a goroutine registered with the caller's WaitGroup.
+func (s *Supervisor) Run(shutdown <-chan struct{}) {
+	s.Reconcile()
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			s.Reconcile()
+		case <-shutdown:
+			return
+		}
+	}
+}
+
+// Reconcile brings the live watcher set in line with the provider's desired
+// set: start a watcher for every desired path not already watched, stop and
+// drop every watched path no longer desired. Safe for concurrent use.
+func (s *Supervisor) Reconcile() {
+	desired, err := s.paths()
+	if err != nil {
+		// Deliberately NOT silent, and deliberately non-destructive: keep the
+		// watchers we have. See PathsProvider's doc comment.
+		slog.Error("auto-scan: failed to enumerate watch paths; keeping existing watchers",
+			"err", err, "active_watchers", s.count())
+		if s.onError != nil {
+			s.onError(err)
+		}
+		return
+	}
+
+	desiredSet := make(map[string]bool, len(desired))
+	for _, p := range desired {
+		if p != "" {
+			desiredSet[p] = true
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Stop watchers whose path disappeared or was disabled.
+	for path, w := range s.active {
+		if !desiredSet[path] {
+			w.Stop()
+			delete(s.active, path)
+			slog.Info("auto-scan: file watcher stopped (path no longer watched)", "path", path)
+		}
+	}
+
+	// Start watchers for newly desired paths. Watcher.Start is documented
+	// safe-to-call-once, so each path gets its own fresh Watcher instance.
+	for path := range desiredSet {
+		if _, ok := s.active[path]; ok {
+			continue
+		}
+		w := s.newWatcher()
+		if startErr := w.Start(path); startErr != nil {
+			slog.Warn("auto-scan: failed to start file watcher", "path", path, "err", startErr)
+			if s.onError != nil {
+				s.onError(startErr)
+			}
+			continue
+		}
+		s.active[path] = w
+		slog.Info("auto-scan: file watcher started", "path", path)
+	}
+
+	if len(s.active) == 0 && len(desiredSet) > 0 {
+		slog.Warn("auto-scan: no file watchers running despite configured paths", "desired", len(desiredSet))
+	}
+}
+
+// StopAll stops every live watcher and empties the set. Idempotent.
+func (s *Supervisor) StopAll() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for path, w := range s.active {
+		w.Stop()
+		delete(s.active, path)
+	}
+}
+
+// WatchedPaths returns the sorted set of paths currently watched.
+func (s *Supervisor) WatchedPaths() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(s.active))
+	for p := range s.active {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (s *Supervisor) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.active)
+}

--- a/internal/watcher/supervisor.go
+++ b/internal/watcher/supervisor.go
@@ -1,5 +1,5 @@
 // file: internal/watcher/supervisor.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6d1f4a08-5c93-4b27-9e10-72a8c4f3bd15
 // last-edited: 2026-08-11
 
@@ -60,6 +60,11 @@ type Supervisor struct {
 
 	mu     sync.Mutex
 	active map[string]managedWatcher
+	// closed is set by StopAll and makes every later Reconcile a no-op. The
+	// server tears watchers down before it waits on its background WaitGroup,
+	// so without this a tick landing in that window would happily start fresh
+	// watchers that nobody ever stops.
+	closed bool
 }
 
 // NewSupervisor builds a Supervisor that creates real fsnotify-backed Watchers.
@@ -109,6 +114,9 @@ func (s *Supervisor) Run(shutdown <-chan struct{}) {
 // set: start a watcher for every desired path not already watched, stop and
 // drop every watched path no longer desired. Safe for concurrent use.
 func (s *Supervisor) Reconcile() {
+	if s.isClosed() {
+		return
+	}
 	desired, err := s.paths()
 	if err != nil {
 		// Deliberately NOT silent, and deliberately non-destructive: keep the
@@ -130,6 +138,10 @@ func (s *Supervisor) Reconcile() {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Re-check under the lock: StopAll may have landed while s.paths() ran.
+	if s.closed {
+		return
+	}
 
 	// Stop watchers whose path disappeared or was disabled.
 	for path, w := range s.active {
@@ -163,14 +175,23 @@ func (s *Supervisor) Reconcile() {
 	}
 }
 
-// StopAll stops every live watcher and empties the set. Idempotent.
+// StopAll stops every live watcher and empties the set. Idempotent, and
+// TERMINAL: any later Reconcile is a no-op, so a tick racing process shutdown
+// cannot resurrect watchers nobody will stop.
 func (s *Supervisor) StopAll() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.closed = true
 	for path, w := range s.active {
 		w.Stop()
 		delete(s.active, path)
 	}
+}
+
+func (s *Supervisor) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
 }
 
 // WatchedPaths returns the sorted set of paths currently watched.

--- a/internal/watcher/supervisor_test.go
+++ b/internal/watcher/supervisor_test.go
@@ -1,0 +1,287 @@
+// file: internal/watcher/supervisor_test.go
+// version: 1.0.0
+// guid: 3a7e0b52-8f14-4d69-b0c3-51d2e9af7c86
+// last-edited: 2026-08-11
+
+package watcher
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeWatcher is a managedWatcher that records Start/Stop instead of touching
+// the filesystem, so Supervisor's reconcile logic can be tested without real
+// directories or real fsnotify events.
+type fakeWatcher struct {
+	mu      sync.Mutex
+	started string
+	stopped bool
+	startFn func(string) error
+}
+
+func (f *fakeWatcher) Start(rootDir string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.startFn != nil {
+		if err := f.startFn(rootDir); err != nil {
+			return err
+		}
+	}
+	f.started = rootDir
+	return nil
+}
+
+func (f *fakeWatcher) Stop() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stopped = true
+}
+
+func (f *fakeWatcher) wasStopped() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.stopped
+}
+
+// pathSource is a mutable PathsProvider backing store for the tests.
+type pathSource struct {
+	mu    sync.Mutex
+	paths []string
+	err   error
+}
+
+func (p *pathSource) provider() ([]string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.err != nil {
+		return nil, p.err
+	}
+	out := make([]string, len(p.paths))
+	copy(out, p.paths)
+	return out, nil
+}
+
+func (p *pathSource) set(paths []string, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.paths = paths
+	p.err = err
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestSupervisorWatchesRuntimeAddedImportPath is the regression test for the
+// boot-only enumeration bug: server_lifecycle.go read GetAllImportPaths exactly
+// once at startup, so an import path added later got no watcher until the
+// process restarted. The Supervisor must pick it up on the next reconcile.
+func TestSupervisorWatchesRuntimeAddedImportPath(t *testing.T) {
+	src := &pathSource{paths: []string{"/library/one"}}
+
+	var mu sync.Mutex
+	created := map[string]*fakeWatcher{}
+	// The factory records each instance under the path it was started with, so
+	// the test can assert on a specific watcher. One watcher per path.
+	factory := func() managedWatcher {
+		fw := &fakeWatcher{}
+		fw.startFn = func(root string) error {
+			mu.Lock()
+			created[root] = fw
+			mu.Unlock()
+			return nil
+		}
+		return fw
+	}
+
+	sup := newSupervisorWithFactory(src.provider, factory, time.Hour)
+
+	sup.Reconcile()
+	if got := sup.WatchedPaths(); !equalStrings(got, []string{"/library/one"}) {
+		t.Fatalf("after first reconcile: watched=%v, want [/library/one]", got)
+	}
+
+	// A NEW import path appears at runtime (user added it in the UI).
+	src.set([]string{"/library/one", "/library/two"}, nil)
+	sup.Reconcile()
+
+	if got := sup.WatchedPaths(); !equalStrings(got, []string{"/library/one", "/library/two"}) {
+		t.Fatalf("runtime-added import path was not watched: watched=%v, want [/library/one /library/two]", got)
+	}
+
+	// The pre-existing watcher must NOT have been torn down and recreated.
+	mu.Lock()
+	first := created["/library/one"]
+	mu.Unlock()
+	if first == nil {
+		t.Fatal("expected a watcher to have been started for /library/one")
+	}
+	if first.wasStopped() {
+		t.Error("existing watcher for /library/one was stopped during reconcile; it should have been left alone")
+	}
+}
+
+// TestSupervisorStopsRemovedPath covers the other half of reconcile: a path
+// that is deleted or disabled must have its watcher stopped, not leaked.
+func TestSupervisorStopsRemovedPath(t *testing.T) {
+	src := &pathSource{paths: []string{"/library/one", "/library/two"}}
+
+	var mu sync.Mutex
+	created := map[string]*fakeWatcher{}
+	factory := func() managedWatcher {
+		fw := &fakeWatcher{}
+		fw.startFn = func(root string) error {
+			mu.Lock()
+			created[root] = fw
+			mu.Unlock()
+			return nil
+		}
+		return fw
+	}
+
+	sup := newSupervisorWithFactory(src.provider, factory, time.Hour)
+	sup.Reconcile()
+
+	src.set([]string{"/library/one"}, nil)
+	sup.Reconcile()
+
+	if got := sup.WatchedPaths(); !equalStrings(got, []string{"/library/one"}) {
+		t.Fatalf("watched=%v, want [/library/one]", got)
+	}
+	mu.Lock()
+	two := created["/library/two"]
+	mu.Unlock()
+	if two == nil || !two.wasStopped() {
+		t.Error("watcher for the removed path was not stopped")
+	}
+}
+
+// TestSupervisorProviderErrorIsReportedAndNonDestructive pins the fix for the
+// discarded GetAllImportPaths error. The old code was
+// `if err == nil && len(importPaths) > 0 { ... }` — a failed read silently
+// started zero watchers with no log line. Now the error must reach the error
+// hook, and existing watchers must survive the blip.
+func TestSupervisorProviderErrorIsReportedAndNonDestructive(t *testing.T) {
+	src := &pathSource{paths: []string{"/library/one"}}
+	sup := newSupervisorWithFactory(src.provider, func() managedWatcher { return &fakeWatcher{} }, time.Hour)
+
+	var mu sync.Mutex
+	var reported []error
+	sup.SetErrorHook(func(err error) {
+		mu.Lock()
+		reported = append(reported, err)
+		mu.Unlock()
+	})
+
+	sup.Reconcile()
+	if got := sup.WatchedPaths(); !equalStrings(got, []string{"/library/one"}) {
+		t.Fatalf("watched=%v, want [/library/one]", got)
+	}
+
+	boom := errors.New("pebble: read failed")
+	src.set(nil, boom)
+	sup.Reconcile()
+
+	mu.Lock()
+	n := len(reported)
+	var first error
+	if n > 0 {
+		first = reported[0]
+	}
+	mu.Unlock()
+
+	if n != 1 {
+		t.Fatalf("provider error was not reported: got %d reports, want 1", n)
+	}
+	if !errors.Is(first, boom) {
+		t.Errorf("reported error = %v, want %v", first, boom)
+	}
+	if got := sup.WatchedPaths(); !equalStrings(got, []string{"/library/one"}) {
+		t.Errorf("a transient provider error tore down live watchers: watched=%v, want [/library/one]", got)
+	}
+}
+
+// TestSupervisorStartErrorIsReported ensures a watcher that fails to start is
+// reported and not recorded as active (so the next reconcile retries it).
+func TestSupervisorStartErrorIsReported(t *testing.T) {
+	src := &pathSource{paths: []string{"/library/nope"}}
+	boom := errors.New("no such directory")
+	sup := newSupervisorWithFactory(src.provider, func() managedWatcher {
+		return &fakeWatcher{startFn: func(string) error { return boom }}
+	}, time.Hour)
+
+	var mu sync.Mutex
+	var reported int
+	sup.SetErrorHook(func(error) {
+		mu.Lock()
+		reported++
+		mu.Unlock()
+	})
+
+	sup.Reconcile()
+
+	if got := sup.WatchedPaths(); len(got) != 0 {
+		t.Errorf("failed watcher was recorded as active: %v", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if reported != 1 {
+		t.Errorf("start failure reports = %d, want 1", reported)
+	}
+}
+
+// TestSupervisorRunReconcilesOnTicker proves Run actually drives Reconcile on
+// its interval — not just once at startup.
+func TestSupervisorRunReconcilesOnTicker(t *testing.T) {
+	src := &pathSource{paths: []string{"/library/one"}}
+	sup := newSupervisorWithFactory(src.provider, func() managedWatcher { return &fakeWatcher{} }, 5*time.Millisecond)
+
+	shutdown := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sup.Run(shutdown)
+	}()
+	defer func() {
+		close(shutdown)
+		<-done
+		sup.StopAll()
+	}()
+
+	// Add a path AFTER Run has already done its initial reconcile.
+	deadline := time.After(2 * time.Second)
+	for {
+		if len(sup.WatchedPaths()) == 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("initial reconcile never ran")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	src.set([]string{"/library/one", "/library/two"}, nil)
+
+	deadline = time.After(2 * time.Second)
+	for {
+		if equalStrings(sup.WatchedPaths(), []string{"/library/one", "/library/two"}) {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("ticker never reconciled the new path: watched=%v", sup.WatchedPaths())
+		case <-time.After(time.Millisecond):
+		}
+	}
+}

--- a/internal/watcher/supervisor_test.go
+++ b/internal/watcher/supervisor_test.go
@@ -1,5 +1,5 @@
 // file: internal/watcher/supervisor_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3a7e0b52-8f14-4d69-b0c3-51d2e9af7c86
 // last-edited: 2026-08-11
 
@@ -238,6 +238,26 @@ func TestSupervisorStartErrorIsReported(t *testing.T) {
 	defer mu.Unlock()
 	if reported != 1 {
 		t.Errorf("start failure reports = %d, want 1", reported)
+	}
+}
+
+// TestSupervisorStopAllIsTerminal guards the shutdown race: the server stops
+// watchers BEFORE it waits on its background WaitGroup, so a reconcile tick
+// landing in that window must not start fresh watchers nobody will stop.
+func TestSupervisorStopAllIsTerminal(t *testing.T) {
+	src := &pathSource{paths: []string{"/library/one"}}
+	sup := newSupervisorWithFactory(src.provider, func() managedWatcher { return &fakeWatcher{} }, time.Hour)
+
+	sup.Reconcile()
+	if got := sup.WatchedPaths(); len(got) != 1 {
+		t.Fatalf("watched=%v, want 1 path", got)
+	}
+
+	sup.StopAll()
+	sup.Reconcile()
+
+	if got := sup.WatchedPaths(); len(got) != 0 {
+		t.Errorf("Reconcile after StopAll resurrected watchers: %v", got)
 	}
 }
 


### PR DESCRIPTION
## The defect

Newly-added books never appeared in the library because **nothing ever scanned for them**. Not "the scan was too slow" or "the scan skipped them" — there was no scheduled scan at all:

- `scheduled.library_scan` did not exist as a config family.
- `library_scan` was **absent from `MaintenanceOrder()`**, so even the maintenance-window path could not reach it. The Settings checkbox for it was wired to nothing.
- The fsnotify watcher enumerated import paths **once at boot** and never again, so a path added later was never watched, and a removed path leaked its watcher.
- `GetAllImportPaths`'s error was discarded, so a transient failure tore down every watcher silently.

## The fix — both mechanisms, timed scan primary

**Primary: periodic scheduled scan.** New `scheduled.library_scan` (`enabled`/`interval`/`on_startup`), shipping **enabled at 360 min**. It is the only member of that family defaulting on, because it is the only unattended discovery path. fsnotify cannot be the sole mechanism — it does not see writes from remote NFS/SMB clients and can exhaust the kernel watch limit on a large tree. The scan is incremental (unchanged files skipped via the scan cache), so 6h is cheap.

**Secondary: fsnotify, now actually dynamic.** New `watcher.Supervisor` re-reads the desired path set every 5 min: new/enabled paths get a watcher, removed/disabled paths get theirs stopped rather than leaked. `StopAll` is terminal so a tick racing shutdown cannot resurrect watchers. The provider error is now logged via slog **and** pushed to the activity log; a transient failure keeps existing watchers instead of tearing them down.

`IsEnabled`/`RunOnStart` still honour legacy `scan_on_startup` so nobody loses their startup scan. `GetInterval` deliberately does **not** — the legacy flag alone must not start a ticker.

`library_scan` is added to `MaintenanceOrder()` **last**, not first: `scheduler_maintenance_window_op.go:131` breaks out of the loop when the window closes, so a multi-hour walk at the front would starve dedup/purge/optimize.

**RootDir stays excluded** from the default scan, and the exclusion is now logged out loud. RootDir is organize's destination and `scanFolder` invokes `AutoOrganizeFn` on what it processes, so a 6-hourly walk would loop organized books back through organize. `force_update` still includes it.

## Tests

`internal/scheduler` **37 pass / 0 fail**; `internal/scanner` **374 pass / 0 fail**; `internal/watcher` **14 pass**; `internal/config` **456 pass**; `internal/server` **ok, 486s**. `go build ./...` exit 0, `go vet ./...` exit 0. Exit codes read from the tool, never through a pipe.

**Six negative controls**, each reverted to RED then restored to GREEN, with `git diff` verified empty after each restore:

| # | Reverted | Test | Red | Green |
|---|---|---|---|---|
| 1 | `GetInterval` returns 0 | `TestLibraryScanIsScheduledUnderDefaultConfig`, `…IntervalIsConfigurable` | FAIL | PASS |
| 2 | `library_scan` out of `maintenanceOrder` | `TestLibraryScanIsReachableFromMaintenanceWindow` | FAIL | PASS |
| 3 | ticker gate `> 0` to `> time.Hour` | `TestStartCreatesTickerForNonZeroInterval` | FAIL (never fired) | PASS |
| 4 | `Reconcile` made boot-only | 3 supervisor tests | FAIL x3 | PASS |
| 5 | provider error discarded | `TestSupervisorProviderErrorIsReportedAndNonDestructive` | FAIL | PASS |
| 6 | `Scheduled` dropped from `ResetToDefaults()` | `TestResetToDefaultsKeepsPeriodicScanOn`, `…StoredSettingsDoNotDisable…` | FAIL x2 | PASS |

## Not claimed

- **No UI control** for `scheduled.library_scan.*` — settable through the settings path only. The existing `maintenance.library_scan` checkbox now actually does something.
- **Interval is not live-reconfigurable** — snapshotted in `Start()`, same as the other ~20 tasks. Takes effect on restart. Unchanged by this PR.
- **`auto_scan_enabled` is still evaluated once at boot.** The supervisor makes the path set dynamic, not the feature flag.
- **Known and unfixed:** `library_scan`'s TriggerFn still creates a legacy `"scan"` operation row that nothing completes. At 0 ticks/day that never mattered; at 4/day it accumulates, and `IsTaskRunning("library_scan")` reads those legacy rows. The new `previousRunID` guard reads **v2** rows so the ticker is unaffected, and the window path is default-off. Follow-up needed.
- **`previousRunID` has no dedicated test or negative control** — build/vet only.
- **Not deployed, not verified on prod.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp