### PR TITLE
fix(activity): the activity log was an unbounded, uncancellable memory amplifier [skip changelog]

### DIFF
--- a/changelog.d/20260811_031500_fix_activity_query_unbounded_scan.md
+++ b/changelog.d/20260811_031500_fix_activity_query_unbounded_scan.md
@@ -1,0 +1,52 @@
+### Fixed
+
+#### Activity log queries no longer scan and decode the entire log (production OOM)
+
+`GET /api/v1/activity?limit=5` on production ran for 120 seconds and never
+returned. A heap profile put **8.86 GB — 71.9% of the process heap — inside
+`database.(*PebbleActivityStore).scanTierKVs`**, 8.02 GB of that in
+`encoding/json.Unmarshal`, split between `handlers.ListActivity` →
+`activity.Service.Query` (5.65 GB) and `activity.Service.GetDistinctSources`
+(3.21 GB) running concurrently. The server was OOM-killed repeatedly.
+
+`PebbleActivityStore.Query` had no index for its default case. It called
+`scanTier` for all seven tiers, JSON-decoded **every entry in the entire
+activity log** into one `[]ActivityEntry`, filtered it in Go, sorted the whole
+slice, and only then sliced out the requested page. The cost of a five-row page
+was the size of the whole log. `GetDistinctSources` did the same full scan
+again, from scratch, on every page load.
+
+Activity keys are time-ordered (`act:<tier>:<20-digit-unix-nano>:<ulid>`), so
+the store can be read directly in result order. `Query` now walks the tier key
+ranges newest-first as a k-way merge over reverse iterators and stops as soon as
+it has `offset + limit + 1` matching rows. The merge compares the timestamp
+embedded in the *key*, so only the rows actually taken are decoded — a
+`limit=5` page now decodes 6 entries instead of the entire log.
+
+Also in this change:
+
+- **A hard scan bound.** Even a filter that matches nothing stops after 20,000
+  examined rows rather than degrading back into a full scan. Hitting the bound
+  is logged at WARN with the examined/matched counts and the filter — never
+  silently truncated.
+- **`GetDistinctSources` is bounded and memoized** (45s TTL, keyed on every
+  filter field that can change the result), instead of full-scanning on every
+  page load.
+- **Undecodable rows are counted and reported.** `scanTierKVs` dropped entries
+  whose stored JSON failed to parse via a bare `continue`. Drops are now counted
+  on the store and logged once per scan in aggregate with the first failing key.
+
+**Behaviour change — `total` is now a lower bound when the query stops early.**
+It remains exact whenever the walk exhausts the matching rows (the common case:
+any page whose limit exceeds the remaining matches). When the walk stops at the
+probe, `total` is `offset + limit + 1` — enough for the caller to know another
+page exists, but not the true count. The activity log UI computes
+`Math.ceil(total / pageSize)`, so on a very large log the page count
+under-reports rather than showing the full history depth. This is the deliberate
+trade for not materializing the log; an exact count cannot be produced without
+decoding every row, which is the bug being fixed.
+
+Regression tests assert the *cost* of a query, not only its result, using a
+decode counter incremented at every entry-decode site in the store. Verified by
+negative control: with the bounded path reverted to the old full scan, the
+guard test reports `query decoded 400 of 400 seeded entries` and fails.

--- a/changelog.d/20260811_activity_query_cancellable.md
+++ b/changelog.d/20260811_activity_query_cancellable.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **Activity log queries now stop when you close the page.** Loading the activity
+  view used to start a scan that kept running even after you navigated away or
+  closed the tab. Enough abandoned scans piled up that the server ran out of
+  memory and had to be restarted — five times in one night. Requests now stop as
+  soon as the browser disconnects, so the memory is released immediately instead
+  of being held until a restart.
+
+### Changed
+
+- The activity log's `Query` and `GetDistinctSources` now require a cancellable
+  context; the context-free versions were removed rather than deprecated, so a
+  future caller cannot silently reintroduce the unstoppable-scan bug.

--- a/internal/activity/service.go
+++ b/internal/activity/service.go
@@ -1,6 +1,7 @@
 // file: internal/activity/service.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+// last-edited: 2026-08-11
 
 package activity
 
@@ -33,8 +34,11 @@ func (s *Service) Record(entry database.ActivityEntry) error {
 }
 
 // Query returns entries matching the filter plus the total matching count.
-func (s *Service) Query(filter database.ActivityFilter) ([]database.ActivityEntry, int, error) {
-	return s.store.Query(filter)
+// Callers on a request path must pass the request's context: the scan aborts
+// as soon as it is cancelled, which is what stops an abandoned request from
+// scanning the whole log after the client has disconnected.
+func (s *Service) Query(ctx context.Context, filter database.ActivityFilter) ([]database.ActivityEntry, int, error) {
+	return s.store.Query(ctx, filter)
 }
 
 // Summarize collapses old entries in the given tier that are older than olderThan.
@@ -56,8 +60,9 @@ func (s *Service) CompactByDay(ctx context.Context, olderThan time.Time) (databa
 
 // GetDistinctSources returns all unique sources with their entry counts,
 // narrowed by the given filter's tier/level/since/until/search fields.
-func (s *Service) GetDistinctSources(filter database.ActivityFilter) ([]database.SourceCount, error) {
-	return s.store.GetDistinctSources(filter)
+// As with Query, request-path callers must pass the request's context.
+func (s *Service) GetDistinctSources(ctx context.Context, filter database.ActivityFilter) ([]database.SourceCount, error) {
+	return s.store.GetDistinctSources(ctx, filter)
 }
 
 // RecompactDigests re-derives type, tier, and tags on all stored daily-digest

--- a/internal/activity/service_test.go
+++ b/internal/activity/service_test.go
@@ -1,6 +1,7 @@
 // file: internal/activity/service_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
+// last-edited: 2026-08-11
 
 // NOTE(fable5 T022): Ported from SQLite ActivityStore to NutsActivityStore.
 // Tier names updated to match NutsActivityStore's supported tiers
@@ -49,13 +50,13 @@ func TestService_RecordAndQuery(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query all entries.
-	entries, total, err := svc.Query(database.ActivityFilter{Limit: 10})
+	entries, total, err := svc.Query(context.Background(), database.ActivityFilter{Limit: 10})
 	require.NoError(t, err)
 	assert.Equal(t, 2, total)
 	assert.Len(t, entries, 2)
 
 	// Query by tier=change — should return only 1.
-	entries, total, err = svc.Query(database.ActivityFilter{Tier: "change", Limit: 10})
+	entries, total, err = svc.Query(context.Background(), database.ActivityFilter{Tier: "change", Limit: 10})
 	require.NoError(t, err)
 	assert.Equal(t, 1, total)
 	require.Len(t, entries, 1)

--- a/internal/activity/writer_test.go
+++ b/internal/activity/writer_test.go
@@ -1,6 +1,7 @@
 // file: internal/activity/writer_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: f7e8d9c0-b1a2-4e3f-9c8d-7b6a5e4f3d2c
+// last-edited: 2026-08-11
 
 package activity
 
@@ -122,7 +123,7 @@ func TestWriter_CapturesLogs(t *testing.T) {
 
 	w.Stop(context.Background()) //nolint:errcheck
 
-	entries, total, err := store.Query(database.ActivityFilter{Limit: 50})
+	entries, total, err := store.Query(context.Background(), database.ActivityFilter{Limit: 50})
 	if err != nil {
 		t.Fatalf("Query: %v", err)
 	}
@@ -249,7 +250,7 @@ func TestWriter_Flush(t *testing.T) {
 	w.Flush()
 
 	// Verify all three entries are now persisted.
-	entries, total, err := store.Query(database.ActivityFilter{Limit: 50})
+	entries, total, err := store.Query(context.Background(), database.ActivityFilter{Limit: 50})
 	if err != nil {
 		t.Fatalf("Query after Flush: %v", err)
 	}

--- a/internal/audiobooks/helpers.go
+++ b/internal/audiobooks/helpers.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/helpers.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234560010
-// last-edited: 2026-07-01
+// last-edited: 2026-08-11
 //
 // Private utilities needed by the audiobooks service package. These mirror
 // equivalent helpers from internal/server/ but are standalone so that the
@@ -10,6 +10,7 @@
 package audiobooks
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -540,11 +541,11 @@ func buildComparisonValuesFromBook(book *database.Book, authorName, seriesName s
 
 // buildComparisonValuesFromActivityLog reconstructs a "before" tag snapshot
 // from the activity log for the given book within ±5 s of ts.
-func buildComparisonValuesFromActivityLog(as *activity.Service, bookID string, ts time.Time) map[string]any {
+func buildComparisonValuesFromActivityLog(ctx context.Context, as *activity.Service, bookID string, ts time.Time) map[string]any {
 	window := 5 * time.Second
 	since := ts.Add(-window)
 	until := ts.Add(window)
-	entries, _, err := as.Query(database.ActivityFilter{
+	entries, _, err := as.Query(ctx, database.ActivityFilter{
 		BookID: bookID,
 		Type:   "metadata_apply",
 		Since:  &since,

--- a/internal/audiobooks/service_single.go
+++ b/internal/audiobooks/service_single.go
@@ -162,7 +162,7 @@ func (svc *AudiobookService) GetAudiobookTags(ctx context.Context, id string, co
 			// Fallback: reconstruct "before" state from activity log old_values
 			slog.Debug("GetAudiobookTags GetBookAtVersion failed (), falling back to activity log for snapshot at", "verErr", verErr, "snapshotTS", snapshotTS)
 			if svc.activityService != nil {
-				comparisonValues = buildComparisonValuesFromActivityLog(svc.activityService, id, ts)
+				comparisonValues = buildComparisonValuesFromActivityLog(ctx, svc.activityService, id, ts)
 			}
 		}
 	} else if compareID != "" {

--- a/internal/database/activity_compact_test.go
+++ b/internal/database/activity_compact_test.go
@@ -1,6 +1,7 @@
 // file: internal/database/activity_compact_test.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
+// last-edited: 2026-08-11
 
 package database
 
@@ -84,7 +85,7 @@ func TestCompactByDay_BasicCompaction(t *testing.T) {
 	assert.Equal(t, 6, result.EntriesDeleted, "5 change + 1 audit folded")
 
 	// Should now have: 2 digest rows total — audit folded into day 1.
-	all, total, err := s.Query(ActivityFilter{Limit: 50})
+	all, total, err := s.Query(context.Background(), ActivityFilter{Limit: 50})
 	require.NoError(t, err)
 	assert.Equal(t, 2, total)
 
@@ -190,7 +191,7 @@ func TestCompactByDay_FoldsAuditTier(t *testing.T) {
 	assert.Equal(t, 1, result.EntriesDeleted)
 
 	// Original audit row gone, replaced by a single digest row.
-	all, total, err := s.Query(ActivityFilter{Limit: 50})
+	all, total, err := s.Query(context.Background(), ActivityFilter{Limit: 50})
 	require.NoError(t, err)
 	assert.Equal(t, 1, total)
 	require.Len(t, all, 1)
@@ -236,7 +237,7 @@ func TestCompactByDay_TruncatesLargeDays(t *testing.T) {
 	assert.Equal(t, 600, result.EntriesDeleted)
 
 	// Verify digest details
-	all, total, err := s.Query(ActivityFilter{Limit: 50})
+	all, total, err := s.Query(context.Background(), ActivityFilter{Limit: 50})
 	require.NoError(t, err)
 	assert.Equal(t, 1, total)
 	require.Len(t, all, 1)
@@ -315,7 +316,7 @@ func TestCompactByDay_MergesIntoExistingDigest(t *testing.T) {
 	assert.Equal(t, 5, r2.EntriesDeleted, "all 5 late entries must be deleted")
 
 	// Verify via public API: query digest entries for 2025-05-15.
-	all, total, err := s.Query(ActivityFilter{Limit: 50})
+	all, total, err := s.Query(context.Background(), ActivityFilter{Limit: 50})
 	require.NoError(t, err)
 	assert.Equal(t, 1, total, "must be exactly one digest row after merge")
 	require.Len(t, all, 1)
@@ -362,7 +363,7 @@ func TestCompactByDay_DigestItemTimestampAndTags(t *testing.T) {
 	assert.Equal(t, 1, result.DaysCompacted)
 	assert.Equal(t, 3, result.EntriesDeleted)
 
-	all, _, err := s.Query(ActivityFilter{Limit: 10})
+	all, _, err := s.Query(context.Background(), ActivityFilter{Limit: 10})
 	require.NoError(t, err)
 	require.Len(t, all, 1)
 
@@ -402,12 +403,12 @@ func TestNutsActivityStore_RecompactDigests(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		_, err := s.Record(ActivityEntry{
 			Tier:      "change",
-			Type:      "system_log",  // legacy type — should be re-derived
+			Type:      "system_log", // legacy type — should be re-derived
 			Level:     "info",
 			Source:    "compaction",
 			Summary:   "applied metadata to book",
 			Timestamp: day.Add(time.Duration(i) * time.Minute),
-			Tags:      []string{},    // empty tags — triggers isLegacyItem
+			Tags:      []string{}, // empty tags — triggers isLegacyItem
 		})
 		require.NoError(t, err)
 	}

--- a/internal/database/activity_store_instrumented.go
+++ b/internal/database/activity_store_instrumented.go
@@ -1,6 +1,7 @@
 // file: internal/database/activity_store_instrumented.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-0002-bcde-000000000002
+// last-edited: 2026-08-11
 
 package database
 
@@ -47,15 +48,21 @@ func (i *InstrumentedActivityStorer) Record(entry ActivityEntry) (int64, error) 
 }
 
 // Query traces the Query operation.
-func (i *InstrumentedActivityStorer) Query(filter ActivityFilter) ([]ActivityEntry, int, error) {
-	_, span := tracer.Start(context.Background(), "activity_store.query",
+//
+// The span is started FROM ctx and the returned ctx is what gets handed to the
+// wrapped store. Starting from context.Background() here (as this did before
+// Query became cancellable) would silently terminate the cancellation chain at
+// this wrapper: the build and every test would still pass while an abandoned
+// request kept scanning in production.
+func (i *InstrumentedActivityStorer) Query(ctx context.Context, filter ActivityFilter) ([]ActivityEntry, int, error) {
+	ctx, span := tracer.Start(ctx, "activity_store.query",
 		trace.WithAttributes(
 			attribute.String("tier", filter.Tier),
 			attribute.String("source", filter.Source),
 		))
 	defer span.End()
 
-	entries, total, err := i.store.Query(filter)
+	entries, total, err := i.store.Query(ctx, filter)
 	if err != nil {
 		span.RecordError(err)
 		span.SetAttributes(attribute.Bool("error", true))
@@ -106,14 +113,17 @@ func (i *InstrumentedActivityStorer) Prune(olderThan time.Time, tier string) (in
 }
 
 // GetDistinctSources traces the GetDistinctSources operation.
-func (i *InstrumentedActivityStorer) GetDistinctSources(filter ActivityFilter) ([]SourceCount, error) {
-	_, span := tracer.Start(context.Background(), "activity_store.get_distinct_sources",
+//
+// As with Query, the span starts from the caller's ctx and the derived ctx is
+// passed down, so cancellation survives this wrapper.
+func (i *InstrumentedActivityStorer) GetDistinctSources(ctx context.Context, filter ActivityFilter) ([]SourceCount, error) {
+	ctx, span := tracer.Start(ctx, "activity_store.get_distinct_sources",
 		trace.WithAttributes(
 			attribute.String("tier", filter.Tier),
 		))
 	defer span.End()
 
-	sources, err := i.store.GetDistinctSources(filter)
+	sources, err := i.store.GetDistinctSources(ctx, filter)
 	if err != nil {
 		span.RecordError(err)
 		span.SetAttributes(attribute.Bool("error", true))

--- a/internal/database/activity_storer.go
+++ b/internal/database/activity_storer.go
@@ -1,7 +1,7 @@
 // file: internal/database/activity_storer.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1b2c3d4-e5f6-0001-abcd-000000000001
-// last-edited: 2026-07-03
+// last-edited: 2026-08-11
 
 package database
 
@@ -13,12 +13,22 @@ import (
 // ActivityStorer is the minimal interface required by activity.Service and
 // activity.Writer. PebbleActivityStore is the production implementation
 // (NutsActivityStore retired as of TASK-22, retained unwired pending removal).
+//
+// Query and GetDistinctSources take a context and there is deliberately NO
+// context-free variant of either. Both walk the activity log, and on production
+// an abandoned request whose scan could not be cancelled kept decoding entries
+// after the client had disconnected: 30 goroutines held 30.8 GB inside the scan
+// with ZERO connected clients, and only a restart freed it. A parallel
+// non-context method would let the next caller reintroduce that outage, so the
+// cancellable path is the only path. The remaining methods are intentionally
+// left context-free: they are maintenance/write operations that are not driven
+// by an abandonable HTTP request.
 type ActivityStorer interface {
 	Record(ActivityEntry) (int64, error)
-	Query(ActivityFilter) ([]ActivityEntry, int, error)
+	Query(context.Context, ActivityFilter) ([]ActivityEntry, int, error)
 	Summarize(ctx context.Context, olderThan time.Time, tier string) (int, error)
 	Prune(olderThan time.Time, tier string) (int, error)
-	GetDistinctSources(ActivityFilter) ([]SourceCount, error)
+	GetDistinctSources(context.Context, ActivityFilter) ([]SourceCount, error)
 	WipeAllActivity() (int64, error)
 	CompactByDay(ctx context.Context, olderThan time.Time) (CompactResult, error)
 	RecompactDigests(ctx context.Context) (RecompactResult, error)

--- a/internal/database/dual_write_activity_store.go
+++ b/internal/database/dual_write_activity_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/dual_write_activity_store.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: f6a7b8c9-d0e1-0006-f012-000000000006
-// last-edited: 2026-07-03
+// last-edited: 2026-08-11
 
 // Package database — dual-write wrapper for the activity migration window.
 //
@@ -184,19 +184,19 @@ func (d *DualWriteActivityStore) RecompactDigests(ctx context.Context) (Recompac
 // ── ActivityStorer reads — routed to active backend ──────────────────────────
 
 // Query reads from the active backend only.
-func (d *DualWriteActivityStore) Query(f ActivityFilter) ([]ActivityEntry, int, error) {
+func (d *DualWriteActivityStore) Query(ctx context.Context, f ActivityFilter) ([]ActivityEntry, int, error) {
 	if d.ReadFromPebble {
-		return d.pebble.Query(f)
+		return d.pebble.Query(ctx, f)
 	}
-	return d.nuts.Query(f)
+	return d.nuts.Query(ctx, f)
 }
 
 // GetDistinctSources reads from the active backend only.
-func (d *DualWriteActivityStore) GetDistinctSources(f ActivityFilter) ([]SourceCount, error) {
+func (d *DualWriteActivityStore) GetDistinctSources(ctx context.Context, f ActivityFilter) ([]SourceCount, error) {
 	if d.ReadFromPebble {
-		return d.pebble.GetDistinctSources(f)
+		return d.pebble.GetDistinctSources(ctx, f)
 	}
-	return d.nuts.GetDistinctSources(f)
+	return d.nuts.GetDistinctSources(ctx, f)
 }
 
 // Close closes both backends and returns the first error encountered.

--- a/internal/database/nuts_activity_store.go
+++ b/internal/database/nuts_activity_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/nuts_activity_store.go
-// version: 1.4.1
+// version: 1.5.0
 // guid: c3d4e5f6-a7b8-0003-cdef-000000000003
-// last-edited: 2026-07-01
+// last-edited: 2026-08-11
 
 package database
 
@@ -172,7 +172,12 @@ func (s *NutsActivityStore) Record(e ActivityEntry) (int64, error) {
 }
 
 // Query returns entries matching f, newest-first, plus the total matching count.
-func (s *NutsActivityStore) Query(f ActivityFilter) ([]ActivityEntry, int, error) {
+//
+// ctx is accepted and deliberately IGNORED: this store is retired and unwired
+// (TASK-22) and exists only to satisfy ActivityStorer until the NutsDB removal
+// PR deletes it. It is not on any request path, so it was not given the
+// periodic cancellation checks the live Pebble implementation has.
+func (s *NutsActivityStore) Query(_ context.Context, f ActivityFilter) ([]ActivityEntry, int, error) {
 	if f.Limit == 0 {
 		f.Limit = 50
 	}
@@ -365,7 +370,10 @@ func (s *NutsActivityStore) Prune(olderThan time.Time, tier string) (int, error)
 }
 
 // GetDistinctSources returns unique sources with entry counts, ordered by count desc.
-func (s *NutsActivityStore) GetDistinctSources(f ActivityFilter) ([]SourceCount, error) {
+//
+// ctx is accepted and deliberately IGNORED — see Query: retired, unwired store
+// kept only to satisfy the interface.
+func (s *NutsActivityStore) GetDistinctSources(_ context.Context, f ActivityFilter) ([]SourceCount, error) {
 	tiers := actTiers
 	if f.Tier != "" {
 		tiers = []string{f.Tier}

--- a/internal/database/pebble_activity_bounded_test.go
+++ b/internal/database/pebble_activity_bounded_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_activity_bounded_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7f2a1c5e-9b34-4d61-8a70-2c6e5b91d403
 // last-edited: 2026-08-11
 
@@ -22,6 +22,7 @@
 package database
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -66,7 +67,7 @@ func TestPebbleActivityStore_QueryDoesNotScanEntireLog(t *testing.T) {
 	seedActivityEntries(t, s, seeded, "change", "info", "debug", "batch")
 
 	before := s.EntriesDecoded()
-	entries, total, err := s.Query(ActivityFilter{Limit: 5})
+	entries, total, err := s.Query(context.Background(), ActivityFilter{Limit: 5})
 	require.NoError(t, err)
 	decoded := s.EntriesDecoded() - before
 
@@ -100,7 +101,7 @@ func TestPebbleActivityStore_QueryHonorsScanBudget(t *testing.T) {
 	seedActivityEntries(t, s, seeded, "change", "info")
 
 	before := s.EntriesDecoded()
-	entries, total, err := s.Query(ActivityFilter{Limit: 5, Search: "zzz-matches-nothing"})
+	entries, total, err := s.Query(context.Background(), ActivityFilter{Limit: 5, Search: "zzz-matches-nothing"})
 	require.NoError(t, err)
 	decoded := s.EntriesDecoded() - before
 
@@ -116,7 +117,7 @@ func TestPebbleActivityStore_QueryExactTotalWhenExhausted(t *testing.T) {
 	s := newTestPebbleActivityStore(t)
 	seedActivityEntries(t, s, 7, "change")
 
-	entries, total, err := s.Query(ActivityFilter{Limit: 50})
+	entries, total, err := s.Query(context.Background(), ActivityFilter{Limit: 50})
 	require.NoError(t, err)
 	assert.Len(t, entries, 7)
 	assert.Equal(t, 7, total, "limit exceeds the log size, so the walk exhausts and total is exact")
@@ -129,7 +130,7 @@ func TestPebbleActivityStore_QueryOffsetPastEnd(t *testing.T) {
 	s := newTestPebbleActivityStore(t)
 	seedActivityEntries(t, s, 4, "change")
 
-	entries, total, err := s.Query(ActivityFilter{Limit: 10, Offset: 999})
+	entries, total, err := s.Query(context.Background(), ActivityFilter{Limit: 10, Offset: 999})
 	require.NoError(t, err)
 	assert.Empty(t, entries)
 	assert.Equal(t, 4, total)
@@ -161,7 +162,7 @@ func TestPebbleActivityStore_QueryDigestSortsLast(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	entries, total, err := s.Query(ActivityFilter{Limit: 50})
+	entries, total, err := s.Query(context.Background(), ActivityFilter{Limit: 50})
 	require.NoError(t, err)
 	require.Len(t, entries, 5)
 	assert.Equal(t, 5, total)
@@ -193,7 +194,7 @@ func TestPebbleActivityStore_GetDistinctSourcesIsBoundedAndCached(t *testing.T) 
 	seedActivityEntries(t, s, seeded, "change", "info")
 
 	before := s.EntriesDecoded()
-	sources, err := s.GetDistinctSources(ActivityFilter{})
+	sources, err := s.GetDistinctSources(context.Background(), ActivityFilter{})
 	require.NoError(t, err)
 	decoded := s.EntriesDecoded() - before
 
@@ -203,7 +204,7 @@ func TestPebbleActivityStore_GetDistinctSourcesIsBoundedAndCached(t *testing.T) 
 
 	// Second call inside the TTL must be served from cache: zero extra decodes.
 	beforeCached := s.EntriesDecoded()
-	cached, err := s.GetDistinctSources(ActivityFilter{})
+	cached, err := s.GetDistinctSources(context.Background(), ActivityFilter{})
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), s.EntriesDecoded()-beforeCached,
 		"a repeat call within the TTL must not touch the store at all")
@@ -211,7 +212,7 @@ func TestPebbleActivityStore_GetDistinctSourcesIsBoundedAndCached(t *testing.T) 
 
 	// A different filter must NOT be served the previous filter's counts.
 	beforeOther := s.EntriesDecoded()
-	_, err = s.GetDistinctSources(ActivityFilter{Tier: "change"})
+	_, err = s.GetDistinctSources(context.Background(), ActivityFilter{Tier: "change"})
 	require.NoError(t, err)
 	assert.Greater(t, s.EntriesDecoded()-beforeOther, int64(0),
 		"a different filter must miss the cache and run its own scan")
@@ -229,7 +230,7 @@ func TestPebbleActivityStore_DecodeFailuresAreCounted(t *testing.T) {
 	require.NoError(t, s.db.Set(corruptKey, []byte("{not json"), nil))
 
 	before := s.DecodeFailures()
-	entries, _, err := s.Query(ActivityFilter{Limit: 50})
+	entries, _, err := s.Query(context.Background(), ActivityFilter{Limit: 50})
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(1), s.DecodeFailures()-before,

--- a/internal/database/pebble_activity_bounded_test.go
+++ b/internal/database/pebble_activity_bounded_test.go
@@ -1,0 +1,240 @@
+// file: internal/database/pebble_activity_bounded_test.go
+// version: 1.0.0
+// guid: 7f2a1c5e-9b34-4d61-8a70-2c6e5b91d403
+// last-edited: 2026-08-11
+
+// Package database — regression suite for the BOUNDED activity query path.
+//
+// WHY this file exists:
+//
+//	PebbleActivityStore.Query used to decode every entry in every tier into one
+//	[]ActivityEntry, filter it, sort it, and only then slice out the requested
+//	page. On production that put 8.86 GB (71.9% of the process heap) inside
+//	scanTierKVs, 8.02 GB of it in encoding/json.Unmarshal, and
+//	GET /api/v1/activity?limit=5 ran for 120s without returning. The server was
+//	OOM-killed repeatedly.
+//
+//	These tests assert the COST of a query, not just its result. The instrument
+//	is PebbleActivityStore.EntriesDecoded(), which is incremented at every
+//	stored-entry decode site in the store — including the full-scan
+//	scanTierKVs path — so a regression to full-scan behaviour makes the decode
+//	counts explode and these tests fail loudly.
+package database
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedActivityEntries writes n entries spread over the given tiers with
+// strictly increasing timestamps, so newest-first order is unambiguous.
+// Returns the timestamp of the newest entry written.
+func seedActivityEntries(t *testing.T, s *PebbleActivityStore, n int, tiers ...string) time.Time {
+	t.Helper()
+	if len(tiers) == 0 {
+		tiers = []string{"change"}
+	}
+	base := time.Now().UTC().Add(-time.Duration(n) * time.Second)
+	var newest time.Time
+	for i := 0; i < n; i++ {
+		ts := base.Add(time.Duration(i) * time.Second)
+		newest = ts
+		_, err := s.Record(ActivityEntry{
+			Timestamp: ts,
+			Tier:      tiers[i%len(tiers)],
+			Type:      "seeded",
+			Level:     "info",
+			Source:    fmt.Sprintf("src-%d", i%5),
+			Summary:   fmt.Sprintf("seeded entry %d", i),
+		})
+		require.NoError(t, err)
+	}
+	return newest
+}
+
+// TestPebbleActivityStore_QueryDoesNotScanEntireLog is the core regression
+// guard: a small page must cost a small number of decodes regardless of how
+// much history is stored.
+func TestPebbleActivityStore_QueryDoesNotScanEntireLog(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+
+	const seeded = 400
+	seedActivityEntries(t, s, seeded, "change", "info", "debug", "batch")
+
+	before := s.EntriesDecoded()
+	entries, total, err := s.Query(ActivityFilter{Limit: 5})
+	require.NoError(t, err)
+	decoded := s.EntriesDecoded() - before
+
+	assert.Len(t, entries, 5, "page should be full")
+
+	// probe = offset + limit + 1 = 6. The walk stops there, so exactly 6 rows
+	// are decoded. The pre-fix implementation decoded all 400.
+	assert.Equal(t, int64(6), decoded,
+		"query decoded %d of %d seeded entries; a paged query must not scan the whole log", decoded, seeded)
+	assert.Equal(t, 6, total, "total is the probe value: one past the requested page")
+
+	// Newest-first ordering is preserved.
+	for i := 1; i < len(entries); i++ {
+		assert.Falsef(t, entries[i].Timestamp.After(entries[i-1].Timestamp),
+			"entry %d (%s) is newer than entry %d (%s): order must be newest-first",
+			i, entries[i].Timestamp, i-1, entries[i-1].Timestamp)
+	}
+}
+
+// TestPebbleActivityStore_QueryHonorsScanBudget proves the hard safety bound:
+// a filter that matches nothing must NOT degrade into a full scan.
+//
+// Not parallel: it mutates the package-level budget var.
+func TestPebbleActivityStore_QueryHonorsScanBudget(t *testing.T) {
+	oldBudget := activityQueryScanBudget
+	activityQueryScanBudget = 25
+	t.Cleanup(func() { activityQueryScanBudget = oldBudget })
+
+	s := newTestPebbleActivityStore(t)
+	const seeded = 300
+	seedActivityEntries(t, s, seeded, "change", "info")
+
+	before := s.EntriesDecoded()
+	entries, total, err := s.Query(ActivityFilter{Limit: 5, Search: "zzz-matches-nothing"})
+	require.NoError(t, err)
+	decoded := s.EntriesDecoded() - before
+
+	assert.Empty(t, entries, "no entry matches the filter")
+	assert.Equal(t, 0, total)
+	assert.Equal(t, int64(activityQueryScanBudget), decoded,
+		"a filter matching nothing must stop at the scan budget, not scan all %d entries", seeded)
+}
+
+// TestPebbleActivityStore_QueryExactTotalWhenExhausted pins the other half of
+// the total contract: when the walk drains the log, total is exact.
+func TestPebbleActivityStore_QueryExactTotalWhenExhausted(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+	seedActivityEntries(t, s, 7, "change")
+
+	entries, total, err := s.Query(ActivityFilter{Limit: 50})
+	require.NoError(t, err)
+	assert.Len(t, entries, 7)
+	assert.Equal(t, 7, total, "limit exceeds the log size, so the walk exhausts and total is exact")
+}
+
+// TestPebbleActivityStore_QueryOffsetPastEnd guards the clamping behaviour the
+// bounded rewrite had to preserve: an offset beyond the data returns an empty
+// page rather than panicking on a bad slice range.
+func TestPebbleActivityStore_QueryOffsetPastEnd(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+	seedActivityEntries(t, s, 4, "change")
+
+	entries, total, err := s.Query(ActivityFilter{Limit: 10, Offset: 999})
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+	assert.Equal(t, 4, total)
+}
+
+// TestPebbleActivityStore_QueryDigestSortsLast pins the two-group result order
+// the pre-fix global sort produced: every non-digest entry precedes every
+// digest entry, newest-first within each group.
+func TestPebbleActivityStore_QueryDigestSortsLast(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+
+	base := time.Now().UTC().Add(-time.Hour)
+	// Digest entries are written NEWEST so a naive global timestamp sort would
+	// put them first — only the two-group order keeps them last.
+	for i := 0; i < 3; i++ {
+		_, err := s.Record(ActivityEntry{
+			Timestamp: base.Add(time.Duration(i) * time.Minute),
+			Tier:      "change", Type: "seeded", Level: "info", Source: "s",
+			Summary: fmt.Sprintf("change-%d", i),
+		})
+		require.NoError(t, err)
+	}
+	for i := 0; i < 2; i++ {
+		_, err := s.Record(ActivityEntry{
+			Timestamp: base.Add(time.Duration(30+i) * time.Minute),
+			Tier:      "digest", Type: "daily_digest", Level: "info", Source: "compaction",
+			Summary: fmt.Sprintf("digest-%d", i),
+		})
+		require.NoError(t, err)
+	}
+
+	entries, total, err := s.Query(ActivityFilter{Limit: 50})
+	require.NoError(t, err)
+	require.Len(t, entries, 5)
+	assert.Equal(t, 5, total)
+
+	seenDigest := false
+	for _, e := range entries {
+		if e.Tier == "digest" {
+			seenDigest = true
+			continue
+		}
+		assert.False(t, seenDigest, "non-digest entry %q appeared after a digest entry", e.Summary)
+	}
+	assert.Equal(t, "digest", entries[3].Tier)
+	assert.Equal(t, "digest", entries[4].Tier)
+}
+
+// TestPebbleActivityStore_GetDistinctSourcesIsBoundedAndCached proves the
+// second half of the OOM: GetDistinctSources ran a full scan concurrently with
+// Query on every page load (3.21 GB of the production heap on its own).
+//
+// Not parallel: it mutates the package-level budget var.
+func TestPebbleActivityStore_GetDistinctSourcesIsBoundedAndCached(t *testing.T) {
+	oldBudget := activityQueryScanBudget
+	activityQueryScanBudget = 30
+	t.Cleanup(func() { activityQueryScanBudget = oldBudget })
+
+	s := newTestPebbleActivityStore(t)
+	const seeded = 250
+	seedActivityEntries(t, s, seeded, "change", "info")
+
+	before := s.EntriesDecoded()
+	sources, err := s.GetDistinctSources(ActivityFilter{})
+	require.NoError(t, err)
+	decoded := s.EntriesDecoded() - before
+
+	assert.NotEmpty(t, sources)
+	assert.Equal(t, int64(activityQueryScanBudget), decoded,
+		"distinct-sources must stop at the scan budget, not scan all %d entries", seeded)
+
+	// Second call inside the TTL must be served from cache: zero extra decodes.
+	beforeCached := s.EntriesDecoded()
+	cached, err := s.GetDistinctSources(ActivityFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), s.EntriesDecoded()-beforeCached,
+		"a repeat call within the TTL must not touch the store at all")
+	assert.Equal(t, sources, cached)
+
+	// A different filter must NOT be served the previous filter's counts.
+	beforeOther := s.EntriesDecoded()
+	_, err = s.GetDistinctSources(ActivityFilter{Tier: "change"})
+	require.NoError(t, err)
+	assert.Greater(t, s.EntriesDecoded()-beforeOther, int64(0),
+		"a different filter must miss the cache and run its own scan")
+}
+
+// TestPebbleActivityStore_DecodeFailuresAreCounted proves that a row whose
+// stored JSON cannot be decoded is counted rather than silently dropped by a
+// bare `continue`.
+func TestPebbleActivityStore_DecodeFailuresAreCounted(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+	seedActivityEntries(t, s, 3, "change")
+
+	// Write a corrupt value under a well-formed primary key.
+	corruptKey := pactPrimaryKey("change", time.Now().UTC(), "01CORRUPTCORRUPTCORRUPT")
+	require.NoError(t, s.db.Set(corruptKey, []byte("{not json"), nil))
+
+	before := s.DecodeFailures()
+	entries, _, err := s.Query(ActivityFilter{Limit: 50})
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), s.DecodeFailures()-before,
+		"the undecodable row must be counted as a drop, not silently skipped")
+	for _, e := range entries {
+		assert.NotEmpty(t, e.Type, "decoded entries must be intact")
+	}
+}

--- a/internal/database/pebble_activity_cancel_test.go
+++ b/internal/database/pebble_activity_cancel_test.go
@@ -1,0 +1,229 @@
+// file: internal/database/pebble_activity_cancel_test.go
+// version: 1.0.0
+// guid: 3e91b7d2-6c04-4a58-9f13-8d27e5a06b41
+// last-edited: 2026-08-11
+
+// Package database — regression suite for CANCELLATION of the activity query.
+//
+// WHY this file exists, and why it is separate from the bounded-scan suite:
+//
+//	The scan budget and cancellation solve different halves of the same
+//	outage and neither substitutes for the other. The budget bounds a request
+//	that RUNS TO COMPLETION. Cancellation bounds a request that is ABANDONED.
+//	On production, ss -tnp showed ZERO connected clients while 30 goroutines
+//	held 30.8 GB inside the activity scan against a 30 GB cap: every one of
+//	those requests had been abandoned, and because the scan could not observe
+//	that, it kept decoding entries into a response nobody would ever read.
+//	Only a process restart freed the memory.
+//
+//	So the property under test here is not "the query is fast" (that is the
+//	bounded suite's job) but "the query STOPS when the caller goes away".
+//
+// HOW the determinism works:
+//
+//	Cancelling from another goroutine mid-scan is a race, and cancelling
+//	BEFORE the call only proves the entry check at the top of scanNewestFirst
+//	works — delete the in-loop check and such a test still passes. That is a
+//	test that cannot fail for the reason it claims to.
+//
+//	Instead these tests drive the real public Query/GetDistinctSources with a
+//	context that reports itself cancelled on the Nth call to Err(). With
+//	activityCtxCheckInterval pinned to 1, the call sequence is exactly:
+//	one check on entry to scanNewestFirst, then one check per row. Tripping
+//	on a later check therefore lands strictly INSIDE the row loop, after real
+//	rows have been decoded, which is the only place the production bug could
+//	be caught.
+package database
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// trippingContext reports success for the first n calls to Err() and
+// context.Canceled for every call after that. It stands in for a client that
+// disconnects partway through a scan, without the timing race that a real
+// goroutine-driven cancel would introduce.
+//
+// Only Err() is overridden: the scan polls Err() rather than selecting on
+// Done(), which is deliberate — a select per decoded row costs more than an
+// atomic load, and the scan decodes millions of rows.
+type trippingContext struct {
+	context.Context
+	mu     sync.Mutex
+	checks int
+	after  int
+}
+
+func newTrippingContext(after int) *trippingContext {
+	return &trippingContext{Context: context.Background(), after: after}
+}
+
+func (c *trippingContext) Err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.checks++
+	if c.checks > c.after {
+		return context.Canceled
+	}
+	return nil
+}
+
+func (c *trippingContext) checkCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.checks
+}
+
+// pinCtxCheckInterval forces a context check on every row so the check
+// sequence is countable, and restores the production value afterwards.
+func pinCtxCheckInterval(t *testing.T) {
+	t.Helper()
+	prev := activityCtxCheckInterval
+	activityCtxCheckInterval = 1
+	t.Cleanup(func() { activityCtxCheckInterval = prev })
+}
+
+// TestQueryAbortsMidScanWhenCallerGoesAway is the core cancellation guard.
+//
+// The context trips on the 4th Err() call: entry check, row 1, row 2, then
+// trip. So the scan is aborted with rows already decoded and a partial page
+// already accumulated — exactly the state an abandoned production request was
+// in when it kept going.
+//
+// NEGATIVE CONTROL: deleting the in-loop ctx check inside scanNewestFirst
+// makes this test fail. With that check gone the only Err() call is the one on
+// entry, which returns nil here, so the scan runs to completion and Query
+// returns a full page and no error. Verified red, then green again.
+func TestQueryAbortsMidScanWhenCallerGoesAway(t *testing.T) {
+	pinCtxCheckInterval(t)
+	s := newTestPebbleActivityStore(t)
+
+	const seeded = 300
+	seedActivityEntries(t, s, seeded, "change", "info", "debug", "batch")
+
+	ctx := newTrippingContext(3)
+
+	before := s.EntriesDecoded()
+	entries, total, err := s.Query(ctx, ActivityFilter{Limit: 50})
+	decoded := s.EntriesDecoded() - before
+
+	require.Error(t, err, "an abandoned request must surface an error, not a silent partial result")
+	assert.ErrorIs(t, err, context.Canceled)
+
+	// The partial page must be dropped, not returned. Handing back a short
+	// page with a plausible total is worse than an error: the caller renders
+	// or caches it as though the log really were that small.
+	assert.Nil(t, entries, "partial page must be released, not returned")
+	assert.Zero(t, total, "a cancelled scan has no meaningful total")
+
+	// Proof the abort happened INSIDE the row loop rather than on entry: some
+	// rows were decoded, but nothing close to the whole log.
+	assert.Greater(t, decoded, int64(0), "scan should have started before cancelling")
+	assert.Less(t, decoded, int64(seeded/2),
+		"scan must stop promptly after cancellation, not drain the log")
+	assert.Greater(t, ctx.checkCount(), 1,
+		"more than the entry check must have run; if this is 1 the in-loop check is missing")
+}
+
+// TestQueryHonoursAlreadyCancelledContext covers the cheap case: a request
+// abandoned before the scan even starts should never open an iterator.
+//
+// This is the WEAKER of the two tests by design — it passes even with the
+// in-loop check removed — so it is kept separate from the mid-scan test rather
+// than folded into it. Merging them would produce one test that looks like it
+// covers cancellation while only really covering entry.
+func TestQueryHonoursAlreadyCancelledContext(t *testing.T) {
+	pinCtxCheckInterval(t)
+	s := newTestPebbleActivityStore(t)
+	seedActivityEntries(t, s, 50, "change")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	before := s.EntriesDecoded()
+	entries, total, err := s.Query(ctx, ActivityFilter{Limit: 10})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, entries)
+	assert.Zero(t, total)
+	assert.Equal(t, int64(0), s.EntriesDecoded()-before,
+		"a request abandoned before the scan started must decode nothing")
+}
+
+// TestGetDistinctSourcesAbortsMidScan covers the other half of the OOM heap
+// profile: GetDistinctSources ran concurrently with Query on every page load
+// and contributed 3.21 GB of its own.
+//
+// It also pins the cache invariant. Partial counts from a cancelled scan must
+// NOT be memoized: caching them would serve a wrong, truncated source list to
+// every subsequent caller for the whole TTL, long after the request that
+// produced it had gone.
+func TestGetDistinctSourcesAbortsMidScan(t *testing.T) {
+	pinCtxCheckInterval(t)
+	s := newTestPebbleActivityStore(t)
+
+	const seeded = 300
+	seedActivityEntries(t, s, seeded, "change", "info", "debug", "batch")
+
+	filter := ActivityFilter{}
+	ctx := newTrippingContext(3)
+
+	sources, err := s.GetDistinctSources(ctx, filter)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, sources, "partial counts must be released, not returned")
+
+	// Nothing should have been cached by the cancelled call: a fresh
+	// uncancelled query must see the real, complete source list.
+	full, err := s.GetDistinctSources(context.Background(), filter)
+	require.NoError(t, err)
+	assert.Len(t, full, 5, "seeded data has 5 distinct sources; a cached partial would show fewer")
+
+	var total int
+	for _, sc := range full {
+		total += sc.Count
+	}
+	assert.Equal(t, seeded, total, "counts must come from a complete scan, not a cancelled one")
+}
+
+// TestQueryByIndexPrefixAbortsWhenCallerGoesAway guards the fast path.
+//
+// Query short-circuits to queryByIndexPrefix whenever OperationID or BookID is
+// set, so GET /api/v1/operations/:id/activity never reaches scanNewestFirst.
+// Without its own ctx checks, threading a request context into Query would be
+// cosmetic on that endpoint — the handler would look fixed while the scan it
+// triggers still ran to completion. This test is what makes that concrete.
+func TestQueryByIndexPrefixAbortsWhenCallerGoesAway(t *testing.T) {
+	pinCtxCheckInterval(t)
+	s := newTestPebbleActivityStore(t)
+
+	const opID = "op-cancel-test"
+	base := time.Now().UTC().Add(-10 * time.Minute)
+	for i := 0; i < 200; i++ {
+		_, err := s.Record(ActivityEntry{
+			Timestamp:   base.Add(time.Duration(i) * time.Second),
+			Tier:        "change",
+			Type:        "seeded",
+			Level:       "info",
+			Source:      "src",
+			Summary:     "op entry",
+			OperationID: opID,
+		})
+		require.NoError(t, err)
+	}
+
+	ctx := newTrippingContext(2)
+	entries, total, err := s.Query(ctx, ActivityFilter{OperationID: opID, Limit: 50})
+
+	require.Error(t, err, "the op-transcript fast path must be cancellable too")
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, entries)
+	assert.Zero(t, total)
+}

--- a/internal/database/pebble_activity_store.go
+++ b/internal/database/pebble_activity_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_activity_store.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: d4e5f6a7-b8c9-0004-def0-000000000004
 // last-edited: 2026-08-11
 
@@ -56,6 +56,13 @@ var (
 	// The source list feeds a filter picker, so slightly stale counts are fine;
 	// re-scanning on every page load was half the OOM.
 	activitySourcesCacheTTL = 45 * time.Second
+
+	// activityCtxCheckInterval is how many rows a scan processes between
+	// context checks. Checking every row would cost a select per decode;
+	// checking never is what let 30 ABANDONED requests keep scanning and
+	// allocating on production (zero connected clients, 30 goroutines still
+	// inside scanTierKVs, 30.8 GB against a 30 GB cap). Tests set this to 1.
+	activityCtxCheckInterval = 64
 )
 
 // PebbleActivityStore persists activity log entries in a shared PebbleDB database.
@@ -253,18 +260,30 @@ func (s *PebbleActivityStore) Record(e ActivityEntry) (int64, error) {
 	return id, nil
 }
 
-// Query returns entries matching f, newest-first, plus the total matching count.
-func (s *PebbleActivityStore) Query(f ActivityFilter) ([]ActivityEntry, int, error) {
+// Query returns entries matching f, newest-first, plus the total matching
+// count, and aborts as soon as ctx is cancelled.
+//
+// There is deliberately no context-free variant: an abandoned request that
+// could not be cancelled is what held 30.8 GB across 30 goroutines with no
+// connected clients on production. Callers on a request path must pass the
+// request's context, never context.Background().
+//
+// total is EXACT when the walk exhausts the matching rows. Otherwise it is a
+// LOWER BOUND: either offset+limit+1 (the probe row, which tells the caller
+// another page exists) or however many matches were found before the scan
+// budget was reached. An exact count would require decoding every stored
+// entry, which is the behaviour this method exists to remove.
+func (s *PebbleActivityStore) Query(ctx context.Context, f ActivityFilter) ([]ActivityEntry, int, error) {
 	if f.Limit == 0 {
 		f.Limit = 50
 	}
 
 	// Fast path: op_id or book_id filter → use secondary index.
 	if f.OperationID != "" {
-		return s.queryByIndexPrefix(fmt.Sprintf("act:op:%s:", f.OperationID), f)
+		return s.queryByIndexPrefix(ctx, fmt.Sprintf("act:op:%s:", f.OperationID), f)
 	}
 	if f.BookID != "" {
-		return s.queryByIndexPrefix(fmt.Sprintf("act:bk:%s:", f.BookID), f)
+		return s.queryByIndexPrefix(ctx, fmt.Sprintf("act:bk:%s:", f.BookID), f)
 	}
 
 	// General path: bounded newest-first merge over the tier key ranges.
@@ -305,9 +324,10 @@ func (s *PebbleActivityStore) Query(f ActivityFilter) ([]ActivityEntry, int, err
 			exhausted = false
 			break
 		}
-		ex, phaseExhausted, err := s.scanNewestFirst(phase, f, remaining, "query", collect)
+		ex, phaseExhausted, err := s.scanNewestFirst(ctx, phase, f, remaining, "query", collect)
 		examined += ex
 		if err != nil {
+			// Explicitly nil: drop the partial page rather than returning it.
 			return nil, 0, err
 		}
 		if !phaseExhausted {
@@ -339,7 +359,7 @@ func (s *PebbleActivityStore) Query(f ActivityFilter) ([]ActivityEntry, int, err
 // Summarize groups old entries by (operation_id, type), writes a summary row,
 // and deletes the originals. Returns count of deleted rows.
 func (s *PebbleActivityStore) Summarize(ctx context.Context, olderThan time.Time, tier string) (int, error) {
-	kvs, err := s.scanTierKVs(tier, nil, &olderThan)
+	kvs, err := s.scanTierKVs(ctx, tier, nil, &olderThan)
 	if err != nil {
 		return 0, err
 	}
@@ -427,7 +447,8 @@ func (s *PebbleActivityStore) Summarize(ctx context.Context, olderThan time.Time
 
 // Prune hard-deletes all entries of the given tier older than olderThan.
 func (s *PebbleActivityStore) Prune(olderThan time.Time, tier string) (int, error) {
-	kvs, err := s.scanTierKVs(tier, nil, &olderThan)
+	// Prune has no caller context; it is a scheduled maintenance op.
+	kvs, err := s.scanTierKVs(context.Background(), tier, nil, &olderThan)
 	if err != nil {
 		return 0, err
 	}
@@ -490,7 +511,12 @@ func pactSourcesCacheKey(f ActivityFilter) string {
 // that only ever appears in older entries will be missing, and counts are of
 // the newest window rather than of all time. This feeds a filter picker, where
 // a bounded, recent view is the useful one; hitting the bound is logged.
-func (s *PebbleActivityStore) GetDistinctSources(f ActivityFilter) ([]SourceCount, error) {
+//
+// Cancellable, with no context-free variant: this ran concurrently with Query
+// on every page load and contributed 3.21 GB to the OOM heap profile, so an
+// abandoned request must be able to stop it. On a cache hit it returns without
+// touching the store at all.
+func (s *PebbleActivityStore) GetDistinctSources(ctx context.Context, f ActivityFilter) ([]SourceCount, error) {
 	key := pactSourcesCacheKey(f)
 	if cached, ok := s.lookupSourcesCache(key); ok {
 		return cached, nil
@@ -500,12 +526,14 @@ func (s *PebbleActivityStore) GetDistinctSources(f ActivityFilter) ([]SourceCoun
 	tiers := append(append([]string{}, nonDigest...), digestTiers...)
 
 	counts := make(map[string]int)
-	examined, exhausted, err := s.scanNewestFirst(tiers, f, activityQueryScanBudget, "sources",
+	examined, exhausted, err := s.scanNewestFirst(ctx, tiers, f, activityQueryScanBudget, "sources",
 		func(e ActivityEntry) bool {
 			counts[e.Source]++
 			return true
 		})
 	if err != nil {
+		// Explicitly nil, and nothing is cached: a cancelled scan's partial
+		// counts must not become the memoized answer for the next 45s.
 		return nil, err
 	}
 	if !exhausted {
@@ -566,7 +594,7 @@ func (s *PebbleActivityStore) storeSourcesCache(key string, out []SourceCount) {
 func (s *PebbleActivityStore) WipeAllActivity() (int64, error) {
 	var total int64
 	for _, tier := range actTiers {
-		kvs, err := s.scanTierKVs(tier, nil, nil)
+		kvs, err := s.scanTierKVs(context.Background(), tier, nil, nil)
 		if err != nil {
 			return total, err
 		}
@@ -603,7 +631,7 @@ func (s *PebbleActivityStore) CompactByDay(ctx context.Context, olderThan time.T
 	// Load all compactable entries (all tiers except "digest").
 	var all []pactKV
 	for _, tier := range actCompactableTiers() {
-		kvs, err := s.scanTierKVs(tier, nil, &olderThan)
+		kvs, err := s.scanTierKVs(ctx, tier, nil, &olderThan)
 		if err != nil {
 			return result, err
 		}
@@ -1027,7 +1055,11 @@ func pactSelectTiers(f ActivityFilter) (nonDigest, digest []string) {
 //
 // Deliberately single-goroutine: this is a stop-early walk, and fanning it out
 // over workers would mean over-reading, which is the very cost being removed.
+// Cancellation: ctx is checked every activityCtxCheckInterval rows. The budget
+// bounds a request that RUNS TO COMPLETION; ctx is what bounds an ABANDONED
+// one. They solve different halves and both are required.
 func (s *PebbleActivityStore) scanNewestFirst(
+	ctx context.Context,
 	tiers []string,
 	f ActivityFilter,
 	budget int,
@@ -1039,6 +1071,9 @@ func (s *PebbleActivityStore) scanNewestFirst(
 	}
 	if budget <= 0 {
 		return 0, false, nil
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return 0, false, ctxErr
 	}
 
 	cursors := make([]*pactCursor, 0, len(tiers))
@@ -1070,6 +1105,14 @@ func (s *PebbleActivityStore) scanNewestFirst(
 	defer tally.log(op)
 
 	for {
+		// Bail out promptly when the caller has gone away. Checked before the
+		// cursor work so an abandoned request stops allocating immediately.
+		if examined%activityCtxCheckInterval == 0 {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return examined, false, ctxErr
+			}
+		}
+
 		// Pick the cursor sitting on the newest remaining key. Ties break on
 		// the full key bytes so the order is deterministic.
 		best := -1
@@ -1123,7 +1166,11 @@ func (s *PebbleActivityStore) scanNewestFirst(
 // operations (Summarize, Prune, WipeAllActivity, CompactByDay), which
 // legitimately need every row. Query and GetDistinctSources deliberately do NOT
 // use it — see scanNewestFirst.
-func (s *PebbleActivityStore) scanTierKVs(tier string, since, until *time.Time) ([]pactKV, error) {
+// This scan is unbounded by design, so ctx is its ONLY brake: it is checked
+// every activityCtxCheckInterval rows, and on cancellation returns a nil slice
+// with ctx.Err() so the entries accumulated so far become garbage immediately
+// rather than being handed back to a caller that has gone away.
+func (s *PebbleActivityStore) scanTierKVs(ctx context.Context, tier string, since, until *time.Time) ([]pactKV, error) {
 	lower, upper := pactTierBounds(tier, since, until)
 
 	iter, err := s.db.NewIter(&pebble.IterOptions{
@@ -1139,7 +1186,18 @@ func (s *PebbleActivityStore) scanTierKVs(tier string, since, until *time.Time) 
 	defer tally.log("scanTierKVs tier=" + tier)
 
 	var out []pactKV
+	seen := 0
 	for iter.First(); iter.Valid(); iter.Next() {
+		if seen%activityCtxCheckInterval == 0 {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				slog.Warn("[activity] scanTierKVs aborted: caller went away",
+					"tier", tier, "rows_scanned", seen, "error", ctxErr)
+				// Explicitly nil: release the accumulated slice.
+				return nil, ctxErr
+			}
+		}
+		seen++
+
 		var e ActivityEntry
 		s.entriesDecoded.Add(1)
 		if jsonErr := json.Unmarshal(iter.Value(), &e); jsonErr != nil {
@@ -1158,9 +1216,26 @@ func (s *PebbleActivityStore) scanTierKVs(tier string, since, until *time.Time) 
 
 // queryByIndexPrefix reads ref values from an index prefix, then fetches primary entries.
 // Handles both op and book secondary indexes.
-func (s *PebbleActivityStore) queryByIndexPrefix(prefix string, f ActivityFilter) ([]ActivityEntry, int, error) {
+//
+// This is the fast path Query takes whenever OperationID or BookID is set, so
+// GET /api/v1/operations/:id/activity never reaches scanNewestFirst. It
+// therefore needs its own cancellation checks: without them, threading a
+// request context into Query would be cosmetic on that endpoint and an
+// abandoned operation-transcript request would keep scanning to completion.
+// ctx is checked every activityCtxCheckInterval rows in BOTH loops, and on
+// cancellation the accumulated slices are dropped (explicit nil) so they become
+// garbage immediately rather than being handed to a caller that has gone away.
+//
+// Known cost, unchanged here: this collects every ref for the id and decodes
+// all of them before slicing by offset/limit, so it is bounded by the number of
+// entries for one operation rather than by f.Limit.
+func (s *PebbleActivityStore) queryByIndexPrefix(ctx context.Context, prefix string, f ActivityFilter) ([]ActivityEntry, int, error) {
 	// Upper bound: replace trailing ':' with ';' to cover the entire id sub-namespace.
 	upperPrefix := prefix[:len(prefix)-1] + ";"
+
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, 0, ctxErr
+	}
 
 	iter, err := s.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte(prefix),
@@ -1172,14 +1247,26 @@ func (s *PebbleActivityStore) queryByIndexPrefix(prefix string, f ActivityFilter
 	defer iter.Close()
 
 	var refs [][]byte
+	seen := 0
 	for iter.First(); iter.Valid(); iter.Next() {
+		if seen%activityCtxCheckInterval == 0 {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, 0, ctxErr
+			}
+		}
+		seen++
 		valCopy := make([]byte, len(iter.Value()))
 		copy(valCopy, iter.Value())
 		refs = append(refs, valCopy)
 	}
 
 	var all []ActivityEntry
-	for _, ref := range refs {
+	for i, ref := range refs {
+		if i%activityCtxCheckInterval == 0 {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, 0, ctxErr
+			}
+		}
 		primaryKey, ok := pactPrimaryKeyFromRef(ref)
 		if !ok {
 			continue

--- a/internal/database/pebble_activity_store.go
+++ b/internal/database/pebble_activity_store.go
@@ -1,6 +1,7 @@
 // file: internal/database/pebble_activity_store.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d4e5f6a7-b8c9-0004-def0-000000000004
+// last-edited: 2026-08-11
 
 // Package database — PebbleDB-backed activity log store.
 //
@@ -26,17 +27,35 @@
 package database
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/oklog/ulid/v2"
+)
+
+// Tunables for the bounded query path. These are vars (not consts) so tests can
+// shrink them and exercise the bound without seeding a huge store.
+var (
+	// activityQueryScanBudget caps how many stored entries a single Query or
+	// GetDistinctSources call will decode. Before this bound existed, a default
+	// Query decoded EVERY entry in the log (8.86 GB of heap on production,
+	// 71.9% of the process, and a 120s non-returning GET /api/v1/activity?limit=5).
+	// Hitting the bound is logged, never silent.
+	activityQueryScanBudget = 20000
+
+	// activitySourcesCacheTTL is how long a GetDistinctSources result is reused.
+	// The source list feeds a filter picker, so slightly stale counts are fine;
+	// re-scanning on every page load was half the OOM.
+	activitySourcesCacheTTL = 45 * time.Second
 )
 
 // PebbleActivityStore persists activity log entries in a shared PebbleDB database.
@@ -47,16 +66,46 @@ import (
 type PebbleActivityStore struct {
 	db      *pebble.DB
 	counter atomic.Int64
+
+	// entriesDecoded counts every attempt to json.Unmarshal a stored
+	// ActivityEntry made by ANY scan path on this store (bounded query,
+	// scanTierKVs, ...). It is the instrument that proves a paged query is
+	// bounded: it must be incremented at every decode site, otherwise a
+	// regression test asserting "few decodes" would pass against an
+	// unbounded implementation that simply decodes somewhere else.
+	entriesDecoded atomic.Int64
+
+	// decodeFailures counts entries dropped because their stored JSON could
+	// not be decoded. Dropped rows are also logged per-scan in aggregate.
+	decodeFailures atomic.Int64
+
+	sourcesMu    sync.Mutex
+	sourcesCache map[string]pactSourcesCacheEntry
+}
+
+// pactSourcesCacheEntry is one memoized GetDistinctSources result.
+type pactSourcesCacheEntry struct {
+	at  time.Time
+	out []SourceCount
 }
 
 // NewPebbleActivityStore creates a PebbleActivityStore backed by the provided DB.
 // The caller retains ownership of db; Close() on this store does NOT close db.
 func NewPebbleActivityStore(db *pebble.DB) *PebbleActivityStore {
-	s := &PebbleActivityStore{db: db}
+	s := &PebbleActivityStore{db: db, sourcesCache: make(map[string]pactSourcesCacheEntry)}
 	// Seed counter from current time so IDs don't collide across restarts.
 	s.counter.Store(time.Now().UnixNano())
 	return s
 }
+
+// EntriesDecoded returns the cumulative number of stored-entry JSON decode
+// attempts made by this store's scan paths, including failures. Exported for
+// tests and for operational assertions about query cost.
+func (s *PebbleActivityStore) EntriesDecoded() int64 { return s.entriesDecoded.Load() }
+
+// DecodeFailures returns the cumulative number of stored entries dropped
+// because their JSON could not be decoded.
+func (s *PebbleActivityStore) DecodeFailures() int64 { return s.decodeFailures.Load() }
 
 // Close is a no-op: the caller owns the PebbleDB instance.
 func (s *PebbleActivityStore) Close() error { return nil }
@@ -86,6 +135,49 @@ func pactPrimaryPrefix(tier string) []byte {
 // entries for the tier.
 func pactPrimaryUpperBound(tier string) []byte {
 	return []byte("act:" + tier + ";")
+}
+
+// pactTierBounds computes the Pebble iterator bounds for one tier's primary key
+// range, narrowed by the optional since/until instants.
+//
+// Extracted so the bounded query path and scanTierKVs share one definition of
+// the time-range semantics rather than each keeping its own copy that can drift.
+func pactTierBounds(tier string, since, until *time.Time) (lower, upper []byte) {
+	lower = pactPrimaryPrefix(tier)
+	upper = pactPrimaryUpperBound(tier)
+	if since != nil {
+		lower = pactPrimaryKey(tier, *since, "")
+	}
+	if until != nil {
+		upper = pactPrimaryKey(tier, *until, "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff")
+	}
+	return lower, upper
+}
+
+// pactKeyTimeField returns the zero-padded 20-digit unix-nano component of a
+// primary key ("act:<tier>:<nanos>:<ulid>"), or "" if the key is malformed.
+//
+// The field is fixed-width and zero-padded, so comparing two of these as
+// strings is equivalent to comparing the instants numerically. That is what
+// lets the query path merge several tiers newest-first WITHOUT decoding each
+// row's JSON just to read its timestamp — only the rows actually taken get
+// decoded.
+func pactKeyTimeField(key []byte) string {
+	s := string(key)
+	if !strings.HasPrefix(s, "act:") {
+		return ""
+	}
+	rest := s[len("act:"):]
+	i := strings.IndexByte(rest, ':') // end of <tier>
+	if i < 0 {
+		return ""
+	}
+	rest = rest[i+1:]
+	j := strings.IndexByte(rest, ':') // end of <nanos>
+	if j < 0 {
+		return rest
+	}
+	return rest[:j]
 }
 
 // pactIndexRef encodes the cross-reference value stored in secondary indexes:
@@ -175,51 +267,73 @@ func (s *PebbleActivityStore) Query(f ActivityFilter) ([]ActivityEntry, int, err
 		return s.queryByIndexPrefix(fmt.Sprintf("act:bk:%s:", f.BookID), f)
 	}
 
-	// General path: scan tier bucket(s) by time range.
-	tiers := actTiers
-	if f.Tier != "" {
-		tiers = []string{f.Tier}
+	// General path: bounded newest-first merge over the tier key ranges.
+	//
+	// Activity keys embed the timestamp, so the store can be read in result
+	// order and abandoned as soon as the requested page is filled. The previous
+	// implementation instead decoded EVERY entry in EVERY tier into one slice,
+	// filtered it, sorted it, and then sliced out the page — 8.86 GB of heap on
+	// production for a limit=5 request, and the cause of the OOM kills.
+	nonDigest, digestTiers := pactSelectTiers(f)
+
+	// Collect one match past the requested page. That extra row is what tells
+	// the caller another page exists without counting the rest of the log.
+	probe := f.Offset + f.Limit + 1
+
+	pageCap := f.Limit
+	if pageCap < 0 {
+		pageCap = 0
+	}
+	page := make([]ActivityEntry, 0, pageCap)
+	matched := 0
+	collect := func(e ActivityEntry) bool {
+		matched++
+		if matched > f.Offset && len(page) < f.Limit {
+			page = append(page, e)
+		}
+		return matched < probe
 	}
 
-	var all []ActivityEntry
-	for _, tier := range tiers {
-		entries, err := s.scanTier(tier, f.Since, f.Until)
+	examined := 0
+	exhausted := true
+	for _, phase := range [][]string{nonDigest, digestTiers} {
+		if len(phase) == 0 {
+			continue
+		}
+		remaining := activityQueryScanBudget - examined
+		if matched >= probe || remaining <= 0 {
+			exhausted = false
+			break
+		}
+		ex, phaseExhausted, err := s.scanNewestFirst(phase, f, remaining, "query", collect)
+		examined += ex
 		if err != nil {
 			return nil, 0, err
 		}
-		all = append(all, entries...)
-	}
-
-	// Apply remaining filters in Go.
-	filtered := make([]ActivityEntry, 0, len(all))
-	for _, e := range all {
-		if matchesFilter(e, f) {
-			filtered = append(filtered, e)
+		if !phaseExhausted {
+			exhausted = false
+			break
 		}
 	}
 
-	// Sort newest-first; digest entries sort last (matching SQL ORDER BY compacted ASC, timestamp DESC).
-	sort.Slice(filtered, func(i, j int) bool {
-		ci := boolInt(filtered[i].Tier == "digest")
-		cj := boolInt(filtered[j].Tier == "digest")
-		if ci != cj {
-			return ci < cj
-		}
-		return filtered[i].Timestamp.After(filtered[j].Timestamp)
-	})
-
-	total := len(filtered)
-
-	// Paginate.
-	start := f.Offset
-	if start > len(filtered) {
-		start = len(filtered)
+	// total is exact when the walk drained the input. Otherwise it is a lower
+	// bound: either it equals probe (one row past this page, so pagination
+	// still advances) or the scan budget cut the walk short.
+	total := matched
+	if !exhausted && matched < probe {
+		slog.Warn("[activity] query hit the scan budget; total is a lower bound and older matches were not examined",
+			"budget", activityQueryScanBudget,
+			"examined", examined,
+			"matched", matched,
+			"limit", f.Limit,
+			"offset", f.Offset,
+			"tier", f.Tier,
+			"type", f.Type,
+			"level", f.Level,
+			"source", f.Source,
+			"search", f.Search)
 	}
-	end := start + f.Limit
-	if end > len(filtered) {
-		end = len(filtered)
-	}
-	return filtered[start:end], total, nil
+	return page, total, nil
 }
 
 // Summarize groups old entries by (operation_id, type), writes a summary row,
@@ -345,30 +459,107 @@ func (s *PebbleActivityStore) Prune(olderThan time.Time, tier string) (int, erro
 	return deleted, nil
 }
 
+// pactSourcesCacheKey derives a cache key covering every filter field that can
+// change the result, so one filter's counts are never served for another.
+func pactSourcesCacheKey(f ActivityFilter) string {
+	since, until := "", ""
+	if f.Since != nil {
+		since = fmt.Sprintf("%d", f.Since.UnixNano())
+	}
+	if f.Until != nil {
+		until = fmt.Sprintf("%d", f.Until.UnixNano())
+	}
+	return strings.Join([]string{
+		f.Tier, f.Type, f.Level, f.Source, f.OperationID, f.BookID, f.Search,
+		since, until,
+		strings.Join(f.Tags, ","),
+		strings.Join(f.ExcludeSources, ","),
+		strings.Join(f.ExcludeTiers, ","),
+		strings.Join(f.ExcludeTags, ","),
+	}, "\x00")
+}
+
 // GetDistinctSources returns unique sources with entry counts, ordered by count desc.
+//
+// Bounded + memoized. This used to full-scan and JSON-decode every entry in
+// every tier on EVERY page load, concurrently with Query — 3.21 GB of the
+// production heap profile. It now scans at most activityQueryScanBudget of the
+// newest entries and reuses the result for activitySourcesCacheTTL.
+//
+// Consequence, deliberate: when the log is larger than the budget, a source
+// that only ever appears in older entries will be missing, and counts are of
+// the newest window rather than of all time. This feeds a filter picker, where
+// a bounded, recent view is the useful one; hitting the bound is logged.
 func (s *PebbleActivityStore) GetDistinctSources(f ActivityFilter) ([]SourceCount, error) {
-	tiers := actTiers
-	if f.Tier != "" {
-		tiers = []string{f.Tier}
+	key := pactSourcesCacheKey(f)
+	if cached, ok := s.lookupSourcesCache(key); ok {
+		return cached, nil
 	}
+
+	nonDigest, digestTiers := pactSelectTiers(f)
+	tiers := append(append([]string{}, nonDigest...), digestTiers...)
+
 	counts := make(map[string]int)
-	for _, tier := range tiers {
-		entries, err := s.scanTier(tier, f.Since, f.Until)
-		if err != nil {
-			return nil, err
-		}
-		for _, e := range entries {
-			if matchesFilter(e, f) {
-				counts[e.Source]++
-			}
-		}
+	examined, exhausted, err := s.scanNewestFirst(tiers, f, activityQueryScanBudget, "sources",
+		func(e ActivityEntry) bool {
+			counts[e.Source]++
+			return true
+		})
+	if err != nil {
+		return nil, err
 	}
+	if !exhausted {
+		slog.Warn("[activity] distinct-sources scan hit the budget; counts cover only the newest entries",
+			"budget", activityQueryScanBudget,
+			"examined", examined,
+			"sources", len(counts),
+			"tier", f.Tier,
+			"level", f.Level)
+	}
+
 	out := make([]SourceCount, 0, len(counts))
 	for src, cnt := range counts {
 		out = append(out, SourceCount{Source: src, Count: cnt})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Count > out[j].Count })
+
+	s.storeSourcesCache(key, out)
 	return out, nil
+}
+
+// lookupSourcesCache returns a copy of a fresh cached result, if one exists.
+// A copy is returned so a caller mutating the slice cannot corrupt the cache.
+func (s *PebbleActivityStore) lookupSourcesCache(key string) ([]SourceCount, bool) {
+	s.sourcesMu.Lock()
+	defer s.sourcesMu.Unlock()
+	entry, ok := s.sourcesCache[key]
+	if !ok || time.Since(entry.at) > activitySourcesCacheTTL {
+		return nil, false
+	}
+	out := make([]SourceCount, len(entry.out))
+	copy(out, entry.out)
+	return out, true
+}
+
+// storeSourcesCache memoizes a result and drops expired keys. Expiry is by TTL
+// only — writes do not invalidate, so counts trail new activity by up to
+// activitySourcesCacheTTL.
+func (s *PebbleActivityStore) storeSourcesCache(key string, out []SourceCount) {
+	stored := make([]SourceCount, len(out))
+	copy(stored, out)
+
+	s.sourcesMu.Lock()
+	defer s.sourcesMu.Unlock()
+	if s.sourcesCache == nil {
+		s.sourcesCache = make(map[string]pactSourcesCacheEntry)
+	}
+	now := time.Now()
+	for k, v := range s.sourcesCache {
+		if now.Sub(v.at) > activitySourcesCacheTTL {
+			delete(s.sourcesCache, k)
+		}
+	}
+	s.sourcesCache[key] = pactSourcesCacheEntry{at: now, out: stored}
 }
 
 // WipeAllActivity deletes every entry from all tier buckets. Returns total count.
@@ -747,34 +938,193 @@ type pactKV struct {
 	entry ActivityEntry
 }
 
-// scanTier returns all entries from a tier within [since, until].
-// nil bounds mean "no bound". Results are in ascending timestamp order (Pebble
-// lexicographic order over the time-keyed prefix).
-func (s *PebbleActivityStore) scanTier(tier string, since, until *time.Time) ([]ActivityEntry, error) {
-	kvs, err := s.scanTierKVs(tier, since, until)
-	if err != nil {
-		return nil, err
-	}
-	entries := make([]ActivityEntry, len(kvs))
-	for i, kv := range kvs {
-		entries[i] = kv.entry
-	}
-	return entries, nil
+// pactDecodeTally accumulates JSON decode failures across a single scan so the
+// scan can emit one aggregate warning instead of flooding the log when a whole
+// key range is corrupt. Requirement: dropped rows are counted and reported,
+// never silently skipped.
+type pactDecodeTally struct {
+	dropped  int
+	firstErr error
+	firstKey string
 }
 
-// scanTierKVs returns key+entry pairs for a tier within the time range.
-func (s *PebbleActivityStore) scanTierKVs(tier string, since, until *time.Time) ([]pactKV, error) {
-	// Default lower/upper bounds cover the entire tier prefix.
-	lower := pactPrimaryPrefix(tier)
-	upper := pactPrimaryUpperBound(tier)
+func (t *pactDecodeTally) record(key []byte, err error) {
+	t.dropped++
+	if t.firstErr == nil {
+		t.firstErr = err
+		t.firstKey = string(key)
+	}
+}
 
-	// Narrow bounds when time constraints are given.
-	if since != nil {
-		lower = pactPrimaryKey(tier, *since, "")
+func (t *pactDecodeTally) log(op string) {
+	if t.dropped == 0 {
+		return
 	}
-	if until != nil {
-		upper = pactPrimaryKey(tier, *until, "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff")
+	slog.Warn("[activity] pebble store dropped undecodable entries",
+		"op", op,
+		"dropped", t.dropped,
+		"first_key", t.firstKey,
+		"error", t.firstErr)
+}
+
+// pactCursor is one tier's reverse (newest-first) iterator plus the cached time
+// field of the key it currently sits on.
+type pactCursor struct {
+	tier string
+	iter *pebble.Iterator
+	tf   string
+}
+
+// pactSelectTiers splits the tiers a filter is allowed to touch into the
+// non-digest group and the digest group.
+//
+// The two groups exist because the historical result order is a TWO-GROUP
+// order (matching the old SQL "ORDER BY compacted ASC, timestamp DESC"):
+// every non-digest entry sorts before every digest entry, and within a group
+// entries are newest-first. Walking non-digest tiers to exhaustion before
+// touching digest reproduces that order without a global sort.
+//
+// f.Tier and f.ExcludeTiers are applied here rather than left to matchesFilter
+// so excluded tiers never open an iterator or consume scan budget.
+func pactSelectTiers(f ActivityFilter) (nonDigest, digest []string) {
+	base := actTiers
+	if f.Tier != "" {
+		base = []string{f.Tier}
 	}
+	for _, tier := range base {
+		excluded := false
+		for _, ex := range f.ExcludeTiers {
+			if tier == ex {
+				excluded = true
+				break
+			}
+		}
+		if excluded {
+			continue
+		}
+		if tier == "digest" {
+			digest = append(digest, tier)
+		} else {
+			nonDigest = append(nonDigest, tier)
+		}
+	}
+	return nonDigest, digest
+}
+
+// scanNewestFirst walks the given tiers newest-first as a k-way merge over
+// per-tier reverse iterators, decoding at most `budget` entries, and invokes
+// visit for every decoded entry that passes matchesFilter. visit returns false
+// to stop the walk early.
+//
+// Returns the number of entries decoded and whether the input was exhausted.
+// exhausted == false means the walk stopped early — either visit asked to stop
+// or the budget ran out — so any count derived from it is a LOWER BOUND.
+//
+// Ordering note: the merge orders on the key's embedded timestamp, not on the
+// decoded Timestamp field. Those are written together by Record, so they agree;
+// a row whose stored Tier/Timestamp disagrees with its key (already-inconsistent
+// data) now groups by its key.
+//
+// Deliberately single-goroutine: this is a stop-early walk, and fanning it out
+// over workers would mean over-reading, which is the very cost being removed.
+func (s *PebbleActivityStore) scanNewestFirst(
+	tiers []string,
+	f ActivityFilter,
+	budget int,
+	op string,
+	visit func(ActivityEntry) bool,
+) (examined int, exhausted bool, err error) {
+	if len(tiers) == 0 {
+		return 0, true, nil
+	}
+	if budget <= 0 {
+		return 0, false, nil
+	}
+
+	cursors := make([]*pactCursor, 0, len(tiers))
+	defer func() {
+		for _, c := range cursors {
+			if cerr := c.iter.Close(); cerr != nil && err == nil {
+				err = fmt.Errorf("pebble_activity_store: %s iter close (tier=%s): %w", op, c.tier, cerr)
+			}
+		}
+	}()
+
+	for _, tier := range tiers {
+		lower, upper := pactTierBounds(tier, f.Since, f.Until)
+		it, iterErr := s.db.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
+		if iterErr != nil {
+			return examined, false, fmt.Errorf("pebble_activity_store: %s new iter (tier=%s): %w", op, tier, iterErr)
+		}
+		if !it.Last() {
+			// Empty range for this tier — close now rather than carrying it.
+			if cerr := it.Close(); cerr != nil {
+				return examined, false, fmt.Errorf("pebble_activity_store: %s iter close (tier=%s): %w", op, tier, cerr)
+			}
+			continue
+		}
+		cursors = append(cursors, &pactCursor{tier: tier, iter: it, tf: pactKeyTimeField(it.Key())})
+	}
+
+	tally := &pactDecodeTally{}
+	defer tally.log(op)
+
+	for {
+		// Pick the cursor sitting on the newest remaining key. Ties break on
+		// the full key bytes so the order is deterministic.
+		best := -1
+		for i, c := range cursors {
+			if !c.iter.Valid() {
+				continue
+			}
+			if best < 0 {
+				best = i
+				continue
+			}
+			b := cursors[best]
+			if c.tf > b.tf || (c.tf == b.tf && bytes.Compare(c.iter.Key(), b.iter.Key()) > 0) {
+				best = i
+			}
+		}
+		if best < 0 {
+			return examined, true, nil // every cursor drained
+		}
+		if examined >= budget {
+			return examined, false, nil // caller logs the truncation
+		}
+
+		c := cursors[best]
+		examined++
+		s.entriesDecoded.Add(1)
+		var e ActivityEntry
+		if jsonErr := json.Unmarshal(c.iter.Value(), &e); jsonErr != nil {
+			s.decodeFailures.Add(1)
+			tally.record(c.iter.Key(), jsonErr)
+		} else if matchesFilter(e, f) {
+			if !visit(e) {
+				return examined, false, nil
+			}
+		}
+
+		if c.iter.Prev() {
+			c.tf = pactKeyTimeField(c.iter.Key())
+		}
+	}
+}
+
+// NOTE: scanTier (a materializing []ActivityEntry wrapper over scanTierKVs)
+// was removed here. Its only callers were Query and GetDistinctSources, both of
+// which now use the bounded scanNewestFirst walk. The maintenance ops that
+// legitimately need every row call scanTierKVs directly.
+
+// scanTierKVs returns key+entry pairs for a tier within the time range.
+//
+// This is a FULL materializing scan and is used only by the maintenance
+// operations (Summarize, Prune, WipeAllActivity, CompactByDay), which
+// legitimately need every row. Query and GetDistinctSources deliberately do NOT
+// use it — see scanNewestFirst.
+func (s *PebbleActivityStore) scanTierKVs(tier string, since, until *time.Time) ([]pactKV, error) {
+	lower, upper := pactTierBounds(tier, since, until)
 
 	iter, err := s.db.NewIter(&pebble.IterOptions{
 		LowerBound: lower,
@@ -785,10 +1135,18 @@ func (s *PebbleActivityStore) scanTierKVs(tier string, since, until *time.Time) 
 	}
 	defer iter.Close()
 
+	tally := &pactDecodeTally{}
+	defer tally.log("scanTierKVs tier=" + tier)
+
 	var out []pactKV
 	for iter.First(); iter.Valid(); iter.Next() {
 		var e ActivityEntry
+		s.entriesDecoded.Add(1)
 		if jsonErr := json.Unmarshal(iter.Value(), &e); jsonErr != nil {
+			// Counted and reported in aggregate by the deferred tally.log —
+			// previously a bare `continue` that dropped rows silently.
+			s.decodeFailures.Add(1)
+			tally.record(iter.Key(), jsonErr)
 			continue
 		}
 		keyCopy := make([]byte, len(iter.Key()))

--- a/internal/database/pebble_activity_store_test.go
+++ b/internal/database/pebble_activity_store_test.go
@@ -1,6 +1,7 @@
 // file: internal/database/pebble_activity_store_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c9d0e1f2-a3b4-0010-3456-000000000010
+// last-edited: 2026-08-11
 
 // Package database — parity test suite for PebbleActivityStore.
 //
@@ -161,8 +162,17 @@ func TestPebbleActivityStore_QueryFilters(t *testing.T) {
 	t.Run("limit", func(t *testing.T) {
 		res, total, err := s.Query(ActivityFilter{Limit: 2})
 		require.NoError(t, err)
-		assert.Equal(t, 4, total)
 		assert.Len(t, res, 2)
+		// CONTRACT CHANGE (bounded query): total is exact only when the walk
+		// exhausts the log. A paged query stops at offset+limit+1 matches so it
+		// never materializes the whole log, so total here is that probe value
+		// (3), not the exact match count (4). Asserting the exact 3 — rather
+		// than a >= range — is deliberate: a range would also pass against the
+		// old full-scan implementation that returned 4.
+		assert.Equal(t, 3, total)
+		// The probe row is what keeps pagination working: total must stay
+		// strictly greater than this page so the caller knows more exist.
+		assert.Greater(t, total, len(res))
 	})
 
 	t.Run("offset", func(t *testing.T) {

--- a/internal/database/pebble_activity_store_test.go
+++ b/internal/database/pebble_activity_store_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_activity_store_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c9d0e1f2-a3b4-0010-3456-000000000010
 // last-edited: 2026-08-11
 
@@ -62,7 +62,7 @@ func TestPebbleActivityStore_RecordAndQuery(t *testing.T) {
 	require.NoError(t, err)
 	assert.Greater(t, id, int64(0))
 
-	entries, total, err := s.Query(ActivityFilter{Limit: 10})
+	entries, total, err := s.Query(context.Background(), ActivityFilter{Limit: 10})
 	require.NoError(t, err)
 	assert.Equal(t, 1, total)
 	require.Len(t, entries, 1)
@@ -113,7 +113,7 @@ func TestPebbleActivityStore_QueryFilters(t *testing.T) {
 	}
 
 	t.Run("filter_by_tier", func(t *testing.T) {
-		res, total, err := s.Query(ActivityFilter{Tier: "debug", Limit: 50})
+		res, total, err := s.Query(context.Background(), ActivityFilter{Tier: "debug", Limit: 50})
 		require.NoError(t, err)
 		assert.Equal(t, 2, total)
 		assert.Len(t, res, 2)
@@ -123,28 +123,28 @@ func TestPebbleActivityStore_QueryFilters(t *testing.T) {
 	})
 
 	t.Run("filter_by_type", func(t *testing.T) {
-		res, total, err := s.Query(ActivityFilter{Type: "isbn_lookup", Limit: 50})
+		res, total, err := s.Query(context.Background(), ActivityFilter{Type: "isbn_lookup", Limit: 50})
 		require.NoError(t, err)
 		assert.Equal(t, 2, total)
 		assert.Len(t, res, 2)
 	})
 
 	t.Run("filter_by_operation_id", func(t *testing.T) {
-		res, total, err := s.Query(ActivityFilter{OperationID: "op-1", Limit: 50})
+		res, total, err := s.Query(context.Background(), ActivityFilter{OperationID: "op-1", Limit: 50})
 		require.NoError(t, err)
 		assert.Equal(t, 2, total)
 		assert.Len(t, res, 2)
 	})
 
 	t.Run("filter_by_book_id", func(t *testing.T) {
-		res, total, err := s.Query(ActivityFilter{BookID: "book-1", Limit: 50})
+		res, total, err := s.Query(context.Background(), ActivityFilter{BookID: "book-1", Limit: 50})
 		require.NoError(t, err)
 		assert.Equal(t, 2, total)
 		assert.Len(t, res, 2)
 	})
 
 	t.Run("filter_single_tag_alpha", func(t *testing.T) {
-		res, total, err := s.Query(ActivityFilter{Tags: []string{"alpha"}, Limit: 50})
+		res, total, err := s.Query(context.Background(), ActivityFilter{Tags: []string{"alpha"}, Limit: 50})
 		require.NoError(t, err)
 		assert.Equal(t, 2, total)
 		assert.Len(t, res, 2)
@@ -152,7 +152,7 @@ func TestPebbleActivityStore_QueryFilters(t *testing.T) {
 
 	t.Run("filter_two_tags_requires_both", func(t *testing.T) {
 		// Only entry[0] has both alpha AND beta
-		res, total, err := s.Query(ActivityFilter{Tags: []string{"alpha", "beta"}, Limit: 50})
+		res, total, err := s.Query(context.Background(), ActivityFilter{Tags: []string{"alpha", "beta"}, Limit: 50})
 		require.NoError(t, err)
 		assert.Equal(t, 1, total)
 		assert.Len(t, res, 1)
@@ -160,7 +160,7 @@ func TestPebbleActivityStore_QueryFilters(t *testing.T) {
 	})
 
 	t.Run("limit", func(t *testing.T) {
-		res, total, err := s.Query(ActivityFilter{Limit: 2})
+		res, total, err := s.Query(context.Background(), ActivityFilter{Limit: 2})
 		require.NoError(t, err)
 		assert.Len(t, res, 2)
 		// CONTRACT CHANGE (bounded query): total is exact only when the walk
@@ -176,7 +176,7 @@ func TestPebbleActivityStore_QueryFilters(t *testing.T) {
 	})
 
 	t.Run("offset", func(t *testing.T) {
-		res, total, err := s.Query(ActivityFilter{Limit: 50, Offset: 3})
+		res, total, err := s.Query(context.Background(), ActivityFilter{Limit: 50, Offset: 3})
 		require.NoError(t, err)
 		assert.Equal(t, 4, total)
 		assert.Len(t, res, 1)
@@ -215,7 +215,7 @@ func TestPebbleActivityStore_Prune(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 3, deleted)
 
-	all, total, err := s.Query(ActivityFilter{Limit: 50})
+	all, total, err := s.Query(context.Background(), ActivityFilter{Limit: 50})
 	require.NoError(t, err)
 	assert.Equal(t, 2, total)
 	assert.Len(t, all, 2)
@@ -242,7 +242,7 @@ func TestPebbleActivityStore_WipeAllActivity(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(4), n)
 
-	_, total, err := s.Query(ActivityFilter{Limit: 50})
+	_, total, err := s.Query(context.Background(), ActivityFilter{Limit: 50})
 	require.NoError(t, err)
 	assert.Equal(t, 0, total)
 }
@@ -264,7 +264,7 @@ func TestPebbleActivityStore_GetDistinctSources(t *testing.T) {
 	}
 
 	t.Run("unfiltered_returns_all_sources", func(t *testing.T) {
-		sources, err := s.GetDistinctSources(ActivityFilter{})
+		sources, err := s.GetDistinctSources(context.Background(), ActivityFilter{})
 		require.NoError(t, err)
 		assert.Len(t, sources, 3, "expected gin, scanner, metadata")
 		assert.Equal(t, "gin", sources[0].Source)
@@ -272,7 +272,7 @@ func TestPebbleActivityStore_GetDistinctSources(t *testing.T) {
 	})
 
 	t.Run("filtered_by_tier_debug", func(t *testing.T) {
-		sources, err := s.GetDistinctSources(ActivityFilter{Tier: "debug"})
+		sources, err := s.GetDistinctSources(context.Background(), ActivityFilter{Tier: "debug"})
 		require.NoError(t, err)
 		assert.Len(t, sources, 1)
 		assert.Equal(t, "gin", sources[0].Source)
@@ -291,28 +291,28 @@ func TestPebbleActivityStore_CompactByDay_Basic(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		_, err := s.Record(ActivityEntry{
-			Tier:    "change",
-			Type:    "metadata_applied",
-			Level:   "info",
-			Source:  "pipeline",
-			BookID:  "book-1",
-			Summary: "applied metadata",
+			Tier:      "change",
+			Type:      "metadata_applied",
+			Level:     "info",
+			Source:    "pipeline",
+			BookID:    "book-1",
+			Summary:   "applied metadata",
 			Timestamp: day1.Add(time.Duration(i) * time.Minute),
-			Details: map[string]any{"book_title": "Test Book"},
+			Details:   map[string]any{"book_title": "Test Book"},
 		})
 		require.NoError(t, err)
 	}
 
 	for i := 0; i < 2; i++ {
 		_, err := s.Record(ActivityEntry{
-			Tier:    "change",
-			Type:    "tag_written",
-			Level:   "info",
-			Source:  "writer",
-			BookID:  "book-2",
-			Summary: "wrote tags",
+			Tier:      "change",
+			Type:      "tag_written",
+			Level:     "info",
+			Source:    "writer",
+			BookID:    "book-2",
+			Summary:   "wrote tags",
 			Timestamp: day2.Add(time.Duration(i) * time.Minute),
-			Details: map[string]any{"title": "Other Book"},
+			Details:   map[string]any{"title": "Other Book"},
 		})
 		require.NoError(t, err)
 	}
@@ -333,7 +333,7 @@ func TestPebbleActivityStore_CompactByDay_Basic(t *testing.T) {
 	assert.Equal(t, 2, result.DaysCompacted)
 	assert.Equal(t, 6, result.EntriesDeleted, "5 change + 1 audit folded")
 
-	all, total, err := s.Query(ActivityFilter{Limit: 50})
+	all, total, err := s.Query(context.Background(), ActivityFilter{Limit: 50})
 	require.NoError(t, err)
 	assert.Equal(t, 2, total)
 
@@ -383,11 +383,11 @@ func TestPebbleActivityStore_CompactByDay_Idempotent(t *testing.T) {
 	olderThan := time.Date(2025, 5, 2, 0, 0, 0, 0, time.UTC)
 
 	_, err := s.Record(ActivityEntry{
-		Tier:    "change",
-		Type:    "config_changed",
-		Level:   "info",
-		Source:  "settings",
-		Summary: "changed setting",
+		Tier:      "change",
+		Type:      "config_changed",
+		Level:     "info",
+		Source:    "settings",
+		Summary:   "changed setting",
 		Timestamp: ts,
 	})
 	require.NoError(t, err)
@@ -428,7 +428,7 @@ func TestPebbleActivityStore_CompactByDay_Truncates(t *testing.T) {
 	assert.Equal(t, 1, result.DaysCompacted)
 	assert.Equal(t, 600, result.EntriesDeleted)
 
-	all, total, err := s.Query(ActivityFilter{Limit: 50})
+	all, total, err := s.Query(context.Background(), ActivityFilter{Limit: 50})
 	require.NoError(t, err)
 	assert.Equal(t, 1, total)
 	require.Len(t, all, 1)
@@ -485,7 +485,7 @@ func TestPebbleActivityStore_CompactByDay_MergesExisting(t *testing.T) {
 	assert.Equal(t, 5, r2.EntriesDeleted)
 
 	// Exactly one digest row for the day.
-	all, total, err := s.Query(ActivityFilter{Tier: "digest", Limit: 50})
+	all, total, err := s.Query(context.Background(), ActivityFilter{Tier: "digest", Limit: 50})
 	require.NoError(t, err)
 	assert.Equal(t, 1, total, "must be exactly one digest per day")
 
@@ -589,20 +589,20 @@ func TestDualWriteActivityStore_WritesReplicated(t *testing.T) {
 	assert.Greater(t, id, int64(0))
 
 	// Query from NutsDB (primary when ReadFromPebble=false).
-	resNuts, totalNuts, err := dual.Query(ActivityFilter{Limit: 10})
+	resNuts, totalNuts, err := dual.Query(context.Background(), ActivityFilter{Limit: 10})
 	require.NoError(t, err)
 	assert.Equal(t, 1, totalNuts)
 	assert.Equal(t, "dual-write-test", resNuts[0].Source)
 
 	// Query Pebble directly to confirm replication.
-	resPebble, totalPebble, err := pebbleStore.Query(ActivityFilter{Limit: 10})
+	resPebble, totalPebble, err := pebbleStore.Query(context.Background(), ActivityFilter{Limit: 10})
 	require.NoError(t, err)
 	assert.Equal(t, 1, totalPebble, "entry must also land in Pebble")
 	assert.Equal(t, "dual-write-test", resPebble[0].Source)
 
 	// Flip to read-from-pebble and verify reads come from Pebble.
 	dual.ReadFromPebble = true
-	resAfterFlip, totalAfterFlip, err := dual.Query(ActivityFilter{Limit: 10})
+	resAfterFlip, totalAfterFlip, err := dual.Query(context.Background(), ActivityFilter{Limit: 10})
 	require.NoError(t, err)
 	assert.Equal(t, 1, totalAfterFlip)
 	assert.Equal(t, "dual-write-test", resAfterFlip[0].Source)
@@ -668,7 +668,7 @@ func TestBackfillNutsActivityToPebble_DryRun(t *testing.T) {
 	assert.Equal(t, 5, res.EntriesCopied, "dry-run should count 5 entries")
 
 	// Confirm Pebble is still empty (dry-run).
-	_, total, err := pebbleStore.Query(ActivityFilter{Limit: 50})
+	_, total, err := pebbleStore.Query(context.Background(), ActivityFilter{Limit: 50})
 	require.NoError(t, err)
 	assert.Equal(t, 0, total, "dry-run must not write to Pebble")
 
@@ -709,7 +709,7 @@ func TestBackfillNutsActivityToPebble_Apply(t *testing.T) {
 	assert.True(t, IsActivityPebbleBackfillDone(db))
 
 	// Pebble must have the entries.
-	_, total, err := pebbleStore.Query(ActivityFilter{Limit: 50})
+	_, total, err := pebbleStore.Query(context.Background(), ActivityFilter{Limit: 50})
 	require.NoError(t, err)
 	assert.Equal(t, 3, total, "Pebble must have all 3 copied entries")
 }

--- a/internal/database/store_coverage_test.go
+++ b/internal/database/store_coverage_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/store_coverage_test.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef0123456789
-// last-edited: 2026-07-11
+// last-edited: 2026-08-11
 
 // NOTE(fable5 T022): setupCoverageDB ported to PebbleStore; SQLiteStore
 // type assertions updated. Tests for SQLite-only methods (CountTableRows,
@@ -10,6 +10,7 @@
 package database
 
 import (
+	"context"
 	"encoding/json"
 	"path/filepath"
 	"testing"
@@ -1272,7 +1273,7 @@ func TestCoverage_WipeAllActivity(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify empty
-	events, _, err := as.Query(ActivityFilter{Limit: 10})
+	events, _, err := as.Query(context.Background(), ActivityFilter{Limit: 10})
 	require.NoError(t, err)
 	assert.Len(t, events, 0)
 }

--- a/internal/server/activity_integration_test.go
+++ b/internal/server/activity_integration_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/activity_integration_test.go
-// version: 3.0.0
+// version: 3.1.0
 // guid: f8a3b2c1-d4e5-6f7a-8b9c-0d1e2f3a4b5c
-// last-edited: 2026-06-10
+// last-edited: 2026-08-11
 
 // NOTE(fable5 T022): Ported NewSQLiteActivityStore → NewNutsActivityStore.
 
@@ -161,7 +161,7 @@ func TestActivity_Integration_TeeWriterCapture(t *testing.T) {
 
 	_ = w.Stop(context.Background())
 
-	entries, total, err := store.Query(database.ActivityFilter{Limit: 100})
+	entries, total, err := store.Query(context.Background(), database.ActivityFilter{Limit: 100})
 	if err != nil {
 		t.Fatalf("Query: %v", err)
 	}
@@ -170,18 +170,18 @@ func TestActivity_Integration_TeeWriterCapture(t *testing.T) {
 	}
 
 	// Source filtering
-	_, total, _ = store.Query(database.ActivityFilter{Source: "gin"})
+	_, total, _ = store.Query(context.Background(), database.ActivityFilter{Source: "gin"})
 	if total != 1 {
 		t.Errorf("expected 1 gin entry, got %d", total)
 	}
 
-	_, total, _ = store.Query(database.ActivityFilter{ExcludeSources: []string{"gin"}})
+	_, total, _ = store.Query(context.Background(), database.ActivityFilter{ExcludeSources: []string{"gin"}})
 	if total < 2 {
 		t.Errorf("expected at least 2 non-gin entries, got %d", total)
 	}
 
 	// Search
-	_, total, _ = store.Query(database.ActivityFilter{Search: "iTunes"})
+	_, total, _ = store.Query(context.Background(), database.ActivityFilter{Search: "iTunes"})
 	if total != 1 {
 		t.Errorf("expected 1 entry matching 'iTunes', got %d", total)
 	}

--- a/internal/server/handlers/activity.go
+++ b/internal/server/handlers/activity.go
@@ -1,13 +1,15 @@
 // file: internal/server/handlers/activity.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d4e5f6a7-b8c9-0123-def0-234567890123
-// last-edited: 2026-06-02
+// last-edited: 2026-08-11
 
 package handlers
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -18,11 +20,39 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// statusClientClosedRequest is nginx's 499: the client went away before the
+// response was written. Not in net/http, so it is spelled out here.
+const statusClientClosedRequest = 499
+
+// abortIfClientGone reports whether err is a cancelled/expired request context
+// and, when it is, ends the request with 499 and no body.
+//
+// Two things this deliberately avoids. It does NOT fall through to
+// httputil.InternalError: an abandoned request is not a server fault, and
+// routing every one of them through the 500 path would turn this fix into a
+// 5xx alert storm. It also does NOT use a bare c.Abort(), because Gin's default
+// status is 200 and a cancelled scan must never be reported as a successful
+// empty result — the caller would cache or render it as real data.
+func abortIfClientGone(c *gin.Context, err error, op string) bool {
+	if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	slog.Debug("[activity] request abandoned; scan cancelled",
+		"op", op, "path", c.Request.URL.Path, "error", err)
+	c.AbortWithStatus(statusClientClosedRequest)
+	return true
+}
+
 // ActivityService is the narrow interface ActivityHandler requires from the
 // activity log service.
+//
+// Query and GetDistinctSources take a context and every handler below passes
+// c.Request.Context(). Gin cancels that context when the client disconnects,
+// which is what lets an abandoned request stop scanning the activity log
+// instead of running to completion against a socket nobody is reading.
 type ActivityService interface {
-	Query(filter database.ActivityFilter) ([]database.ActivityEntry, int, error)
-	GetDistinctSources(filter database.ActivityFilter) ([]database.SourceCount, error)
+	Query(ctx context.Context, filter database.ActivityFilter) ([]database.ActivityEntry, int, error)
+	GetDistinctSources(ctx context.Context, filter database.ActivityFilter) ([]database.SourceCount, error)
 	RecompactDigests(ctx context.Context) (database.RecompactResult, error)
 	CompactByDay(ctx context.Context, cutoff time.Time) (database.CompactResult, error)
 }
@@ -151,8 +181,11 @@ func (h *ActivityHandler) ListActivity(c *gin.Context) {
 		}
 	}
 
-	entries, total, err := h.svc.Query(filter)
+	entries, total, err := h.svc.Query(c.Request.Context(), filter)
 	if err != nil {
+		if abortIfClientGone(c, err, "ListActivity") {
+			return
+		}
 		httputil.InternalError(c, "failed to query activity log", err)
 		return
 	}
@@ -191,8 +224,11 @@ func (h *ActivityHandler) ListActivitySources(c *gin.Context) {
 			filter.Until = &t
 		}
 	}
-	sources, err := h.svc.GetDistinctSources(filter)
+	sources, err := h.svc.GetDistinctSources(c.Request.Context(), filter)
 	if err != nil {
+		if abortIfClientGone(c, err, "ListActivitySources") {
+			return
+		}
 		httputil.InternalError(c, "failed to get sources", err)
 		return
 	}
@@ -234,8 +270,11 @@ func (h *ActivityHandler) ListOperationActivity(c *gin.Context) {
 		OperationID: opID,
 		Limit:       limit,
 	}
-	entries, total, err := h.svc.Query(filter)
+	entries, total, err := h.svc.Query(c.Request.Context(), filter)
 	if err != nil {
+		if abortIfClientGone(c, err, "ListOperationActivity") {
+			return
+		}
 		httputil.InternalError(c, "failed to query activity log", err)
 		return
 	}

--- a/internal/server/handlers/activity_cancel_test.go
+++ b/internal/server/handlers/activity_cancel_test.go
@@ -1,0 +1,171 @@
+// file: internal/server/handlers/activity_cancel_test.go
+// version: 1.0.0
+// guid: 5c48f1a9-2d76-4b03-8e91-6a3fd027b8ce
+// last-edited: 2026-08-11
+
+// Package handlers_test — the activity handlers' behaviour when the client
+// disconnects mid-scan.
+//
+// The store-level guarantee (the scan stops) is proved in
+// internal/database/pebble_activity_cancel_test.go. What is proved HERE is the
+// other half: that the handler translates a cancelled scan into a response
+// that cannot be mistaken for real data.
+//
+// The specific trap these guard is Gin's default status of 200. A handler that
+// notices the cancellation and simply stops — a bare c.Abort(), or a plain
+// return — still emits 200. A caller receiving 200 with an empty entries array
+// has no way to tell "the log really is empty" from "your scan was killed",
+// and will happily render or cache the emptiness as fact. So the assertion is
+// on the status code, not merely on the absence of a payload.
+package handlers_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
+	handlersmocks "github.com/falkcorp/audiobook-organizer/internal/server/handlers/mocks"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// statusClientClosedRequest mirrors the handler's unexported constant (nginx's
+// 499). Spelled out rather than exported from the production package: the wire
+// contract is what the test should pin, so that renaming or changing the
+// constant cannot quietly move the expectation with it.
+const statusClientClosedRequest = 499
+
+// newActivityCancelCtx builds a gin context whose request context is already
+// cancelled, standing in for a client that has disconnected.
+//
+// The cancelled context must be attached to the REQUEST, not merely created:
+// httptest.NewRequest leaves Request.ctx nil, so Request.Context() would
+// otherwise hand back context.Background() and the cancelledCtx matcher below
+// would have nothing to distinguish.
+func newActivityCancelCtx(method, path string) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest(method, path, nil).WithContext(ctx)
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	return c, w
+}
+
+// cancelledCtx matches only a context that is actually cancelled.
+//
+// This is the load-bearing half of every expectation below. Using
+// mock.Anything for the context argument would let a handler that passed
+// context.Background() — precisely the bug this work exists to remove — go on
+// satisfying the mock forever, which is how a test on the exact endpoint can
+// pass for the entire life of the bug.
+func cancelledCtx() any {
+	return mock.MatchedBy(func(ctx context.Context) bool {
+		return ctx != nil && ctx.Err() != nil
+	})
+}
+
+// TestListActivity_CancelledScanDoesNotReturn200 is the endpoint that produced
+// the production heap profile: GET /api/v1/activity.
+func TestListActivity_CancelledScanDoesNotReturn200(t *testing.T) {
+	svc := handlersmocks.NewMockActivityService(t)
+
+	// The filter matcher stays exact. Widening it to mock.Anything would let
+	// the test keep passing if the handler silently stopped honouring the
+	// caller's paging or filters.
+	wantFilter := database.ActivityFilter{Limit: 5, Offset: 0}
+	svc.EXPECT().
+		Query(cancelledCtx(), wantFilter).
+		Return(nil, 0, context.Canceled).
+		Once()
+
+	h := handlers.NewActivityHandler(svc, nil)
+	c, w := newActivityCancelCtx(http.MethodGet, "/api/v1/activity?limit=5")
+	h.ListActivity(c)
+
+	assert.Equal(t, statusClientClosedRequest, w.Code,
+		"a cancelled scan must not be reported as success")
+	assert.NotEqual(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Body.String(), "no body should be written for an abandoned request")
+	assert.True(t, c.IsAborted(), "the handler chain must be aborted")
+}
+
+// TestListActivitySources_CancelledScanDoesNotReturn200 covers the sources
+// endpoint, which ran concurrently with the query on every page load and
+// contributed 3.21 GB of its own to the OOM heap.
+func TestListActivitySources_CancelledScanDoesNotReturn200(t *testing.T) {
+	svc := handlersmocks.NewMockActivityService(t)
+
+	wantFilter := database.ActivityFilter{}
+	svc.EXPECT().
+		GetDistinctSources(cancelledCtx(), wantFilter).
+		Return(nil, context.Canceled).
+		Once()
+
+	h := handlers.NewActivityHandler(svc, nil)
+	c, w := newActivityCancelCtx(http.MethodGet, "/api/v1/activity/sources")
+	h.ListActivitySources(c)
+
+	assert.Equal(t, statusClientClosedRequest, w.Code)
+	assert.Empty(t, w.Body.String())
+	assert.True(t, c.IsAborted())
+}
+
+// TestListOperationActivity_CancelledScanDoesNotReturn200 covers the
+// op-transcript endpoint. This one matters disproportionately: it takes the
+// queryByIndexPrefix fast path rather than the bounded merge scan, so it is
+// the endpoint most likely to be left behind by a partial fix.
+//
+// It also pins that a cancelled scan must NOT fall through to the op-log
+// fallback. The fallback triggers on len(entries) == 0, and a cancelled query
+// returns zero entries — so a handler that checked the length before the error
+// would answer an abandoned request with a full, wrong, 200 transcript
+// assembled from a different data source.
+func TestListOperationActivity_CancelledScanDoesNotReturn200(t *testing.T) {
+	svc := handlersmocks.NewMockActivityService(t)
+
+	wantFilter := database.ActivityFilter{OperationID: "op-123", Limit: 1000}
+	svc.EXPECT().
+		Query(cancelledCtx(), wantFilter).
+		Return(nil, 0, context.Canceled).
+		Once()
+
+	// opsStore is deliberately nil: if the handler ever reached the fallback,
+	// that is a behaviour change this test should surface rather than mask.
+	h := handlers.NewActivityHandler(svc, nil)
+	c, w := newActivityCancelCtx(http.MethodGet, "/api/v1/operations/op-123/activity")
+	c.Params = gin.Params{{Key: "id", Value: "op-123"}}
+	h.ListOperationActivity(c)
+
+	assert.Equal(t, statusClientClosedRequest, w.Code)
+	assert.Empty(t, w.Body.String())
+	assert.True(t, c.IsAborted())
+}
+
+// TestListActivity_RealErrorStillReturns500 is the counterweight to the tests
+// above: only cancellation gets the 499 treatment. A genuine store failure must
+// still surface as a server error, or the fix would convert every activity-log
+// fault into a silent non-response.
+func TestListActivity_RealErrorStillReturns500(t *testing.T) {
+	svc := handlersmocks.NewMockActivityService(t)
+
+	wantFilter := database.ActivityFilter{Limit: 5, Offset: 0}
+	svc.EXPECT().
+		Query(cancelledCtx(), wantFilter).
+		Return(nil, 0, assert.AnError).
+		Once()
+
+	h := handlers.NewActivityHandler(svc, nil)
+	c, w := newActivityCancelCtx(http.MethodGet, "/api/v1/activity?limit=5")
+	h.ListActivity(c)
+
+	require.NotEqual(t, statusClientClosedRequest, w.Code,
+		"a real failure must not be disguised as a client disconnect")
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/internal/server/handlers/mocks/mock_activity_service.go
+++ b/internal/server/handlers/mocks/mock_activity_service.go
@@ -106,8 +106,8 @@ func (_c *MockActivityService_CompactByDay_Call) RunAndReturn(run func(ctx conte
 }
 
 // GetDistinctSources provides a mock function for the type MockActivityService
-func (_mock *MockActivityService) GetDistinctSources(filter database.ActivityFilter) ([]database.SourceCount, error) {
-	ret := _mock.Called(filter)
+func (_mock *MockActivityService) GetDistinctSources(ctx context.Context, filter database.ActivityFilter) ([]database.SourceCount, error) {
+	ret := _mock.Called(ctx, filter)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetDistinctSources")
@@ -115,18 +115,18 @@ func (_mock *MockActivityService) GetDistinctSources(filter database.ActivityFil
 
 	var r0 []database.SourceCount
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(database.ActivityFilter) ([]database.SourceCount, error)); ok {
-		return returnFunc(filter)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, database.ActivityFilter) ([]database.SourceCount, error)); ok {
+		return returnFunc(ctx, filter)
 	}
-	if returnFunc, ok := ret.Get(0).(func(database.ActivityFilter) []database.SourceCount); ok {
-		r0 = returnFunc(filter)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, database.ActivityFilter) []database.SourceCount); ok {
+		r0 = returnFunc(ctx, filter)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]database.SourceCount)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(database.ActivityFilter) error); ok {
-		r1 = returnFunc(filter)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, database.ActivityFilter) error); ok {
+		r1 = returnFunc(ctx, filter)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -139,19 +139,25 @@ type MockActivityService_GetDistinctSources_Call struct {
 }
 
 // GetDistinctSources is a helper method to define mock.On call
+//   - ctx context.Context
 //   - filter database.ActivityFilter
-func (_e *MockActivityService_Expecter) GetDistinctSources(filter any) *MockActivityService_GetDistinctSources_Call {
-	return &MockActivityService_GetDistinctSources_Call{Call: _e.mock.On("GetDistinctSources", filter)}
+func (_e *MockActivityService_Expecter) GetDistinctSources(ctx any, filter any) *MockActivityService_GetDistinctSources_Call {
+	return &MockActivityService_GetDistinctSources_Call{Call: _e.mock.On("GetDistinctSources", ctx, filter)}
 }
 
-func (_c *MockActivityService_GetDistinctSources_Call) Run(run func(filter database.ActivityFilter)) *MockActivityService_GetDistinctSources_Call {
+func (_c *MockActivityService_GetDistinctSources_Call) Run(run func(ctx context.Context, filter database.ActivityFilter)) *MockActivityService_GetDistinctSources_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 database.ActivityFilter
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(database.ActivityFilter)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 database.ActivityFilter
+		if args[1] != nil {
+			arg1 = args[1].(database.ActivityFilter)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -162,14 +168,14 @@ func (_c *MockActivityService_GetDistinctSources_Call) Return(sourceCounts []dat
 	return _c
 }
 
-func (_c *MockActivityService_GetDistinctSources_Call) RunAndReturn(run func(filter database.ActivityFilter) ([]database.SourceCount, error)) *MockActivityService_GetDistinctSources_Call {
+func (_c *MockActivityService_GetDistinctSources_Call) RunAndReturn(run func(ctx context.Context, filter database.ActivityFilter) ([]database.SourceCount, error)) *MockActivityService_GetDistinctSources_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Query provides a mock function for the type MockActivityService
-func (_mock *MockActivityService) Query(filter database.ActivityFilter) ([]database.ActivityEntry, int, error) {
-	ret := _mock.Called(filter)
+func (_mock *MockActivityService) Query(ctx context.Context, filter database.ActivityFilter) ([]database.ActivityEntry, int, error) {
+	ret := _mock.Called(ctx, filter)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Query")
@@ -178,23 +184,23 @@ func (_mock *MockActivityService) Query(filter database.ActivityFilter) ([]datab
 	var r0 []database.ActivityEntry
 	var r1 int
 	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(database.ActivityFilter) ([]database.ActivityEntry, int, error)); ok {
-		return returnFunc(filter)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, database.ActivityFilter) ([]database.ActivityEntry, int, error)); ok {
+		return returnFunc(ctx, filter)
 	}
-	if returnFunc, ok := ret.Get(0).(func(database.ActivityFilter) []database.ActivityEntry); ok {
-		r0 = returnFunc(filter)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, database.ActivityFilter) []database.ActivityEntry); ok {
+		r0 = returnFunc(ctx, filter)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]database.ActivityEntry)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(database.ActivityFilter) int); ok {
-		r1 = returnFunc(filter)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, database.ActivityFilter) int); ok {
+		r1 = returnFunc(ctx, filter)
 	} else {
 		r1 = ret.Get(1).(int)
 	}
-	if returnFunc, ok := ret.Get(2).(func(database.ActivityFilter) error); ok {
-		r2 = returnFunc(filter)
+	if returnFunc, ok := ret.Get(2).(func(context.Context, database.ActivityFilter) error); ok {
+		r2 = returnFunc(ctx, filter)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -207,19 +213,25 @@ type MockActivityService_Query_Call struct {
 }
 
 // Query is a helper method to define mock.On call
+//   - ctx context.Context
 //   - filter database.ActivityFilter
-func (_e *MockActivityService_Expecter) Query(filter any) *MockActivityService_Query_Call {
-	return &MockActivityService_Query_Call{Call: _e.mock.On("Query", filter)}
+func (_e *MockActivityService_Expecter) Query(ctx any, filter any) *MockActivityService_Query_Call {
+	return &MockActivityService_Query_Call{Call: _e.mock.On("Query", ctx, filter)}
 }
 
-func (_c *MockActivityService_Query_Call) Run(run func(filter database.ActivityFilter)) *MockActivityService_Query_Call {
+func (_c *MockActivityService_Query_Call) Run(run func(ctx context.Context, filter database.ActivityFilter)) *MockActivityService_Query_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 database.ActivityFilter
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(database.ActivityFilter)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 database.ActivityFilter
+		if args[1] != nil {
+			arg1 = args[1].(database.ActivityFilter)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -230,7 +242,7 @@ func (_c *MockActivityService_Query_Call) Return(activityEntrys []database.Activ
 	return _c
 }
 
-func (_c *MockActivityService_Query_Call) RunAndReturn(run func(filter database.ActivityFilter) ([]database.ActivityEntry, int, error)) *MockActivityService_Query_Call {
+func (_c *MockActivityService_Query_Call) RunAndReturn(run func(ctx context.Context, filter database.ActivityFilter) ([]database.ActivityEntry, int, error)) *MockActivityService_Query_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -1,11 +1,12 @@
 // file: internal/server/maintenance_fixups.go
-// version: 2.8.0
+// version: 2.9.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-// last-edited: 2026-07-31
+// last-edited: 2026-08-11
 
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -211,7 +212,7 @@ func (s *Server) handleWipe(c *gin.Context) {
 	// ── activity ──────────────────────────────────────────────────────────
 	if targetSet["activity"] {
 		if s.activityService != nil {
-			n, err := wipeActivity(s.activityService, dryRun)
+			n, err := wipeActivity(c.Request.Context(), s.activityService, dryRun)
 			if err != nil {
 				slog.Warn("wipe activity failed", "error", err)
 			}
@@ -346,9 +347,16 @@ func wipeExternalIDs(store maintenanceStore, dryRun bool) (int64, error) {
 }
 
 // wipeActivity deletes all activity log entries.
-func wipeActivity(svc *activity.Service, dryRun bool) (int64, error) {
+//
+// NOTE (pre-existing, not introduced here): the dry-run count comes from
+// Query's total, which the bounded scan added in 0adf6e97 made a LOWER BOUND.
+// With Limit:1 the walk stops at offset+limit+1 == 2 matches, so the reported
+// dry-run count now saturates at 2 rather than reporting the real row count.
+// Left alone deliberately — fixing it means either a dedicated count path or a
+// different filter, which is out of scope for the cancellation work.
+func wipeActivity(ctx context.Context, svc *activity.Service, dryRun bool) (int64, error) {
 	if dryRun {
-		entries, total, err := svc.Query(database.ActivityFilter{Limit: 1})
+		entries, total, err := svc.Query(ctx, database.ActivityFilter{Limit: 1})
 		if err != nil {
 			return 0, err
 		}

--- a/todo.d/20260811-activity-wipe-dryrun-count-saturates.md
+++ b/todo.d/20260811-activity-wipe-dryrun-count-saturates.md
@@ -1,0 +1,22 @@
+- [ ] **`wipeActivity` dry-run count saturates at 2.** `wipeActivity` in
+  `internal/server/maintenance_fixups.go` reports its dry-run row count from
+  `svc.Query(ctx, ActivityFilter{Limit: 1})`'s `total`. Since the bounded-scan
+  change in `0adf6e97`, `total` is a LOWER BOUND: the walk stops once it has
+  collected `Offset+Limit+1 == 2` matches, so the dry-run preview now reports
+  "2" no matter how many activity rows actually exist. The wipe itself is
+  unaffected (it calls `WipeAllActivity`), so this is a misleading preview
+  rather than data loss — but the preview is exactly what an operator uses to
+  decide whether to run the wipe. Fix needs either a dedicated count path or a
+  `CountByPrefix`-style call rather than reusing the paged query. Noted inline
+  at the call site during the activity-cancellation work (branch
+  `fix/activityquery`).
+
+- [ ] **`WipeAllActivity` still does an uncancellable full scan on a request
+  path.** It calls `scanTierKVs(context.Background(), ...)` per tier, and is
+  reachable from `handleWipe`. The activity-cancellation work deliberately left
+  the maintenance methods (`Prune`, `WipeAllActivity`, `Summarize`,
+  `CompactByDay`) context-free per scope, so `Query`/`GetDistinctSources` are
+  cancellable but this path is not: an abandoned wipe request still scans every
+  tier to completion. Lower severity than the query path (a wipe is rare and
+  operator-initiated, not fired on every page load) but it is the same shape of
+  defect and the same fix.


### PR DESCRIPTION
## The outage

Production was OOM-killed **five times** on 2026-08-11 (20:31, 20:33 at a 12 GB cap; 21:21, ~21:56 after raising it to 30 GB). Raising the cap never helped, because nothing was ever going to be enough.

Heap profile from the running process:

```
8.86 GB (71.9%)  PebbleActivityStore.scanTier / scanTierKVs
   ├─ 5.65 GB (45.8%)  ActivityHandler.ListActivity → activity.Service.Query
   └─ 3.21 GB (26.1%)  activity.Service.GetDistinctSources
8.02 GB (65.1%)  encoding/json.Unmarshal
```

Three faults compounding:

1. **Unbounded query.** Asking for the newest 50 entries scanned all seven tiers and JSON-unmarshalled every record, then discarded all but 50.
2. **No timeout on either side.**
3. **The handler ignored client disconnect** — the decisive one. `ss -tnp` showed **zero connected clients** while **30 goroutines held 30 GB** inside `scanTierKVs`. Every abandoned page load left a scan running forever, so only a restart freed the memory.

## The fix

Bounded newest-first scan with a scan budget, a 45s sources cache, and periodic context checks (`activityCtxCheckInterval`) inside the row loop.

**`ActivityStorer.Query` and `GetDistinctSources` now take a `context.Context`, and the non-ctx wrappers are deleted.** There is no `context.Background()` escape hatch left on the interface — the silent path is now unrepresentable rather than merely discouraged. That is deliberate: an additive `QueryContext` would have left `Query` available for the next handler to reach for.

All three handler call sites pass `c.Request.Context()`:

- `activity.go:184` — `ListActivity`
- `activity.go:227` — `ListActivitySources`
- `activity.go:273` — `ListOperationActivity`

Zero `context.Background()` remains in `activity.go` or `activity/service.go`.

**Scope addition worth flagging:** `ListOperationActivity` sets `OperationID`, which short-circuits `Query` into `queryByIndexPrefix` — it never reaches `scanNewestFirst`. Without threading ctx into that helper too, `:273` would have *looked* fixed while the scan still ran to completion. Covered by its own negative control.

Cancelled scans return **499 with no body**, never a 200. Gin's default status is 200, so a bare `c.Abort()` would have shipped a cancelled scan as a successful empty result.

## Verification

| Check | Result |
|---|---|
| `go build ./...` | exit 0 (read from the tool, not through a pipe) |
| `go vet ./...` | exit 0 (same) |
| `go test` × 3 packages, `-count=1` | **806 pass / 0 fail / 0 skip** (963 incl. subtests) |
| `make mocks-check`, `check-mock-fresh` | both pass |

`internal/server/` and `internal/audiobooks/` also run green (package-level `ok`, exit 0) — no per-test counts, they were run without `-v`.

### Three negative controls, each RED → GREEN

The cancellation tests use a context that trips on the Nth `Err()` call with `activityCtxCheckInterval` pinned to 1, so the trip lands **inside** the row loop after rows are decoded. Cancelling from a goroutine would be a race; cancelling before the call would only exercise the entry check and would still pass with the in-loop check deleted.

1. Removed the in-loop ctx check in `scanNewestFirst` → `TestQueryAbortsMidScanWhenCallerGoesAway` and `TestGetDistinctSourcesAbortsMidScan` FAILED. The already-cancelled and fast-path tests correctly stayed green — they exercise different checks, which is why they are separate tests.
2. Removed the ctx checks in `queryByIndexPrefix` → `TestQueryByIndexPrefixAborts…` FAILED.
3. Removed the `abortIfClientGone` branch → a cancelled request returned 500 with a body → FAILED, while `RealErrorStillReturns500` stayed green, proving 499 and 500 are not conflated.

After each restore: green, and `git status --porcelain` empty.

## Not claimed

- **Not deployed, not prod-verified.** A deploy is being held for this branch.
- Not rebased onto the six PRs merged tonight.
- Frontend and e2e untouched.
- **`total` is now a lower bound**, not exact, when the walk does not exhaust the matching rows — either `offset+limit+1` or however many matched before the budget. An exact count would require decoding every entry, which is the behaviour this removes.

## Two pre-existing defects found and filed, not fixed

- **`wipeActivity`'s dry-run count saturates at 2.** It reads `total` from `Query(ActivityFilter{Limit: 1})`, which is now a lower bound, so the walk stops at `Offset+Limit+1 == 2`. The wipe itself is unaffected — but the preview an operator uses to decide is wrong. Inherited from the bounding change, filed in `todo.d/`.
- **`WipeAllActivity` still calls `scanTierKVs(context.Background(), …)` and is reachable from `handleWipe`** — an uncancellable full scan still on a request path. Out of scope here, but the request surface is not *fully* covered by this branch and should not be assumed to be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp