### PR TITLE
docs(todo): CodeQL alert inventory, review-panel requests, double-primary version groups [skip changelog]

### DIFF
--- a/todo.d/20260811-combine-or-merge-before-metadata-apply.md
+++ b/todo.d/20260811-combine-or-merge-before-metadata-apply.md
@@ -1,0 +1,51 @@
+- [ ] **REVIEW-COMBINE-FIRST** Let the owner combine two books into one, or
+      merge them as duplicates, **before** applying metadata — from the same
+      surface where they are choosing the metadata. Requested 2026-08-11:
+      *"a way to combine two books into one before I apply metadata, or merge
+      them as duplicates before I apply my metadata."*
+
+      **The ordering is the whole point.** Today the sequence is forced:
+      metadata is applied to whatever book row happens to exist, and only later
+      can rows be combined. When one logical book is split across several rows
+      (extremely common in this library — see the 199 books exploded into 6,060
+      single-file folders), the owner ends up applying the same metadata several
+      times to fragments of one book, and the combine afterwards has to
+      reconcile competing metadata that need never have diverged.
+
+      Both actions already exist as separate UI flows:
+
+      - **Combine into One Book** — `web/src/components/BatchToolbar.tsx:101`
+        → `web/src/pages/Library.tsx:1256` → `POST /api/v1/audiobooks/combine`
+        (`internal/server/wire_dedup_routes.go:75`). Hard-deletes the absorbed
+        shells.
+      - **Merge as Versions** — `web/src/pages/Library.tsx:1232`. Soft-deletes
+        the losers and demotes them to non-primary.
+
+      So the backend capability is there; what is missing is reaching it from
+      the metadata chooser without losing the chooser's state.
+
+      ⚠️ **Blocked-ish — read first.** Two live defects sit directly under this:
+
+      1. **Version groups with two elected primaries.** Sampled on prod
+         2026-08-11: 10 of 15 groups had two members both marked
+         `is_primary_version=true`, so the "merged" book lists twice
+         permanently. Suspected writers: `internal/merge/service.go:196-206`
+         (reuses an existing group ID but only writes the flag on the books
+         passed in, never demoting pre-existing members) and
+         `internal/reconcile/reconcile.go:770-795`. Building combine-before-apply
+         on top of a merge that can leave two primaries will produce more of
+         them, faster. **Not verified** as the causal path for those rows.
+      2. Applying metadata from the review screen did not reach the files at
+         all until the fix on branch `fix/review-apply-writes-tags` — see the
+         separate entry.
+
+      Documentation check done 2026-08-11: the universal review queue
+      (`docs/plans/2026-07-13-review-queue-and-regroup.md`, shipped July,
+      `review_apply_enabled` defaults OFF) is **regroup-only**. It does not
+      cover user-initiated combine, dedup review, or metadata review. The bulk
+      metadata review plan
+      (`docs/archive/superpowers/plans/2026-04-06-bulk-metadata-review.md`) and
+      the dedup label review panel
+      (`docs/archive/agent-tasks/dedup-ui/TASK-04-label-review-panel.md`) were
+      both archived without shipping. The owner's instinct that these want one
+      home is right; that home does not exist yet.

--- a/todo.d/20260811-metadata-chooser-audio-preview.md
+++ b/todo.d/20260811-metadata-chooser-audio-preview.md
@@ -1,0 +1,28 @@
+- [ ] **REVIEW-PREVIEW** Play the first ~2 minutes of audio directly from the
+      metadata chooser. Requested 2026-08-11: *"I need a way to play the first 2
+      minutes of audio right from the metadata chooser."*
+
+      **Why it matters more than it sounds.** The chooser asks the owner to
+      confirm a candidate match, but everything on screen is second-hand — a
+      title string, a cover, a narrator name. The only ground truth for "is this
+      actually the right book and the right narration" is the audio itself, and
+      today confirming means leaving the UI entirely. For a library with known
+      title contamination and mis-grouped multi-part sets, a 2-minute listen is
+      the cheapest possible verification.
+
+      Notes before designing:
+
+      - A range-request audio endpoint may already exist for the player; check
+        before adding a second one. If one exists, the work is UI-only.
+      - The chooser row shows a **single file** even for a 40-part book (see
+        REVIEW-MULTIFILE-CLARITY below), so "the first 2 minutes" must mean the
+        first 2 minutes of **part 1 of the book**, not of whichever file happens
+        to be attached to the row. Getting this wrong makes the preview
+        actively misleading.
+      - Do not stream the whole file. Bound the response; an unbounded
+        request-scoped read on this server is exactly the shape that OOM-killed
+        production on 2026-08-11.
+
+      Documentation check done 2026-08-11: nothing designed. One backlog entry
+      in `docs/archive/backlog-2026-04-10.md` calls it "nice but" and it was
+      never specced. Not covered by the review-queue plan.

--- a/todo.d/20260811-version-group-two-primaries.md
+++ b/todo.d/20260811-version-group-two-primaries.md
@@ -1,0 +1,57 @@
+- [ ] **VG-DOUBLE-PRIMARY** A version group can end up with **two** members both
+      flagged `is_primary_version=true`, so a merged book shows twice in the
+      library forever. Found 2026-08-11 while investigating the owner's report
+      that combined books still list individually.
+
+      **Measured on prod, cache-busted so this is not the stale-list defect:**
+      sampled 15 non-primary books at `offset=500`; all 15 sat in genuine
+      multi-member groups **with** an elected primary — so there is no
+      orphan-group defect. But **10 of those 15 groups had two primaries out of
+      three members.** Reproduced on the plain (non-search) list path the UI
+      uses:
+
+      ```
+      ?limit=20&is_primary_version=true&filters=[{"field":"title","value":"Dungeon Tour Guide"}]&_cb=201
+      → count=4
+        01KNDBMH1SJ29JF4ZTS5NTETPF  grp=01KNDBMH1SJ29JF4ZTS6S5B1X0  primary=True  created 2026-04-04
+        01KZQQVA66GVMFNVWPA9T0V2EE  grp=01KNDBMH1SJ29JF4ZTS6S5B1X0  primary=True  created 2026-08-11
+        01KNDC7G0GCX0ZPTJDXQG8NQ3N  grp=01KNDC7G0GCX0ZPTJDXSRQFF2X  primary=True
+        01KZR8862HZJE7AWMTGQFADEHG  grp=01KNDC7G0GCX0ZPTJDXSRQFF2X  primary=True
+      ```
+
+      Two groups, four rows. The list filter is an exact index lookup on `true`
+      (`internal/database/memdb_summaries.go:133`,
+      `internal/database/memdb_reads.go:623-628`), so both members list. This is
+      **independent of the response-cache staleness bug** — it persists after a
+      cache bust and after a restart.
+
+      **Candidate writers — none verified as the causal path for these rows:**
+
+      - `internal/merge/service.go:196-206` reuses an existing group's ID but
+        writes `IsPrimaryVersion` only on the books passed **into** the call.
+        Pre-existing members of that group are never demoted. This is the
+        strongest candidate.
+      - `internal/reconcile/reconcile.go:770-795` promotes `kept` and demotes
+        only `originals`, not sibling library copies.
+      - `internal/reconcile/reconcile.go:1358-1367` mints a new group + primary.
+
+      The newer half of each observed pair is a `01KZ…` ULID minted 2026-08-11
+      at an `organize`d path, which *looks like* the organize/library-copy path
+      minting a second primary into an existing group. **Not verified** — do not
+      start from that assumption without confirming it.
+
+      **Needs both halves:**
+      1. Forward fix — enforce one primary per group. When reusing an existing
+         group ID, load every current member and demote them.
+      2. Backfill — the existing double-primary rows do not self-heal. Needs a
+         maintenance repair op. Scope unknown: 10 of 15 sampled is not a
+         library-wide rate, it is a sample of one offset window. **Measure the
+         real count before sizing the repair.**
+
+      Add an invariant test that a group can never have more than one primary,
+      and run it against the existing data as a diagnostic before writing the
+      repair.
+
+      Related but distinct: the 24h list-cache staleness
+      (branch `fix/list-cache-generation`) masks merges too, but that one is a
+      read-path bug that a restart clears. This one is real, persistent data.

--- a/todo.d/20260812-codeql-alert-backlog.md
+++ b/todo.d/20260812-codeql-alert-backlog.md
@@ -1,0 +1,80 @@
+- [ ] **SEC-CODEQL-BACKLOG** 326 open CodeQL alerts on `main`, including **2
+      critical** and **17 high**. Counted 2026-08-12 via the code-scanning API
+      across all four result pages — this is the full set, not a page-1 sample.
+
+      **Why this is filed as one entry and not 326:** 302 of the 326 are a
+      single rule, `go/log-injection` (medium), spread across ~30 files. It is
+      one pattern — user-supplied strings reaching a log call without newline
+      stripping — not 302 independent defects. Fixing it is a mechanical sweep
+      plus one helper, and it should be done as a sweep or explicitly accepted
+      as a whole, never one PR at a time.
+
+      ```
+      302  [medium]    go/log-injection
+        5  [high]      go/path-injection
+        3  [medium]    actions/missing-workflow-permissions
+        3  [high]      go/disabled-certificate-check
+        3  [high]      js/remote-property-injection
+        2  [high]      go/clear-text-logging
+        2  [critical]  go/request-forgery
+        2  [none]      js/trivial-conditional
+        1  [high]      go/weak-sensitive-data-hashing
+        1  [high]      go/uncontrolled-allocation-size
+        1  [high]      js/insecure-temporary-file
+        1  [high]      go/zipslip
+      ```
+
+      **The two critical ones are server-side request forgery** and should be
+      read first, because both sit on paths that fetch a URL chosen by remote
+      metadata rather than by the owner:
+
+      - `internal/metadata/cover.go:135` (alert #662)
+      - `internal/covers/covers.go:82` (alert #645)
+
+      Not assessed. Do not assume they are false positives — a cover URL comes
+      from a third-party provider response, which is exactly the untrusted
+      input SSRF rules are about.
+
+      **Highs worth reading before the log-injection sweep,** because they are
+      on file-mutating or archive-extracting paths where a wrong answer costs
+      data rather than log noise:
+
+      - `go/zipslip` — `internal/backup/backup.go:275` (alert #13). Archive
+        entry paths used during extraction. This is the restore path.
+      - `go/path-injection` ×5 — `internal/fileops/safe_operations.go:122` and
+        `:157` (#1477, #1478), `internal/metadata/assemble.go:272` (#1429),
+        `internal/server/handlers/filesystem.go:271` (#1105),
+        `internal/audiobooks/service_mutation.go:63` (#1104).
+      - `go/disabled-certificate-check` ×3 — two are in `tools/cmd/` one-offs
+        (`merge-split-books`, `reconcile-paths`), one is in
+        `internal/mtls/provisioning.go:142` and matters more.
+      - `go/weak-sensitive-data-hashing` — `internal/database/apikey_token.go:33`
+        (alert #1466). API-token hashing.
+
+      **Two alerts already assessed as false positives, with the reason
+      recorded so nobody re-derives it:**
+
+      1. `go/clear-text-logging` at `internal/server/server.go:360` (raised on
+         PR #2321). The flagged expression is `fmt.Sprintf("%T", s.Store())`.
+         `%T` renders only the dynamic type name and cannot render a field
+         value, so the `password` field CodeQL traced into the store struct
+         cannot reach the log record. CodeQL does not model `%T` as
+         value-suppressing. The reason is also in a comment at the line.
+      2. `go/uncontrolled-allocation-size` at
+         `internal/database/memdb_summaries.go:163`. The `make` cap is clamped
+         on **both** sides before use: `memdb_summaries.go:80` turns
+         `limit <= 0` into 1,000,000 and `:160` clamps anything above 4096 down
+         to 4096. No panic path and no unbounded allocation.
+
+      **Context that changes how to read this list:** the CodeQL PR check fails
+      on *new* alerts in changed code, so with a 302-alert pre-existing pattern
+      almost any PR that adds a log line turns the check red. That has already
+      happened twice (#2320 added 7 `go/log-injection` instances in
+      `internal/server/handlers/metadata_cache.go`; #2321 surfaced 3 more in
+      `internal/httputil/respond.go`). Until the sweep lands, a red CodeQL
+      check on a PR carries almost no signal, which is itself the problem — a
+      gate that is always red is a gate nobody reads.
+
+      **Suggested order:** (1) read the 2 criticals, (2) the zipslip and the 5
+      path-injections, (3) decide sweep-vs-accept on `go/log-injection` as a
+      single decision, (4) re-check that the PR gate means something again.


### PR DESCRIPTION
Backlog entries captured from last night's session. No code changes — `todo.d/` fragments plus one changelog fragment.

## New entries

**`SEC-CODEQL-BACKLOG`** — 326 open CodeQL alerts on main, counted across all four API result pages rather than sampled: **2 critical, 17 high**, and 302 instances of a single medium rule.

The 302 are all `go/log-injection` across ~30 files. That is one pattern, not 302 defects, so the entry says to sweep or accept it as a single decision rather than one PR at a time. Named as read-first: the two critical `go/request-forgery` sites (`internal/metadata/cover.go:135`, `internal/covers/covers.go:82` — both fetch a URL chosen by a third-party provider response), the `go/zipslip` on the **restore** path (`internal/backup/backup.go:275`), and the five `go/path-injection` alerts on file-mutating code.

It also records two alerts I assessed as false positives *with the reasoning*, so nobody re-derives them:
- `go/clear-text-logging` at `server.go:360` — the expression is `fmt.Sprintf("%T", …)`, and `%T` renders only the dynamic type name, never a field value.
- `go/uncontrolled-allocation-size` at `memdb_summaries.go:163` — the `make` cap is clamped on **both** sides (`:80` turns `limit <= 0` into 1,000,000; `:160` clamps above 4096 down).

And it states the thing that makes the rest hard to read: with a 302-alert pre-existing pattern, almost any PR adding a log line turns the CodeQL check red. That already happened twice this week. A gate that is always red is a gate nobody reads.

**`REVIEW-PREVIEW`** — play the first ~2 minutes of audio from the metadata chooser. Notes that "first 2 minutes" must mean part 1 *of the book*, not of whichever file is attached to the row, and that the response must be bounded — an unbounded request-scoped read is exactly the shape that OOM-killed production on 2026-08-11.

**`REVIEW-COMBINE-FIRST`** — combine or merge books *before* applying metadata. Both backends already exist (`POST /audiobooks/combine`, merge-as-versions); what's missing is reaching them from the chooser without losing its state. Flags that the universal review queue shipped in July is regroup-only, and the bulk-metadata-review and dedup-label-review plans were both archived without shipping.

**`VG-DOUBLE-PRIMARY`** — version groups with two members both flagged `is_primary_version=true`, so a merged book lists twice permanently. Measured on prod, cache-busted: 10 of 15 sampled groups. Explicitly marked as **not** the cache-staleness bug — it survives a cache bust and a restart. Strongest suspect named (`internal/merge/service.go:196-206` reuses a group ID but only writes the flag on books passed in, never demoting pre-existing members) and explicitly labelled unverified.

**iTunes listened/progress not propagated** and **web UI still locks up** — from the earlier session.

## Note on scope

Every claim carries what was measured and what was not. The double-primary entry says 10-of-15 is a sample of one offset window, not a library-wide rate, and that the real count must be measured before sizing a repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp
