### PR TITLE
docs(api): one OpenAPI spec instead of two — union merge, and make it validate

### DIFF
--- a/.claude/skills/api-doc/SKILL.md
+++ b/.claude/skills/api-doc/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: api-doc
-description: Update docs/openapi.yaml when adding or modifying API endpoints
+description: Update docs/api/openapi.json when adding or modifying API endpoints
 disable-model-invocation: true
 ---
 
 # Update API Documentation
 
-Keep `docs/openapi.yaml` (OpenAPI 3.0.3) in sync when adding or modifying API endpoints.
+Keep `docs/api/openapi.json` (OpenAPI 3.0.3) in sync when adding or modifying API endpoints.
+
+> **This skill used to target `docs/openapi.yaml`.** That file was a second,
+> independently hand-maintained spec; the two drifted until each held endpoints the
+> other lacked. They were union-merged into `docs/api/openapi.json` on 2026-08-12 and
+> the YAML was archived. **There is exactly one spec now — keep it that way.** If you
+> find yourself creating a second spec file, don't.
 
 ## Arguments
 
@@ -16,57 +22,93 @@ Keep `docs/openapi.yaml` (OpenAPI 3.0.3) in sync when adding or modifying API en
 
 1. **Read the current OpenAPI spec:**
    ```
-   Read docs/openapi.yaml
+   Read docs/api/openapi.json
    ```
 
-2. **Identify the endpoint in Go source** — routes are registered in `internal/server/server.go` using Gin:
+2. **Identify the endpoint in Go source.** Routes are registered in the
+   `internal/server/wire_*_routes.go` files (and some in `server_lifecycle.go`) using
+   Gin, usually on a **group**:
    ```go
-   v1.GET("/endpoint", s.handlerFunc)
+   itunesG := protected.Group("/itunes")
+   itunesG.POST("/sync", s.perm(auth.PermLibraryEditMetadata), itunesH.Sync)
    ```
 
-3. **Read the handler function** to understand request/response types
+   ⚠️ **Write the full path, not the group-relative fragment.** The example above is
+   `/itunes/sync`, *not* `/sync`. The previous spec was built by something that missed
+   group prefixes, leaving ~20 bogus root-level paths (`/login`, `/books`, `/compare`)
+   that had to be untangled by hand.
 
-4. **Update docs/openapi.yaml** with:
-   - Path definition under `paths:`
+   If you are unsure of a full path, ask the router instead of guessing — a temporary
+   test calling `s.router.Routes()` prints every registered method and path.
+
+3. **Read the handler function** to understand request/response types.
+
+4. **Update `docs/api/openapi.json`** with:
+   - Path definition under `paths:`, keyed **without** the `/api/v1` prefix —
+     `servers[0].url` is already `/api/v1`, so a path of `/api/v1/foo` would resolve to
+     `/api/v1/api/v1/foo`.
    - Request body schema (if POST/PUT/PATCH)
    - Response schemas (200, 400, 404, 500)
    - Proper tag assignment (match existing tags)
-   - Parameter definitions (path params, query params)
+   - Parameter definitions. **Every `{name}` in the path needs a declaration** with
+     `in: path` and `required: true`, or the spec fails validation. Declare them once at
+     the path-item level so all operations on that path share them.
 
-5. **Bump the version** in the openapi.yaml header and `info.version`
+5. **Bump `info.version`.**
+
+6. **Validate before you finish** — the spec is valid OpenAPI 3.0.3 today and should
+   stay that way:
+   ```bash
+   python3 -m pip install --user openapi-spec-validator
+   python3 -c "import json;from openapi_spec_validator import validate;validate(json.load(open('docs/api/openapi.json')))"
+   ```
 
 ## Template for a new endpoint
 
-```yaml
-  /endpoint:
-    get:
-      tags:
-        - TagName
-      summary: Short description
-      description: Longer description
-      operationId: operationName
-      parameters:
-        - $ref: '#/components/parameters/idPath'
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  field:
-                    type: string
-        '404':
-          description: Not found
-      security:
-        - bearerAuth: []
+```json
+  "/endpoint/{id}": {
+    "parameters": [
+      {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Unique identifier.",
+        "schema": { "type": "string" }
+      }
+    ],
+    "get": {
+      "tags": ["TagName"],
+      "summary": "Short description",
+      "description": "Longer description",
+      "operationId": "operationName",
+      "responses": {
+        "200": {
+          "description": "Success",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": { "field": { "type": "string" } }
+              }
+            }
+          }
+        },
+        "404": { "description": "Not found" }
+      },
+      "security": [{ "bearerAuth": [] }]
+    }
+  }
 ```
 
 ## Rules
 
-- Follow OpenAPI 3.0.3 spec
-- Use existing `$ref` components where possible (parameters, schemas)
-- All endpoints require `security: [bearerAuth: []]` except Health and Events
-- Use existing tags — only add new tags if truly a new domain
-- Keep response schemas consistent with actual Go struct JSON output
+- Follow OpenAPI 3.0.3.
+- **Document only endpoints that actually exist.** Do not add a path speculatively or
+  leave one behind after deleting a route. The spec previously advertised
+  `/audiobooks/search` and 16 `/maintenance/*` endpoints that no router serves — a
+  client that trusts the spec and gets a 404 is worse off than one with no spec.
+- Use existing `$ref` components where possible (parameters, schemas).
+- All endpoints require `security: [{"bearerAuth": []}]` except Health and Events.
+- Use existing tags — only add new tags if truly a new domain.
+- Keep response schemas consistent with the actual Go struct JSON output.
+- `operationId` must be unique across the whole document.

--- a/changelog.d/20260812_113000_openapi_union_merge.md
+++ b/changelog.d/20260812_113000_openapi_union_merge.md
@@ -1,0 +1,24 @@
+### Changed
+
+- **There is now one OpenAPI spec instead of two.** `docs/openapi.yaml` and
+  `docs/api/openapi.json` were both hand-maintained, neither was generated from code, and they
+  had drifted until each documented endpoints the other lacked. Union-merged onto
+  `docs/api/openapi.json` (288 paths): 24 YAML-only paths carried across — `/health`, the
+  `/auth/*` login and session endpoints, 10 `/itunes/*`, and the 7 `/ai/scans/*` — plus the 19
+  component schemas and 5 shared parameters the JSON had none of. The YAML is archived with a
+  banner explaining why it must not come back.
+
+### Fixed
+
+- **Every path in the OpenAPI spec was double-prefixed.** All 266 paths began with `/api/v1`
+  while `servers[0].url` was *also* `/api/v1`, so a generated client would have called
+  `/api/v1/api/v1/audiobooks`. Prefix stripped from every path.
+- **The spec did not validate, and now does.** No path in the document declared its path
+  parameters, failing OpenAPI 3.0.3 validation on 129 operations; 115 declarations were added at
+  path-item level. Two operations sharing `operationId: "unknown"` were removed as generator
+  artifacts — `/compare` is a group-relative fragment of `/ai/scans/compare`, and `/path` was
+  scraped out of a **code comment**.
+- **`.claude/skills/api-doc` pointed at the retired file.** It was the repo's only instruction
+  for keeping the spec current, so leaving it aimed at `docs/openapi.yaml` would have re-created
+  the divergence at the next endpoint change. Repointed, and taught the group-prefix, path-param
+  and no-phantom-endpoint rules that the old spec's defects came from.

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2,25 +2,678 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Audiobook Organizer API",
-    "version": "0.215.0",
+    "version": "0.218.1",
     "description": "REST API for the audiobook organizer."
   },
   "servers": [
     {
-      "url": "/api/v1"
+      "url": "/api/v1",
+      "description": "Relative path (production and same-origin clients)"
+    },
+    {
+      "url": "http://localhost:8484/api/v1",
+      "description": "Local development server"
     }
   ],
   "components": {
+    "parameters": {
+      "idPath": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "ulid"
+        }
+      },
+      "intIdPath": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "limitQuery": {
+        "name": "limit",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "default": 50,
+          "minimum": 1,
+          "maximum": 10000
+        }
+      },
+      "offsetQuery": {
+        "name": "offset",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "default": 0,
+          "minimum": 0
+        }
+      },
+      "dryRunQuery": {
+        "name": "dry_run",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
+        },
+        "description": "When \"true\", shows what would happen without making changes."
+      }
+    },
+    "schemas": {
+      "Book": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "ulid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "author_id": {
+            "type": "integer",
+            "nullable": true
+          },
+          "author_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "series_id": {
+            "type": "integer",
+            "nullable": true
+          },
+          "series_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "series_position": {
+            "type": "integer",
+            "nullable": true
+          },
+          "file_path": {
+            "type": "string"
+          },
+          "duration": {
+            "type": "integer",
+            "description": "Duration in seconds",
+            "nullable": true
+          },
+          "narrator": {
+            "type": "string",
+            "nullable": true
+          },
+          "language": {
+            "type": "string",
+            "nullable": true
+          },
+          "publisher": {
+            "type": "string",
+            "nullable": true
+          },
+          "cover_image": {
+            "type": "string",
+            "nullable": true
+          },
+          "bitrate": {
+            "type": "integer",
+            "description": "Bitrate in kbps",
+            "nullable": true
+          },
+          "codec": {
+            "type": "string",
+            "nullable": true
+          },
+          "sample_rate": {
+            "type": "integer",
+            "description": "Sample rate in Hz",
+            "nullable": true
+          },
+          "quality": {
+            "type": "string",
+            "nullable": true
+          },
+          "is_primary_version": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "version_group_id": {
+            "type": "string",
+            "format": "ulid",
+            "nullable": true
+          },
+          "version_notes": {
+            "type": "string",
+            "nullable": true
+          },
+          "deleted_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "file_path",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "Author": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "created_at"
+        ]
+      },
+      "Series": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "author_id": {
+            "type": "integer",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "created_at"
+        ]
+      },
+      "ImportPath": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "path": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_scan": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "book_count": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "path",
+          "name",
+          "enabled",
+          "created_at",
+          "book_count"
+        ]
+      },
+      "MetadataResult": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "author": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "publisher": {
+            "type": "string",
+            "nullable": true
+          },
+          "publish_year": {
+            "type": "integer",
+            "nullable": true
+          },
+          "isbn": {
+            "type": "string",
+            "nullable": true
+          },
+          "cover_url": {
+            "type": "string",
+            "nullable": true
+          },
+          "language": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "SystemStatus": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "library": {
+            "type": "object",
+            "properties": {
+              "book_count": {
+                "type": "integer"
+              },
+              "folder_count": {
+                "type": "integer"
+              },
+              "total_size": {
+                "type": "integer",
+                "description": "Total size in bytes"
+              }
+            }
+          },
+          "memory": {
+            "type": "object",
+            "properties": {
+              "alloc_bytes": {
+                "type": "integer"
+              },
+              "total_alloc_bytes": {
+                "type": "integer"
+              },
+              "sys_bytes": {
+                "type": "integer"
+              },
+              "num_gc": {
+                "type": "integer"
+              }
+            }
+          },
+          "runtime": {
+            "type": "object",
+            "properties": {
+              "go_version": {
+                "type": "string"
+              },
+              "num_goroutine": {
+                "type": "integer"
+              },
+              "num_cpu": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "Config": {
+        "type": "object",
+        "properties": {
+          "root_dir": {
+            "type": "string"
+          },
+          "database_path": {
+            "type": "string"
+          },
+          "playlist_dir": {
+            "type": "string"
+          },
+          "organization_strategy": {
+            "type": "string",
+            "enum": [
+              "copy",
+              "hardlink",
+              "reflink",
+              "auto"
+            ]
+          },
+          "scan_on_startup": {
+            "type": "boolean"
+          },
+          "auto_organize": {
+            "type": "boolean"
+          },
+          "folder_naming_pattern": {
+            "type": "string"
+          },
+          "file_naming_pattern": {
+            "type": "string"
+          },
+          "auto_fetch_metadata": {
+            "type": "boolean"
+          },
+          "log_level": {
+            "type": "string",
+            "enum": [
+              "debug",
+              "info",
+              "warn",
+              "error"
+            ]
+          }
+        }
+      },
+      "Work": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "ulid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "author_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "VersionGroup": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "ulid"
+          },
+          "primary_book_id": {
+            "type": "string",
+            "format": "ulid",
+            "nullable": true
+          },
+          "books": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Book"
+            }
+          }
+        }
+      },
+      "BlockedHash": {
+        "type": "object",
+        "properties": {
+          "hash": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "Operation": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "progress": {
+            "type": "number"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          }
+        }
+      },
+      "Message": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "PaginatedBooks": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "integer",
+            "description": "Total number of matching audiobooks (not page size)"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Book"
+            }
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          }
+        }
+      },
+      "CountResponse": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "integer"
+          }
+        }
+      },
+      "DuplicateGroupsResponse": {
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Book"
+              }
+            }
+          },
+          "group_count": {
+            "type": "integer"
+          },
+          "duplicate_count": {
+            "type": "integer"
+          }
+        }
+      },
+      "AuthorAlias": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "author_id": {
+            "type": "integer"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "BrokenSegmentResult": {
+        "type": "object",
+        "properties": {
+          "books_checked": {
+            "type": "integer"
+          },
+          "broken_books": {
+            "type": "integer"
+          },
+          "marked_for_review": {
+            "type": "integer"
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "book_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "file_path": {
+                  "type": "string"
+                },
+                "total_segments": {
+                  "type": "integer"
+                },
+                "missing_segments": {
+                  "type": "integer"
+                },
+                "missing_paths": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "MergeDuplicatesResult": {
+        "type": "object",
+        "properties": {
+          "total_no_vg": {
+            "type": "integer"
+          },
+          "matched_to_vg": {
+            "type": "integer"
+          },
+          "self_duplicates": {
+            "type": "integer"
+          },
+          "metadata_merged": {
+            "type": "integer"
+          },
+          "soft_deleted": {
+            "type": "integer"
+          },
+          "remaining_orphans": {
+            "type": "integer"
+          },
+          "errors": {
+            "type": "integer"
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "duplicate_id": {
+                  "type": "string"
+                },
+                "primary_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "fields_merged": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "action": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "securitySchemes": {
       "session": {
         "type": "apiKey",
         "in": "cookie",
         "name": "ao_session"
+      },
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
       }
     }
   },
   "paths": {
-    "/api/v1/accept-invite": {
+    "/accept-invite": {
       "post": {
         "operationId": "handleAcceptInvite",
         "summary": "Accept Invite",
@@ -44,7 +697,7 @@
         }
       }
     },
-    "/api/v1/activity": {
+    "/activity": {
       "get": {
         "operationId": "listActivity",
         "summary": "list Activity",
@@ -72,7 +725,7 @@
         }
       }
     },
-    "/api/v1/activity/compact": {
+    "/activity/compact": {
       "post": {
         "operationId": "compactActivity",
         "summary": "compact Activity",
@@ -100,7 +753,7 @@
         }
       }
     },
-    "/api/v1/activity/sources": {
+    "/activity/sources": {
       "get": {
         "operationId": "listActivitySources",
         "summary": "list Activity Sources",
@@ -128,7 +781,7 @@
         }
       }
     },
-    "/api/v1/ai/parse-filename": {
+    "/ai/parse-filename": {
       "post": {
         "operationId": "parseFilenameWithAI",
         "summary": "parse Filename With A I",
@@ -156,7 +809,311 @@
         }
       }
     },
-    "/api/v1/ai/test-connection": {
+    "/ai/scans": {
+      "post": {
+        "tags": [
+          "AIScans"
+        ],
+        "summary": "Start an AI scan",
+        "description": "Starts a new AI-powered metadata scan of the library.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "scope": {
+                    "type": "string",
+                    "description": "Scan scope filter"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "AI scan started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "AIScans"
+        ],
+        "summary": "List AI scans",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of AI scans",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "completed_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ai/scans/compare": {
+      "get": {
+        "tags": [
+          "AIScans"
+        ],
+        "summary": "Compare AI scans",
+        "description": "Compares results between two AI scans.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "scan_a",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scan_b",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Comparison results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ai/scans/{id}": {
+      "get": {
+        "tags": [
+          "AIScans"
+        ],
+        "summary": "Get AI scan details",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/idPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AI scan details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Scan not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "AIScans"
+        ],
+        "summary": "Delete an AI scan",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/idPath"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Scan deleted"
+          },
+          "404": {
+            "description": "Scan not found"
+          }
+        }
+      }
+    },
+    "/ai/scans/{id}/apply": {
+      "post": {
+        "tags": [
+          "AIScans"
+        ],
+        "summary": "Apply AI scan results",
+        "description": "Applies the suggestions from an AI scan to the library.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/idPath"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "result_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Results applied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ai/scans/{id}/cancel": {
+      "post": {
+        "tags": [
+          "AIScans"
+        ],
+        "summary": "Cancel an AI scan",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/idPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Scan cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ai/scans/{id}/results": {
+      "get": {
+        "tags": [
+          "AIScans"
+        ],
+        "summary": "Get AI scan results",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/idPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Scan results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ai/test-connection": {
       "post": {
         "operationId": "testAIConnection",
         "summary": "test A I Connection",
@@ -184,7 +1141,7 @@
         }
       }
     },
-    "/api/v1/audiobooks": {
+    "/audiobooks": {
       "get": {
         "operationId": "listAudiobooks",
         "summary": "list Audiobooks",
@@ -212,7 +1169,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/batch": {
+    "/audiobooks/batch": {
       "post": {
         "operationId": "batchUpdateAudiobooks",
         "summary": "batch Update Audiobooks",
@@ -240,7 +1197,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/batch-operations": {
+    "/audiobooks/batch-operations": {
       "post": {
         "operationId": "batchOperations",
         "summary": "batch Operations",
@@ -268,7 +1225,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/batch-tags": {
+    "/audiobooks/batch-tags": {
       "post": {
         "operationId": "batchUpdateTags",
         "summary": "batch Update Tags",
@@ -296,7 +1253,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/batch-write-back": {
+    "/audiobooks/batch-write-back": {
       "post": {
         "operationId": "batchWriteBackAudiobooks",
         "summary": "batch Write Back Audiobooks",
@@ -324,7 +1281,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/bulk-write-back": {
+    "/audiobooks/bulk-write-back": {
       "post": {
         "operationId": "handleBulkWriteBack",
         "summary": "Bulk Write Back",
@@ -352,7 +1309,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/count": {
+    "/audiobooks/count": {
       "get": {
         "operationId": "countAudiobooks",
         "summary": "count Audiobooks",
@@ -380,7 +1337,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/duplicates": {
+    "/audiobooks/duplicates": {
       "get": {
         "operationId": "listDuplicateAudiobooks",
         "summary": "list Duplicate Audiobooks",
@@ -408,7 +1365,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/duplicates/dismiss": {
+    "/audiobooks/duplicates/dismiss": {
       "post": {
         "operationId": "dismissBookDuplicateGroup",
         "summary": "dismiss Book Duplicate Group",
@@ -436,7 +1393,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/duplicates/merge": {
+    "/audiobooks/duplicates/merge": {
       "post": {
         "operationId": "mergeBookDuplicatesAsVersions",
         "summary": "merge Book Duplicates As Versions",
@@ -464,7 +1421,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/duplicates/scan": {
+    "/audiobooks/duplicates/scan": {
       "post": {
         "operationId": "scanBookDuplicates",
         "summary": "scan Book Duplicates",
@@ -492,7 +1449,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/duplicates/scan-results": {
+    "/audiobooks/duplicates/scan-results": {
       "get": {
         "operationId": "listBookDuplicateScanResults",
         "summary": "list Book Duplicate Scan Results",
@@ -520,7 +1477,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/merge": {
+    "/audiobooks/merge": {
       "post": {
         "operationId": "mergeBooks",
         "summary": "merge Books",
@@ -548,7 +1505,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/purge-soft-deleted": {
+    "/audiobooks/purge-soft-deleted": {
       "delete": {
         "operationId": "purgeSoftDeletedAudiobooks",
         "summary": "purge Soft Deleted Audiobooks",
@@ -576,7 +1533,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/soft-deleted": {
+    "/audiobooks/soft-deleted": {
       "get": {
         "operationId": "listSoftDeletedAudiobooks",
         "summary": "list Soft Deleted Audiobooks",
@@ -604,7 +1561,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}": {
+    "/audiobooks/{id}": {
       "get": {
         "operationId": "getAudiobook",
         "summary": "get Audiobook",
@@ -684,7 +1641,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/alternative-titles": {
+    "/audiobooks/{id}/alternative-titles": {
       "get": {
         "operationId": "getBookAlternativeTitles",
         "summary": "get Book Alternative Titles",
@@ -764,7 +1721,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/apply-metadata": {
+    "/audiobooks/{id}/apply-metadata": {
       "post": {
         "operationId": "applyAudiobookMetadata",
         "summary": "apply Audiobook Metadata",
@@ -792,7 +1749,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/changelog": {
+    "/audiobooks/{id}/changelog": {
       "get": {
         "operationId": "getBookChangelog",
         "summary": "get Book Changelog",
@@ -820,7 +1777,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/changes": {
+    "/audiobooks/{id}/changes": {
       "get": {
         "operationId": "getBookChanges",
         "summary": "get Book Changes",
@@ -848,7 +1805,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/cover": {
+    "/audiobooks/{id}/cover": {
       "get": {
         "operationId": "serveAudiobookCover",
         "summary": "serve Audiobook Cover",
@@ -876,7 +1833,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/cover-history": {
+    "/audiobooks/{id}/cover-history": {
       "get": {
         "operationId": "handleListCoverHistory",
         "summary": "List Cover History",
@@ -904,7 +1861,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/cover-history/restore": {
+    "/audiobooks/{id}/cover-history/restore": {
       "post": {
         "operationId": "handleRestoreCover",
         "summary": "Restore Cover",
@@ -932,7 +1889,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/cow-versions": {
+    "/audiobooks/{id}/cow-versions": {
       "get": {
         "operationId": "listBookCOWVersions",
         "summary": "list Book C O W Versions",
@@ -960,7 +1917,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/cow-versions/prune": {
+    "/audiobooks/{id}/cow-versions/prune": {
       "post": {
         "operationId": "pruneBookCOWVersions",
         "summary": "prune Book C O W Versions",
@@ -988,7 +1945,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/external-ids": {
+    "/audiobooks/{id}/external-ids": {
       "get": {
         "operationId": "getAudiobookExternalIDs",
         "summary": "get Audiobook External I Ds",
@@ -1016,7 +1973,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/extract-track-info": {
+    "/audiobooks/{id}/extract-track-info": {
       "post": {
         "operationId": "extractTrackInfo",
         "summary": "extract Track Info",
@@ -1044,7 +2001,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/fetch-metadata": {
+    "/audiobooks/{id}/fetch-metadata": {
       "post": {
         "operationId": "fetchAudiobookMetadata",
         "summary": "fetch Audiobook Metadata",
@@ -1072,7 +2029,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/field-states": {
+    "/audiobooks/{id}/field-states": {
       "get": {
         "operationId": "getAudiobookFieldStates",
         "summary": "get Audiobook Field States",
@@ -1100,7 +2057,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/files": {
+    "/audiobooks/{id}/files": {
       "get": {
         "operationId": "listBookFiles",
         "summary": "list Book Files",
@@ -1128,7 +2085,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/mark-no-match": {
+    "/audiobooks/{id}/mark-no-match": {
       "post": {
         "operationId": "markAudiobookNoMatch",
         "summary": "mark Audiobook No Match",
@@ -1156,7 +2113,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/metadata-history": {
+    "/audiobooks/{id}/metadata-history": {
       "get": {
         "operationId": "getBookMetadataHistory",
         "summary": "get Book Metadata History",
@@ -1184,7 +2141,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/metadata-history/{field}": {
+    "/audiobooks/{id}/metadata-history/{field}": {
       "get": {
         "operationId": "getFieldMetadataHistory",
         "summary": "get Field Metadata History",
@@ -1212,7 +2169,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/metadata-history/{field}/undo": {
+    "/audiobooks/{id}/metadata-history/{field}/undo": {
       "post": {
         "operationId": "undoMetadataChange",
         "summary": "undo Metadata Change",
@@ -1240,7 +2197,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/move-segments": {
+    "/audiobooks/{id}/move-segments": {
       "post": {
         "operationId": "moveSegments",
         "summary": "move Segments",
@@ -1268,7 +2225,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/narrators": {
+    "/audiobooks/{id}/narrators": {
       "get": {
         "operationId": "listAudiobookNarrators",
         "summary": "list Audiobook Narrators",
@@ -1322,7 +2279,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/organize": {
+    "/audiobooks/{id}/organize": {
       "post": {
         "operationId": "organizeBook",
         "summary": "organize Book",
@@ -1350,7 +2307,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/parse-with-ai": {
+    "/audiobooks/{id}/parse-with-ai": {
       "post": {
         "operationId": "parseAudiobookWithAI",
         "summary": "parse Audiobook With A I",
@@ -1378,7 +2335,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/path-history": {
+    "/audiobooks/{id}/path-history": {
       "get": {
         "operationId": "getBookPathHistory",
         "summary": "get Book Path History",
@@ -1406,7 +2363,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/preview-organize": {
+    "/audiobooks/{id}/preview-organize": {
       "get": {
         "operationId": "previewOrganize",
         "summary": "preview Organize",
@@ -1434,7 +2391,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/relocate": {
+    "/audiobooks/{id}/relocate": {
       "post": {
         "operationId": "relocateBookFiles",
         "summary": "relocate Book Files",
@@ -1462,7 +2419,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/rename/apply": {
+    "/audiobooks/{id}/rename/apply": {
       "post": {
         "operationId": "applyRename",
         "summary": "apply Rename",
@@ -1490,7 +2447,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/rename/preview": {
+    "/audiobooks/{id}/rename/preview": {
       "post": {
         "operationId": "previewRename",
         "summary": "preview Rename",
@@ -1518,7 +2475,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/restore": {
+    "/audiobooks/{id}/restore": {
       "post": {
         "operationId": "restoreAudiobook",
         "summary": "restore Audiobook",
@@ -1546,7 +2503,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/revert-metadata": {
+    "/audiobooks/{id}/revert-metadata": {
       "post": {
         "operationId": "revertAudiobookMetadata",
         "summary": "revert Audiobook Metadata",
@@ -1574,7 +2531,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/search-metadata": {
+    "/audiobooks/{id}/search-metadata": {
       "post": {
         "operationId": "searchAudiobookMetadata",
         "summary": "search Audiobook Metadata",
@@ -1602,7 +2559,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/segments": {
+    "/audiobooks/{id}/segments": {
       "get": {
         "operationId": "listAudiobookSegments",
         "summary": "list Audiobook Segments",
@@ -1630,7 +2587,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/segments/{segmentId}/tags": {
+    "/audiobooks/{id}/segments/{segmentId}/tags": {
       "get": {
         "operationId": "getSegmentTags",
         "summary": "get Segment Tags",
@@ -1658,7 +2615,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/set-primary": {
+    "/audiobooks/{id}/set-primary": {
       "put": {
         "operationId": "setAudiobookPrimary",
         "summary": "set Audiobook Primary",
@@ -1686,7 +2643,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/similar": {
+    "/audiobooks/{id}/similar": {
       "get": {
         "operationId": "handleSimilarBooks",
         "summary": "Similar Books",
@@ -1714,7 +2671,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/split-to-books": {
+    "/audiobooks/{id}/split-to-books": {
       "post": {
         "operationId": "splitSegmentsToBooks",
         "summary": "split Segments To Books",
@@ -1742,7 +2699,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/split-version": {
+    "/audiobooks/{id}/split-version": {
       "post": {
         "operationId": "splitVersion",
         "summary": "split Version",
@@ -1770,7 +2727,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/tags": {
+    "/audiobooks/{id}/tags": {
       "get": {
         "operationId": "getAudiobookTags",
         "summary": "get Audiobook Tags",
@@ -1798,7 +2755,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/tags-detailed": {
+    "/audiobooks/{id}/tags-detailed": {
       "get": {
         "operationId": "getBookTagsDetailed",
         "summary": "get Book Tags Detailed",
@@ -1826,7 +2783,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/undo-last-apply": {
+    "/audiobooks/{id}/undo-last-apply": {
       "post": {
         "operationId": "undoLastApply",
         "summary": "undo Last Apply",
@@ -1854,7 +2811,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/user-tags": {
+    "/audiobooks/{id}/user-tags": {
       "get": {
         "operationId": "getBookUserTags",
         "summary": "get Book User Tags",
@@ -1882,7 +2839,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/versions": {
+    "/audiobooks/{id}/versions": {
       "get": {
         "operationId": "listAudiobookVersions",
         "summary": "list Audiobook Versions",
@@ -1936,7 +2893,7 @@
         }
       }
     },
-    "/api/v1/audiobooks/{id}/write-back": {
+    "/audiobooks/{id}/write-back": {
       "post": {
         "operationId": "writeBackAudiobookMetadata",
         "summary": "write Back Audiobook Metadata",
@@ -1964,7 +2921,267 @@
         }
       }
     },
-    "/api/v1/authors": {
+    "/auth/login": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Login",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "username",
+                  "password"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Login successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "username": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid credentials"
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Logout",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Logged out"
+          }
+        }
+      }
+    },
+    "/auth/me": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Get current user",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current user info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "username": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated"
+          }
+        }
+      }
+    },
+    "/auth/sessions": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "List active sessions",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of sessions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "last_active": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "user_agent": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/sessions/{id}": {
+      "delete": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Revoke a session",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Session revoked"
+          },
+          "404": {
+            "description": "Session not found"
+          }
+        }
+      }
+    },
+    "/auth/setup": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Setup initial admin account",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "username",
+                  "password"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Admin account created"
+          },
+          "400": {
+            "description": "Setup already completed or invalid input"
+          },
+          "409": {
+            "description": "Admin already exists"
+          }
+        }
+      }
+    },
+    "/auth/status": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Check authentication status",
+        "description": "Returns whether auth is enabled and if initial setup is needed.",
+        "responses": {
+          "200": {
+            "description": "Auth status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "auth_enabled": {
+                      "type": "boolean"
+                    },
+                    "setup_required": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/authors": {
       "get": {
         "operationId": "listAuthors",
         "summary": "list Authors",
@@ -1992,7 +3209,7 @@
         }
       }
     },
-    "/api/v1/authors/bulk-delete": {
+    "/authors/bulk-delete": {
       "post": {
         "operationId": "bulkDeleteAuthors",
         "summary": "bulk Delete Authors",
@@ -2020,7 +3237,7 @@
         }
       }
     },
-    "/api/v1/authors/count": {
+    "/authors/count": {
       "get": {
         "operationId": "countAuthors",
         "summary": "count Authors",
@@ -2048,7 +3265,7 @@
         }
       }
     },
-    "/api/v1/authors/duplicates": {
+    "/authors/duplicates": {
       "get": {
         "operationId": "listDuplicateAuthors",
         "summary": "list Duplicate Authors",
@@ -2076,7 +3293,7 @@
         }
       }
     },
-    "/api/v1/authors/duplicates/ai-review": {
+    "/authors/duplicates/ai-review": {
       "post": {
         "operationId": "aiReviewDuplicateAuthors",
         "summary": "ai Review Duplicate Authors",
@@ -2104,7 +3321,7 @@
         }
       }
     },
-    "/api/v1/authors/duplicates/ai-review/apply": {
+    "/authors/duplicates/ai-review/apply": {
       "post": {
         "operationId": "applyAIAuthorReview",
         "summary": "apply A I Author Review",
@@ -2132,7 +3349,7 @@
         }
       }
     },
-    "/api/v1/authors/duplicates/refresh": {
+    "/authors/duplicates/refresh": {
       "post": {
         "operationId": "refreshDuplicateAuthors",
         "summary": "refresh Duplicate Authors",
@@ -2160,7 +3377,7 @@
         }
       }
     },
-    "/api/v1/authors/merge": {
+    "/authors/merge": {
       "post": {
         "operationId": "mergeAuthors",
         "summary": "merge Authors",
@@ -2188,7 +3405,7 @@
         }
       }
     },
-    "/api/v1/authors/{id}": {
+    "/authors/{id}": {
       "delete": {
         "operationId": "deleteAuthorHandler",
         "summary": "delete Author",
@@ -2216,7 +3433,7 @@
         }
       }
     },
-    "/api/v1/authors/{id}/aliases": {
+    "/authors/{id}/aliases": {
       "get": {
         "operationId": "getAuthorAliases",
         "summary": "get Author Aliases",
@@ -2270,7 +3487,7 @@
         }
       }
     },
-    "/api/v1/authors/{id}/aliases/{aliasId}": {
+    "/authors/{id}/aliases/{aliasId}": {
       "delete": {
         "operationId": "deleteAuthorAlias",
         "summary": "delete Author Alias",
@@ -2298,7 +3515,7 @@
         }
       }
     },
-    "/api/v1/authors/{id}/books": {
+    "/authors/{id}/books": {
       "get": {
         "operationId": "getAuthorBooks",
         "summary": "get Author Books",
@@ -2326,7 +3543,7 @@
         }
       }
     },
-    "/api/v1/authors/{id}/name": {
+    "/authors/{id}/name": {
       "put": {
         "operationId": "renameAuthor",
         "summary": "rename Author",
@@ -2354,7 +3571,7 @@
         }
       }
     },
-    "/api/v1/authors/{id}/reclassify-as-narrator": {
+    "/authors/{id}/reclassify-as-narrator": {
       "post": {
         "operationId": "reclassifyAuthorAsNarrator",
         "summary": "reclassify Author As Narrator",
@@ -2382,7 +3599,7 @@
         }
       }
     },
-    "/api/v1/authors/{id}/resolve-production": {
+    "/authors/{id}/resolve-production": {
       "post": {
         "operationId": "resolveProductionAuthor",
         "summary": "resolve Production Author",
@@ -2410,7 +3627,7 @@
         }
       }
     },
-    "/api/v1/authors/{id}/split": {
+    "/authors/{id}/split": {
       "post": {
         "operationId": "splitCompositeAuthor",
         "summary": "split Composite Author",
@@ -2438,7 +3655,7 @@
         }
       }
     },
-    "/api/v1/authors/{id}/tags": {
+    "/authors/{id}/tags": {
       "get": {
         "operationId": "handleGetAuthorTags",
         "summary": "Get Author Tags",
@@ -2492,7 +3709,7 @@
         }
       }
     },
-    "/api/v1/backup/create": {
+    "/backup/create": {
       "post": {
         "operationId": "createBackup",
         "summary": "create Backup",
@@ -2520,7 +3737,7 @@
         }
       }
     },
-    "/api/v1/backup/list": {
+    "/backup/list": {
       "get": {
         "operationId": "listBackups",
         "summary": "list Backups",
@@ -2548,7 +3765,7 @@
         }
       }
     },
-    "/api/v1/backup/restore": {
+    "/backup/restore": {
       "post": {
         "operationId": "restoreBackup",
         "summary": "restore Backup",
@@ -2576,7 +3793,7 @@
         }
       }
     },
-    "/api/v1/backup/{filename}": {
+    "/backup/{filename}": {
       "delete": {
         "operationId": "deleteBackup",
         "summary": "delete Backup",
@@ -2604,7 +3821,7 @@
         }
       }
     },
-    "/api/v1/blocked-hashes": {
+    "/blocked-hashes": {
       "get": {
         "operationId": "listBlockedHashes",
         "summary": "list Blocked Hashes",
@@ -2658,7 +3875,7 @@
         }
       }
     },
-    "/api/v1/blocked-hashes/{hash}": {
+    "/blocked-hashes/{hash}": {
       "delete": {
         "operationId": "removeBlockedHash",
         "summary": "remove Blocked Hash",
@@ -2686,7 +3903,7 @@
         }
       }
     },
-    "/api/v1/books": {
+    "/books": {
       "get": {
         "operationId": "handleListITunesBooks",
         "summary": "List I Tunes Books",
@@ -2714,7 +3931,7 @@
         }
       }
     },
-    "/api/v1/books/{id}/position": {
+    "/books/{id}/position": {
       "post": {
         "operationId": "handleSetPosition",
         "summary": "Set Position",
@@ -2760,7 +3977,7 @@
         }
       }
     },
-    "/api/v1/books/{id}/state": {
+    "/books/{id}/state": {
       "get": {
         "operationId": "handleGetBookState",
         "summary": "Get Book State",
@@ -2784,7 +4001,7 @@
         }
       }
     },
-    "/api/v1/books/{id}/status": {
+    "/books/{id}/status": {
       "patch": {
         "operationId": "handleSetBookStatus",
         "summary": "Set Book Status",
@@ -2830,7 +4047,7 @@
         }
       }
     },
-    "/api/v1/books/{id}/versions/{vid}": {
+    "/books/{id}/versions/{vid}": {
       "delete": {
         "operationId": "handleTrashVersion",
         "summary": "Trash Version",
@@ -2858,7 +4075,7 @@
         }
       }
     },
-    "/api/v1/books/{id}/versions/{vid}/purge-now": {
+    "/books/{id}/versions/{vid}/purge-now": {
       "post": {
         "operationId": "handlePurgeVersion",
         "summary": "Purge Version",
@@ -2886,7 +4103,7 @@
         }
       }
     },
-    "/api/v1/books/{id}/versions/{vid}/restore": {
+    "/books/{id}/versions/{vid}/restore": {
       "post": {
         "operationId": "handleRestoreVersion",
         "summary": "Restore Version",
@@ -2914,7 +4131,7 @@
         }
       }
     },
-    "/api/v1/compare": {
+    "/compare": {
       "get": {
         "operationId": "unknown",
         "summary": "unknown",
@@ -2938,7 +4155,7 @@
         }
       }
     },
-    "/api/v1/config": {
+    "/config": {
       "get": {
         "operationId": "getConfig",
         "summary": "get Config",
@@ -2992,7 +4209,7 @@
         }
       }
     },
-    "/api/v1/covers/local/{filename}": {
+    "/covers/local/{filename}": {
       "get": {
         "operationId": "handleLocalCover",
         "summary": "Local Cover",
@@ -3020,7 +4237,7 @@
         }
       }
     },
-    "/api/v1/covers/proxy": {
+    "/covers/proxy": {
       "get": {
         "operationId": "handleCoverProxy",
         "summary": "Cover Proxy",
@@ -3048,7 +4265,7 @@
         }
       }
     },
-    "/api/v1/dashboard": {
+    "/dashboard": {
       "get": {
         "operationId": "getDashboard",
         "summary": "get Dashboard",
@@ -3076,7 +4293,7 @@
         }
       }
     },
-    "/api/v1/dedup/candidates": {
+    "/dedup/candidates": {
       "get": {
         "operationId": "listDedupCandidates",
         "summary": "list Dedup Candidates",
@@ -3104,7 +4321,7 @@
         }
       }
     },
-    "/api/v1/dedup/candidates/bulk-merge": {
+    "/dedup/candidates/bulk-merge": {
       "post": {
         "operationId": "bulkMergeDedupCandidates",
         "summary": "bulk Merge Dedup Candidates",
@@ -3132,7 +4349,7 @@
         }
       }
     },
-    "/api/v1/dedup/candidates/dismiss-cluster": {
+    "/dedup/candidates/dismiss-cluster": {
       "post": {
         "operationId": "dismissDedupCluster",
         "summary": "dismiss Dedup Cluster",
@@ -3160,7 +4377,7 @@
         }
       }
     },
-    "/api/v1/dedup/candidates/export": {
+    "/dedup/candidates/export": {
       "get": {
         "operationId": "exportDedupCandidates",
         "summary": "export Dedup Candidates",
@@ -3188,7 +4405,7 @@
         }
       }
     },
-    "/api/v1/dedup/candidates/merge-cluster": {
+    "/dedup/candidates/merge-cluster": {
       "post": {
         "operationId": "mergeDedupCluster",
         "summary": "merge Dedup Cluster",
@@ -3216,7 +4433,7 @@
         }
       }
     },
-    "/api/v1/dedup/candidates/merge-series": {
+    "/dedup/candidates/merge-series": {
       "post": {
         "operationId": "mergeDedupCandidateSeries",
         "summary": "merge Dedup Candidate Series",
@@ -3244,7 +4461,7 @@
         }
       }
     },
-    "/api/v1/dedup/candidates/remove-from-cluster": {
+    "/dedup/candidates/remove-from-cluster": {
       "post": {
         "operationId": "removeFromDedupCluster",
         "summary": "remove From Dedup Cluster",
@@ -3272,7 +4489,7 @@
         }
       }
     },
-    "/api/v1/dedup/candidates/series-summary": {
+    "/dedup/candidates/series-summary": {
       "get": {
         "operationId": "listDedupCandidateSeries",
         "summary": "list Dedup Candidate Series",
@@ -3300,7 +4517,7 @@
         }
       }
     },
-    "/api/v1/dedup/candidates/{id}/dismiss": {
+    "/dedup/candidates/{id}/dismiss": {
       "post": {
         "operationId": "dismissDedupCandidate",
         "summary": "dismiss Dedup Candidate",
@@ -3328,7 +4545,7 @@
         }
       }
     },
-    "/api/v1/dedup/candidates/{id}/merge": {
+    "/dedup/candidates/{id}/merge": {
       "post": {
         "operationId": "mergeDedupCandidate",
         "summary": "merge Dedup Candidate",
@@ -3356,7 +4573,7 @@
         }
       }
     },
-    "/api/v1/dedup/refresh": {
+    "/dedup/refresh": {
       "post": {
         "operationId": "triggerDedupRefresh",
         "summary": "trigger Dedup Refresh",
@@ -3384,7 +4601,7 @@
         }
       }
     },
-    "/api/v1/dedup/scan": {
+    "/dedup/scan": {
       "post": {
         "operationId": "triggerDedupScan",
         "summary": "trigger Dedup Scan",
@@ -3412,7 +4629,7 @@
         }
       }
     },
-    "/api/v1/dedup/scan-llm": {
+    "/dedup/scan-llm": {
       "post": {
         "operationId": "triggerDedupLLM",
         "summary": "trigger Dedup L L M",
@@ -3440,7 +4657,7 @@
         }
       }
     },
-    "/api/v1/dedup/stats": {
+    "/dedup/stats": {
       "get": {
         "operationId": "getDedupStats",
         "summary": "get Dedup Stats",
@@ -3468,7 +4685,7 @@
         }
       }
     },
-    "/api/v1/dedup/validate": {
+    "/dedup/validate": {
       "post": {
         "operationId": "validateDedupEntry",
         "summary": "validate Dedup Entry",
@@ -3496,7 +4713,7 @@
         }
       }
     },
-    "/api/v1/diagnostics/ai-results/{operationId}": {
+    "/diagnostics/ai-results/{operationId}": {
       "get": {
         "operationId": "getDiagnosticsAIResults",
         "summary": "get Diagnostics A I Results",
@@ -3524,7 +4741,7 @@
         }
       }
     },
-    "/api/v1/diagnostics/apply-suggestions": {
+    "/diagnostics/apply-suggestions": {
       "post": {
         "operationId": "applyDiagnosticsSuggestions",
         "summary": "apply Diagnostics Suggestions",
@@ -3552,7 +4769,7 @@
         }
       }
     },
-    "/api/v1/diagnostics/export": {
+    "/diagnostics/export": {
       "post": {
         "operationId": "startDiagnosticsExport",
         "summary": "start Diagnostics Export",
@@ -3580,7 +4797,7 @@
         }
       }
     },
-    "/api/v1/diagnostics/export/{operationId}/download": {
+    "/diagnostics/export/{operationId}/download": {
       "get": {
         "operationId": "downloadDiagnosticsExport",
         "summary": "download Diagnostics Export",
@@ -3608,7 +4825,7 @@
         }
       }
     },
-    "/api/v1/diagnostics/submit-ai": {
+    "/diagnostics/submit-ai": {
       "post": {
         "operationId": "submitDiagnosticsAI",
         "summary": "submit Diagnostics A I",
@@ -3636,7 +4853,7 @@
         }
       }
     },
-    "/api/v1/file-ops/pending": {
+    "/file-ops/pending": {
       "get": {
         "operationId": "handleListPendingFileOps",
         "summary": "List Pending File Ops",
@@ -3664,7 +4881,7 @@
         }
       }
     },
-    "/api/v1/filesystem/browse": {
+    "/filesystem/browse": {
       "get": {
         "operationId": "browseFilesystem",
         "summary": "browse Filesystem",
@@ -3692,7 +4909,7 @@
         }
       }
     },
-    "/api/v1/filesystem/exclude": {
+    "/filesystem/exclude": {
       "post": {
         "operationId": "createExclusion",
         "summary": "create Exclusion",
@@ -3746,7 +4963,7 @@
         }
       }
     },
-    "/api/v1/filesystem/home": {
+    "/filesystem/home": {
       "get": {
         "operationId": "getHomeDirectory",
         "summary": "get Home Directory",
@@ -3774,7 +4991,43 @@
         }
       }
     },
-    "/api/v1/import": {
+    "/health": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Health check",
+        "description": "Returns health status with library counts. Also available at /health, /api/health.",
+        "responses": {
+          "200": {
+            "description": "Healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    },
+                    "book_count": {
+                      "type": "integer"
+                    },
+                    "author_count": {
+                      "type": "integer"
+                    },
+                    "series_count": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/import": {
       "post": {
         "operationId": "handleITunesImport",
         "summary": "I Tunes Import",
@@ -3802,7 +5055,7 @@
         }
       }
     },
-    "/api/v1/import-paths": {
+    "/import-paths": {
       "get": {
         "operationId": "listImportPaths",
         "summary": "list Import Paths",
@@ -3856,7 +5109,7 @@
         }
       }
     },
-    "/api/v1/import-paths/{id}": {
+    "/import-paths/{id}": {
       "delete": {
         "operationId": "removeImportPath",
         "summary": "remove Import Path",
@@ -3884,7 +5137,7 @@
         }
       }
     },
-    "/api/v1/import-status/bulk": {
+    "/import-status/bulk": {
       "post": {
         "operationId": "handleITunesImportStatusBulk",
         "summary": "I Tunes Import Status Bulk",
@@ -3912,7 +5165,7 @@
         }
       }
     },
-    "/api/v1/import-status/{id}": {
+    "/import-status/{id}": {
       "get": {
         "operationId": "handleITunesImportStatus",
         "summary": "I Tunes Import Status",
@@ -3940,7 +5193,7 @@
         }
       }
     },
-    "/api/v1/import/collision-preview": {
+    "/import/collision-preview": {
       "post": {
         "operationId": "handleImportCollisionPreview",
         "summary": "Import Collision Preview",
@@ -3968,7 +5221,7 @@
         }
       }
     },
-    "/api/v1/import/file": {
+    "/import/file": {
       "post": {
         "operationId": "importFile",
         "summary": "import File",
@@ -3996,7 +5249,7 @@
         }
       }
     },
-    "/api/v1/invite": {
+    "/invite": {
       "post": {
         "operationId": "handleCreateInvite",
         "summary": "Create Invite",
@@ -4024,7 +5277,7 @@
         }
       }
     },
-    "/api/v1/invites": {
+    "/invites": {
       "get": {
         "operationId": "handleListInvites",
         "summary": "List Invites",
@@ -4052,7 +5305,7 @@
         }
       }
     },
-    "/api/v1/invites/{token}": {
+    "/invites/{token}": {
       "delete": {
         "operationId": "handleDeleteInvite",
         "summary": "Delete Invite",
@@ -4080,7 +5333,435 @@
         }
       }
     },
-    "/api/v1/library-status": {
+    "/itunes/books": {
+      "get": {
+        "tags": [
+          "iTunes"
+        ],
+        "summary": "List iTunes books",
+        "description": "Returns books from the parsed iTunes library.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "iTunes book list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/itunes/import": {
+      "post": {
+        "tags": [
+          "iTunes"
+        ],
+        "summary": "Import from iTunes library",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "mapping": {
+                    "type": "object",
+                    "properties": {
+                      "itunes_path": {
+                        "type": "string"
+                      },
+                      "local_path": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "path"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Import started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "operation_id": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/itunes/import-status/bulk": {
+      "post": {
+        "tags": [
+          "iTunes"
+        ],
+        "summary": "Get iTunes import status for multiple books",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bulk import status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "imported": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/itunes/import-status/{id}": {
+      "get": {
+        "tags": [
+          "iTunes"
+        ],
+        "summary": "Get iTunes import status for a book",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/idPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Import status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "imported": {
+                      "type": "boolean"
+                    },
+                    "itunes_id": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/itunes/library-status": {
+      "get": {
+        "tags": [
+          "iTunes"
+        ],
+        "summary": "Get iTunes library status",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Library status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "configured": {
+                      "type": "boolean"
+                    },
+                    "path": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "track_count": {
+                      "type": "integer"
+                    },
+                    "last_sync": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/itunes/sync": {
+      "post": {
+        "tags": [
+          "iTunes"
+        ],
+        "summary": "Sync iTunes library",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sync started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "operation_id": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/itunes/test-mapping": {
+      "post": {
+        "tags": [
+          "iTunes"
+        ],
+        "summary": "Test iTunes path mapping",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "itunes_path": {
+                    "type": "string"
+                  },
+                  "local_path": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "itunes_path",
+                  "local_path"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Mapping test result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "valid": {
+                      "type": "boolean"
+                    },
+                    "sample_mappings": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "itunes": {
+                            "type": "string"
+                          },
+                          "local": {
+                            "type": "string"
+                          },
+                          "exists": {
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/itunes/validate": {
+      "post": {
+        "tags": [
+          "iTunes"
+        ],
+        "summary": "Validate iTunes library path",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Validation result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "valid": {
+                      "type": "boolean"
+                    },
+                    "track_count": {
+                      "type": "integer"
+                    },
+                    "error": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/itunes/write-back": {
+      "post": {
+        "tags": [
+          "iTunes"
+        ],
+        "summary": "Write back to iTunes library",
+        "description": "Writes updated metadata back to the iTunes .itl binary file.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Write-back result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/itunes/write-back/preview": {
+      "post": {
+        "tags": [
+          "iTunes"
+        ],
+        "summary": "Preview iTunes write-back",
+        "description": "Shows what changes would be written to the iTunes library without applying them.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Write-back preview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/library-status": {
       "get": {
         "operationId": "handleITunesLibraryStatus",
         "summary": "I Tunes Library Status",
@@ -4108,7 +5789,7 @@
         }
       }
     },
-    "/api/v1/login": {
+    "/login": {
       "post": {
         "operationId": "login",
         "summary": "login",
@@ -4132,7 +5813,7 @@
         }
       }
     },
-    "/api/v1/logout": {
+    "/logout": {
       "post": {
         "operationId": "logout",
         "summary": "logout",
@@ -4156,7 +5837,7 @@
         }
       }
     },
-    "/api/v1/maintenance-window/run": {
+    "/maintenance-window/run": {
       "post": {
         "operationId": "runMaintenanceWindowNow",
         "summary": "run Maintenance Window Now",
@@ -4184,7 +5865,7 @@
         }
       }
     },
-    "/api/v1/maintenance/backfill-book-files": {
+    "/maintenance/backfill-book-files": {
       "post": {
         "operationId": "handleBackfillBookFiles",
         "summary": "Backfill Book Files",
@@ -4212,7 +5893,7 @@
         }
       }
     },
-    "/api/v1/maintenance/cleanup-backups": {
+    "/maintenance/cleanup-backups": {
       "post": {
         "operationId": "handleCleanupBackups",
         "summary": "Cleanup Backups",
@@ -4240,7 +5921,7 @@
         }
       }
     },
-    "/api/v1/maintenance/cleanup-empty-folders": {
+    "/maintenance/cleanup-empty-folders": {
       "post": {
         "operationId": "handleCleanupEmptyFolders",
         "summary": "Cleanup Empty Folders",
@@ -4268,7 +5949,7 @@
         }
       }
     },
-    "/api/v1/maintenance/cleanup-organize-mess": {
+    "/maintenance/cleanup-organize-mess": {
       "post": {
         "operationId": "handleCleanupOrganizeMess",
         "summary": "Cleanup Organize Mess",
@@ -4296,7 +5977,7 @@
         }
       }
     },
-    "/api/v1/maintenance/cleanup-series": {
+    "/maintenance/cleanup-series": {
       "post": {
         "operationId": "handleCleanupSeries",
         "summary": "Cleanup Series",
@@ -4324,7 +6005,7 @@
         }
       }
     },
-    "/api/v1/maintenance/dedup-books": {
+    "/maintenance/dedup-books": {
       "post": {
         "operationId": "handleDedupBooks",
         "summary": "Dedup Books",
@@ -4352,7 +6033,7 @@
         }
       }
     },
-    "/api/v1/maintenance/enrich-book-files": {
+    "/maintenance/enrich-book-files": {
       "post": {
         "operationId": "handleEnrichBookFiles",
         "summary": "Enrich Book Files",
@@ -4380,7 +6061,7 @@
         }
       }
     },
-    "/api/v1/maintenance/fix-author-narrator-swap": {
+    "/maintenance/fix-author-narrator-swap": {
       "post": {
         "operationId": "handleFixAuthorNarratorSwap",
         "summary": "Fix Author Narrator Swap",
@@ -4408,7 +6089,7 @@
         }
       }
     },
-    "/api/v1/maintenance/fix-book-file-paths": {
+    "/maintenance/fix-book-file-paths": {
       "post": {
         "operationId": "handleFixBookFilePaths",
         "summary": "Fix Book File Paths",
@@ -4436,7 +6117,7 @@
         }
       }
     },
-    "/api/v1/maintenance/fix-library-states": {
+    "/maintenance/fix-library-states": {
       "post": {
         "operationId": "handleFixLibraryStates",
         "summary": "Fix Library States",
@@ -4464,7 +6145,7 @@
         }
       }
     },
-    "/api/v1/maintenance/fix-read-by-narrator": {
+    "/maintenance/fix-read-by-narrator": {
       "post": {
         "operationId": "handleFixReadByNarrator",
         "summary": "Fix Read By Narrator",
@@ -4492,7 +6173,7 @@
         }
       }
     },
-    "/api/v1/maintenance/fix-version-groups": {
+    "/maintenance/fix-version-groups": {
       "post": {
         "operationId": "handleFixVersionGroups",
         "summary": "Fix Version Groups",
@@ -4520,7 +6201,7 @@
         }
       }
     },
-    "/api/v1/maintenance/generate-itl-tests": {
+    "/maintenance/generate-itl-tests": {
       "post": {
         "operationId": "handleGenerateITLTests",
         "summary": "Generate I T L Tests",
@@ -4548,7 +6229,7 @@
         }
       }
     },
-    "/api/v1/maintenance/recompute-itunes-paths": {
+    "/maintenance/recompute-itunes-paths": {
       "post": {
         "operationId": "handleRecomputeITunesPaths",
         "summary": "Recompute I Tunes Paths",
@@ -4576,7 +6257,7 @@
         }
       }
     },
-    "/api/v1/maintenance/refetch-missing-authors": {
+    "/maintenance/refetch-missing-authors": {
       "post": {
         "operationId": "handleRefetchMissingAuthors",
         "summary": "Refetch Missing Authors",
@@ -4604,7 +6285,7 @@
         }
       }
     },
-    "/api/v1/me": {
+    "/me": {
       "get": {
         "operationId": "me",
         "summary": "me",
@@ -4628,7 +6309,7 @@
         }
       }
     },
-    "/api/v1/me/{status}": {
+    "/me/{status}": {
       "get": {
         "operationId": "handleListByStatus",
         "summary": "List By Status",
@@ -4652,7 +6333,7 @@
         }
       }
     },
-    "/api/v1/metadata-sources/test": {
+    "/metadata-sources/test": {
       "post": {
         "operationId": "testMetadataSource",
         "summary": "test Metadata Source",
@@ -4680,7 +6361,7 @@
         }
       }
     },
-    "/api/v1/metadata/batch-apply-candidates": {
+    "/metadata/batch-apply-candidates": {
       "post": {
         "operationId": "handleBatchApplyCandidates",
         "summary": "Batch Apply Candidates",
@@ -4708,7 +6389,7 @@
         }
       }
     },
-    "/api/v1/metadata/batch-fetch-candidates": {
+    "/metadata/batch-fetch-candidates": {
       "post": {
         "operationId": "handleBatchFetchCandidates",
         "summary": "Batch Fetch Candidates",
@@ -4736,7 +6417,7 @@
         }
       }
     },
-    "/api/v1/metadata/batch-reject-candidates": {
+    "/metadata/batch-reject-candidates": {
       "post": {
         "operationId": "handleRejectCandidates",
         "summary": "Reject Candidates",
@@ -4764,7 +6445,7 @@
         }
       }
     },
-    "/api/v1/metadata/batch-unreject-candidates": {
+    "/metadata/batch-unreject-candidates": {
       "post": {
         "operationId": "handleUnrejectCandidates",
         "summary": "Unreject Candidates",
@@ -4792,7 +6473,7 @@
         }
       }
     },
-    "/api/v1/metadata/batch-update": {
+    "/metadata/batch-update": {
       "post": {
         "operationId": "batchUpdateMetadata",
         "summary": "batch Update Metadata",
@@ -4820,7 +6501,7 @@
         }
       }
     },
-    "/api/v1/metadata/bulk-fetch": {
+    "/metadata/bulk-fetch": {
       "post": {
         "operationId": "bulkFetchMetadata",
         "summary": "bulk Fetch Metadata",
@@ -4848,7 +6529,7 @@
         }
       }
     },
-    "/api/v1/metadata/export": {
+    "/metadata/export": {
       "get": {
         "operationId": "exportMetadata",
         "summary": "export Metadata",
@@ -4876,7 +6557,7 @@
         }
       }
     },
-    "/api/v1/metadata/fields": {
+    "/metadata/fields": {
       "get": {
         "operationId": "getMetadataFields",
         "summary": "get Metadata Fields",
@@ -4904,7 +6585,7 @@
         }
       }
     },
-    "/api/v1/metadata/import": {
+    "/metadata/import": {
       "post": {
         "operationId": "importMetadata",
         "summary": "import Metadata",
@@ -4932,7 +6613,7 @@
         }
       }
     },
-    "/api/v1/metadata/recent-fetches": {
+    "/metadata/recent-fetches": {
       "get": {
         "operationId": "handleGetLatestMetadataFetch",
         "summary": "Get Latest Metadata Fetch",
@@ -4960,7 +6641,7 @@
         }
       }
     },
-    "/api/v1/metadata/search": {
+    "/metadata/search": {
       "get": {
         "operationId": "searchMetadata",
         "summary": "search Metadata",
@@ -4988,7 +6669,7 @@
         }
       }
     },
-    "/api/v1/metadata/validate": {
+    "/metadata/validate": {
       "post": {
         "operationId": "validateMetadata",
         "summary": "validate Metadata",
@@ -5016,7 +6697,7 @@
         }
       }
     },
-    "/api/v1/narrators": {
+    "/narrators": {
       "get": {
         "operationId": "listNarrators",
         "summary": "list Narrators",
@@ -5044,7 +6725,7 @@
         }
       }
     },
-    "/api/v1/narrators/count": {
+    "/narrators/count": {
       "get": {
         "operationId": "countNarrators",
         "summary": "count Narrators",
@@ -5072,7 +6753,7 @@
         }
       }
     },
-    "/api/v1/openlibrary/data": {
+    "/openlibrary/data": {
       "delete": {
         "operationId": "deleteOLData",
         "summary": "delete O L Data",
@@ -5100,7 +6781,7 @@
         }
       }
     },
-    "/api/v1/openlibrary/download": {
+    "/openlibrary/download": {
       "post": {
         "operationId": "startOLDownload",
         "summary": "start O L Download",
@@ -5128,7 +6809,7 @@
         }
       }
     },
-    "/api/v1/openlibrary/import": {
+    "/openlibrary/import": {
       "post": {
         "operationId": "startOLImport",
         "summary": "start O L Import",
@@ -5156,7 +6837,7 @@
         }
       }
     },
-    "/api/v1/openlibrary/status": {
+    "/openlibrary/status": {
       "get": {
         "operationId": "getOLStatus",
         "summary": "get O L Status",
@@ -5184,7 +6865,7 @@
         }
       }
     },
-    "/api/v1/openlibrary/upload": {
+    "/openlibrary/upload": {
       "post": {
         "operationId": "uploadOLDump",
         "summary": "upload O L Dump",
@@ -5212,7 +6893,7 @@
         }
       }
     },
-    "/api/v1/operations": {
+    "/operations": {
       "get": {
         "operationId": "listOperations",
         "summary": "list Operations",
@@ -5240,7 +6921,7 @@
         }
       }
     },
-    "/api/v1/operations/active": {
+    "/operations/active": {
       "get": {
         "operationId": "listActiveOperations",
         "summary": "list Active Operations",
@@ -5268,7 +6949,7 @@
         }
       }
     },
-    "/api/v1/operations/assign-orphan-vgs": {
+    "/operations/assign-orphan-vgs": {
       "post": {
         "operationId": "assignOrphanVGsHandler",
         "summary": "assign Orphan V Gs",
@@ -5296,7 +6977,7 @@
         }
       }
     },
-    "/api/v1/operations/audit-files": {
+    "/operations/audit-files": {
       "get": {
         "operationId": "auditFileConsistency",
         "summary": "audit File Consistency",
@@ -5324,7 +7005,7 @@
         }
       }
     },
-    "/api/v1/operations/cleanup-version-groups": {
+    "/operations/cleanup-version-groups": {
       "post": {
         "operationId": "cleanupDuplicateVersionGroupsHandler",
         "summary": "cleanup Duplicate Version Groups",
@@ -5352,7 +7033,7 @@
         }
       }
     },
-    "/api/v1/operations/clear-stale": {
+    "/operations/clear-stale": {
       "post": {
         "operationId": "clearStaleOperations",
         "summary": "clear Stale Operations",
@@ -5380,7 +7061,7 @@
         }
       }
     },
-    "/api/v1/operations/history": {
+    "/operations/history": {
       "delete": {
         "operationId": "deleteOperationHistory",
         "summary": "delete Operation History",
@@ -5408,7 +7089,7 @@
         }
       }
     },
-    "/api/v1/operations/itunes-path-reconcile": {
+    "/operations/itunes-path-reconcile": {
       "post": {
         "operationId": "startITunesPathReconcile",
         "summary": "start I Tunes Path Reconcile",
@@ -5436,7 +7117,7 @@
         }
       }
     },
-    "/api/v1/operations/mark-broken-segments": {
+    "/operations/mark-broken-segments": {
       "post": {
         "operationId": "markBrokenSegmentBooksHandler",
         "summary": "mark Broken Segment Books",
@@ -5464,7 +7145,7 @@
         }
       }
     },
-    "/api/v1/operations/merge-novg-duplicates": {
+    "/operations/merge-novg-duplicates": {
       "post": {
         "operationId": "mergeNoVGDuplicatesHandler",
         "summary": "merge No V G Duplicates",
@@ -5492,7 +7173,7 @@
         }
       }
     },
-    "/api/v1/operations/optimize-database": {
+    "/operations/optimize-database": {
       "post": {
         "operationId": "optimizeDatabase",
         "summary": "optimize Database",
@@ -5520,7 +7201,7 @@
         }
       }
     },
-    "/api/v1/operations/organize": {
+    "/operations/organize": {
       "post": {
         "operationId": "startOrganize",
         "summary": "start Organize",
@@ -5548,7 +7229,7 @@
         }
       }
     },
-    "/api/v1/operations/recent": {
+    "/operations/recent": {
       "get": {
         "operationId": "handleGetRecentOperations",
         "summary": "Get Recent Operations",
@@ -5576,7 +7257,7 @@
         }
       }
     },
-    "/api/v1/operations/reconcile": {
+    "/operations/reconcile": {
       "post": {
         "operationId": "startReconcile",
         "summary": "start Reconcile",
@@ -5604,7 +7285,7 @@
         }
       }
     },
-    "/api/v1/operations/reconcile/preview": {
+    "/operations/reconcile/preview": {
       "get": {
         "operationId": "reconcilePreview",
         "summary": "reconcile Preview",
@@ -5632,7 +7313,7 @@
         }
       }
     },
-    "/api/v1/operations/reconcile/scan": {
+    "/operations/reconcile/scan": {
       "post": {
         "operationId": "startReconcileScan",
         "summary": "start Reconcile Scan",
@@ -5660,7 +7341,7 @@
         }
       }
     },
-    "/api/v1/operations/reconcile/scan/latest": {
+    "/operations/reconcile/scan/latest": {
       "get": {
         "operationId": "latestReconcileScan",
         "summary": "latest Reconcile Scan",
@@ -5688,7 +7369,7 @@
         }
       }
     },
-    "/api/v1/operations/scan": {
+    "/operations/scan": {
       "post": {
         "operationId": "startScan",
         "summary": "start Scan",
@@ -5716,7 +7397,7 @@
         }
       }
     },
-    "/api/v1/operations/stale": {
+    "/operations/stale": {
       "get": {
         "operationId": "listStaleOperations",
         "summary": "list Stale Operations",
@@ -5744,7 +7425,7 @@
         }
       }
     },
-    "/api/v1/operations/sweep-tombstones": {
+    "/operations/sweep-tombstones": {
       "post": {
         "operationId": "sweepTombstones",
         "summary": "sweep Tombstones",
@@ -5772,7 +7453,7 @@
         }
       }
     },
-    "/api/v1/operations/transcode": {
+    "/operations/transcode": {
       "post": {
         "operationId": "startTranscode",
         "summary": "start Transcode",
@@ -5800,7 +7481,7 @@
         }
       }
     },
-    "/api/v1/operations/{id}": {
+    "/operations/{id}": {
       "delete": {
         "operationId": "cancelOperation",
         "summary": "cancel Operation",
@@ -5828,7 +7509,7 @@
         }
       }
     },
-    "/api/v1/operations/{id}/changes": {
+    "/operations/{id}/changes": {
       "get": {
         "operationId": "getOperationChanges",
         "summary": "get Operation Changes",
@@ -5856,7 +7537,7 @@
         }
       }
     },
-    "/api/v1/operations/{id}/logs": {
+    "/operations/{id}/logs": {
       "get": {
         "operationId": "getOperationLogs",
         "summary": "get Operation Logs",
@@ -5884,7 +7565,7 @@
         }
       }
     },
-    "/api/v1/operations/{id}/result": {
+    "/operations/{id}/result": {
       "get": {
         "operationId": "getOperationResult",
         "summary": "get Operation Result",
@@ -5912,7 +7593,7 @@
         }
       }
     },
-    "/api/v1/operations/{id}/results": {
+    "/operations/{id}/results": {
       "get": {
         "operationId": "handleGetOperationResults",
         "summary": "Get Operation Results",
@@ -5940,7 +7621,7 @@
         }
       }
     },
-    "/api/v1/operations/{id}/revert": {
+    "/operations/{id}/revert": {
       "post": {
         "operationId": "revertOperation",
         "summary": "revert Operation",
@@ -5968,7 +7649,7 @@
         }
       }
     },
-    "/api/v1/operations/{id}/status": {
+    "/operations/{id}/status": {
       "get": {
         "operationId": "getOperationStatus",
         "summary": "get Operation Status",
@@ -5996,7 +7677,7 @@
         }
       }
     },
-    "/api/v1/operations/{id}/undo/preflight": {
+    "/operations/{id}/undo/preflight": {
       "get": {
         "operationId": "undoPreflightHandler",
         "summary": "undo Preflight",
@@ -6024,7 +7705,7 @@
         }
       }
     },
-    "/api/v1/path": {
+    "/path": {
       "get": {
         "operationId": "unknown",
         "summary": "unknown",
@@ -6052,7 +7733,7 @@
         }
       }
     },
-    "/api/v1/playlists": {
+    "/playlists": {
       "get": {
         "operationId": "handleListPlaylists",
         "summary": "List Playlists",
@@ -6098,7 +7779,7 @@
         }
       }
     },
-    "/api/v1/playlists/{id}": {
+    "/playlists/{id}": {
       "get": {
         "operationId": "handleGetPlaylist",
         "summary": "Get Playlist",
@@ -6166,7 +7847,7 @@
         }
       }
     },
-    "/api/v1/playlists/{id}/books": {
+    "/playlists/{id}/books": {
       "post": {
         "operationId": "handleAddBooksToPlaylist",
         "summary": "Add Books To Playlist",
@@ -6190,7 +7871,7 @@
         }
       }
     },
-    "/api/v1/playlists/{id}/books/{bookID}": {
+    "/playlists/{id}/books/{bookID}": {
       "delete": {
         "operationId": "handleRemoveBookFromPlaylist",
         "summary": "Remove Book From Playlist",
@@ -6214,7 +7895,7 @@
         }
       }
     },
-    "/api/v1/playlists/{id}/materialize": {
+    "/playlists/{id}/materialize": {
       "post": {
         "operationId": "handleMaterializePlaylist",
         "summary": "Materialize Playlist",
@@ -6238,7 +7919,7 @@
         }
       }
     },
-    "/api/v1/playlists/{id}/reorder": {
+    "/playlists/{id}/reorder": {
       "post": {
         "operationId": "handleReorderPlaylist",
         "summary": "Reorder Playlist",
@@ -6262,7 +7943,7 @@
         }
       }
     },
-    "/api/v1/preferences/{key}": {
+    "/preferences/{key}": {
       "get": {
         "operationId": "getUserPreference",
         "summary": "get User Preference",
@@ -6342,7 +8023,7 @@
         }
       }
     },
-    "/api/v1/purged-versions/{vid}": {
+    "/purged-versions/{vid}": {
       "delete": {
         "operationId": "handleHardDeleteVersion",
         "summary": "Hard Delete Version",
@@ -6370,7 +8051,7 @@
         }
       }
     },
-    "/api/v1/rebuild": {
+    "/rebuild": {
       "post": {
         "operationId": "rebuildITLHandler",
         "summary": "rebuild I T L",
@@ -6398,7 +8079,7 @@
         }
       }
     },
-    "/api/v1/series": {
+    "/series": {
       "get": {
         "operationId": "listSeries",
         "summary": "list Series",
@@ -6426,7 +8107,7 @@
         }
       }
     },
-    "/api/v1/series/bulk-delete": {
+    "/series/bulk-delete": {
       "post": {
         "operationId": "bulkDeleteSeries",
         "summary": "bulk Delete Series",
@@ -6454,7 +8135,7 @@
         }
       }
     },
-    "/api/v1/series/count": {
+    "/series/count": {
       "get": {
         "operationId": "countSeries",
         "summary": "count Series",
@@ -6482,7 +8163,7 @@
         }
       }
     },
-    "/api/v1/series/deduplicate": {
+    "/series/deduplicate": {
       "post": {
         "operationId": "deduplicateSeriesHandler",
         "summary": "deduplicate Series",
@@ -6510,7 +8191,7 @@
         }
       }
     },
-    "/api/v1/series/duplicates": {
+    "/series/duplicates": {
       "get": {
         "operationId": "listSeriesDuplicates",
         "summary": "list Series Duplicates",
@@ -6538,7 +8219,7 @@
         }
       }
     },
-    "/api/v1/series/duplicates/refresh": {
+    "/series/duplicates/refresh": {
       "post": {
         "operationId": "refreshSeriesDuplicates",
         "summary": "refresh Series Duplicates",
@@ -6566,7 +8247,7 @@
         }
       }
     },
-    "/api/v1/series/merge": {
+    "/series/merge": {
       "post": {
         "operationId": "mergeSeriesGroup",
         "summary": "merge Series Group",
@@ -6594,7 +8275,7 @@
         }
       }
     },
-    "/api/v1/series/prune": {
+    "/series/prune": {
       "post": {
         "operationId": "seriesPrune",
         "summary": "series Prune",
@@ -6622,7 +8303,7 @@
         }
       }
     },
-    "/api/v1/series/prune/preview": {
+    "/series/prune/preview": {
       "get": {
         "operationId": "seriesPrunePreview",
         "summary": "series Prune Preview",
@@ -6650,7 +8331,7 @@
         }
       }
     },
-    "/api/v1/series/{id}": {
+    "/series/{id}": {
       "patch": {
         "operationId": "updateSeriesName",
         "summary": "update Series Name",
@@ -6704,7 +8385,7 @@
         }
       }
     },
-    "/api/v1/series/{id}/books": {
+    "/series/{id}/books": {
       "get": {
         "operationId": "getSeriesBooks",
         "summary": "get Series Books",
@@ -6732,7 +8413,7 @@
         }
       }
     },
-    "/api/v1/series/{id}/name": {
+    "/series/{id}/name": {
       "put": {
         "operationId": "renameSeriesHandler",
         "summary": "rename Series",
@@ -6760,7 +8441,7 @@
         }
       }
     },
-    "/api/v1/series/{id}/split": {
+    "/series/{id}/split": {
       "post": {
         "operationId": "splitSeriesHandler",
         "summary": "split Series",
@@ -6788,7 +8469,7 @@
         }
       }
     },
-    "/api/v1/series/{id}/tags": {
+    "/series/{id}/tags": {
       "get": {
         "operationId": "handleGetSeriesTags",
         "summary": "Get Series Tags",
@@ -6842,7 +8523,7 @@
         }
       }
     },
-    "/api/v1/sessions": {
+    "/sessions": {
       "get": {
         "operationId": "listMySessions",
         "summary": "list My Sessions",
@@ -6866,7 +8547,7 @@
         }
       }
     },
-    "/api/v1/sessions/{id}": {
+    "/sessions/{id}": {
       "delete": {
         "operationId": "revokeMySession",
         "summary": "revoke My Session",
@@ -6890,7 +8571,7 @@
         }
       }
     },
-    "/api/v1/setup": {
+    "/setup": {
       "post": {
         "operationId": "setupInitialAdmin",
         "summary": "setup Initial Admin",
@@ -6914,7 +8595,7 @@
         }
       }
     },
-    "/api/v1/status": {
+    "/status": {
       "get": {
         "operationId": "handleDelugeStatus",
         "summary": "Deluge Status",
@@ -6942,7 +8623,7 @@
         }
       }
     },
-    "/api/v1/sync": {
+    "/sync": {
       "post": {
         "operationId": "handleITunesSync",
         "summary": "I Tunes Sync",
@@ -6970,7 +8651,7 @@
         }
       }
     },
-    "/api/v1/system/activity-log": {
+    "/system/activity-log": {
       "get": {
         "operationId": "getSystemActivityLog",
         "summary": "get System Activity Log",
@@ -6998,7 +8679,7 @@
         }
       }
     },
-    "/api/v1/system/announcements": {
+    "/system/announcements": {
       "get": {
         "operationId": "getSystemAnnouncements",
         "summary": "get System Announcements",
@@ -7026,7 +8707,7 @@
         }
       }
     },
-    "/api/v1/system/factory-reset": {
+    "/system/factory-reset": {
       "post": {
         "operationId": "factoryReset",
         "summary": "factory Reset",
@@ -7054,7 +8735,7 @@
         }
       }
     },
-    "/api/v1/system/logs": {
+    "/system/logs": {
       "get": {
         "operationId": "getSystemLogs",
         "summary": "get System Logs",
@@ -7082,7 +8763,7 @@
         }
       }
     },
-    "/api/v1/system/reset": {
+    "/system/reset": {
       "post": {
         "operationId": "resetSystem",
         "summary": "reset System",
@@ -7110,7 +8791,7 @@
         }
       }
     },
-    "/api/v1/system/status": {
+    "/system/status": {
       "get": {
         "operationId": "getSystemStatus",
         "summary": "get System Status",
@@ -7138,7 +8819,7 @@
         }
       }
     },
-    "/api/v1/system/storage": {
+    "/system/storage": {
       "get": {
         "operationId": "getSystemStorage",
         "summary": "get System Storage",
@@ -7166,7 +8847,7 @@
         }
       }
     },
-    "/api/v1/tags": {
+    "/tags": {
       "get": {
         "operationId": "listAllUserTags",
         "summary": "list All User Tags",
@@ -7194,7 +8875,7 @@
         }
       }
     },
-    "/api/v1/tasks": {
+    "/tasks": {
       "get": {
         "operationId": "listTasks",
         "summary": "list Tasks",
@@ -7222,7 +8903,7 @@
         }
       }
     },
-    "/api/v1/tasks/{name}": {
+    "/tasks/{name}": {
       "put": {
         "operationId": "updateTaskConfig",
         "summary": "update Task Config",
@@ -7250,7 +8931,7 @@
         }
       }
     },
-    "/api/v1/tasks/{name}/run": {
+    "/tasks/{name}/run": {
       "post": {
         "operationId": "runTask",
         "summary": "run Task",
@@ -7278,7 +8959,7 @@
         }
       }
     },
-    "/api/v1/test-connection": {
+    "/test-connection": {
       "post": {
         "operationId": "handleDelugeTestConnection",
         "summary": "Deluge Test Connection",
@@ -7306,7 +8987,7 @@
         }
       }
     },
-    "/api/v1/test-mapping": {
+    "/test-mapping": {
       "post": {
         "operationId": "handleITunesTestMapping",
         "summary": "I Tunes Test Mapping",
@@ -7334,7 +9015,7 @@
         }
       }
     },
-    "/api/v1/torrents": {
+    "/torrents": {
       "get": {
         "operationId": "handleDelugeListTorrents",
         "summary": "Deluge List Torrents",
@@ -7362,7 +9043,7 @@
         }
       }
     },
-    "/api/v1/update/apply": {
+    "/update/apply": {
       "post": {
         "operationId": "applyUpdate",
         "summary": "apply Update",
@@ -7390,7 +9071,7 @@
         }
       }
     },
-    "/api/v1/update/check": {
+    "/update/check": {
       "post": {
         "operationId": "checkForUpdate",
         "summary": "check For Update",
@@ -7418,7 +9099,7 @@
         }
       }
     },
-    "/api/v1/update/status": {
+    "/update/status": {
       "get": {
         "operationId": "getUpdateStatus",
         "summary": "get Update Status",
@@ -7446,7 +9127,7 @@
         }
       }
     },
-    "/api/v1/validate": {
+    "/validate": {
       "post": {
         "operationId": "handleITunesValidate",
         "summary": "I Tunes Validate",
@@ -7474,7 +9155,7 @@
         }
       }
     },
-    "/api/v1/version-groups/{id}": {
+    "/version-groups/{id}": {
       "get": {
         "operationId": "getVersionGroup",
         "summary": "get Version Group",
@@ -7502,7 +9183,7 @@
         }
       }
     },
-    "/api/v1/work": {
+    "/work": {
       "get": {
         "operationId": "listWork",
         "summary": "list Work",
@@ -7530,7 +9211,7 @@
         }
       }
     },
-    "/api/v1/work/stats": {
+    "/work/stats": {
       "get": {
         "operationId": "getWorkStats",
         "summary": "get Work Stats",
@@ -7558,7 +9239,7 @@
         }
       }
     },
-    "/api/v1/works": {
+    "/works": {
       "get": {
         "operationId": "listWorks",
         "summary": "list Works",
@@ -7612,7 +9293,7 @@
         }
       }
     },
-    "/api/v1/works/{id}": {
+    "/works/{id}": {
       "get": {
         "operationId": "getWork",
         "summary": "get Work",
@@ -7692,7 +9373,7 @@
         }
       }
     },
-    "/api/v1/works/{id}/books": {
+    "/works/{id}/books": {
       "get": {
         "operationId": "listWorkBooks",
         "summary": "list Work Books",
@@ -7720,7 +9401,7 @@
         }
       }
     },
-    "/api/v1/write-back": {
+    "/write-back": {
       "post": {
         "operationId": "handleITunesWriteBack",
         "summary": "I Tunes Write Back",
@@ -7748,7 +9429,7 @@
         }
       }
     },
-    "/api/v1/write-back-all": {
+    "/write-back-all": {
       "post": {
         "operationId": "handleITunesWriteBackAll",
         "summary": "I Tunes Write Back All",
@@ -7776,7 +9457,7 @@
         }
       }
     },
-    "/api/v1/write-back/preview": {
+    "/write-back/preview": {
       "post": {
         "operationId": "handleITunesWriteBackPreview",
         "summary": "I Tunes Write Back Preview",
@@ -7804,7 +9485,7 @@
         }
       }
     },
-    "/api/v1/{id}": {
+    "/{id}": {
       "get": {
         "operationId": "getAIScan",
         "summary": "get A I Scan",
@@ -7858,7 +9539,7 @@
         }
       }
     },
-    "/api/v1/{id}/apply": {
+    "/{id}/apply": {
       "post": {
         "operationId": "applyAIScanResults",
         "summary": "apply A I Scan Results",
@@ -7886,7 +9567,7 @@
         }
       }
     },
-    "/api/v1/{id}/cancel": {
+    "/{id}/cancel": {
       "post": {
         "operationId": "cancelAIScan",
         "summary": "cancel A I Scan",
@@ -7914,7 +9595,7 @@
         }
       }
     },
-    "/api/v1/{id}/deactivate": {
+    "/{id}/deactivate": {
       "post": {
         "operationId": "handleDeactivateUser",
         "summary": "Deactivate User",
@@ -7942,7 +9623,7 @@
         }
       }
     },
-    "/api/v1/{id}/reactivate": {
+    "/{id}/reactivate": {
       "post": {
         "operationId": "handleReactivateUser",
         "summary": "Reactivate User",
@@ -7970,7 +9651,7 @@
         }
       }
     },
-    "/api/v1/{id}/reset-password": {
+    "/{id}/reset-password": {
       "post": {
         "operationId": "handleResetPassword",
         "summary": "Reset Password",
@@ -7998,7 +9679,7 @@
         }
       }
     },
-    "/api/v1/{id}/results": {
+    "/{id}/results": {
       "get": {
         "operationId": "getAIScanResults",
         "summary": "get A I Scan Results",

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -944,6 +944,17 @@
       }
     },
     "/ai/scans/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "tags": [
           "AIScans"
@@ -1002,6 +1013,17 @@
       }
     },
     "/ai/scans/{id}/apply": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "tags": [
           "AIScans"
@@ -1050,6 +1072,17 @@
       }
     },
     "/ai/scans/{id}/cancel": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "tags": [
           "AIScans"
@@ -1080,6 +1113,17 @@
       }
     },
     "/ai/scans/{id}/results": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "tags": [
           "AIScans"
@@ -1562,6 +1606,17 @@
       }
     },
     "/audiobooks/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getAudiobook",
         "summary": "get Audiobook",
@@ -1642,6 +1697,17 @@
       }
     },
     "/audiobooks/{id}/alternative-titles": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getBookAlternativeTitles",
         "summary": "get Book Alternative Titles",
@@ -1722,6 +1788,17 @@
       }
     },
     "/audiobooks/{id}/apply-metadata": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "applyAudiobookMetadata",
         "summary": "apply Audiobook Metadata",
@@ -1750,6 +1827,17 @@
       }
     },
     "/audiobooks/{id}/changelog": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getBookChangelog",
         "summary": "get Book Changelog",
@@ -1778,6 +1866,17 @@
       }
     },
     "/audiobooks/{id}/changes": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getBookChanges",
         "summary": "get Book Changes",
@@ -1806,6 +1905,17 @@
       }
     },
     "/audiobooks/{id}/cover": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "serveAudiobookCover",
         "summary": "serve Audiobook Cover",
@@ -1834,6 +1944,17 @@
       }
     },
     "/audiobooks/{id}/cover-history": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "handleListCoverHistory",
         "summary": "List Cover History",
@@ -1862,6 +1983,17 @@
       }
     },
     "/audiobooks/{id}/cover-history/restore": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "handleRestoreCover",
         "summary": "Restore Cover",
@@ -1890,6 +2022,17 @@
       }
     },
     "/audiobooks/{id}/cow-versions": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "listBookCOWVersions",
         "summary": "list Book C O W Versions",
@@ -1918,6 +2061,17 @@
       }
     },
     "/audiobooks/{id}/cow-versions/prune": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "pruneBookCOWVersions",
         "summary": "prune Book C O W Versions",
@@ -1946,6 +2100,17 @@
       }
     },
     "/audiobooks/{id}/external-ids": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getAudiobookExternalIDs",
         "summary": "get Audiobook External I Ds",
@@ -1974,6 +2139,17 @@
       }
     },
     "/audiobooks/{id}/extract-track-info": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "extractTrackInfo",
         "summary": "extract Track Info",
@@ -2002,6 +2178,17 @@
       }
     },
     "/audiobooks/{id}/fetch-metadata": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "fetchAudiobookMetadata",
         "summary": "fetch Audiobook Metadata",
@@ -2030,6 +2217,17 @@
       }
     },
     "/audiobooks/{id}/field-states": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getAudiobookFieldStates",
         "summary": "get Audiobook Field States",
@@ -2058,6 +2256,17 @@
       }
     },
     "/audiobooks/{id}/files": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "listBookFiles",
         "summary": "list Book Files",
@@ -2086,6 +2295,17 @@
       }
     },
     "/audiobooks/{id}/mark-no-match": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "markAudiobookNoMatch",
         "summary": "mark Audiobook No Match",
@@ -2114,6 +2334,17 @@
       }
     },
     "/audiobooks/{id}/metadata-history": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getBookMetadataHistory",
         "summary": "get Book Metadata History",
@@ -2142,6 +2373,26 @@
       }
     },
     "/audiobooks/{id}/metadata-history/{field}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "field",
+          "in": "path",
+          "required": true,
+          "description": "The field path parameter.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getFieldMetadataHistory",
         "summary": "get Field Metadata History",
@@ -2170,6 +2421,26 @@
       }
     },
     "/audiobooks/{id}/metadata-history/{field}/undo": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "field",
+          "in": "path",
+          "required": true,
+          "description": "The field path parameter.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "undoMetadataChange",
         "summary": "undo Metadata Change",
@@ -2198,6 +2469,17 @@
       }
     },
     "/audiobooks/{id}/move-segments": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "moveSegments",
         "summary": "move Segments",
@@ -2226,6 +2508,17 @@
       }
     },
     "/audiobooks/{id}/narrators": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "listAudiobookNarrators",
         "summary": "list Audiobook Narrators",
@@ -2280,6 +2573,17 @@
       }
     },
     "/audiobooks/{id}/organize": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "organizeBook",
         "summary": "organize Book",
@@ -2308,6 +2612,17 @@
       }
     },
     "/audiobooks/{id}/parse-with-ai": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "parseAudiobookWithAI",
         "summary": "parse Audiobook With A I",
@@ -2336,6 +2651,17 @@
       }
     },
     "/audiobooks/{id}/path-history": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getBookPathHistory",
         "summary": "get Book Path History",
@@ -2364,6 +2690,17 @@
       }
     },
     "/audiobooks/{id}/preview-organize": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "previewOrganize",
         "summary": "preview Organize",
@@ -2392,6 +2729,17 @@
       }
     },
     "/audiobooks/{id}/relocate": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "relocateBookFiles",
         "summary": "relocate Book Files",
@@ -2420,6 +2768,17 @@
       }
     },
     "/audiobooks/{id}/rename/apply": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "applyRename",
         "summary": "apply Rename",
@@ -2448,6 +2807,17 @@
       }
     },
     "/audiobooks/{id}/rename/preview": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "previewRename",
         "summary": "preview Rename",
@@ -2476,6 +2846,17 @@
       }
     },
     "/audiobooks/{id}/restore": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "restoreAudiobook",
         "summary": "restore Audiobook",
@@ -2504,6 +2885,17 @@
       }
     },
     "/audiobooks/{id}/revert-metadata": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "revertAudiobookMetadata",
         "summary": "revert Audiobook Metadata",
@@ -2532,6 +2924,17 @@
       }
     },
     "/audiobooks/{id}/search-metadata": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "searchAudiobookMetadata",
         "summary": "search Audiobook Metadata",
@@ -2560,6 +2963,17 @@
       }
     },
     "/audiobooks/{id}/segments": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "listAudiobookSegments",
         "summary": "list Audiobook Segments",
@@ -2588,6 +3002,26 @@
       }
     },
     "/audiobooks/{id}/segments/{segmentId}/tags": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "segmentId",
+          "in": "path",
+          "required": true,
+          "description": "The segmentId path parameter.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getSegmentTags",
         "summary": "get Segment Tags",
@@ -2616,6 +3050,17 @@
       }
     },
     "/audiobooks/{id}/set-primary": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "put": {
         "operationId": "setAudiobookPrimary",
         "summary": "set Audiobook Primary",
@@ -2644,6 +3089,17 @@
       }
     },
     "/audiobooks/{id}/similar": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "handleSimilarBooks",
         "summary": "Similar Books",
@@ -2672,6 +3128,17 @@
       }
     },
     "/audiobooks/{id}/split-to-books": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "splitSegmentsToBooks",
         "summary": "split Segments To Books",
@@ -2700,6 +3167,17 @@
       }
     },
     "/audiobooks/{id}/split-version": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "splitVersion",
         "summary": "split Version",
@@ -2728,6 +3206,17 @@
       }
     },
     "/audiobooks/{id}/tags": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getAudiobookTags",
         "summary": "get Audiobook Tags",
@@ -2756,6 +3245,17 @@
       }
     },
     "/audiobooks/{id}/tags-detailed": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getBookTagsDetailed",
         "summary": "get Book Tags Detailed",
@@ -2784,6 +3284,17 @@
       }
     },
     "/audiobooks/{id}/undo-last-apply": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "undoLastApply",
         "summary": "undo Last Apply",
@@ -2812,6 +3323,17 @@
       }
     },
     "/audiobooks/{id}/user-tags": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getBookUserTags",
         "summary": "get Book User Tags",
@@ -2840,6 +3362,17 @@
       }
     },
     "/audiobooks/{id}/versions": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "listAudiobookVersions",
         "summary": "list Audiobook Versions",
@@ -2894,6 +3427,17 @@
       }
     },
     "/audiobooks/{id}/write-back": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "writeBackAudiobookMetadata",
         "summary": "write Back Audiobook Metadata",
@@ -3406,6 +3950,17 @@
       }
     },
     "/authors/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "delete": {
         "operationId": "deleteAuthorHandler",
         "summary": "delete Author",
@@ -3434,6 +3989,17 @@
       }
     },
     "/authors/{id}/aliases": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getAuthorAliases",
         "summary": "get Author Aliases",
@@ -3488,6 +4054,26 @@
       }
     },
     "/authors/{id}/aliases/{aliasId}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "aliasId",
+          "in": "path",
+          "required": true,
+          "description": "The aliasId path parameter.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "delete": {
         "operationId": "deleteAuthorAlias",
         "summary": "delete Author Alias",
@@ -3516,6 +4102,17 @@
       }
     },
     "/authors/{id}/books": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getAuthorBooks",
         "summary": "get Author Books",
@@ -3544,6 +4141,17 @@
       }
     },
     "/authors/{id}/name": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "put": {
         "operationId": "renameAuthor",
         "summary": "rename Author",
@@ -3572,6 +4180,17 @@
       }
     },
     "/authors/{id}/reclassify-as-narrator": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "reclassifyAuthorAsNarrator",
         "summary": "reclassify Author As Narrator",
@@ -3600,6 +4219,17 @@
       }
     },
     "/authors/{id}/resolve-production": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "resolveProductionAuthor",
         "summary": "resolve Production Author",
@@ -3628,6 +4258,17 @@
       }
     },
     "/authors/{id}/split": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "splitCompositeAuthor",
         "summary": "split Composite Author",
@@ -3656,6 +4297,17 @@
       }
     },
     "/authors/{id}/tags": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "handleGetAuthorTags",
         "summary": "Get Author Tags",
@@ -3794,6 +4446,17 @@
       }
     },
     "/backup/{filename}": {
+      "parameters": [
+        {
+          "name": "filename",
+          "in": "path",
+          "required": true,
+          "description": "The filename path parameter.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "delete": {
         "operationId": "deleteBackup",
         "summary": "delete Backup",
@@ -3876,6 +4539,17 @@
       }
     },
     "/blocked-hashes/{hash}": {
+      "parameters": [
+        {
+          "name": "hash",
+          "in": "path",
+          "required": true,
+          "description": "The hash path parameter.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "delete": {
         "operationId": "removeBlockedHash",
         "summary": "remove Blocked Hash",
@@ -3932,6 +4606,17 @@
       }
     },
     "/books/{id}/position": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "handleSetPosition",
         "summary": "Set Position",
@@ -3978,6 +4663,17 @@
       }
     },
     "/books/{id}/state": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "handleGetBookState",
         "summary": "Get Book State",
@@ -4002,6 +4698,17 @@
       }
     },
     "/books/{id}/status": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "patch": {
         "operationId": "handleSetBookStatus",
         "summary": "Set Book Status",
@@ -4048,6 +4755,26 @@
       }
     },
     "/books/{id}/versions/{vid}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "vid",
+          "in": "path",
+          "required": true,
+          "description": "The vid path parameter.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "delete": {
         "operationId": "handleTrashVersion",
         "summary": "Trash Version",
@@ -4076,6 +4803,26 @@
       }
     },
     "/books/{id}/versions/{vid}/purge-now": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "vid",
+          "in": "path",
+          "required": true,
+          "description": "The vid path parameter.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "handlePurgeVersion",
         "summary": "Purge Version",
@@ -4104,6 +4851,26 @@
       }
     },
     "/books/{id}/versions/{vid}/restore": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "vid",
+          "in": "path",
+          "required": true,
+          "description": "The vid path parameter.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "handleRestoreVersion",
         "summary": "Restore Version",
@@ -4115,30 +4882,6 @@
             "session": []
           }
         ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Bad request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not found"
-          }
-        }
-      }
-    },
-    "/compare": {
-      "get": {
-        "operationId": "unknown",
-        "summary": "unknown",
-        "tags": [
-          "general"
-        ],
-        "security": [],
         "responses": {
           "200": {
             "description": "Success"
@@ -4210,6 +4953,17 @@
       }
     },
     "/covers/local/{filename}": {
+      "parameters": [
+        {
+          "name": "filename",
+          "in": "path",
+          "required": true,
+          "description": "The filename path parameter.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "handleLocalCover",
         "summary": "Local Cover",
@@ -4518,6 +5272,17 @@
       }
     },
     "/dedup/candidates/{id}/dismiss": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "dismissDedupCandidate",
         "summary": "dismiss Dedup Candidate",
@@ -4546,6 +5311,17 @@
       }
     },
     "/dedup/candidates/{id}/merge": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "mergeDedupCandidate",
         "summary": "merge Dedup Candidate",
@@ -4714,6 +5490,17 @@
       }
     },
     "/diagnostics/ai-results/{operationId}": {
+      "parameters": [
+        {
+          "name": "operationId",
+          "in": "path",
+          "required": true,
+          "description": "The operationId path parameter.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getDiagnosticsAIResults",
         "summary": "get Diagnostics A I Results",
@@ -4798,6 +5585,17 @@
       }
     },
     "/diagnostics/export/{operationId}/download": {
+      "parameters": [
+        {
+          "name": "operationId",
+          "in": "path",
+          "required": true,
+          "description": "The operationId path parameter.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "downloadDiagnosticsExport",
         "summary": "download Diagnostics Export",
@@ -5110,6 +5908,17 @@
       }
     },
     "/import-paths/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "delete": {
         "operationId": "removeImportPath",
         "summary": "remove Import Path",
@@ -5166,6 +5975,17 @@
       }
     },
     "/import-status/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "handleITunesImportStatus",
         "summary": "I Tunes Import Status",
@@ -5306,6 +6126,17 @@
       }
     },
     "/invites/{token}": {
+      "parameters": [
+        {
+          "name": "token",
+          "in": "path",
+          "required": true,
+          "description": "The token path parameter.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "delete": {
         "operationId": "handleDeleteInvite",
         "summary": "Delete Invite",
@@ -5474,6 +6305,17 @@
       }
     },
     "/itunes/import-status/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "tags": [
           "iTunes"
@@ -6310,6 +7152,17 @@
       }
     },
     "/me/{status}": {
+      "parameters": [
+        {
+          "name": "status",
+          "in": "path",
+          "required": true,
+          "description": "The status path parameter.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "handleListByStatus",
         "summary": "List By Status",
@@ -7482,6 +8335,17 @@
       }
     },
     "/operations/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "delete": {
         "operationId": "cancelOperation",
         "summary": "cancel Operation",
@@ -7510,6 +8374,17 @@
       }
     },
     "/operations/{id}/changes": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getOperationChanges",
         "summary": "get Operation Changes",
@@ -7538,6 +8413,17 @@
       }
     },
     "/operations/{id}/logs": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getOperationLogs",
         "summary": "get Operation Logs",
@@ -7566,6 +8452,17 @@
       }
     },
     "/operations/{id}/result": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getOperationResult",
         "summary": "get Operation Result",
@@ -7594,6 +8491,17 @@
       }
     },
     "/operations/{id}/results": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "handleGetOperationResults",
         "summary": "Get Operation Results",
@@ -7622,6 +8530,17 @@
       }
     },
     "/operations/{id}/revert": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "revertOperation",
         "summary": "revert Operation",
@@ -7650,6 +8569,17 @@
       }
     },
     "/operations/{id}/status": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getOperationStatus",
         "summary": "get Operation Status",
@@ -7678,39 +8608,22 @@
       }
     },
     "/operations/{id}/undo/preflight": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "undoPreflightHandler",
         "summary": "undo Preflight",
         "tags": [
           "operations"
-        ],
-        "security": [
-          {
-            "session": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Bad request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not found"
-          }
-        }
-      }
-    },
-    "/path": {
-      "get": {
-        "operationId": "unknown",
-        "summary": "unknown",
-        "tags": [
-          "general"
         ],
         "security": [
           {
@@ -7780,6 +8693,17 @@
       }
     },
     "/playlists/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "handleGetPlaylist",
         "summary": "Get Playlist",
@@ -7848,6 +8772,17 @@
       }
     },
     "/playlists/{id}/books": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "handleAddBooksToPlaylist",
         "summary": "Add Books To Playlist",
@@ -7872,6 +8807,26 @@
       }
     },
     "/playlists/{id}/books/{bookID}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "bookID",
+          "in": "path",
+          "required": true,
+          "description": "The bookID path parameter.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "delete": {
         "operationId": "handleRemoveBookFromPlaylist",
         "summary": "Remove Book From Playlist",
@@ -7896,6 +8851,17 @@
       }
     },
     "/playlists/{id}/materialize": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "handleMaterializePlaylist",
         "summary": "Materialize Playlist",
@@ -7920,6 +8886,17 @@
       }
     },
     "/playlists/{id}/reorder": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "handleReorderPlaylist",
         "summary": "Reorder Playlist",
@@ -7944,6 +8921,17 @@
       }
     },
     "/preferences/{key}": {
+      "parameters": [
+        {
+          "name": "key",
+          "in": "path",
+          "required": true,
+          "description": "Setting key.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getUserPreference",
         "summary": "get User Preference",
@@ -8024,6 +9012,17 @@
       }
     },
     "/purged-versions/{vid}": {
+      "parameters": [
+        {
+          "name": "vid",
+          "in": "path",
+          "required": true,
+          "description": "The vid path parameter.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "delete": {
         "operationId": "handleHardDeleteVersion",
         "summary": "Hard Delete Version",
@@ -8332,6 +9331,17 @@
       }
     },
     "/series/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "patch": {
         "operationId": "updateSeriesName",
         "summary": "update Series Name",
@@ -8386,6 +9396,17 @@
       }
     },
     "/series/{id}/books": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getSeriesBooks",
         "summary": "get Series Books",
@@ -8414,6 +9435,17 @@
       }
     },
     "/series/{id}/name": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "put": {
         "operationId": "renameSeriesHandler",
         "summary": "rename Series",
@@ -8442,6 +9474,17 @@
       }
     },
     "/series/{id}/split": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "splitSeriesHandler",
         "summary": "split Series",
@@ -8470,6 +9513,17 @@
       }
     },
     "/series/{id}/tags": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "handleGetSeriesTags",
         "summary": "Get Series Tags",
@@ -8548,6 +9602,17 @@
       }
     },
     "/sessions/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "delete": {
         "operationId": "revokeMySession",
         "summary": "revoke My Session",
@@ -8904,6 +9969,17 @@
       }
     },
     "/tasks/{name}": {
+      "parameters": [
+        {
+          "name": "name",
+          "in": "path",
+          "required": true,
+          "description": "Resource name.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "put": {
         "operationId": "updateTaskConfig",
         "summary": "update Task Config",
@@ -8932,6 +10008,17 @@
       }
     },
     "/tasks/{name}/run": {
+      "parameters": [
+        {
+          "name": "name",
+          "in": "path",
+          "required": true,
+          "description": "Resource name.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "runTask",
         "summary": "run Task",
@@ -9156,6 +10243,17 @@
       }
     },
     "/version-groups/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getVersionGroup",
         "summary": "get Version Group",
@@ -9294,6 +10392,17 @@
       }
     },
     "/works/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getWork",
         "summary": "get Work",
@@ -9374,6 +10483,17 @@
       }
     },
     "/works/{id}/books": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "listWorkBooks",
         "summary": "list Work Books",
@@ -9486,6 +10606,17 @@
       }
     },
     "/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getAIScan",
         "summary": "get A I Scan",
@@ -9540,6 +10671,17 @@
       }
     },
     "/{id}/apply": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "applyAIScanResults",
         "summary": "apply A I Scan Results",
@@ -9568,6 +10710,17 @@
       }
     },
     "/{id}/cancel": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "cancelAIScan",
         "summary": "cancel A I Scan",
@@ -9596,6 +10749,17 @@
       }
     },
     "/{id}/deactivate": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "handleDeactivateUser",
         "summary": "Deactivate User",
@@ -9624,6 +10788,17 @@
       }
     },
     "/{id}/reactivate": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "handleReactivateUser",
         "summary": "Reactivate User",
@@ -9652,6 +10827,17 @@
       }
     },
     "/{id}/reset-password": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "operationId": "handleResetPassword",
         "summary": "Reset Password",
@@ -9680,6 +10866,17 @@
       }
     },
     "/{id}/results": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "getAIScanResults",
         "summary": "get A I Scan Results",

--- a/docs/archive/openapi.yaml
+++ b/docs/archive/openapi.yaml
@@ -1,3 +1,18 @@
+# ARCHIVED 2026-08-12 — DO NOT EDIT, DO NOT RESURRECT.
+#
+# This was a second, independently hand-maintained OpenAPI spec living alongside
+# docs/api/openapi.json. Neither was generated from code, and they drifted until
+# each held endpoints the other lacked (25 here that the JSON did not have; 117
+# there that this did not). Everything real here was union-merged into
+# docs/api/openapi.json, which is now the single spec.
+#
+# Kept only as provenance for that merge. One endpoint was deliberately NOT
+# carried across: /audiobooks/search, which no router has ever served.
+#
+# The .claude/skills/api-doc skill was repointed at the JSON in the same change —
+# it was the repo's only maintenance instruction, and leaving it aimed here is
+# what would have re-created the divergence.
+
 # file: docs/openapi.yaml
 # version: 2.1.0
 # guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a

--- a/todo.d/2026-08-12-openapi-phantom-endpoints.md
+++ b/todo.d/2026-08-12-openapi-phantom-endpoints.md
@@ -1,0 +1,79 @@
+## Docs / API
+
+- [ ] **The OpenAPI spec still documents 48 endpoints that no router serves.** After the
+      2026-08-12 union merge, `docs/api/openapi.json` was diffed against the **real** route
+      table (obtained by calling `s.router.Routes()` on the actual router, not by grepping),
+      and 48 documented operations have no matching route. They fall into three groups:
+
+      1. **Group-relative artifacts** — the spec's generator missed Gin group prefixes, so it
+         recorded `/login` instead of `/auth/login`, `/books` instead of `/itunes/books`,
+         `/{id}` instead of `/ai/scans/{id}`, and so on. The correctly-prefixed paths are now
+         present (they came from the YAML), so these are duplicates of real endpoints.
+      2. **Removed maintenance endpoints** — 16 `POST /maintenance/*` paths. Only
+         `/maintenance/wipe` still exists as a POST; the rest became registry operations
+         (`maintenance.dedup-books` etc.) dispatched through the ops API.
+      3. **`/torrents`** — group-relative fragment of the Deluge integration group.
+
+      Two more (`/compare`, `/path`) were already removed in the merge because duplicate
+      `operationId: "unknown"` made the spec fail validation. `/path` is the sharpest
+      illustration of the whole problem: it was scraped out of a **code comment** at
+      `internal/server/server.go:988`.
+
+      This matters for the same reason as the `/auth/openid` and `/socket.io` probes: a
+      client that trusts the spec and gets a 404 is worse off than one with no spec at all.
+
+      Not removed in the merge PR because each deserves individual confirmation, and because
+      a test-server route table may omit conditionally-registered routes (integrations behind
+      a flag). The group-relative ones are safe to delete on sight; the maintenance ones
+      should be checked against whether an ops-API equivalent should be documented instead.
+
+      Full list:
+
+  - `DELETE /invites/{token}`
+  - `DELETE /sessions/{id}`
+  - `DELETE /{id}`
+  - `GET /books`
+  - `GET /import-status/{id}`
+  - `GET /invites`
+  - `GET /library-status`
+  - `GET /me`
+  - `GET /sessions`
+  - `GET /status`
+  - `GET /torrents`
+  - `GET /{id}`
+  - `GET /{id}/results`
+  - `POST /accept-invite`
+  - `POST /import`
+  - `POST /import-status/bulk`
+  - `POST /invite`
+  - `POST /login`
+  - `POST /logout`
+  - `POST /maintenance/backfill-book-files`
+  - `POST /maintenance/cleanup-backups`
+  - `POST /maintenance/cleanup-empty-folders`
+  - `POST /maintenance/cleanup-organize-mess`
+  - `POST /maintenance/cleanup-series`
+  - `POST /maintenance/dedup-books`
+  - `POST /maintenance/enrich-book-files`
+  - `POST /maintenance/fix-author-narrator-swap`
+  - `POST /maintenance/fix-book-file-paths`
+  - `POST /maintenance/fix-library-states`
+  - `POST /maintenance/fix-read-by-narrator`
+  - `POST /maintenance/fix-version-groups`
+  - `POST /maintenance/generate-itl-tests`
+  - `POST /maintenance/recompute-itunes-paths`
+  - `POST /maintenance/refetch-missing-authors`
+  - `POST /rebuild`
+  - `POST /setup`
+  - `POST /sync`
+  - `POST /test-connection`
+  - `POST /test-mapping`
+  - `POST /validate`
+  - `POST /write-back`
+  - `POST /write-back-all`
+  - `POST /write-back/preview`
+  - `POST /{id}/apply`
+  - `POST /{id}/cancel`
+  - `POST /{id}/deactivate`
+  - `POST /{id}/reactivate`
+  - `POST /{id}/reset-password`


### PR DESCRIPTION
Closes §1.6 of the [2026-08-11 docs inventory](https://github.com/falkcorp/audiobook-organizer/blob/main/docs/audits/2026-08-11-docs-inventory.md), which deferred this because a pick-a-winner would have lost real API surface.

Two commits, so the merge is reviewable separately from the validity fixes.

## 1. The union merge

`docs/openapi.yaml` (174 paths) and `docs/api/openapi.json` (266) were both hand-maintained, **neither generated from anything**, and had drifted until each held endpoints the other lacked.

Merged onto the JSON. **24 YAML-only paths carried across** — `/health`, the 7 `/auth/*` login/session endpoints, 10 `/itunes/*`, and the 7 `/ai/scans/*` — plus **19 component schemas and 5 shared parameters**, which the JSON had *none* of.

Every one was verified against the Go router first rather than taken on trust. **One was rejected:**

> **`/audiobooks/search` was NOT carried across.** No such route is registered — `wire_audiobooks_routes.go:25` registers `GET /audiobooks` and nothing else, and search goes through `/metadata/search` or `/audiobooks/:id/search-metadata`. Importing it would have documented an endpoint that doesn't exist.

## 2. Three defects found while merging

**Every path was double-prefixed.** All 266 JSON paths began with `/api/v1` while `servers[0].url` was *also* `/api/v1` — a generated client would call `/api/v1/api/v1/audiobooks`. This also blocked a coherent merge, since the YAML used the correct convention. Prefix stripped.

**The spec did not validate.** Not one path declared its path parameters — 129 operations failed. Added 115 declarations at path-item level (OpenAPI applies those to every operation on the path, so `/audiobooks/{id}` needs one, not three). Type is `string` throughout: these ids are ULIDs/UUIDs, and guessing `integer` would break generated clients.

**Two operations shared `operationId: "unknown"`.** Both are generator artifacts:
- `/compare` — a *group-relative* fragment of `aiScans.GET("/compare")`; the real `/ai/scans/compare` is now present
- `/path` — scraped out of a **code comment** at `internal/server/server.go:988`, which reads ``// in route registration: `protected.GET("/path", s.perm(P), s.handler)` ``

**The spec now validates as OpenAPI 3.0.3.**

## 3. The part that keeps this from undoing itself

`.claude/skills/api-doc/SKILL.md` — the repo's **only** instruction for maintaining the spec — targeted `docs/openapi.yaml`. Nothing anywhere pointed at the JSON. Retiring the YAML without repointing that skill guarantees the divergence comes straight back at the next endpoint change, or an agent edits a file that no longer exists.

Repointed, and taught it the three rules the old spec's defects came from: write the **full** path (not the group-relative fragment), declare path parameters, and never document an endpoint that doesn't exist. Added a validation step.

`docs/openapi.yaml` is archived with a banner rather than deleted, consistent with this consolidation's no-DELETE-bucket rule.

## Not done here — filed instead

**48 documented operations have no matching route.** Established by diffing the spec against the *real* route table — obtained by calling `s.router.Routes()` on the actual router, not by grepping. Three groups:

1. **Group-relative artifacts** — `/login`, `/books`, `/{id}`, `/sessions`… the generator missed Gin group prefixes throughout
2. **16 removed `POST /maintenance/*`** — only `/maintenance/wipe` survives; the rest became registry operations dispatched through the ops API
3. **`/torrents`** — fragment of the Deluge integration group

Not removed here because each deserves individual confirmation, and a test-server route table can omit conditionally-registered routes (integrations behind a flag). Full list in the `todo.d` fragment.

## Verification

- Merged spec **validates** as OpenAPI 3.0.3 (`openapi-spec-validator`)
- 0 dangling `$ref`s; 0 component-name collisions (checked, not assumed — the JSON had zero schemas)
- 0 paths still carrying the redundant `/api/v1` prefix
- Route table taken from `s.router.Routes()` (399 `/api/v1` routes), not from grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t