### PR TITLE
fix(search): filter the whole match set, not one already-cut page [skip changelog]

### DIFF
--- a/changelog.d/20260812_fix_search_postfilter_pagination.md
+++ b/changelog.d/20260812_fix_search_postfilter_pagination.md
@@ -1,0 +1,29 @@
+### Fixed
+
+#### Search past page 1 returned nothing, and the result count was the page length
+
+Searching with any filter active returned rows on page 1 and an empty page for every
+page after it. The library UI always sends `is_primary_version=true`, so this was every
+user-facing search, not an edge case.
+
+Bleve was asked for one page of `limit` rows, the `is_primary_version` /
+`exclude_quarantined` / tag post-filters then deleted most of that already-cut page with
+nothing left to refill it, and `paginateFilteredBooks` re-sliced the remainder by the
+ORIGINAL offset — out of range for a `<=limit` slice, so it returned zero rows. Measured
+on production before the fix, `search=honour&is_primary_version=true&limit=5` gave
+1 / 0 / 0 / 0 rows at offsets 0 / 5 / 10 / 20, while the identical query with no filter
+paged correctly at 5 / 5 / 5.
+
+The search branch now over-fetches a window of matches when post-filters will run,
+filters the whole set, and paginates last. A guard for the same defect already existed
+one branch away (`didPushdown`), which is where the shape of the fix came from.
+
+Separately, the reported `count` was `len(page)` rather than the number of matches, so it
+tracked the requested limit: the same query reported `count=5` at `limit=5`, `count=3` at
+`limit=3` and `count=21` at `limit=250`. A caller could never learn how many matches
+existed, so "page 2 of N" was fiction. `GetAudiobooksWithTotal` now returns a real match
+total (Bleve's own hit count when it paginates, or the filtered-set size when post-filters
+run), and `-1` when no true total is available so the caller keeps its previous behaviour.
+
+Not claimed: the over-fetch window is 10,000 matches. Beyond that the count is an
+explicitly-logged lower bound rather than exact, and the warning names the query.

--- a/internal/audiobooks/service_query.go
+++ b/internal/audiobooks/service_query.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_query.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: c5f9d4e3-f6a7-8b90-ac1d-2e3f4a5b6c7d
-// last-edited: 2026-07-18
+// last-edited: 2026-08-12
 
 package audiobooks
 
@@ -21,8 +21,26 @@ import (
 // GetAudiobooks retrieves audiobooks with optional filtering.
 // Supports search, author_id, series_id, is_primary_version, and library_state filters.
 func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offset int, search string, authorID *int, seriesID *int, filters ...ListFilters) ([]database.Book, error) {
+	books, _, err := svc.GetAudiobooksWithTotal(ctx, limit, offset, search, authorID, seriesID, filters...)
+	return books, err
+}
+
+// GetAudiobooksWithTotal is GetAudiobooks plus the number of MATCHES for the
+// request, which is not the same thing as the length of the page returned.
+//
+// The int is -1 when this layer cannot establish a true total (the generic
+// unfiltered list path, where the caller already has cheaper dedicated count
+// queries, and the non-Bleve substring fallback which exposes no count).
+// Callers must treat -1 as "unknown" and fall back to their previous
+// behaviour rather than rendering it.
+//
+// A caveat worth stating rather than burying: when a search is combined with
+// post-filters, the total is exact only while the match set fits inside
+// searchPostFilterWindow. Past that it is a lower bound and a warning is
+// logged. It is not silently capped.
+func (svc *AudiobookService) GetAudiobooksWithTotal(ctx context.Context, limit int, offset int, search string, authorID *int, seriesID *int, filters ...ListFilters) ([]database.Book, int, error) {
 	if svc.store == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, 0, fmt.Errorf("database not initialized")
 	}
 
 	// Normalize limit and offset
@@ -76,10 +94,49 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 	// page isn't needlessly re-sorted.
 	alreadySortedAndPaginated := false
 
+	// resultTotal is the number of MATCHES for this request, as distinct from
+	// the length of the page returned. It stays -1 until a branch below can
+	// establish it; -1 means "not known here", and the caller substitutes the
+	// page length exactly as it always did.
+	resultTotal := -1
+
 	// Apply filters in order of precedence
 	if search != "" {
 		if svc.searchIndex != nil {
-			books, err = svc.searchWithBleve(search, limit, offset, f.UserID)
+			// When post-filters will run below, the index must hand back the
+			// whole candidate set, NOT one page.
+			//
+			// Fetching a single page here and then post-filtering it produced
+			// two compounding faults, both measured against production on
+			// 2026-08-12 with search=honour&is_primary_version=true&limit=5:
+			// offset=0 returned 1 row instead of a full page, because the
+			// filter deleted most of an already-cut page and nothing refilled
+			// it; and offset=5/10/20 each returned 0 rows, because
+			// paginateFilteredBooks then re-sliced that short page by the
+			// ORIGINAL offset, which is out of range for a <=limit slice.
+			// The same query without the filter paged correctly (5/5/5), which
+			// is what made this look like a search-quality problem rather than
+			// a pagination one.
+			//
+			// The non-search pushdown path already guards the identical hazard
+			// by clearing hasPostFilters once the store has filtered AND
+			// paginated (see the didPushdown branch below, and its comment
+			// naming the same "page 2 returns zero rows" symptom). The search
+			// path never got that guard. Over-fetching is the equivalent fix
+			// for a path that cannot push the filter down: filter the full set
+			// first, then let the existing post-filter block paginate it.
+			fetchLimit, fetchOffset := limit, offset
+			if hasPostFilters {
+				fetchLimit, fetchOffset = searchPostFilterWindow, 0
+			}
+			books, resultTotal, err = svc.searchWithBleve(search, fetchLimit, fetchOffset, f.UserID)
+			if hasPostFilters && len(books) >= searchPostFilterWindow {
+				// Truncated: rows past the window were never considered, so any
+				// count derived below is a lower bound. Say so rather than
+				// reporting a confident wrong number.
+				slog.Warn("search: post-filter over-fetch window exhausted; count is a lower bound",
+					"window", searchPostFilterWindow, "query", search)
+			}
 		} else {
 			books, err = svc.store.SearchBooks(search, limit, offset)
 		}
@@ -127,7 +184,7 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 			cacheKey := fmt.Sprintf("all:%d:%d:p=%s:sb=%s:asc=%v:noq=%v",
 				limit, offset, primaryKey, f.SortBy, sortAsc, f.ExcludeQuarantined)
 			if cached, ok := svc.listCache.Get(cacheKey); ok {
-				return cached, nil
+				return cached, -1, nil
 			}
 			summaries, didPushdown, sErr := svc.summariesPushdown(storeLimit, storeOffset, f.IsPrimaryVersion, f.SortBy, sortAsc, f.ExcludeQuarantined)
 			if sErr == nil && summaries != nil {
@@ -225,7 +282,7 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	// Apply post-filters
@@ -243,7 +300,7 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 				}
 				ids, tagErr := svc.store.GetBooksByTag(tag)
 				if tagErr != nil {
-					return nil, tagErr
+					return nil, 0, tagErr
 				}
 				curSet := make(map[string]struct{}, len(ids))
 				for _, id := range ids {
@@ -370,6 +427,15 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 			filtered = perUserFiltered
 		}
 
+		// The post-filtered set is the real match set for this request, so its
+		// length is the real total — but only if `filtered` was built from the
+		// full candidate set rather than from one page. That holds for the
+		// search path because the branch above over-fetches when
+		// hasPostFilters, and for the author/series paths because those fetch
+		// every row up front. Capture it BEFORE paginating; taking it after is
+		// the bug.
+		resultTotal = len(filtered)
+
 		// Apply pagination after filtering
 		books = paginateFilteredBooks(filtered, limit, offset)
 	}
@@ -387,7 +453,7 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 		books = []database.Book{}
 	}
 
-	return books, nil
+	return books, resultTotal, nil
 }
 
 // CountAudiobooksFiltered returns the count of audiobooks matching the
@@ -585,23 +651,34 @@ const searchPostFilterWindow = 10000
 //
 // Falls back to an empty slice (not nil) on zero matches so callers
 // get consistent JSON shape.
-func (svc *AudiobookService) searchWithBleve(query string, limit, offset int, userID string) ([]database.Book, error) {
+// The int return is the number of MATCHES, not the length of the returned
+// page. Bleve computes it on every query and hands it back as the second
+// value of SearchNative; this function used to discard it with `_`, and the
+// caller then substituted len(page) — which is always a plausible-looking
+// number, which is why it survived so long. See searchTotalIsExact for when
+// the figure is exact and when it is a lower bound.
+func (svc *AudiobookService) searchWithBleve(query string, limit, offset int, userID string) ([]database.Book, int, error) {
 	ast, err := search.ParseQuery(query)
 	if err != nil {
 		// Parser failure: fall back to the substring search path so
 		// users still see results for simple queries the DSL parser
 		// rejects (e.g. punctuation-heavy book titles).
-		return svc.store.SearchBooks(query, limit, offset)
+		books, sErr := svc.store.SearchBooks(query, limit, offset)
+		// SearchBooks exposes no match count, so the only honest figure
+		// available here is the page length. Callers must not treat this as
+		// a true total; it is the pre-existing behaviour for this fallback.
+		return books, len(books), sErr
 	}
 	bleveQ, perUser, err := search.Translate(ast)
 	if err != nil {
-		return svc.store.SearchBooks(query, limit, offset)
+		books, sErr := svc.store.SearchBooks(query, limit, offset)
+		return books, len(books), sErr
 	}
 
 	if len(perUser) > 0 && userID != "" && !config.AppConfig.DisablePerUserSearchFilters {
 		hits, _, err := svc.searchIndex.SearchNative(bleveQ, 0, searchPostFilterWindow)
 		if err != nil {
-			return nil, fmt.Errorf("bleve search: %w", err)
+			return nil, 0, fmt.Errorf("bleve search: %w", err)
 		}
 		if len(hits) >= searchPostFilterWindow {
 			slog.Warn("search: post-filter window exhausted; results beyond it are truncated",
@@ -635,6 +712,9 @@ func (svc *AudiobookService) searchWithBleve(query string, limit, offset int, us
 			}
 			filtered = append(filtered, b)
 		}
+		// Capture the match count BEFORE the slice below cuts it to a page.
+		// Taking it afterwards is exactly the bug this change fixes.
+		perUserTotal := len(filtered)
 		// Apply pagination after filtering — offset beyond len yields an
 		// empty slice, not an error (mirrors GetAudiobooks' heavy
 		// post-filter slicing above).
@@ -649,7 +729,12 @@ func (svc *AudiobookService) searchWithBleve(query string, limit, offset int, us
 		if filtered == nil {
 			filtered = []database.Book{}
 		}
-		return filtered, nil
+		// perUserTotal is counted BEFORE the offset/limit slice above, so it is
+		// the number of matches, not the page length. It is exact unless the
+		// over-fetch window was exhausted (warned about above), in which case
+		// it is a lower bound — Bleve's own total cannot be used here because
+		// the per-user predicate is evaluated in Go, outside the index.
+		return filtered, perUserTotal, nil
 	}
 
 	if len(perUser) > 0 {
@@ -661,9 +746,12 @@ func (svc *AudiobookService) searchWithBleve(query string, limit, offset int, us
 			"filters", len(perUser), "reason", reason)
 	}
 
-	hits, _, err := svc.searchIndex.SearchNative(bleveQ, offset, limit)
+	// bleveTotal is the match count for the whole query, independent of the
+	// offset/limit page requested. This value was previously discarded with
+	// `_`, and the HTTP layer reported len(page) in its place.
+	hits, bleveTotal, err := svc.searchIndex.SearchNative(bleveQ, offset, limit)
 	if err != nil {
-		return nil, fmt.Errorf("bleve search: %w", err)
+		return nil, 0, fmt.Errorf("bleve search: %w", err)
 	}
 	ids := make([]string, 0, len(hits))
 	for _, h := range hits {
@@ -682,5 +770,5 @@ func (svc *AudiobookService) searchWithBleve(query string, limit, offset int, us
 	if books == nil {
 		books = []database.Book{}
 	}
-	return books, nil
+	return books, int(bleveTotal), nil
 }

--- a/internal/audiobooks/service_query_search_pagination_test.go
+++ b/internal/audiobooks/service_query_search_pagination_test.go
@@ -1,0 +1,152 @@
+// file: internal/audiobooks/service_query_search_pagination_test.go
+// version: 1.0.0
+// guid: 8b1c4f27-9d3e-4a60-b5c8-1e70a2f43d96
+// last-edited: 2026-08-12
+
+// Regression tests for search + post-filter pagination.
+//
+// Measured on production 2026-08-12, before the fix, with
+// search=honour&is_primary_version=true&limit=5:
+//
+//	offset=0  -> 1 row
+//	offset=5  -> 0 rows
+//	offset=10 -> 0 rows
+//	offset=20 -> 0 rows
+//
+// while the identical query with no filter paged correctly (5/5/5). Bleve
+// returned one page, the post-filter block deleted most of that already-cut
+// page with nothing to refill it, and paginateFilteredBooks then re-sliced the
+// remainder by the ORIGINAL offset — out of range for a <=limit slice, so
+// every page after the first was empty. The library UI always sends
+// is_primary_version=true, so every user-facing search took this path.
+//
+// These tests pin both halves: page 2 must be full, and the reported count
+// must be the number of MATCHES rather than the length of the page.
+
+package audiobooks
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/database/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// paginationTestBookIDs returns n stable IDs, zero-padded so Bleve's ordering
+// and the assertions below stay legible when a case fails.
+func paginationTestBookIDs(n int) []string {
+	ids := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		ids = append(ids, fmt.Sprintf("bk%02d", i))
+	}
+	return ids
+}
+
+// newPaginationTestService wires a throwaway Bleve index over n books that all
+// match author:sanderson, with every book flagged primary so the
+// is_primary_version post-filter keeps the whole set. That isolates the
+// pagination arithmetic: any row missing from a page is the slicing bug, not
+// the predicate.
+func newPaginationTestService(t *testing.T, n int) *AudiobookService {
+	t.Helper()
+	ids := paginationTestBookIDs(n)
+	idx := buildSearchTestIndex(t, ids...)
+
+	mockStore := mocks.NewMockStore(t)
+	mockStore.EXPECT().GetBooksByIDs(mock.Anything).RunAndReturn(func(reqIDs []string) ([]database.Book, error) {
+		primary := true
+		books := make([]database.Book, 0, len(reqIDs))
+		for _, id := range reqIDs {
+			books = append(books, database.Book{ID: id, IsPrimaryVersion: &primary})
+		}
+		return books, nil
+	}).Maybe()
+
+	svc := NewAudiobookService(mockStore)
+	svc.SetSearchIndex(idx)
+	return svc
+}
+
+// TestSearchWithPostFilterReturnsFullSecondPage is the core regression. Before
+// the fix this returned zero rows for every offset > 0.
+func TestSearchWithPostFilterReturnsFullSecondPage(t *testing.T) {
+	const total, limit = 12, 5
+	svc := newPaginationTestService(t, total)
+	primary := true
+
+	cases := []struct {
+		name       string
+		offset     int
+		wantOnPage int
+	}{
+		{"page 1", 0, limit},
+		{"page 2", limit, limit},                       // returned 0 before the fix
+		{"page 3 partial", 2 * limit, total - 2*limit}, // 2 rows
+		{"past the end", 3 * limit, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, gotTotal, err := svc.GetAudiobooksWithTotal(
+				context.Background(), limit, tc.offset, "author:sanderson", nil, nil,
+				ListFilters{IsPrimaryVersion: &primary},
+			)
+			assert.NoError(t, err)
+			assert.Len(t, got, tc.wantOnPage,
+				"offset=%d should yield %d rows; a short or empty page here is the "+
+					"post-filter-after-pagination bug", tc.offset, tc.wantOnPage)
+			assert.Equal(t, total, gotTotal,
+				"count must be the number of MATCHES (%d), not the length of the page", total)
+		})
+	}
+}
+
+// TestSearchCountDoesNotTrackLimit pins the second half of the defect: the
+// reported count moved with the requested limit, because len(page) was being
+// substituted for a real total. A caller could therefore never learn how many
+// matches existed.
+func TestSearchCountDoesNotTrackLimit(t *testing.T) {
+	const total = 12
+	svc := newPaginationTestService(t, total)
+	primary := true
+
+	for _, limit := range []int{1, 3, 5, 50} {
+		t.Run(fmt.Sprintf("limit=%d", limit), func(t *testing.T) {
+			got, gotTotal, err := svc.GetAudiobooksWithTotal(
+				context.Background(), limit, 0, "author:sanderson", nil, nil,
+				ListFilters{IsPrimaryVersion: &primary},
+			)
+			assert.NoError(t, err)
+			assert.Equal(t, total, gotTotal,
+				"count tracked the limit instead of reporting the match total")
+
+			wantPage := limit
+			if wantPage > total {
+				wantPage = total
+			}
+			assert.Len(t, got, wantPage, "page length should still honour limit")
+		})
+	}
+}
+
+// TestSearchWithoutPostFilterStillPages is the positive control. This path was
+// already correct before the fix — Bleve paginated it directly — so it must
+// stay correct. If this breaks, the over-fetch was applied where it should not
+// have been.
+func TestSearchWithoutPostFilterStillPages(t *testing.T) {
+	const total, limit = 12, 5
+	svc := newPaginationTestService(t, total)
+
+	for _, offset := range []int{0, limit} {
+		got, gotTotal, err := svc.GetAudiobooksWithTotal(
+			context.Background(), limit, offset, "author:sanderson", nil, nil, ListFilters{},
+		)
+		assert.NoError(t, err)
+		assert.Len(t, got, limit, "unfiltered search paged correctly before the fix and must still")
+		assert.Equal(t, total, gotTotal, "Bleve's own total should be reported verbatim")
+	}
+}

--- a/internal/server/audiobooks_helpers.go
+++ b/internal/server/audiobooks_helpers.go
@@ -1,7 +1,7 @@
 // file: internal/server/audiobooks_helpers.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 439aa827-edea-481d-8918-ddacd2c140b7
-// last-edited: 2026-07-11
+// last-edited: 2026-08-12
 
 // Server-package helpers relocated out of audiobooks_handlers.go when the
 // audiobooks HTTP handlers were extracted into the handlers/audiobooks
@@ -58,7 +58,7 @@ func (s *Server) buildAudiobookListResponse(ctx context.Context, limit, offset i
 		filters.ExcludeQuarantined = true
 	}
 
-	books, err := s.audiobookService.GetAudiobooks(ctx, limit, offset, search, authorID, seriesID, filters)
+	books, matchTotal, err := s.audiobookService.GetAudiobooksWithTotal(ctx, limit, offset, search, authorID, seriesID, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,23 @@ func (s *Server) buildAudiobookListResponse(ctx context.Context, limit, offset i
 		enriched[i].LastFingerprintedAt = lastFp
 	}
 
+	// len(enriched) is the PAGE length. It is only ever the right answer when
+	// the page happens to hold every match, which is why reporting it looked
+	// correct in casual testing and was wrong the moment a limit bit.
+	//
+	// Measured on production 2026-08-12 before this change: search=honour
+	// reported count=5 at limit=5, count=3 at limit=3 and count=21 at
+	// limit=250. The count tracked the limit, so the UI could never show how
+	// many matches existed and any "page 2 of N" was fiction.
 	totalCount := len(enriched)
+
+	// The service returns -1 when it cannot establish a true total; anything
+	// >= 0 is a real match count (exact, or an explicitly-warned lower bound
+	// when a post-filter over-fetch window was exhausted). Prefer it.
+	if matchTotal >= 0 {
+		totalCount = matchTotal
+	}
+
 	hasFilters := filters.IsPrimaryVersion != nil || filters.ExcludeQuarantined || filters.LibraryState != "" || filters.Tag != "" || len(filters.Tags) > 0
 	if search == "" && authorID == nil && seriesID == nil {
 		if hasFilters {


### PR DESCRIPTION
## What was wrong

Search with **any** filter active returned rows on page 1 and an **empty page for every page after it**. The library UI always sends `is_primary_version=true`, so this was every user-facing search — not an edge case.

Two defects, same code path:

**1. Post-filter after pagination.** Bleve was asked for one page of `limit` rows. The `is_primary_version` / `exclude_quarantined` / tag post-filters then deleted most of that already-cut page, with nothing left to refill it. `paginateFilteredBooks` then re-sliced the remainder by the **original offset** — out of range for a `<=limit` slice, so it returned zero rows.

**2. The count was the page length.** `len(enriched)` was reported as `count`, so the count tracked the requested limit and a caller could never learn how many matches existed. "Page 2 of N" was fiction.

## Measured on production, 2026-08-12, before the fix

`search=honour&is_primary_version=true&limit=5`:

| offset | rows returned |
|---|---|
| 0 | 1 |
| 5 | **0** |
| 10 | **0** |
| 20 | **0** |

The identical query with **no filter** paged correctly: 5 / 5 / 5.

Count tracking the limit, same query: `count=5` at `limit=5`, `count=3` at `limit=3`, `count=21` at `limit=250`.

## The fix

The search branch now over-fetches a window of matches when post-filters will run, filters the **whole set**, and paginates **last**. `GetAudiobooks` becomes a thin wrapper over a new `GetAudiobooksWithTotal`, which returns a real match total — Bleve's own hit count when Bleve paginates, or the filtered-set size when post-filters run — and `-1` when no true total is available, so callers keep their previous behaviour.

A guard for this exact defect **already existed one branch away**: `if didPushdown { hasPostFilters = false }`, whose comment describes the same out-of-bounds re-slice. That asymmetric sibling is where the shape of the fix came from.

## Negative control

Generated from the committed artifact, not a paraphrase. Removing **only** the over-fetch reproduced the production symptom in the test:

```
offset=5 should yield 5 rows, but has 0
```

while `TestSearchWithoutPostFilterStillPages` — the unfiltered positive control, a path that was already correct — stayed **green**. Restoring the fix: exit 0, clean tree. The control discriminates: it fails on the broken path and only the broken path.

## Not claimed

- The over-fetch window is **10,000 matches**. Beyond that the count is an explicitly-logged lower bound, not exact, and the warning names the query.
- This does **not** address search *precision* (the neutral-weight unfielded `_all` child making multi-word queries behave close to an OR). That is a separate, still-open defect.

## Tests

3 new tests, 9 subtests, in `internal/audiobooks/service_query_search_pagination_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp
