### PR TITLE
ci: raise the Go Tests cap upstream, bump the pin, and correct my wrong attribution [skip changelog]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/ci.yml
-# version: 3.3.0
+# version: 3.3.1
 # guid: f1a2b3c4-d5e6-f7a8-b9c0-d1e2f3a4b5c6
-# last-edited: 2026-08-11
+# last-edited: 2026-08-12
 
 # Fast parallel CI for PRs and pushes.
 # Runs go vet/build, short tests, frontend lint/build, and frontend unit tests
@@ -134,16 +134,25 @@ jobs:
     name: Coverage Floor (PR gate)
     runs-on: ubuntu-latest
     # 35, not 20. `make test-short` runs go test with `-timeout 25m`, so a cap
-    # of 20 guaranteed the runner killed the job BEFORE Go's own timeout could
+    # of 20 would let the runner kill this job BEFORE Go's own timeout could
     # fire — and Go's timeout is the only thing that prints a goroutine dump
-    # naming the stuck test. Every hang therefore surfaced as a bare
-    # `conclusion=cancelled` with no diagnosis, three times on 2026-08-11 alone
-    # (#2311, #2315), and `cancelled` reads as a test failure on the PR even
-    # though nothing failed.
+    # naming the stuck test.
     #
-    # The job cap must stay strictly greater than the longest `-timeout` passed
-    # to any go test invocation in the steps below, plus setup. If you raise the
-    # test timeout, raise this too.
+    # INVARIANT: the job cap must stay strictly greater than the longest
+    # `-timeout` passed to any go test invocation in the steps below, plus
+    # setup. If you raise the test timeout, raise this too.
+    #
+    # CORRECTION (2026-08-12): an earlier version of this comment credited the
+    # #2311/#2315 `conclusion=cancelled` failures to this job. That was wrong.
+    # Those cancellations were on `Minimal CI / Go Tests (short, race)`, which
+    # is NOT defined in this file — the `Minimal CI /` prefix means it comes
+    # from the reusable workflow referenced by the `ci` job above
+    # (falkcorp/github-common/.github/workflows/reusable-ci-minimal.yml), where
+    # the cap was 20 against its own `go test -timeout 30m`. This job is a
+    # different job that has never been the one cancelled; it completed in
+    # 13m21s on the run where Go Tests was killed at 20m16s. Fixed upstream in
+    # falkcorp/github-common#346; that workflow exposes no timeout input, so it
+    # could not have been fixed from this repo.
     #
     # This is a diagnosis fix, not a performance fix: internal/server alone is a
     # ~500s package (TODO-SRVTIMEOUT) and sharding it is still open.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/ci.yml
-# version: 3.3.1
+# version: 3.4.0
 # guid: f1a2b3c4-d5e6-f7a8-b9c0-d1e2f3a4b5c6
 # last-edited: 2026-08-12
 
@@ -28,7 +28,15 @@ jobs:
   # Parallel fast jobs via reusable minimal workflow
   ci:
     name: Minimal CI
-    uses: falkcorp/github-common/.github/workflows/reusable-ci-minimal.yml@d0c3326b96557c8ea9117c1c196b628e5e028186 # main 2026-07-05 (fixes jdfalk/ghcommon -> falkcorp/github-common stale-ref 400 error)
+    # Pin bumped 2026-08-12 to pick up falkcorp/github-common#346, which raises
+    # the `Go Tests (short, race)` job cap from 20 to 35 minutes. That job runs
+    # `go test -short -race -timeout 30m ./...`, so at a cap of 20 the runner
+    # killed it ten minutes before Go's own timeout could print the goroutine
+    # dump naming the stuck test — every slow run surfaced as a bare
+    # `conclusion=cancelled` that reads on the PR as a test failure (#2311,
+    # #2315, #2319 at exactly 20m16s). The cap is only settable upstream: this
+    # workflow exposes no timeout input.
+    uses: falkcorp/github-common/.github/workflows/reusable-ci-minimal.yml@85a290960317dca5e50c0c18107f5e3d663658aa # main 2026-08-12 (raises Go Tests cap above its own go test -timeout)
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/changelog.d/20260812-ci-gotests-cap-is-external.md
+++ b/changelog.d/20260812-ci-gotests-cap-is-external.md
@@ -1,0 +1,25 @@
+### Fixed
+
+#### Corrected a wrong attribution in `ci.yml` about which CI job kept getting cancelled
+
+`ci.yml` carried a comment claiming that raising `Coverage Floor (PR gate)` to
+`timeout-minutes: 35` fixed the repeated `conclusion=cancelled` failures seen in
+#2311 and #2315. It did not.
+
+Those cancellations were on `Minimal CI / Go Tests (short, race)`, which is not
+defined in this repository at all — the `Minimal CI /` prefix on a check name
+means the job comes from a called workflow, here
+`falkcorp/github-common/.github/workflows/reusable-ci-minimal.yml`. That job
+capped at 20 minutes while running `go test -short -race -timeout 30m ./...`,
+so the runner killed it ten minutes before Go's own timeout could print the
+goroutine dump naming the stuck test.
+
+Measured on #2319: `Go Tests (short, race)` cancelled at 20m16s, while
+`Coverage Floor (PR gate)` — the job that had actually been raised — completed
+successfully in 13m21s in the very same run.
+
+The real fix is upstream in falkcorp/github-common#346; that workflow exposes no
+timeout input, so it could not have been fixed from this repo. The `35` here
+stays, because it is independently correct for this job (`make test-short` runs
+with `-timeout 25m`), but the comment now states the invariant without claiming
+credit for someone else's bug.


### PR DESCRIPTION
I merged #2317 tonight claiming it fixed the repeated `conclusion=cancelled` failures on this repo's Go tests. It did not, and the comment making that claim is currently sitting on main where it will mislead whoever reads it next.

## What actually happens

The check that keeps getting cancelled is `Minimal CI / Go Tests (short, race)`. **That job is not defined in this repository.** The `Minimal CI /` prefix on a check name means the job comes from a called workflow — here `falkcorp/github-common/.github/workflows/reusable-ci-minimal.yml`, pinned at `d0c3326b`. In that file:

```
100:    name: Go Tests (short, race)
102:    timeout-minutes: 20
137:    run: go test -short -race -timeout 30m ./...
```

A 20-minute job cap against a 30-minute `go test` timeout. The runner kills the job ten minutes before Go's own timeout can fire, and Go's `-timeout` is the only thing that prints a goroutine dump naming the stuck test. So the run ends as bare `cancelled` with no evidence, and `cancelled` renders on the PR as a test failure.

## The measurement that settles it

From run `31561741823` on #2319 — a docs-only PR:

```
cancelled   Minimal CI / Go Tests (short, race)   03:58:53Z -> 04:19:09Z   (20m16s)
success     Coverage Floor (PR gate)              03:58:48Z -> 04:12:09Z   (13m21s)
```

`Coverage Floor (PR gate)` is the job #2317 raised to 35. It finished comfortably, in the very same run where the other job was killed at its cap. It has never been the job being cancelled.

## What this PR changes

Comment only — no behaviour. The `timeout-minutes: 35` stays, because it is independently correct for that job on its own terms (`make test-short` runs with `-timeout 25m`, so 35 > 25 satisfies the invariant). What changes is that the comment no longer claims credit for a bug in another repository, and it now records where the real cap lives so the next person doesn't repeat my grep.

The real fix is upstream in **falkcorp/github-common#346**. It could not have been made here: that workflow exposes no timeout input (`go-version`, `node-version`, `go-experiment`, `system-packages`, `frontend-working-dir`, `run-frontend`).

## Why I got it wrong

I grepped `timeout-minutes` in `ci.yml`, found one, and changed it. The grep answered "is there a timeout in this file" when the question was "what caps *that* job." The `/` in the check name was the available tell and I didn't read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp
