### PR TITLE
docs(dedup): the prod drain DID run — TODO.md was the stale one

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4985,10 +4985,18 @@ Companion docs:
 
 ## Dedup (10)
 
-1. **CONS-10 / INIT-2 T6 — prod drain/triage of the exact-candidate backlog** (H1:983;
-   [plan](docs/plans/2026-07-10-dedup-pipeline-hardening.md)) — code merged, run NOT
-   executed; operator-gated; validate on the dedup sandbox first (private runbook in
-   falkcorp/infra-docs). Real backlog ~15,269 pending.
+1. ~~**CONS-10 / INIT-2 T6 — prod drain/triage of the exact-candidate backlog**~~ — ✅ **RAN ON
+   PROD 2026-07-18**, verified 2026-08-12 from the prod journal, not from a status doc:
+   `dedup triage: complete scanned=10319 purgeable=7891 keep=278 review=2150 apply=true
+   dismissed=7891 dismiss_errors=0`, `outcome=completed duration_ms=3860`
+   (op `01KXV22ZJ6QWWZ1SF1FZGXBC82`, 12:48:54–12:48:58 EDT). This entry previously read
+   "code merged, run NOT executed" and was **wrong** — see
+   [`docs/dedup/STATUS.md`](docs/dedup/STATUS.md).
+   **Open follow-up instead:** the backlog has re-accumulated. Post-run exact-pending was
+   **1,311**; measured **5,947** on 2026-08-12 (dismissed 8,258). The drain worked; whatever
+   produces the junk candidates was never stopped, so this needs a *source* fix, not another
+   drain. Filed as a `todo.d` fragment rather than added here directly (new tasks are
+   add-only via fragments).
 2. **PH-2 — run `maintenance.dedup-exact-triage` on prod + review populations; PH-2b
    per-population purge wave** (H1:916) — never blanket-purge; four residual
    populations (see `docs/dedup/STATUS.md`). **Apply path now exists** (T03-BUILD):
@@ -5301,14 +5309,23 @@ H1/H2/H3/H4/H8/H9/M1/M2/M3/M7 logging batch (T05) (#2010).
 ### Remaining — execution state (briefs)
 
 - [x] **T01** — organizer data-loss fixes landed (#1986)
-- [x] **T02** — sandbox triage measured: purgeable **7,878** (title_leak) / genuine 278 /
-      fragment 392 / unknown 1,756 of 10,304 (was purgeable=1, unknown=9,950 pre-work —
+- [x] **T02** — **sandbox** triage measured: purgeable **7,878** (title_leak) / genuine 278 /
+      fragment 392 / unknown 1,756 **of 10,304** (was purgeable=1, unknown=9,950 pre-work —
       the title-repair → breakdown-backfill → relaxed-triage chain is proven). Formal
       doc recording folded into T13.
-- [ ] **T03** — sandbox purge wave: `maintenance.dedup-exact-triage {"apply":true}` (dismiss
+      > ⚠️ **7,878 is the SANDBOX number. Prod's is 7,891 of 10,319.** These are two
+      > populations, not a drift — the sandbox replica had 15 fewer candidates. A 2026-08-11
+      > docs audit mistakenly reported them as a contradiction; they are both correct.
+- [ ] **T03** — **sandbox** purge wave: `maintenance.dedup-exact-triage {"apply":true}` (dismiss
       ~7,878 purgeable, op merged in #2008) → purge-stale → full-scan → measure vs 9,074
-      baseline. Needs sandbox redeploy with current main first. NOT yet run.
-- [ ] **T04** — prod deploy (nothing deployed since 2026-07-17) + prod dry-runs + ⚠️ HUMAN-GATED apply
+      baseline. Needs sandbox redeploy with current main first. NOT yet run **on the sandbox**
+      — note prod (T04) went ahead and ran, so this is now a validation-parity gap, not a
+      blocker.
+- [x] **T04** — ✅ **prod deploy + dry-run + apply ALL DONE 2026-07-18.** Verified 2026-08-12
+      from the prod journal: deploy `v0.217.8-rc.80-2-g0b474707`, then
+      `maintenance.dedup-exact-triage` with `apply=true` → `dismissed=7891 dismiss_errors=0`,
+      `outcome=completed`. This box previously read "nothing deployed since 2026-07-17" and
+      was **wrong**.
 - [x] **T05** — logging H/M batch: H1 H2 H3 H4 H8 H9 M1 M2 M3 M7 (#2010)
 - [x] **T06** — R-1: `op.terminal` SSE backend publisher (#2002) + dep-fail publisher (#2005)
 - [x] **T07** — R-6: AssignOrphanVGs worker pool + VG clobber guard (#2003)

--- a/changelog.d/20260812_110000_prod_drain_truthup.md
+++ b/changelog.d/20260812_110000_prod_drain_truthup.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **`TODO.md` claimed a production run that had in fact happened.** Two entries — the
+  CONS-10/INIT-2 T6 exact-backlog drain and error-correction T04 — recorded the 2026-07-18 prod
+  triage as never executed, while `docs/dedup/STATUS.md` and `docs/operations/pending-prod-actions.md`
+  recorded it as done. Settled against the production journal rather than either document:
+  the op ran with `apply=true`, `dismissed=7891`, `dismiss_errors=0`, `outcome=completed`.
+  `TODO.md` was the stale one and is corrected.
+- **A reported "purgeable count drift" was not one.** The 2026-08-11 docs audit flagged 7,878
+  vs 7,891 as an unexplained inconsistency. They are the **sandbox** (10,304 candidates) and
+  **production** (10,319) measurements of the same operation — both correct. Neither line said
+  which population it described; both now do.

--- a/docs/agent-tasks/README.md
+++ b/docs/agent-tasks/README.md
@@ -29,7 +29,7 @@ a brief is not evidence. Full per-brief evidence with `file:line` citations is i
 |---|---|---|---|
 | [`abs-sync/`](abs-sync/) | ACTIVE | **10 / 10 written** (index lists 12; TASK-11 and TASK-12 have no brief) | 9 live TODO items; TASK-12's three identity gaps are absent at HEAD |
 | [`bug-techdebt/`](bug-techdebt/) | ACTIVE | 5 / 7 | TASK-01 warn-log absent; TASK-02 `staticcheck` exits 1 (5 test-file findings, post-completion drift); TODO #33/#34 |
-| [`dedup-pipeline-hardening/`](dedup-pipeline-hardening/) | **PARTIAL — closest to archivable** | 5 / 5 code + 1 operational | one contradictory bookkeeping line: `TODO.md:4988` says the prod drain was never run, `docs/operations/pending-prod-actions.md:26` says it ran 2026-07-18 |
+| [`dedup-pipeline-hardening/`](dedup-pipeline-hardening/) | **PARTIAL — closest to archivable** | 5 / 5 code + 1 operational | ~~contradictory bookkeeping~~ **resolved 2026-08-12**: the prod drain *did* run (prod journal, `apply=true dismissed=7891`); `TODO.md` was stale and is corrected. Now blocked only on T03 (the **sandbox** purge wave, still unrun) and T13 |
 | [`error-correction-2026-07/`](error-correction-2026-07/) | ACTIVE | 10 / 13 (inline in `TASKS.md`, no `TASK-*.md` files) | T03 sandbox purge, T04 prod deploy, T13 docs truth-up — the only genuine unchecked boxes in the whole directory |
 | [`ux-small-items/`](ux-small-items/) | ACTIVE | 4 present + 1 partial + 1 N/A-by-design / 8 | TASK-05 and TASK-08 have zero implementation; TODO #5/#28/#29 |
 | [`torrent-relocation/`](torrent-relocation/) | ACTIVE — **human-gated** | 1 / 7 | TASK-02's STOP-FOR-HUMAN Deluge spike never opened, blocking T03–T07 |

--- a/docs/audits/2026-08-11-docs-inventory.md
+++ b/docs/audits/2026-08-11-docs-inventory.md
@@ -1,7 +1,7 @@
 <!-- file: docs/audits/2026-08-11-docs-inventory.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 4d1c8a72-3e6b-4f5a-9c28-7b0d1e4f6a93 -->
-<!-- last-edited: 2026-08-11 -->
+<!-- last-edited: 2026-08-12 -->
 
 # Docs inventory and consolidation — 2026-08-11
 
@@ -27,7 +27,7 @@ SHAs, so commit archaeology is unreliable here; the artifact is the evidence.
 |---|---|---|---|
 | `abs-sync` | ACTIVE | 10/10 written (index claims 12; TASK-11/12 unwritten) | 9 live TODO items; TASK-12's identity gaps absent — `grep -c RepointSync internal/dedup/book_dedup.go internal/scanner/scanner.go` → **0 and 0**, while `book_dedup.go:395 MergeBooks` hard-deletes |
 | `bug-techdebt` | ACTIVE | 5/7 | TASK-01's required warn-log absent; TASK-02's acceptance is `staticcheck` exit 0 but HEAD exits **1** (5 findings, all in `_test.go` touched *after* the brief — drift, not backlog) |
-| `dedup-pipeline-hardening` | **PARTIAL** | 5/5 code + 1 operational | one contradictory line (§1.3) |
+| `dedup-pipeline-hardening` | **PARTIAL** | 5/5 code + 1 operational | ~~one contradictory line~~ resolved 2026-08-12 (§1.3): the prod run **did** happen. Now blocked only on T03 (sandbox purge wave) + T13 |
 | `error-correction-2026-07` | ACTIVE | 10/13 inline in `TASKS.md` | T03, T04, T13 — the only genuine unchecked boxes in the directory |
 | `ux-small-items` | ACTIVE | 4 + 1 partial + 1 N/A / 8 | TASK-05, TASK-08 have zero implementation |
 | `torrent-relocation` | ACTIVE | 1/7 | TASK-02's STOP-FOR-HUMAN Deluge spike never opened |
@@ -43,19 +43,66 @@ SHAs, so commit archaeology is unreliable here; the artifact is the evidence.
 `<!-- file: -->` header), which made this both the highest-yield and lowest-risk move
 available. **Archived** to `docs/archive/superpowers/fleet-done/`.
 
-### 1.3 Two bookkeeping contradictions — NOT resolved here
+### 1.3 Two bookkeeping contradictions — ✅ RESOLVED 2026-08-12
 
-The same event is recorded both ways. Each makes the other unfalsifiable, and **only the
-owner can say which is true**:
+> **Update (2026-08-12).** Settled against production. **The status docs were right and
+> `TODO.md` was wrong.** Details and correction in §1.3.1 below. One of the two "contradictions"
+> turned out not to be one at all — see the 7,878/7,891 correction.
 
-| Says NOT done | Says done |
+The same event was recorded both ways:
+
+| Said NOT done — **wrong** | Said done — **correct** |
 |---|---|
 | `TODO.md:4988` — prod drain "code merged, run NOT executed; operator-gated" | `docs/operations/pending-prod-actions.md:26` — "**EXECUTED ON PROD 2026-07-18**", exact-pending 9,074→1,311 |
 | `TODO.md:5311` — T04 prod deploy `- [ ]`, "nothing deployed since 2026-07-17" | `docs/dedup/STATUS.md:78-86` — "EXECUTED ON PRODUCTION 2026-07-18" |
 
-Purgeable count also drifts: **7,878** (`TODO.md:5304`) vs **7,891** (`STATUS.md:68`).
-Task T13 exists specifically to reconcile this and is itself still open. Resolving it is the
-single thing standing between `dedup-pipeline-hardening` and archivability.
+#### 1.3.1 What production actually says
+
+Neither doc was treated as evidence. The production host's journal still carries the run
+(journald holds 2.2 GB there; 2026-07-18 is within retention):
+
+```
+Jul 18 12:48:54  registry: starting run  op_id=01KXV22ZJ6QWWZ1SF1FZGXBC82
+                 def_id=maintenance.dedup-exact-triage
+Jul 18 12:48:58  dedup triage: complete  scanned=10319 purgeable=7891 keep=278 review=2150
+                 lookup_errors=0 apply=true dismissed=7891 dismiss_errors=0
+Jul 18 12:48:58  operation finished  outcome=completed duration_ms=3860
+```
+
+`apply=true` and `dismissed=7891` — a real apply, not a dry-run, matching `STATUS.md` exactly.
+⇒ **`TODO.md` entries 1 and T04 were stale. Corrected.**
+
+#### 1.3.2 The "purgeable drift" was not a drift — this audit got it wrong
+
+The first version of this document reported **7,878** (`TODO.md:5304`) vs **7,891**
+(`STATUS.md:68`) as an unexplained inconsistency. It is not one:
+
+| Figure | Population | Scanned | Source |
+|---|---|---|---|
+| 7,878 | **dedup sandbox** | 10,304 | `TODO.md` T02 |
+| 7,891 | **production** | 10,319 | prod journal + `STATUS.md` |
+
+Two different datasets — the sandbox replica held 15 fewer candidates. **Both numbers are
+correct.** They were only ever comparable-looking because neither line said which population it
+described; both now do. The lesson is the audit's own: two numbers that differ are not
+automatically in conflict — establish they measure the same thing before calling it a
+contradiction.
+
+#### 1.3.3 New finding: the backlog has re-accumulated
+
+Measured on prod 2026-08-12 via `GET /api/v1/dedup/stats`:
+
+| | post-run 2026-07-18 | 2026-08-12 |
+|---|---|---|
+| exact **pending** | 1,311 | **5,947** |
+| exact dismissed | 9,242 | 8,258 |
+
+The drain did what it claimed. But pending has regrown **~4.5×** in 3.5 weeks, so whatever
+emits the junk candidates was never addressed — this needs a *source* fix, not a second drain.
+Filed as a `todo.d` fragment.
+
+⇒ `dedup-pipeline-hardening` is no longer blocked by a bookkeeping contradiction. Its remaining
+gap is T03 (the **sandbox** purge wave, still unrun) and T13.
 
 ### 1.4 Two files were corrupt at HEAD — fixed
 
@@ -173,7 +220,7 @@ and the `run-sweep.sh` limitation documented inline.
 |---|---|---|
 | **11 UNCERTAIN files** left in place | archiving on a guess is worse than leaving them | owner |
 | **`openapi.yaml` / `openapi.json` union merge** | §1.6 — a content merge that would lose 25 paths if done as a pick-a-winner | needs a session of its own |
-| **The two bookkeeping contradictions** | §1.3 — a documentation pass cannot decide whether a prod run happened | owner |
+| ~~**The two bookkeeping contradictions**~~ | ✅ **RESOLVED 2026-08-12** against the prod journal (§1.3): the run happened, `TODO.md` was stale, and the 7,878/7,891 "drift" was sandbox-vs-prod, not a conflict | — |
 | **`docs/system/**` (9) and `docs/architecture/**` (9)** | out of the classification scope, but **required** to settle the top-level-vs-`docs/system/` duplicate cluster | follow-up pass |
 | **78 remaining missing headers** | 76 of them were the fleet files (now archived, still header-less); the rest are CURRENT files that need headers written, not fixed | follow-up |
 | **`run-sweep.sh` silent no-op** | §1.5 — needs a behaviour decision, not just a doc note | owner |

--- a/todo.d/2026-08-12-dedup-backlog-reaccumulation.md
+++ b/todo.d/2026-08-12-dedup-backlog-reaccumulation.md
@@ -1,0 +1,24 @@
+## Dedup
+
+- [ ] **Exact-candidate backlog is re-accumulating — fix the source, not the symptom.** The
+      2026-07-18 prod triage drain worked exactly as designed (verified from the prod journal:
+      `apply=true dismissed=7891 dismiss_errors=0`), taking exact-pending **9,074 → 1,311**.
+      Measured again on **2026-08-12: exact-pending is 5,947** — a ~4.5× regrowth in 3.5 weeks.
+      Dismissed also fell 9,242 → 8,258, so candidates are moving between states, not just
+      being added.
+
+      A second drain would buy another few weeks and teach us nothing. The question is what
+      keeps *emitting* these candidates: the original population was 7,891 title-leak/stub junk
+      caused by two iTunes-importer bugs (see `docs/dedup/STATUS.md` and the duration-ms /
+      title-leak root-cause notes). Either those bugs still produce leaky titles, or the
+      exact-layer keying still treats a stub as a real match.
+
+      First step is measurement, not code: classify the current 5,947 with
+      `maintenance.dedup-exact-triage` **in dry-run** and compare the population mix against
+      the 2026-07-18 report (purgeable 7,891 / keep 278 / review 2,150). If the mix looks the
+      same, the source bug is live; if it has shifted toward `review`, this is normal library
+      growth and the alarm is false.
+
+      Also note `stale-drain=3,059` and `stale-fp=384` now appear as exact-layer statuses that
+      did not exist in the 2026-07-18 accounting — worth understanding before drawing
+      conclusions from the pending count alone.


### PR DESCRIPTION
Resolves the bookkeeping contradiction flagged in the [2026-08-11 docs inventory](https://github.com/falkcorp/audiobook-organizer/blob/main/docs/audits/2026-08-11-docs-inventory.md) §1.3. **Settled against production, not against either document.**

## Verdict: the status docs were right, `TODO.md` was wrong

The production journal still holds the run (op `01KXV22ZJ6QWWZ1SF1FZGXBC82`, 2026-07-18 12:48:54–12:48:58 EDT):

```
dedup triage: complete  scanned=10319 purgeable=7891 keep=278 review=2150
                        lookup_errors=0 apply=true dismissed=7891 dismiss_errors=0
operation finished      outcome=completed duration_ms=3860
```

`apply=true` — a real apply, not a dry-run, and `dismissed=7891` matches `docs/dedup/STATUS.md` exactly.

Corrected, with the evidence inline so the next reader doesn't have to re-derive it:
- `TODO.md` Dedup #1 — was *"code merged, run NOT executed"* → now ✅ with the journal line
- `TODO.md` T04 — was `- [ ]` *"nothing deployed since 2026-07-17"* → now ✅

## The "purgeable drift" was my error, not the repo's

The audit reported **7,878** vs **7,891** as an unexplained inconsistency. It isn't one:

| Figure | Population | Scanned |
|---|---|---|
| 7,878 | **dedup sandbox** | 10,304 |
| 7,891 | **production** | 10,319 |

Two datasets — the sandbox replica held 15 fewer candidates. **Both correct.** They only looked comparable because neither line said which population it described; both now do. The audit section carries the correction rather than quietly dropping it.

## New finding: the backlog is re-accumulating

| | post-run 2026-07-18 | measured 2026-08-12 |
|---|---|---|
| exact **pending** | 1,311 | **5,947** |
| exact dismissed | 9,242 | 8,258 |

The drain did exactly what it claimed. But pending regrew **~4.5× in 3.5 weeks**, so whatever emits the junk candidates was never addressed. A second drain buys a few weeks and teaches us nothing.

Filed as a `todo.d` fragment proposing **measurement first**: a dry-run reclassification compared against the 2026-07-18 population mix (purgeable 7,891 / keep 278 / review 2,150). *"The backlog grew"* on its own does not distinguish a live source bug from normal library growth — if the mix shifted toward `review`, this alarm is false.

Also noted: `stale-drain=3,059` and `stale-fp=384` are exact-layer statuses that did not exist in the 2026-07-18 accounting, so the pending count alone shouldn't be read as the whole story.

## Effect on archivability

`dedup-pipeline-hardening` is no longer blocked by bookkeeping. It is now blocked only on **T03** (the *sandbox* purge wave, still genuinely unrun) and **T13**.

## Note

The first commit attempt was correctly blocked by the repo's pre-commit hook for including an internal IP in prose. Rewritten to say "the production host" rather than bypassed with `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t