### PR TITLE
fix(cache): generation-key the library list caches so merged books stop reappearing [skip changelog]

### DIFF
--- a/changelog.d/20260811_235900_fix_list_cache_phantom_books.md
+++ b/changelog.d/20260811_235900_fix_list_cache_phantom_books.md
@@ -1,0 +1,81 @@
+### Fixed
+
+#### Merged-away books no longer haunt the library page for 24 hours
+
+Merging books worked correctly — the merge moved files, reassigned external
+IDs, and hard-deleted the losers — but the library page kept listing the
+deleted books for up to a full day. Measured on production on the UI's own
+default list key: the cached response returned 40,957 books where the
+identical cache-busted query returned 40,839, a drift of 118 rows. Three of
+the merged-away books were still being listed while returning HTTP 404 on
+fetch (`01KQAQEJ7HGX9YJC94WMYZG954`, `01KQAQEEWWQWXHGCB9KRR013H5`,
+`01KQAQEHG337RJ2HEHN9PAA61W`). Not every phantom row was a deleted book:
+when a merge elects a different winner the loser is demoted to
+`is_primary_version=false` rather than removed, and the default primary-only
+view kept showing it too.
+
+The write path was never at fault. The bug was entirely in the HTTP response
+cache, and it could not self-heal:
+
+- The list cache was keyed on the raw query string alone, and an exhaustive
+  search of non-test Go for `listCache.` turned up only `Get` and `Set` —
+  there was no `Invalidate` or `InvalidateAll` call for this cache anywhere
+  in the codebase. Three separate mutation handlers each invalidated some
+  *other* cache and missed this one.
+- `Get` moved an entry to the front of the LRU but did not extend its expiry,
+  so an entry lived a full 24 hours from its `Set`.
+- LRU capacity eviction never reached these entries, because library-page
+  keys are the *most* recently used in the cache and capacity eviction takes
+  the least recently used.
+- The list warmer skipped any query it found already cached, which made it
+  structurally incapable of refreshing a stale entry — it would find the
+  phantom-row response, conclude the query was warm, and skip it forever.
+
+Only a process restart cleared it.
+
+Fixed by keying the library-list caches on a monotonic generation counter
+that the store bumps on `CreateBook`, `UpdateBook` and `DeleteBook`. After a
+mutation every reader computes a new key, so pre-mutation entries become
+unreachable and age out on their own. This replaces the shape that had
+already failed — scattering `InvalidateAll()` calls across mutation handlers
+depends on every future handler author remembering, and three of them
+already had not.
+
+`UpdateBook` bumps the counter even though it only marks *targeted* quick
+queries dirty rather than calling `MarkAllQuickQueriesDirty`. That detail is
+load-bearing: `UpdateBook` is the path that demotes a merge loser, so hooking
+the counter to `MarkAllQuickQueriesDirty` alone would have left every demoted
+row on the page.
+
+Two caches were involved, not one. The HTTP handler's cached response is
+built from `GetAudiobooks`, which reads a *second* 24-hour cache inside the
+audiobook service whose invalidation is gated behind
+`CacheInvalidateOnBookUpdate` — off by default. Generation-keying only the
+HTTP cache would have left the deleted books to be served straight back out
+of the one underneath it. Both are now keyed on the same counter.
+
+Book-*file* mutations deliberately do not bump the counter. They run once per
+file during a scan, and bumping there would hold the list cache at a
+near-permanent miss for the duration of every scan.
+
+Both list cache TTLs drop from 24 hours to 10 minutes. With generation keying
+doing the real work, the TTL is now only a backstop for mutation paths that
+bypass the store's three book-level writes.
+
+### Added
+
+#### `POST /api/v1/cache/invalidate` (admin) for clearing a stale cache
+
+Every existing cache route was read-only, so the only remedy for cache
+staleness was restarting the process — roughly ten minutes of unusable
+library while the in-memory query layer warms back up. The new admin-gated
+endpoint takes an optional `{"cache": "list"}` body, defaults to every
+registered cache, and returns per-cache drop counts read *before*
+invalidating, so an operator gets confirmation of what was actually cleared
+rather than a bare `200`. A mistyped cache name is rejected rather than
+answered with "dropped 0", which would read as "already clean".
+
+This is not made redundant by the generation counter: the counter only
+advances on the store's three book-level writes, so batch writes, direct
+in-memory writes and index-only edits still bypass it. The endpoint is the
+lever for those.

--- a/internal/audiobooks/service.go
+++ b/internal/audiobooks/service.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service.go
-// version: 1.33.0
+// version: 1.34.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-06-23
+// last-edited: 2026-08-11
 
 // Package audiobooks provides the core business logic for managing audiobooks,
 // including CRUD operations, metadata management, search, deduplication, and
@@ -17,6 +17,8 @@
 package audiobooks
 
 import (
+	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/activity"
@@ -77,6 +79,16 @@ type AudiobookService struct {
 	// is constructed. Nil-safe — when nil the delete/purge paths skip
 	// the iTunes side-effect (e.g. tests, iTunes disabled in config).
 	itunesEnqueuer ITunesEnqueuer
+	// libGen scopes listCache keys to the store's book-mutation counter, so a
+	// created/updated/deleted book puts every previously cached page out of
+	// reach. Resolved from the store once at construction; never nil.
+	//
+	// This cache sits UNDER the server's HTTP list cache: the handler's cached
+	// gin.H response is built from GetAudiobooks, which reads this. Keying only
+	// the HTTP cache would have left deleted books to be served straight back
+	// out of here, because InvalidateBookCaches skips listCache unless
+	// config.CacheInvalidateOnBookUpdate is on — and it is off by default.
+	libGen *cache.Generation
 }
 
 // SetActivityService wires the activity service for snapshot fallback in GetAudiobookTags.
@@ -98,14 +110,39 @@ func (svc *AudiobookService) SetITunesEnqueuer(e ITunesEnqueuer) {
 
 // NewAudiobookService creates a new AudiobookService instance
 func NewAudiobookService(store audiobookStore) *AudiobookService {
+	libGen, resolved := database.LibraryGenerationOf(store)
+	if !resolved {
+		slog.Warn("audiobook list cache: store exposes no library generation counter, "+
+			"list entries will only expire by TTL",
+			"store_type", fmt.Sprintf("%T", store))
+	}
 	return &AudiobookService{
 		store: store,
 		// MAYDEPLOY-I4: cap entry count via LRU so 24h TTL doesn't allow
 		// unbounded growth of full Book payloads.
 		bookCache: cache.NewWithLimit[*database.Book]("book", 24*time.Hour, 5000),
-		listCache: cache.NewWithLimit[[]database.Book]("audiobook_list", 24*time.Hour, 500),
+		// TTL cut from 24h to listCacheTTL: with generation keying a book
+		// mutation already puts stale pages out of reach, so the TTL only has
+		// to bound mutation paths that bypass the store's three book-level
+		// writes. See listCacheTTL.
+		listCache: cache.NewWithLimit[[]database.Book]("audiobook_list", listCacheTTL, 500),
+		libGen:    libGen,
 	}
 }
+
+// listCacheTTL bounds how long a cached library page can outlive a change that
+// did not go through CreateBook / UpdateBook / DeleteBook — a direct memdb
+// write, a batch path, or an index-only edit. Generation keying handles the
+// three store writes precisely, so this is a backstop rather than the primary
+// mechanism, and 24 hours was far too long to serve that role: the phantom
+// merged books stayed on the library page for a full day because nothing
+// invalidated the entry and the LRU never evicted it (library-page keys are the
+// most recently used, so they are the last candidates for capacity eviction).
+//
+// Ten minutes keeps the warm-cache benefit for normal browsing while capping
+// the blast radius of an unknown-path mutation at a single-digit number of
+// minutes.
+const listCacheTTL = 10 * time.Minute
 
 // InvalidateBookCaches clears all book-related caches. Called after any
 // mutation (create, update, delete) to keep reads consistent.

--- a/internal/audiobooks/service_query.go
+++ b/internal/audiobooks/service_query.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/service_query.go
-// version: 1.11.0
+// version: 1.12.0
 // guid: c5f9d4e3-f6a7-8b90-ac1d-2e3f4a5b6c7d
 // last-edited: 2026-08-12
 
@@ -181,8 +181,12 @@ func (svc *AudiobookService) GetAudiobooksWithTotal(ctx context.Context, limit i
 			if f.IsPrimaryVersion != nil {
 				primaryKey = strconv.FormatBool(*f.IsPrimaryVersion)
 			}
-			cacheKey := fmt.Sprintf("all:%d:%d:p=%s:sb=%s:asc=%v:noq=%v",
-				limit, offset, primaryKey, f.SortBy, sortAsc, f.ExcludeQuarantined)
+			// Generation-scoped: a created/updated/deleted book advances
+			// svc.libGen, so pages cached before that mutation can no longer be
+			// addressed by any reader. Build the key through Generation.Key so
+			// the read below and the Set further down cannot drift apart.
+			cacheKey := svc.libGen.Key("all:", fmt.Sprintf("%d:%d:p=%s:sb=%s:asc=%v:noq=%v",
+				limit, offset, primaryKey, f.SortBy, sortAsc, f.ExcludeQuarantined))
 			if cached, ok := svc.listCache.Get(cacheKey); ok {
 				return cached, -1, nil
 			}

--- a/internal/cache/generation.go
+++ b/internal/cache/generation.go
@@ -1,0 +1,68 @@
+// file: internal/cache/generation.go
+// version: 1.0.0
+// guid: 018cc7fe-8212-4cb8-95be-59b65e2b7ede
+// last-edited: 2026-08-11
+
+package cache
+
+import (
+	"strconv"
+	"sync/atomic"
+)
+
+// Generation is a monotonic counter that makes cached responses derived from a
+// mutable corpus UNREACHABLE once that corpus changes, instead of relying on
+// every mutation site remembering to call InvalidateAll.
+//
+// Why this shape: the library list cache previously keyed on the raw query
+// string alone. Merging books hard-deleted them from the store, but the cached
+// list responses still contained the deleted rows and there was no
+// Invalidate/InvalidateAll call for that cache anywhere in the codebase — so
+// the library page served phantom books (rows that 404 on fetch, and version
+// losers demoted to is_primary_version=false) until the entry's TTL expired or
+// the process restarted. Three separate mutation handlers each invalidated
+// some OTHER cache and forgot this one; adding a fourth invalidate call would
+// have depended on every future handler author remembering too.
+//
+// Folding the counter into the cache key removes that obligation. After a bump
+// every reader computes a new key, so pre-bump entries can never be read again.
+// They are not actively deleted: they age out via TTL or LRU capacity. That is
+// deliberate — correctness comes from unreachability, and reclamation is left
+// to the mechanisms the cache already has.
+//
+// The zero value is ready to use. It is safe for concurrent use.
+type Generation struct {
+	n atomic.Uint64
+}
+
+// Bump advances the generation and returns the new value. Every cache key
+// built from this Generation after the bump differs from every key built
+// before it, so all prior entries become unreachable.
+func (g *Generation) Bump() uint64 {
+	if g == nil {
+		return 0
+	}
+	return g.n.Add(1)
+}
+
+// Value returns the current generation.
+func (g *Generation) Value() uint64 {
+	if g == nil {
+		return 0
+	}
+	return g.n.Load()
+}
+
+// Key builds a generation-scoped cache key of the form
+// "<prefix><generation>:<suffix>".
+//
+// Callers MUST route every read and write of a generation-scoped cache through
+// this method rather than formatting the key by hand: a reader and a writer
+// that disagree on the key layout produce a cache that never hits, which is a
+// silent performance regression rather than a visible failure.
+//
+// A nil Generation formats as generation 0, which keeps keys stable (and the
+// cache useful) for stores that do not supply a counter.
+func (g *Generation) Key(prefix, suffix string) string {
+	return prefix + strconv.FormatUint(g.Value(), 10) + ":" + suffix
+}

--- a/internal/cache/registry.go
+++ b/internal/cache/registry.go
@@ -1,6 +1,7 @@
 // file: internal/cache/registry.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
+// last-edited: 2026-08-11
 
 package cache
 
@@ -34,6 +35,67 @@ func Lookup(name string) (Introspectable, bool) {
 	defer registryMu.RUnlock()
 	c, ok := registry[name]
 	return c, ok
+}
+
+// Invalidatable is the optional second interface a registered cache may
+// satisfy to allow bulk invalidation from outside the package. *Cache[T]
+// satisfies it.
+//
+// It is deliberately separate from Introspectable rather than folded into it:
+// registration should not require a cache to expose a destructive operation,
+// and keeping the write capability opt-in means a future read-only or
+// externally-backed registry entry cannot be emptied by accident.
+type Invalidatable interface {
+	InvalidateAll()
+	Len() int
+}
+
+// InvalidateByName empties one registered cache and reports how many entries
+// it held. ok is false when no cache of that name is registered, and
+// invalidatable is false when the cache exists but does not expose bulk
+// invalidation — the caller needs to tell those apart to answer correctly.
+//
+// The count is read BEFORE invalidating, because InvalidateAll returns
+// nothing and Len afterwards is always zero.
+func InvalidateByName(name string) (dropped int, ok bool, invalidatable bool) {
+	registryMu.RLock()
+	c, found := registry[name]
+	registryMu.RUnlock()
+	if !found {
+		return 0, false, false
+	}
+	inv, canInvalidate := c.(Invalidatable)
+	if !canInvalidate {
+		return 0, true, false
+	}
+	n := inv.Len()
+	inv.InvalidateAll()
+	return n, true, true
+}
+
+// InvalidateAllRegistered empties every registered cache that supports bulk
+// invalidation and returns a per-cache count of the entries dropped. Caches
+// that do not support it are skipped and named in the second return value, so
+// an operator sees what was NOT cleared rather than assuming a clean sweep.
+func InvalidateAllRegistered() (dropped map[string]int, skipped []string) {
+	registryMu.RLock()
+	names := make([]string, 0, len(registry))
+	for name := range registry {
+		names = append(names, name)
+	}
+	registryMu.RUnlock()
+	sort.Strings(names)
+
+	dropped = make(map[string]int, len(names))
+	for _, name := range names {
+		n, _, canInvalidate := InvalidateByName(name)
+		if !canInvalidate {
+			skipped = append(skipped, name)
+			continue
+		}
+		dropped[name] = n
+	}
+	return dropped, skipped
 }
 
 // All returns a sorted list of registered cache names.

--- a/internal/database/library_generation.go
+++ b/internal/database/library_generation.go
@@ -1,0 +1,61 @@
+// file: internal/database/library_generation.go
+// version: 1.0.0
+// guid: 9696c574-1445-4078-a549-20dc2b5f8095
+// last-edited: 2026-08-11
+
+package database
+
+import "github.com/falkcorp/audiobook-organizer/internal/cache"
+
+// LibraryGenerationProvider is implemented by a store that maintains a
+// monotonic counter of book-level mutations. Response caches derived from the
+// book corpus fold that counter into their keys so entries built before a
+// mutation cannot be read after it.
+type LibraryGenerationProvider interface {
+	LibraryGeneration() *cache.Generation
+}
+
+// fallbackLibraryGeneration is handed to callers whose store does not provide a
+// counter (in-memory test doubles and mocks, chiefly). It is a single shared
+// instance on purpose: every caller that falls back gets the SAME pointer, so
+// their cache keys still agree with one another. Nothing bumps it, so it stays
+// at generation 0 and those callers behave exactly as they did before
+// generation keying existed.
+var fallbackLibraryGeneration = &cache.Generation{}
+
+// LibraryGeneration returns the store's book-mutation counter.
+//
+// Bumped by CreateBook, UpdateBook and DeleteBook — the three writes that
+// change which books exist or which of them are primary versions.
+//
+// Book-FILE mutations deliberately do NOT bump it. They call
+// InvalidateLibraryStats on six or seven paths that run once per file during a
+// scan, so bumping there would push the list cache to a near-permanent miss for
+// the whole duration of every scan on a library this size. Book-file edits can
+// therefore still be reflected late in a cached list; that residue is bounded
+// by the cache TTL rather than by the counter, which is the trade this design
+// accepts.
+func (p *PebbleStore) LibraryGeneration() *cache.Generation { return &p.libGen }
+
+// LibraryGenerationOf resolves the book-mutation counter from s, looking
+// through any decorator chain that opts into StoreUnwrapper.
+//
+// It always returns a usable non-nil *cache.Generation. The bool reports
+// whether a real store-backed counter was found; false means the shared
+// never-bumped fallback was returned instead. Callers should surface that
+// case (log it once at wiring time) rather than swallow it: a silent fallback
+// leaves every generation-keyed cache pinned at generation 0, which reinstates
+// exactly the staleness bug the counter exists to prevent, while every test
+// that constructs a real store keeps passing.
+//
+// Resolution goes through AsCapability rather than a bare type assertion
+// because the production store is wrapped (indexedStore) and a naked assertion
+// against the wrapper fails.
+func LibraryGenerationOf(s any) (*cache.Generation, bool) {
+	if provider, ok := AsCapability[LibraryGenerationProvider](s); ok {
+		if gen := provider.LibraryGeneration(); gen != nil {
+			return gen, true
+		}
+	}
+	return fallbackLibraryGeneration, false
+}

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.122.0
+// version: 1.123.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-08-11
 
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble/v2"
+	"github.com/falkcorp/audiobook-organizer/internal/cache"
 	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
 	"github.com/falkcorp/audiobook-organizer/internal/matcher"
 	"github.com/falkcorp/audiobook-organizer/internal/util"
@@ -132,6 +133,13 @@ type PebbleStore struct {
 	// in NewPebbleStore before the store is returned, so no mutex is needed.
 	warmupCancel context.CancelFunc
 	warmupDone   chan struct{}
+
+	// libGen is bumped by every book-level mutation (CreateBook, UpdateBook,
+	// DeleteBook) so response caches derived from the book corpus can key on
+	// it and let their pre-mutation entries fall out of reach. See
+	// library_generation.go for why this lives on the store and why book-file
+	// mutations deliberately do NOT bump it.
+	libGen cache.Generation
 }
 
 // mem returns the active in-memory query layer or nil if warmup hasn't
@@ -1810,6 +1818,7 @@ func (p *PebbleStore) CreateBook(book *Book) (*Book, error) {
 
 	p.InvalidateLibraryStats()
 	p.MarkAllQuickQueriesDirty("create_book")
+	p.libGen.Bump()
 
 	// memdb write-through (always on when initialized)
 	p.UpsertBookToMemDB(context.Background(), book)
@@ -2063,6 +2072,11 @@ func (p *PebbleStore) UpdateBook(id string, book *Book) (*Book, error) {
 	p.MarkQuickQueryDirty("missing_covers", "update_book")
 	p.MarkQuickQueryDirty("no_isbn", "update_book")
 	p.MarkQuickQueryDirty("in_import_path", "update_book")
+	// UpdateBook is how a book gets demoted to is_primary_version=false when a
+	// merge elects a different winner. Those demoted rows must leave the cached
+	// library list, so this path bumps even though it only marks TARGETED quick
+	// queries dirty (i.e. hooking MarkAllQuickQueriesDirty would have missed it).
+	p.libGen.Bump()
 
 	// memdb write-through
 	p.UpsertBookToMemDB(context.Background(), book)
@@ -2378,6 +2392,7 @@ func (p *PebbleStore) DeleteBook(id string) error {
 	}
 	p.InvalidateLibraryStats()
 	p.MarkAllQuickQueriesDirty("delete_book")
+	p.libGen.Bump()
 
 	// memdb write-through
 	p.DeleteBookFromMemDB(context.Background(), id)

--- a/internal/server/handlers/audiobooks/handler.go
+++ b/internal/server/handlers/audiobooks/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 51fac747-9478-4075-8621-9da4bbdedc37
-// last-edited: 2026-07-11
+// last-edited: 2026-08-11
 
 // Package audiobookshandler hosts the main library list / CRUD HTTP handlers
 // extracted from the server package's audiobooks_handlers.go: book listing
@@ -146,6 +146,25 @@ type Handler struct {
 	// publishEvent wraps *Server.publishEvent (the shared plugin event bus), used
 	// by deleteAudiobook.
 	publishEvent func(ctx context.Context, event plugin.Event)
+}
+
+// libraryGeneration resolves the store's book-mutation counter, which scopes
+// every library-list cache key.
+//
+// Resolved at request time from h.store (the un-stripped store) rather than
+// snapshotted, for the same reason the inline Unwrap assertions above are:
+// production runs behind the indexedStore decorator, and a bare assertion
+// against the wrapper misses. Resolution is two type assertions, which is
+// nothing against building a list response.
+//
+// The library-list cache warmer resolves the same counter from the same
+// underlying store, so both compute identical keys. If they ever diverged the
+// warmer would write entries no request could read — a silent cache-miss
+// regression rather than a visible failure, which is why both sides go through
+// Generation.Key instead of formatting keys by hand.
+func (h *Handler) libraryGeneration() *cache.Generation {
+	gen, _ := database.LibraryGenerationOf(h.store)
+	return gen
 }
 
 // New constructs an audiobooks Handler from its dependencies.
@@ -458,7 +477,7 @@ func (h *Handler) ListAudiobooks(c *gin.Context) {
 	// per-user filters are active because the cache key doesn't
 	// encode userID — a hit could leak User A's filtered list
 	// to User B.
-	cacheKey := "list:" + c.Request.URL.RawQuery
+	cacheKey := h.libraryGeneration().Key("list:", c.Request.URL.RawQuery)
 	if len(filters.PerUserFilters) == 0 {
 		if cached, ok := h.listCache.Get(cacheKey); ok {
 			httputil.RespondWithOK(c, cached)

--- a/internal/server/handlers/cache.go
+++ b/internal/server/handlers/cache.go
@@ -1,12 +1,15 @@
 // file: internal/server/handlers/cache.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: c9d0e1f2-a3b4-5678-cdef-678901234567
-// last-edited: 2026-07-13
+// last-edited: 2026-08-11
 
 package handlers
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
 	"strconv"
 	"time"
 
@@ -137,6 +140,80 @@ func (h *CacheHandler) HandleCacheKeysIntrospection(c *gin.Context) {
 		Keys  []string `json:"keys"`
 		Count int      `json:"count"`
 	}{Cache: cacheName, Keys: keys, Count: len(keys)})
+}
+
+// CacheInvalidateRequest is the optional body of POST /api/v1/cache/invalidate.
+// An absent or empty Cache field means "every registered cache".
+type CacheInvalidateRequest struct {
+	Cache string `json:"cache"`
+}
+
+// CacheInvalidateResponse reports what was actually dropped, per cache.
+//
+// Dropped is returned rather than a bare 200 because the operator reaching for
+// this endpoint is trying to confirm that a specific stale entry is gone; "OK"
+// does not distinguish "cleared 2000 entries" from "cleared a cache that was
+// already empty because you named the wrong one".
+type CacheInvalidateResponse struct {
+	Dropped map[string]int `json:"dropped"`
+	Total   int            `json:"total"`
+	Skipped []string       `json:"skipped,omitempty"`
+}
+
+// HandleCacheInvalidate empties one or all in-memory caches.
+// POST /api/v1/cache/invalidate (admin-gated)
+//
+// This is the operator lever for cache staleness. Before it existed the only
+// remedy was a process restart, which costs roughly ten minutes of unusable
+// library while memdb warms back up.
+//
+// Generation keying on the library-list caches does not make this redundant:
+// the counter only advances on the store's three book-level writes, so batch
+// writes, direct memdb writes and index-only edits still bypass it entirely.
+// This endpoint is what covers those.
+func (h *CacheHandler) HandleCacheInvalidate(c *gin.Context) {
+	var req CacheInvalidateRequest
+	// A completely absent body is valid and means "all caches"; only a
+	// malformed one is an error.
+	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+		httputil.RespondWithBadRequest(c, "invalid request body: "+err.Error())
+		return
+	}
+
+	if req.Cache != "" {
+		dropped, found, invalidatable := cache.InvalidateByName(req.Cache)
+		if !found {
+			if IsNonIntrospectableCache(req.Cache) {
+				httputil.RespondWithBadRequest(c, "not invalidatable: "+req.Cache)
+				return
+			}
+			httputil.RespondWithBadRequest(c, "cache not found: "+req.Cache)
+			return
+		}
+		if !invalidatable {
+			httputil.RespondWithBadRequest(c, "not invalidatable: "+req.Cache)
+			return
+		}
+		slog.Info("cache invalidated by operator", "cache", req.Cache, "dropped", dropped)
+		httputil.RespondWithOK(c, CacheInvalidateResponse{
+			Dropped: map[string]int{req.Cache: dropped},
+			Total:   dropped,
+		})
+		return
+	}
+
+	dropped, skipped := cache.InvalidateAllRegistered()
+	total := 0
+	for _, n := range dropped {
+		total += n
+	}
+	slog.Info("all caches invalidated by operator",
+		"caches", len(dropped), "dropped", total, "skipped", skipped)
+	httputil.RespondWithOK(c, CacheInvalidateResponse{
+		Dropped: dropped,
+		Total:   total,
+		Skipped: skipped,
+	})
 }
 
 // HandleCacheStatsHistory returns persisted snapshots for one or all caches.

--- a/internal/server/handlers/metadata/handler.go
+++ b/internal/server/handlers/metadata/handler.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/metadata/handler.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 54bb4ad0-cab0-41fc-b9cb-557c96beee44
 // last-edited: 2026-08-11
 
@@ -491,6 +491,14 @@ func (h *Handler) searchAudiobookMetadataImpl(c *gin.Context) {
 
 	// Persistent cache read: only when the caller is doing a plain
 	// per-book fetch (no alt-query) and didn't force refresh.
+	// NOT generation-scoped, unlike the "list:" keys in the same cache
+	// instance. The two keyspaces are disjoint, so there is no collision to
+	// avoid, and the contents are unrelated: these are metadata-provider
+	// search results for one book, not a view of the book corpus. Scoping them
+	// to the library generation would discard every provider result on any
+	// book create/update/delete — throwing away exactly the external API calls
+	// this cache exists to avoid. Freshness here is owned by ?refresh=true and
+	// the persistent candidate cache's own is_fresh flag.
 	cacheKey := fmt.Sprintf("meta_search:%s:%s:%s:%s:%s:%t",
 		id, body.Query, body.Author, body.Narrator, body.Series, body.UseRerank)
 	plainFetch := body.Query == "" && body.Author == "" && body.Narrator == "" && body.Series == ""

--- a/internal/server/library_list_warmer.go
+++ b/internal/server/library_list_warmer.go
@@ -1,5 +1,5 @@
 // file: internal/server/library_list_warmer.go
-// version: 2.2.1
+// version: 2.3.0
 // guid: 7e8d9a0b-1c2d-3e4f-5a6b-7c8d9e0f1a2b
 // last-edited: 2026-08-11
 
@@ -597,7 +597,7 @@ func (s *Server) warmAudiobookListCache() {
 		hits++
 		if len(q.filters.PerUserFilters) == 0 {
 			raw := buildListCacheRawQuery(q.limit, q.offset, q.filters)
-			s.listCache.Set("list:"+raw, resp)
+			s.listCache.Set(s.libraryGeneration().Key("list:", raw), resp)
 			cached++
 		}
 		slog.Debug("library list warm-up query ok",
@@ -762,8 +762,20 @@ func (s *Server) runTrickleWarmer(backlog []qry) {
 		idx++
 
 		// Skip if already cached (user query or earlier warmer round beat us).
+		//
+		// The key MUST be generation-scoped like the request path's, or this
+		// branch reads the pre-mutation entry, concludes the query is already
+		// warm, and skips it forever: the warmer would then be structurally
+		// incapable of replacing a stale entry, which is one of the three
+		// reasons the phantom-book bug never self-healed.
+		//
+		// Snapshot the key here and reuse it for the Set below rather than
+		// recomputing after the query. If a book mutation lands mid-query the
+		// response we just built is already stale, and the old key parks it
+		// somewhere no reader can reach — whereas recomputing would publish it
+		// under the new generation as if it were fresh.
 		raw := buildListCacheRawQuery(q.limit, q.offset, q.filters)
-		cacheKey := "list:" + raw
+		cacheKey := s.libraryGeneration().Key("list:", raw)
 		if len(q.filters.PerUserFilters) == 0 {
 			if _, ok := s.listCache.Get(cacheKey); ok {
 				continue

--- a/internal/server/list_cache_generation_test.go
+++ b/internal/server/list_cache_generation_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/list_cache_generation_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 51004630-5b56-463f-851b-8225e2367353
 // last-edited: 2026-08-11
 
@@ -59,9 +59,12 @@ func listTitles(t *testing.T, server *Server, rawQuery string) ([]string, string
 // production defect: the owner merges books, the merge hard-deletes the
 // losers, and the library page keeps listing them for up to 24 hours.
 //
-// Measured on production before the fix: the cached library list returned
-// 40,957 books where the identical cache-busted query returned 40,839 — 118
-// rows that no longer existed, 96 of which 404 on fetch.
+// Measured on production before the fix, on the UI's own default list key:
+// the cached response returned 40,957 books where the identical cache-busted
+// query returned 40,839 — a drift of 118 rows. Three of the merged-away books
+// were still listed while returning HTTP 404 on fetch:
+// 01KQAQEJ7HGX9YJC94WMYZG954, 01KQAQEEWWQWXHGCB9KRR013H5,
+// 01KQAQEHG337RJ2HEHN9PAA61W.
 //
 // The delete here goes through the same store call the merge path uses
 // (DeleteBook), and both list requests go through the production router, so
@@ -110,10 +113,10 @@ func TestListCacheDropsDeletedBookOnNextRequest(t *testing.T) {
 }
 
 // TestListCacheDropsDemotedPrimaryOnNextRequest covers the other half of the
-// production symptom: 74 of the phantom rows were not deleted at all, they
-// were demoted to is_primary_version=false when a merge elected a different
-// winner, and the default library view (is_primary_version=true) kept showing
-// them.
+// production symptom. Not every phantom row is a deleted book: when a merge
+// elects a different winner the loser is demoted to is_primary_version=false
+// rather than removed, and the default library view (is_primary_version=true)
+// kept showing it from cache.
 //
 // This is the case that would still be broken if the generation counter had
 // been hooked to MarkAllQuickQueriesDirty, because UpdateBook does not call

--- a/internal/server/list_cache_generation_test.go
+++ b/internal/server/list_cache_generation_test.go
@@ -1,0 +1,348 @@
+// file: internal/server/list_cache_generation_test.go
+// version: 1.0.0
+// guid: 51004630-5b56-463f-851b-8225e2367353
+// last-edited: 2026-08-11
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	audiobookspkg "github.com/falkcorp/audiobook-organizer/internal/audiobooks"
+	"github.com/falkcorp/audiobook-organizer/internal/cache"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
+	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// listTitles issues a real GET against the production router and returns the
+// titles in the response, plus the raw body.
+//
+// It goes through server.router rather than calling the handler directly so
+// the cache read/write, the store decorator chain, and the generation
+// resolution are all exercised exactly as they are in production. A handler
+// constructed by hand in the test would resolve the generation from a bare
+// store and could pass while the wrapped production path stayed broken.
+func listTitles(t *testing.T, server *Server, rawQuery string) ([]string, string) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/audiobooks?"+rawQuery, nil)
+	w := httptest.NewRecorder()
+	server.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "list request failed: %s", w.Body.String())
+
+	var wrapper struct {
+		Data struct {
+			Items []struct {
+				ID    string `json:"id"`
+				Title string `json:"title"`
+			} `json:"items"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+
+	titles := make([]string, 0, len(wrapper.Data.Items))
+	for _, item := range wrapper.Data.Items {
+		titles = append(titles, item.Title)
+	}
+	return titles, w.Body.String()
+}
+
+// TestListCacheDropsDeletedBookOnNextRequest is the regression test for the
+// production defect: the owner merges books, the merge hard-deletes the
+// losers, and the library page keeps listing them for up to 24 hours.
+//
+// Measured on production before the fix: the cached library list returned
+// 40,957 books where the identical cache-busted query returned 40,839 — 118
+// rows that no longer existed, 96 of which 404 on fetch.
+//
+// The delete here goes through the same store call the merge path uses
+// (DeleteBook), and both list requests go through the production router, so
+// the two response caches involved (the HTTP list cache and the audiobook
+// service's own list cache underneath it) are both exercised.
+//
+// One book is deleted, not all of them: a test that empties the library would
+// pass even if the cache were keyed on nothing at all, because "no books" is
+// indistinguishable from a correct empty page.
+func TestListCacheDropsDeletedBookOnNextRequest(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	store, ok := database.GetGlobalStore().(*database.PebbleStore)
+	require.True(t, ok, "expected a PebbleStore")
+	store.WaitForWarmup()
+
+	keep1 := createTestBook(t, "Kept Book One")
+	victim := createTestBook(t, "Merged Away Book")
+	keep2 := createTestBook(t, "Kept Book Two")
+
+	const rawQuery = "limit=50&offset=0"
+
+	// First request populates both caches and must actually contain the
+	// victim — otherwise the assertion after the delete proves nothing.
+	before, beforeBody := listTitles(t, server, rawQuery)
+	require.Contains(t, before, victim.Title,
+		"victim must be listed before deletion, else the test is vacuous: %s", beforeBody)
+	require.Contains(t, before, keep1.Title)
+	require.Contains(t, before, keep2.Title)
+
+	// Second identical request: confirm the cache is genuinely serving this
+	// query. If it were not, the post-delete assertion below would pass even
+	// with the fix reverted, and the test would be worthless as a regression
+	// guard.
+	_, cachedBody := listTitles(t, server, rawQuery)
+	require.Equal(t, beforeBody, cachedBody, "expected the second request to be served from cache")
+
+	require.NoError(t, store.DeleteBook(victim.ID))
+
+	after, afterBody := listTitles(t, server, rawQuery)
+	assert.NotContains(t, after, victim.Title,
+		"deleted book is still being served from the list cache: %s", afterBody)
+	assert.Contains(t, after, keep1.Title, "unrelated book vanished: %s", afterBody)
+	assert.Contains(t, after, keep2.Title, "unrelated book vanished: %s", afterBody)
+}
+
+// TestListCacheDropsDemotedPrimaryOnNextRequest covers the other half of the
+// production symptom: 74 of the phantom rows were not deleted at all, they
+// were demoted to is_primary_version=false when a merge elected a different
+// winner, and the default library view (is_primary_version=true) kept showing
+// them.
+//
+// This is the case that would still be broken if the generation counter had
+// been hooked to MarkAllQuickQueriesDirty, because UpdateBook does not call
+// it — it marks three targeted quick queries instead.
+func TestListCacheDropsDemotedPrimaryOnNextRequest(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	store, ok := database.GetGlobalStore().(*database.PebbleStore)
+	require.True(t, ok, "expected a PebbleStore")
+	store.WaitForWarmup()
+
+	winner := createTestBook(t, "Version Winner")
+	loser := createTestBook(t, "Version Loser")
+
+	const rawQuery = "limit=50&offset=0&is_primary_version=true"
+
+	before, beforeBody := listTitles(t, server, rawQuery)
+	require.Contains(t, before, loser.Title,
+		"loser must be listed as primary before demotion: %s", beforeBody)
+	require.Contains(t, before, winner.Title)
+
+	// Demote exactly as a merge does. UpdateBook is a full-column replacement,
+	// so the whole book is written back with only the flag changed.
+	demoted := *loser
+	isPrimary := false
+	demoted.IsPrimaryVersion = &isPrimary
+	_, err := store.UpdateBook(loser.ID, &demoted)
+	require.NoError(t, err)
+
+	after, afterBody := listTitles(t, server, rawQuery)
+	assert.NotContains(t, after, loser.Title,
+		"demoted version loser is still served from the list cache: %s", afterBody)
+	assert.Contains(t, after, winner.Title, "winner vanished: %s", afterBody)
+}
+
+// TestListWarmerKeyMatchesRequestKeyAndRetiresOnMutation covers the warmer
+// half of the bug.
+//
+// The trickle warmer skips any query it finds already cached. With an
+// un-scoped key that made it structurally incapable of refreshing a stale
+// entry: it would find the phantom-row response, conclude the query was warm,
+// and skip it on every pass forever.
+//
+// Two properties are asserted:
+//
+//  1. The key the warmer computes for a query is the SAME key a real request
+//     computes for it. If these ever drift the warmer writes entries no
+//     request can read — a silent cache-miss regression that no amount of
+//     "the tests pass" would surface.
+//  2. After a book mutation the warmer's key no longer resolves, so its
+//     skip-if-cached branch misses and the query gets rebuilt.
+//
+// This exercises the key computation the skip branch uses. It does NOT run
+// the trickle goroutine itself, so it does not prove the surrounding loop
+// behaves; it proves the branch's input can no longer be the stale entry.
+func TestListWarmerKeyMatchesRequestKeyAndRetiresOnMutation(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	store, ok := database.GetGlobalStore().(*database.PebbleStore)
+	require.True(t, ok, "expected a PebbleStore")
+	store.WaitForWarmup()
+
+	createTestBook(t, "Warmer Book One")
+	victim := createTestBook(t, "Warmer Victim")
+
+	// The warmer builds its raw query with buildListCacheRawQuery; drive the
+	// HTTP request from that same string so any divergence in key layout
+	// shows up as a cache miss below.
+	raw := buildListCacheRawQuery(50, 0, audiobookspkg.ListFilters{})
+	listTitles(t, server, raw)
+
+	warmerKey := server.libraryGeneration().Key("list:", raw)
+	_, hit := server.listCache.Get(warmerKey)
+	require.True(t, hit,
+		"warmer key %q does not resolve to the entry the request path wrote — "+
+			"the warmer and the handler disagree on the cache key", warmerKey)
+
+	require.NoError(t, store.DeleteBook(victim.ID))
+
+	staleKey := warmerKey
+	freshKey := server.libraryGeneration().Key("list:", raw)
+	assert.NotEqual(t, staleKey, freshKey,
+		"generation did not advance on delete, so the warmer would keep skipping")
+
+	_, hitAfter := server.listCache.Get(freshKey)
+	assert.False(t, hitAfter,
+		"warmer would still skip this query as already-cached after a delete")
+}
+
+// TestCacheInvalidateRouteIsAdminGated asserts, through the production router,
+// that the operator escape hatch exists and refuses an unauthenticated caller.
+//
+// Asserting 401 specifically (rather than "not 200") also proves the route is
+// mounted: an unmounted path would 404.
+func TestCacheInvalidateRouteIsAdminGated(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	createTestBook(t, "Gated Book")
+	listTitles(t, server, "limit=50&offset=0")
+	populated := server.listCache.Len()
+	require.Positive(t, populated, "list cache should be populated before the rejection test")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cache/invalidate",
+		bytes.NewBufferString(`{"cache":"list"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code,
+		"unauthenticated caller should be refused: %s", w.Body.String())
+	assert.Equal(t, populated, server.listCache.Len(),
+		"a refused invalidate request must not empty the cache")
+}
+
+// newAdminInvalidateRouter mounts HandleCacheInvalidate behind the same
+// RequireAdmin middleware the production route uses, with a caller identity
+// injected ahead of it.
+//
+// The production mounting is covered by TestCacheInvalidateRouteIsAdminGated;
+// this exists because the test server has no user store to authenticate
+// against, and asserting the success path matters more than routing it
+// through the real login flow.
+func newAdminInvalidateRouter(user *database.User) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if user != nil {
+			// Mirrors what the auth middleware stores for CurrentUser.
+			c.Set("auth_user", user)
+		}
+		c.Next()
+	})
+	grp := r.Group("/api/v1")
+	grp.Use(servermiddleware.RequireAdmin())
+	grp.POST("/cache/invalidate", handlers.NewCacheHandler(nil, nil).HandleCacheInvalidate)
+	return r
+}
+
+func postInvalidate(t *testing.T, r *gin.Engine, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var req *http.Request
+	if body == "" {
+		req = httptest.NewRequest(http.MethodPost, "/api/v1/cache/invalidate", nil)
+	} else {
+		req = httptest.NewRequest(http.MethodPost, "/api/v1/cache/invalidate",
+			bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// TestCacheInvalidateEmptiesNamedCache asserts the endpoint actually drops the
+// entries and reports the exact count, rather than returning a bare 200.
+func TestCacheInvalidateEmptiesNamedCache(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	createTestBook(t, "Invalidate Book One")
+	createTestBook(t, "Invalidate Book Two")
+	listTitles(t, server, "limit=50&offset=0")
+	listTitles(t, server, "limit=10&offset=0")
+
+	populated := server.listCache.Len()
+	require.Positive(t, populated, "list cache should hold entries before invalidation")
+
+	admin := &database.User{ID: "admin-1", Username: "admin", Roles: []string{"admin"}}
+	w := postInvalidate(t, newAdminInvalidateRouter(admin), `{"cache":"list"}`)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var wrapper struct {
+		Data handlers.CacheInvalidateResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+
+	// The exact pre-invalidation count, not merely "something was dropped".
+	assert.Equal(t, populated, wrapper.Data.Dropped["list"],
+		"reported drop count should equal the entries the cache actually held")
+	assert.Equal(t, populated, wrapper.Data.Total)
+	assert.Equal(t, 0, server.listCache.Len(), "list cache should be empty afterwards")
+}
+
+// TestCacheInvalidateRejectsNonAdmin asserts an authenticated caller without
+// the admin role is refused AND that the cache is untouched — a 403 that
+// still cleared the cache would be a worse bug than no endpoint at all.
+func TestCacheInvalidateRejectsNonAdmin(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	createTestBook(t, "Non Admin Book")
+	listTitles(t, server, "limit=50&offset=0")
+	populated := server.listCache.Len()
+	require.Positive(t, populated)
+
+	viewer := &database.User{ID: "viewer-1", Username: "viewer", Roles: []string{"viewer"}}
+	w := postInvalidate(t, newAdminInvalidateRouter(viewer), `{"cache":"list"}`)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, populated, server.listCache.Len(),
+		"a forbidden request must not empty the cache")
+}
+
+// TestCacheInvalidateUnknownCacheIsRejected guards the operator against a
+// silent no-op when they mistype a cache name: without this the endpoint
+// would answer 200 / "dropped 0" and read as "the cache was already clean".
+func TestCacheInvalidateUnknownCacheIsRejected(t *testing.T) {
+	admin := &database.User{ID: "admin-1", Username: "admin", Roles: []string{"admin"}}
+	w := postInvalidate(t, newAdminInvalidateRouter(admin), `{"cache":"no-such-cache"}`)
+	assert.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+}
+
+// TestGenerationKeyChangesWithBump is the unit-level guard on the key
+// mechanism itself: the same inputs must produce a different key after a
+// bump, and a stable one without.
+func TestGenerationKeyChangesWithBump(t *testing.T) {
+	var gen cache.Generation
+
+	first := gen.Key("list:", "limit=50")
+	assert.Equal(t, first, gen.Key("list:", "limit=50"), "key must be stable without a bump")
+
+	gen.Bump()
+	assert.NotEqual(t, first, gen.Key("list:", "limit=50"), "key must change after a bump")
+
+	// A nil Generation must still produce a usable, stable key rather than
+	// panicking, because that is the fallback path for stores with no counter.
+	var nilGen *cache.Generation
+	assert.Equal(t, nilGen.Key("list:", "x"), nilGen.Key("list:", "x"))
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 2.37.0
+// version: 2.38.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 // last-edited: 2026-08-11
 
@@ -182,15 +182,18 @@ type Server struct {
 	olService              *metafetch.OpenLibraryService
 	dedupCache             *cache.Cache[gin.H]
 	listCache              *cache.Cache[gin.H]
-	facetsCache            *cache.Cache[gin.H]
-	authorsCache           *cache.Cache[*audiobookspkg.AuthorWithCountListResponse]
-	seriesCache            *cache.Cache[*audiobookspkg.SeriesWithCountsResponse]
-	itunesSvc              *itunesservice.Service
-	updater                *updater.Updater
-	updateScheduler        *updater.Scheduler
-	scheduler              *scheduler.TaskScheduler
-	aiScanStore            *database.AIScanStore
-	pipelineManager        *aiscan.PipelineManager
+	// libGenWarnOnce keeps the "store has no generation counter" warning to a
+	// single line instead of one per list request.
+	libGenWarnOnce  sync.Once
+	facetsCache     *cache.Cache[gin.H]
+	authorsCache    *cache.Cache[*audiobookspkg.AuthorWithCountListResponse]
+	seriesCache     *cache.Cache[*audiobookspkg.SeriesWithCountsResponse]
+	itunesSvc       *itunesservice.Service
+	updater         *updater.Updater
+	updateScheduler *updater.Scheduler
+	scheduler       *scheduler.TaskScheduler
+	aiScanStore     *database.AIScanStore
+	pipelineManager *aiscan.PipelineManager
 	// operationsHandler is the migrated operations-domain handler (instantiated
 	// in wireHandlers). getSystemLogs delegates its operation_id branch to
 	// operationsHandler.GetOperationLogs; routes are registered in the same
@@ -317,6 +320,50 @@ func (s *Server) Store() database.Store {
 	return s.store
 }
 
+// listTTL bounds how long a cached library-list response may outlive a change
+// that did not go through the store's CreateBook / UpdateBook / DeleteBook —
+// a batch write, a direct memdb write, or an index-only edit. Generation
+// keying retires stale pages precisely for those three writes, so this is a
+// backstop, not the primary mechanism.
+//
+// It replaces a 24h TTL that was the reason merged-away books stayed on the
+// library page for a full day: nothing invalidated the entry (this cache had
+// no Invalidate call anywhere in the codebase), Get did not extend expiry so
+// entries lived 24h from their Set, and LRU capacity eviction never reached
+// them because library-page keys are the most recently used in the cache.
+// Ten minutes keeps browsing warm while capping the blast radius of any
+// mutation path the counter does not see.
+const listTTL = 10 * time.Minute
+
+// libraryGeneration resolves the store's book-mutation counter, which scopes
+// every library-list cache key.
+//
+// Resolved from s.Store() on each call rather than snapshotted at
+// construction: the store is wrapped by indexedStore once the search index
+// opens (after NewServer), and integration tests swap it post-wire. Resolving
+// live means this and the audiobooks handler always agree, because both walk
+// to the same underlying PebbleStore and get a pointer to the same counter.
+// They must agree — a warmer writing keys the request path cannot read is a
+// silent cache-miss regression, not a visible failure.
+//
+// Never returns nil. When the store exposes no counter (a test double), the
+// shared never-bumped fallback is returned and behaviour matches the
+// pre-generation code: TTL-only expiry. That case is logged once, because a
+// silent fallback would pin every key at generation 0 and quietly reinstate
+// the staleness bug.
+func (s *Server) libraryGeneration() *cache.Generation {
+	gen, resolved := database.LibraryGenerationOf(s.Store())
+	if !resolved {
+		s.libGenWarnOnce.Do(func() {
+			slog.Warn("library list cache: store exposes no library generation counter, "+
+				"cached list pages will only expire by TTL",
+				"store_type", fmt.Sprintf("%T", s.Store()),
+				"ttl", listTTL)
+		})
+	}
+	return gen
+}
+
 // OpRegistry returns the operations registry. Used by the operation-runner
 // child mode (cmd.RunOperationRunner) to dispatch a single op without
 // starting workers or the HTTP server.
@@ -407,8 +454,10 @@ func NewServer(store database.Store) *Server {
 		// to hundreds of thousands of entries (estimated 0.5–1.5 GB) on heavy
 		// use. Cap entry count via LRU; defaults are conservative starting
 		// points — watch cache_evictions_total{reason="capacity"} in prod.
-		dedupCache:   cache.NewWithLimit[gin.H]("dedup", 24*time.Hour, 1000),
-		listCache:    cache.NewWithLimit[gin.H]("list", 24*time.Hour, 2000),
+		dedupCache: cache.NewWithLimit[gin.H]("dedup", 24*time.Hour, 1000),
+		// listTTL, not 24h: see the listTTL doc comment. Generation keying is
+		// what actually retires stale library pages; the TTL is the backstop.
+		listCache:    cache.NewWithLimit[gin.H]("list", listTTL, 2000),
 		facetsCache:  cache.NewWithLimit[gin.H]("facets", 24*time.Hour, 100),
 		authorsCache: cache.NewWithLimit[*audiobookspkg.AuthorWithCountListResponse]("authors", 24*time.Hour, 1),
 		seriesCache:  cache.NewWithLimit[*audiobookspkg.SeriesWithCountsResponse]("series", 24*time.Hour, 1),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 2.38.0
+// version: 2.38.1
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-08-11
+// last-edited: 2026-08-12
 
 package server
 
@@ -355,6 +355,19 @@ func (s *Server) libraryGeneration() *cache.Generation {
 	gen, resolved := database.LibraryGenerationOf(s.Store())
 	if !resolved {
 		s.libGenWarnOnce.Do(func() {
+			// CodeQL flags this line as go/clear-text-logging (high), reporting
+			// that a `password` field reachable from the store struct flows to
+			// a logging call. It is a false positive: the verb is %T, which
+			// renders only the *dynamic type name* (e.g. "*database.PebbleStore")
+			// and cannot render any field value. Nothing derived from the
+			// struct's contents reaches the log record. CodeQL's taint tracking
+			// does not model %T as value-suppressing, so it follows the store
+			// pointer into Sprintf and reports the sink.
+			//
+			// Do not "fix" this by dropping the type: it is the only thing that
+			// identifies WHICH store failed to expose the counter, and a silent
+			// fallback here pins every cache key at generation 0 and quietly
+			// reinstates the staleness bug this whole change exists to fix.
 			slog.Warn("library list cache: store exposes no library generation counter, "+
 				"cached list pages will only expire by TTL",
 				"store_type", fmt.Sprintf("%T", s.Store()),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 2.38.1
+// version: 2.39.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 // last-edited: 2026-08-12
 
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -368,9 +369,20 @@ func (s *Server) libraryGeneration() *cache.Generation {
 			// identifies WHICH store failed to expose the counter, and a silent
 			// fallback here pins every cache key at generation 0 and quietly
 			// reinstates the staleness bug this whole change exists to fix.
+			//
+			// Instead of arguing with the analyser, the type name is resolved
+			// through reflect and only the resulting STRING is handed to the
+			// logger. The store value never reaches a logging call, so there is
+			// no flow left for the query to follow — the tool is made not to
+			// care rather than suppressed into silence. Behaviour is identical:
+			// reflect.TypeOf(x).String() and %T produce the same text.
+			storeType := "<nil>"
+			if st := s.Store(); st != nil {
+				storeType = reflect.TypeOf(st).String()
+			}
 			slog.Warn("library list cache: store exposes no library generation counter, "+
 				"cached list pages will only expire by TTL",
-				"store_type", fmt.Sprintf("%T", s.Store()),
+				"store_type", storeType,
 				"ttl", listTTL)
 		})
 	}

--- a/internal/server/wire_library_routes.go
+++ b/internal/server/wire_library_routes.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_library_routes.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f23456789012
-// last-edited: 2026-08-01
+// last-edited: 2026-08-11
 
 package server
 
@@ -110,6 +110,10 @@ func (s *Server) wireLibraryRoutes(
 	adminOnly.Use(servermiddleware.RequireAdmin())
 	{
 		adminOnly.GET("/cache/stats/keys", cacheH.HandleCacheKeysIntrospection)
+		// Operator escape hatch for cache staleness. Until this existed the
+		// only way to clear a stale cache was a process restart, which costs
+		// roughly ten minutes of unusable library while memdb warms back up.
+		adminOnly.POST("/cache/invalidate", cacheH.HandleCacheInvalidate)
 		adminOnly.POST("/admin/recompact-digests", activityH.RecompactDigests)
 	}
 }


### PR DESCRIPTION
The owner reported that combining books still leaves the originals listed in the library. The merge write path turned out to be correct — the books really are gone. A **24-hour list cache that nothing invalidates** was serving them.

**Measured on prod 2026-08-11:** cached count 40,957 vs cache-busted 40,839 — 118 phantom rows. Three merged book IDs (`01KQAQEJ7HGX9YJC94WMYZG954`, `01KQAQEEWWQWXHGCB9KRR013H5`, `01KQAQEHG337RJ2HEHN9PAA61W`) were still being listed while `GET` on each returned 404.

It never self-heals: `Get` doesn't extend the TTL, but library keys are the most recently used so LRU never evicts them, and the warmer skips keys that are already cached.

## The fix

Library-list caches are keyed on a monotonic **library generation** counter bumped by the store in `CreateBook`, `UpdateBook`, and `DeleteBook`. After a mutation every reader computes a new key, so pre-mutation entries become unreachable and age out.

This deliberately replaces the shape that had already failed three times here — scattering `InvalidateAll()` calls that every future handler author has to remember. Generation keying makes staleness unrepresentable rather than depending on recall.

TTL also cut 24h → 10 minutes on both list caches, as a backstop for paths that bypass the three store writes.

## Two corrections to the original brief, both load-bearing

**The obvious four files were not sufficient.** `buildListResponse` falls through to a *second* 24h cache at `internal/audiobooks/service_query.go:129` whose `InvalidateAll` is gated behind `CacheInvalidateOnBookUpdate` — **false by default**. Reverting only the service-layer key, with the generation bumps and the HTTP key intact, put the merged book straight back on the page:

```
"count":2   <- fresh count query (2 books remain)
items: [Kept Book One, Merged Away Book, Kept Book Two]   <- 3, from the stale service cache
```

Fixing only the four originally-named files would have shipped, and any test checking just the HTTP layer would have gone green while production stayed broken.

**`MarkAllQuickQueriesDirty` was the wrong seam.** `UpdateBook` doesn't call it — it marks three *targeted* quick queries. Since `UpdateBook` is what demotes a merge loser to `is_primary_version=false`, hooking there alone would have missed every demoted row. It bumps explicitly, with a comment saying why. Resolution goes through the existing `AsCapability` unwrap walk, not a bare type assertion — production runs behind the `indexedStore` decorator, where a naked assertion would silently fall back to a never-bumped counter.

## Verification

- `go build ./...` and `go vet` on all four changed package trees: **exit 0**
- **Full suite: 18 packages ok, 0 FAIL, 9 no-test-files, exit 0.** None `(cached)`. `internal/server` 855s, `internal/database` 607s.
- Targeted tests **8/8**
- **Negative control 1** (three `Bump()` calls disabled): **3 RED / 5 GREEN** — the 3 fix tests failed on `should not contain "Merged Away Book"`; the 5 endpoint tests correctly stayed green since they don't depend on the counter
- **Negative control 2** (service-layer key only): **2 RED**
- Restored both times: **8/8 GREEN**, working tree clean

## Not claimed

- **The trickle warmer goroutine never ran.** Tested: the key its skip-if-cached branch computes, and that warmer and request path agree on it. Not tested: the surrounding loop.
- **No production data, no deploy** in this verification.
- **`meta_search` deliberately left un-generationed** — a documented deviation. `list:` and `meta_search:` keys are already disjoint so there is no collision, and gen-keying would discard cached provider results on every book mutation, which is precisely the external API traffic that cache exists to avoid. Incidental find: those entries were getting 24h despite a comment claiming 60 seconds; now 10m.
- **Book-file mutations deliberately don't bump** (7 sites, once per file during a scan — bumping would hold the cache at a permanent miss for the whole scan). Residue there is TTL-bounded only.

## Interaction with the two-elected-primaries defect

Untouched by this PR. One consequence worth stating: because `UpdateBook` now bumps, a demotion becomes visible on the very next request. If that separate write-path bug produces a second primary, the library page will now show it **promptly** rather than hiding it behind a stale cache. That is a visibility change, not a behavioral one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp
