### PR TITLE
fix(server): socket.io handshake got the React app instead of a 404

### DIFF
--- a/changelog.d/20260812_104500_socketio_404.md
+++ b/changelog.d/20260812_104500_socketio_404.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **A socket.io handshake no longer gets served the React app.** `GET /socket.io/?EIO=4&transport=polling`
+  matched no route, fell through to the SPA catch-all, and answered `200 text/html` (embedded
+  build) or `302 → /` (non-embedded). Neither is a 404, so an Audiobookshelf client's success
+  guard passed and it then tried to parse `index.html` as an Engine.IO frame — turning "we don't
+  implement real-time" into "real-time is broken." `/socket.io/` now returns 404, which lets the
+  client give up on the websocket and degrade cleanly. This is the same defect as the
+  `/auth/openid` OIDC probe fixed earlier; the prefix list was one entry short.

--- a/internal/server/spa_fallback.go
+++ b/internal/server/spa_fallback.go
@@ -1,7 +1,7 @@
 // file: internal/server/spa_fallback.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1e6d90b4-27a5-4c31-8f9e-a3b715c8d604
-// last-edited: 2026-08-01
+// last-edited: 2026-08-12
 
 package server
 
@@ -36,27 +36,50 @@ import "strings"
 // not take that at face value — it probes. So the advertisement alone is not a
 // sufficient defence; the endpoint itself has to answer honestly.
 //
+// The same failure recurred for socket.io, which is why it is listed below.
+// Absorb (the other target client) opens a real-time connection with an
+// Engine.IO polling handshake:
+//
+//	GET /socket.io/?EIO=4&transport=polling
+//
+// We do not implement socket.io. The honest answer is 404, which lets the client
+// give up on real-time and degrade to polling. Instead the catch-all returned
+// `200 text/html` (embedded build) or `302 → /` (non-embedded) — so the client's
+// 200-guard passed and it then tried to parse the React index page as an
+// Engine.IO frame. A 200 with an HTML body is worse than an error here: it
+// converts "feature absent" into "feature broken."
+//
 // Keep this list to prefixes that are unambiguously server-side. Anything a
 // human might type or bookmark belongs in the SPA.
 var nonSPAPrefixes = []string{
-	"/api",   // the JSON API, including the ABS-compatible surface
-	"/auth/", // login/OAuth/OIDC machinery; registered routes match before NoRoute
+	"/api",        // the JSON API, including the ABS-compatible surface
+	"/auth/",      // login/OAuth/OIDC machinery; registered routes match before NoRoute
+	"/socket.io/", // Engine.IO transport probe; unimplemented, must not look implemented
 }
+
+// nonSPAExact are server-side paths whose prefix form above deliberately
+// requires a trailing slash, so the bare path needs its own exact match. The
+// slash requirement keeps a future SPA route like /authors from being captured
+// by "/auth/".
+var nonSPAExact = []string{"/auth", "/socket.io"}
 
 // isNonSPAPath reports whether an unmatched path must 404 rather than render the
 // SPA shell.
 //
 // Only UNMATCHED paths reach here — this runs from NoRoute, so real routes such
 // as /auth/temp-login are dispatched by gin long before it, and adding a prefix
-// here cannot shadow a registered handler.
+// here cannot shadow a registered handler. Both the embedded and non-embedded
+// static handlers consult this before they diverge, so one entry fixes both.
 func isNonSPAPath(path string) bool {
 	for _, prefix := range nonSPAPrefixes {
 		if strings.HasPrefix(path, prefix) {
 			return true
 		}
 	}
-	// Exact "/auth" with no trailing slash is still server-side; the prefix form
-	// above deliberately requires the slash so a future SPA route like
-	// /authors is not captured by accident.
-	return path == "/auth"
+	for _, exact := range nonSPAExact {
+		if path == exact {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/server/spa_fallback_test.go
+++ b/internal/server/spa_fallback_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/spa_fallback_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9a4c7e01-3f28-4b95-86d0-c1e57b2f0348
-// last-edited: 2026-08-01
+// last-edited: 2026-08-12
 
 package server
 
@@ -29,6 +29,14 @@ func TestIsNonSPAPath(t *testing.T) {
 		"/api",
 		"/api/v1/nope",
 		"/api/me/sessions/xyz",
+		// THE SECOND REGRESSION, same shape as the first. Absorb opens a
+		// real-time connection with an Engine.IO polling handshake; the SPA
+		// shell answered 200, so its 200-guard passed and it then tried to
+		// parse index.html as an Engine.IO frame.
+		"/socket.io/",
+		"/socket.io/?EIO=4&transport=polling",
+		"/socket.io/?EIO=4&transport=websocket&sid=abc",
+		"/socket.io",
 	}
 	for _, p := range mustNotBeSPA {
 		require.True(t, isNonSPAPath(p), "%q is server-side and must 404, not render the SPA", p)
@@ -46,6 +54,9 @@ func TestIsNonSPAPath(t *testing.T) {
 		"/authentication-settings",
 		"/index.html",
 		"/assets/index-abc123.js",
+		// Same slash discipline as /authors: "/socket.io/" must not swallow a
+		// path that merely starts with those characters.
+		"/socket.iodine",
 	}
 	for _, p := range mustBeSPA {
 		require.False(t, isNonSPAPath(p), "%q is a client route and must still render the SPA", p)
@@ -86,6 +97,38 @@ func TestUnimplementedAuthEndpointIs404(t *testing.T) {
 			server.router.ServeHTTP(w, httptest.NewRequest(method, path, nil))
 			require.Equal(t, http.StatusNotFound, w.Code,
 				"%s %s must 404 so a client's capability probe fails honestly", method, path)
+			require.NotContains(t, w.Body.String(), "<!doctype html",
+				"%s %s must not return the SPA shell", method, path)
+		}
+	}
+}
+
+// A socket.io handshake must fail honestly. We do not implement socket.io, and
+// "not implemented" has to be distinguishable from "implemented and broken".
+//
+// The two build variants fail differently without the fix — the embedded build
+// answers 200 text/html, the non-embedded one 302 → /. Asserting 404 pins both,
+// and asserting NOT-2xx-or-3xx states the property the client actually depends
+// on rather than the specific status of whichever variant these tests run under.
+func TestSocketIOHandshakeIs404(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	for _, path := range []string{
+		"/socket.io/?EIO=4&transport=polling",
+		"/socket.io/?EIO=4&transport=polling&t=OaBcDeF",
+		"/socket.io/",
+		"/socket.io",
+	} {
+		for _, method := range []string{http.MethodGet, http.MethodHead} {
+			w := httptest.NewRecorder()
+			server.router.ServeHTTP(w, httptest.NewRequest(method, path, nil))
+
+			require.Equal(t, http.StatusNotFound, w.Code,
+				"%s %s must 404 so the client can give up on real-time and degrade", method, path)
+			require.GreaterOrEqual(t, w.Code, 400,
+				"%s %s must not answer 2xx/3xx: the client's success guard would pass and it "+
+					"would parse the body as an Engine.IO frame", method, path)
 			require.NotContains(t, w.Body.String(), "<!doctype html",
 				"%s %s must not return the SPA shell", method, path)
 		}


### PR DESCRIPTION
Closes **N-1**, the top finding of [the ABS coverage audit](https://github.com/falkcorp/audiobook-organizer/blob/main/docs/audits/2026-08-11-abs-coverage-gap-audit.md).

## The bug

`GET /socket.io/?EIO=4&transport=polling` matched no route, fell through `NoRoute`, failed `isNonSPAPath`, failed the static-file lookup, and hit the SPA catch-all:

| build | answered |
|---|---|
| `embed_frontend` | `200 text/html` + `index.html` |
| non-embedded | `302 → /` |

**Neither is a 404**, and that is the whole problem. This is worse than returning an error: an Audiobookshelf client's success guard *passes* on the 200, and it then tries to parse the React index page as an Engine.IO frame. It converts "we don't implement real-time" into "real-time is broken." Absorb needs this endpoint; AudioBooth never connects.

It is the same defect as the `/auth/openid` OIDC probe fixed earlier — and the comment already sitting above `nonSPAPrefixes` was written to prevent exactly this:

> *"…the advertisement alone is not a sufficient defence; the endpoint itself has to answer honestly."*

The list was one entry short.

## The fix

- `"/socket.io/"` added to `nonSPAPrefixes`.
- The bare-path check generalized from `return path == "/auth"` into a `nonSPAExact` list, rather than growing a chain of `==` comparisons.

**One entry fixes both build variants.** They answer unmatched paths differently, but both call `isNonSPAPath` as the *first statement* of their `NoRoute` handler, before they diverge (`static_embed.go:45`, `static_nonembed.go:107`).

## Tests — verified by removal

Adding a test that passes proves nothing until you've watched it fail. With the fix backed out:

```
--- FAIL: TestIsNonSPAPath
    "/socket.io/" is server-side and must 404, not render the SPA
--- FAIL: TestSocketIOHandshakeIs404
    GET /socket.io/?EIO=4&transport=polling must 404 so the client can give up on real-time and degrade
```

With it restored: `ok github.com/falkcorp/audiobook-organizer/internal/server`.

The new `TestSocketIOHandshakeIs404` asserts 404 *and* `>= 400` — the second is the property the client actually depends on, stated independently of whichever build variant the suite runs under. `/socket.iodine` is pinned as still-SPA, mirroring the existing `/authors` slash-discipline case.

## Not in scope

N-2 … N-12 from the audit remain open and are deliberately untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t