### PR TITLE
fix(agent-tasks): run-sweep.sh reported success after doing nothing

### DIFF
--- a/changelog.d/20260812_112000_run_sweep_hard_fail.md
+++ b/changelog.d/20260812_112000_run_sweep_hard_fail.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **`run-sweep.sh` no longer reports success after doing nothing.** It discovers work with
+  `find -maxdepth 1 -name 'TASK-*.md'`, but four of the ten live agent-task packages keep their
+  work in `AWAIT-APPROVAL.md`, `HOLD-STATUS.md`, or an inline `TASKS.md` instead. For those it
+  created no worktrees, emitted no prompts, and still printed "Next steps (coordinator)" — a
+  silent no-op indistinguishable from "this workstream has nothing to do." It now exits 2 with a
+  diagnostic naming what the package contains and what the gate means. `set -euo pipefail` could
+  not catch this: iterating an empty list is not a command failure.

--- a/docs/agent-tasks/README.md
+++ b/docs/agent-tasks/README.md
@@ -1,7 +1,7 @@
 <!-- file: docs/agent-tasks/README.md -->
-<!-- version: 3.0.0 -->
+<!-- version: 3.1.0 -->
 <!-- guid: 7a1e0c44-9d2b-4f08-bc31-2e5a6b7c8d90 -->
-<!-- last-edited: 2026-08-11 -->
+<!-- last-edited: 2026-08-12 -->
 
 # Agent Task Package
 
@@ -41,8 +41,13 @@ a brief is not evidence. Full per-brief evidence with `file:line` citations is i
 > ⚠️ **`run-sweep.sh` cannot drive four of these ten.** It discovers work with
 > `find -maxdepth 1 -name 'TASK-*.md'`, but `community-fingerprint-index`, `workflow-system`,
 > `responses-api-migration` and `error-correction-2026-07` contain no `TASK-*.md` files —
-> they use `AWAIT-APPROVAL.md`, `HOLD-STATUS.md`, and `TASKS.md` respectively. For those the
-> script creates no worktrees and emits no prompts: a **silent no-op**, not an error.
+> they use `AWAIT-APPROVAL.md`, `HOLD-STATUS.md`, and `TASKS.md` respectively.
+>
+> **It now says so.** As of v1.4.0 the script exits **2** with a diagnostic naming what the
+> package contains instead and what the gate means, rather than creating no worktrees and
+> printing "Next steps" as though it had worked. (Exit **1** remains "no such workstream", so
+> a typo and an unparseable package are distinguishable.) `set -e` could never have caught the
+> old behaviour: iterating an empty list is not a command failure.
 
 ## Completed workstreams (archived)
 

--- a/docs/agent-tasks/run-sweep.sh
+++ b/docs/agent-tasks/run-sweep.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # file: docs/agent-tasks/run-sweep.sh
-# version: 1.3.0
+# version: 1.4.0
 # guid: 9e0f1a2b-4c3d-4e60-af71-2b3c4d5e6f70
-# last-edited: 2026-06-28
+# last-edited: 2026-08-12
 #
 # Portable coordinator helper: for each requested TASK in a workstream, create an
 # isolated git worktree branched off a fresh origin/main and emit a ready-to-paste
@@ -45,6 +45,49 @@ if [[ $# -gt 0 ]]; then
 else
   while IFS= read -r f; do TASK_FILES+=("$f"); done \
     < <(find "$HERE/$WORKSTREAM" -maxdepth 1 -name 'TASK-*.md' | sort)
+fi
+
+# A workstream with no TASK-*.md files must be an ERROR, not a quiet success.
+#
+# Four of the ten live packages (community-fingerprint-index, workflow-system,
+# responses-api-migration, error-correction-2026-07) hold their work in
+# AWAIT-APPROVAL.md, HOLD-STATUS.md or a TASKS.md with inline tasks — not in
+# TASK-*.md files. For those, the loop below simply iterated zero times and the
+# script went on to print "Next steps (coordinator)" as though it had done its
+# job. `set -e` cannot catch this: iterating an empty list is not a failure, and
+# every individual command succeeded.
+#
+# The failure mode was therefore indistinguishable from "this workstream has
+# nothing to do" — the operator saw a clean run and no worktrees, and had no way
+# to tell whether that meant done or unparseable.
+if [[ ${#TASK_FILES[@]} -eq 0 ]]; then
+  {
+    echo "ERROR: no TASK-*.md files in workstream '$WORKSTREAM' — nothing to drive."
+    echo
+    echo "This script only understands workstreams built from TASK-*.md briefs."
+    echo "'$WORKSTREAM' contains:"
+    find "$HERE/$WORKSTREAM" -maxdepth 1 -type f -name '*.md' -exec basename {} \; |
+      sort | sed 's/^/  /'
+    echo
+    for alt in AWAIT-APPROVAL.md HOLD-STATUS.md TASKS.md; do
+      if [[ -f "$HERE/$WORKSTREAM/$alt" ]]; then
+        case "$alt" in
+          AWAIT-APPROVAL.md)
+            echo "  ⇒ $alt: this workstream is gated on a human approval that has not been"
+            echo "    given. Read it and resolve the gate before sweeping." ;;
+          HOLD-STATUS.md)
+            echo "  ⇒ $alt: this workstream is on an explicit hold. Read it and confirm the"
+            echo "    hold is lifted before sweeping." ;;
+          TASKS.md)
+            echo "  ⇒ $alt: tasks are inline in a single file rather than one brief per file."
+            echo "    Run them by hand, or split them into TASK-NN-*.md first." ;;
+        esac
+      fi
+    done
+    echo
+    echo "If you expected briefs here, check the workstream name for a typo."
+  } >&2
+  exit 2
 fi
 
 git -C "$REPO" fetch origin -q


### PR DESCRIPTION
Closes §1.5 of the [2026-08-11 docs inventory](https://github.com/falkcorp/audiobook-organizer/blob/main/docs/audits/2026-08-11-docs-inventory.md), which recorded this as needing a behaviour decision rather than fixing it.

## The bug

`run-sweep.sh` resolves work with `find -maxdepth 1 -name 'TASK-*.md'`. **Four of the ten live packages have no such files:**

| Package | Uses instead |
|---|---|
| `community-fingerprint-index` | `AWAIT-APPROVAL.md` |
| `workflow-system` | `AWAIT-APPROVAL.md` |
| `responses-api-migration` | `HOLD-STATUS.md` |
| `error-correction-2026-07` | `TASKS.md` (13 inline tasks) |

For those, `TASK_FILES` came back empty, the loop iterated zero times, and the script printed **"Next steps (coordinator)"** and exited 0. The operator saw a clean run and no worktrees, with no way to distinguish *"nothing to do"* from *"this script cannot read this package."*

## Why `set -euo pipefail` didn't save us

It can't. `set -e` fires when a **command** returns non-zero — but iterating an empty list isn't a failure, and every individual command succeeded. The script did nothing, successfully.

The general shape: **`set -e` protects against commands that fail, not against work that never happened.** Any discover-then-loop script needs an explicit emptiness check, because the empty case is silent by construction.

## The fix

Exit **2** with a diagnostic that names what the package actually contains and what each gate file means:

```
ERROR: no TASK-*.md files in workstream 'workflow-system' — nothing to drive.

This script only understands workstreams built from TASK-*.md briefs.
'workflow-system' contains:
  AWAIT-APPROVAL.md

  ⇒ AWAIT-APPROVAL.md: this workstream is gated on a human approval that has not been
    given. Read it and resolve the gate before sweeping.

If you expected briefs here, check the workstream name for a typo.
```

Exit **1** still means "no such workstream", so a typo stays distinguishable from an unparseable package.

## Verified across all ten packages

| Result | Packages |
|---|---|
| ✅ passes guard (would sweep) | `abs-sync`, `ux-small-items`, `bug-techdebt`, `torrent-relocation`, `dedup-pipeline-hardening`, `ai-responses-migration` |
| ⛔ exit 2 | the four gate-file packages above |
| ⛔ exit 1 | a bogus workstream name |

Tested by running the discovery-and-guard portion in isolation, stopping before the `git fetch` / worktree side effects, so no worktrees were created.

`docs/agent-tasks/README.md`'s warning is updated from "a silent no-op, not an error" to describe the new behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t