### PR TITLE
ci: raise coverage-gate cap above the go test timeout so hangs get diagnosed [skip changelog]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/ci.yml
-# version: 3.2.0
+# version: 3.3.0
 # guid: f1a2b3c4-d5e6-f7a8-b9c0-d1e2f3a4b5c6
-# last-edited: 2026-08-10
+# last-edited: 2026-08-11
 
 # Fast parallel CI for PRs and pushes.
 # Runs go vet/build, short tests, frontend lint/build, and frontend unit tests
@@ -133,7 +133,21 @@ jobs:
   coverage-gate:
     name: Coverage Floor (PR gate)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 35, not 20. `make test-short` runs go test with `-timeout 25m`, so a cap
+    # of 20 guaranteed the runner killed the job BEFORE Go's own timeout could
+    # fire — and Go's timeout is the only thing that prints a goroutine dump
+    # naming the stuck test. Every hang therefore surfaced as a bare
+    # `conclusion=cancelled` with no diagnosis, three times on 2026-08-11 alone
+    # (#2311, #2315), and `cancelled` reads as a test failure on the PR even
+    # though nothing failed.
+    #
+    # The job cap must stay strictly greater than the longest `-timeout` passed
+    # to any go test invocation in the steps below, plus setup. If you raise the
+    # test timeout, raise this too.
+    #
+    # This is a diagnosis fix, not a performance fix: internal/server alone is a
+    # ~500s package (TODO-SRVTIMEOUT) and sharding it is still open.
+    timeout-minutes: 35
     env:
       GOEXPERIMENT: jsonv2
     steps:

--- a/changelog.d/20260811_233000_fix_ci_coverage_gate_timeout.md
+++ b/changelog.d/20260811_233000_fix_ci_coverage_gate_timeout.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- The Coverage Floor CI job no longer gets killed before it can say what went
+  wrong. Its 20-minute cap was shorter than the 25-minute timeout the tests
+  themselves use, so a hung test was always killed by the runner first — losing
+  the goroutine dump that names the stuck test, and reporting a bare "cancelled"
+  that looks like a failure on the pull request. The cap is now 35 minutes, so
+  the test timeout fires first and prints a diagnosis.


### PR DESCRIPTION
## The problem

`Coverage Floor (PR gate)` had `timeout-minutes: 20`. `make test-short` runs `go test` with `-timeout 25m`.

The runner therefore **always** killed the job before Go's own timeout could fire — and Go's timeout is the only thing that prints a goroutine dump naming the stuck test. So every hang surfaced as a bare `conclusion=cancelled` with zero diagnosis.

It fired three times tonight alone (#2311 twice, #2315 once), and `cancelled` is indistinguishable from a test failure on the PR checks list even though nothing failed. Two merges were blocked on it.

## The fix

Cap raised to 35 minutes, so the test timeout fires first and prints something actionable.

The comment records the invariant so this cannot silently regress: **the job cap must stay strictly greater than the longest `-timeout` passed to any `go test` invocation in the job, plus setup.**

## What this is not

- **Not a performance fix.** `internal/server` is still a ~500s package; sharding it (TODO-SRVTIMEOUT) is untouched and still open. This only ensures that when it does hang, we learn why.
- **Not a fix for the sibling job.** `Minimal CI / Go Tests (short, race)` has the same problem, but its cap lives in the `falkcorp/github-common` reusable workflow pinned at `d0c3326b`. Changing that is a separate repo and a separate decision — flagging it, not doing it.

## Not verified

I have not reproduced a hang on this branch and watched the new cap produce a goroutine dump. The change is a config invariant, verified by reading the two numbers; the payoff only shows up on the next hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp