### PR TITLE
fix(abs): unimplemented ABS namespaces 404 instead of redirecting (N-4), and retract N-3

### DIFF
--- a/changelog.d/20260812_113000_abs_n2_n4.md
+++ b/changelog.d/20260812_113000_abs_n2_n4.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- **Unimplemented Audiobookshelf endpoints redirected into the app API instead of 404ing.**
+  `/api/collections`, `/api/playlists`, `/api/authors`, `/api/series`, `/api/users` and
+  `/api/podcasts` were caught by the `/api/*` → `/api/v1/*` compatibility redirect, so an ABS
+  client probing them got a 301 into a completely different JSON shape (or a 401) rather than an
+  honest "not here". They now 404. The redirect still applies to app-API paths, which is pinned
+  by its own test. Same failure family as the `/socket.io/` and `/auth/openid` probes.
+- **The conformance harness treated four environment-dependent fields as conformance signal.**
+  `fullPath`, `loadedAt`, `ipAddress` and `userAgent` can never match a fixture captured on
+  another machine — `fullPath` in particular was a plain oversight, sitting next to `path` in the
+  same "host-dependent" group of `DefaultVolatileKeys`. Adding them removes a class of false
+  positives that would otherwise have to be explained away every time the value gate is
+  considered.
+
+### Documentation
+
+- **Retracted finding N-3 of the ABS coverage audit — it was wrong.** It claimed `Update: true` /
+  `Delete: true` in `defaultPermissions()` advertise writes we cannot perform. It had scoped only
+  library-item writes and missed the nine `/api/me/*` write routes (progress PATCH/DELETE,
+  bookmark POST/PATCH/DELETE, session DELETE). Acting on it would have advertised
+  `update: false` and broken progress sync and bookmarks in both target clients.

--- a/docs/audits/2026-08-11-abs-coverage-gap-audit.md
+++ b/docs/audits/2026-08-11-abs-coverage-gap-audit.md
@@ -1,7 +1,7 @@
 <!-- file: docs/audits/2026-08-11-abs-coverage-gap-audit.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 2.0.0 -->
 <!-- guid: 8c4f2b19-5d73-46ea-b1c0-3f8a92d6e457 -->
-<!-- last-edited: 2026-08-11 -->
+<!-- last-edited: 2026-08-12 -->
 
 # ABS implementation coverage — gap audit, 2026-08-11
 
@@ -35,7 +35,11 @@ out of scope (contract §11).
 
 ## 1. NOW gaps — ranked
 
-### 🔴 N-1. `GET /socket.io/…` answers **200 with `index.html`**
+### ✅ N-1. ~~`GET /socket.io/…` answers **200 with `index.html`**~~ — **FIXED 2026-08-12** (PR #2325)
+
+> `"/socket.io/"` added to `nonSPAPrefixes`; `GET /socket.io/` now returns 404 in both build
+> variants. Regression test verified by removal — with the fix backed out, `TestIsNonSPAPath`
+> and `TestSocketIOHandshakeIs404` both fail. Original finding below.
 
 | | |
 |---|---|
@@ -90,11 +94,42 @@ conformance tests red**, spanning essentially the whole client-facing surface:
 These are **not** ID/timestamp noise. `CompareBody` normalizes *both* sides before diffing
 (`fixture.go:52-54` — `Compare(n.Normalize(want), n.Normalize(got), opts)`), so every volatile
 key is already canonicalized to a same-typed placeholder by the time values are compared. All
-13 failures are therefore real mismatches on **non-volatile** fields. The change was reverted;
-nothing in this branch turns the gate on.
+13 failures are therefore mismatches on fields the normalizer did **not** cover.
+
+> ⚠️ That last sentence originally read *"real mismatches on non-volatile fields"*, which
+> invited the reading that all 13 are defects. **They are not** — see the correction below.
+> "Not normalized" turned out to mean three different things, only one of which is a bug.
 
 ⇒ This is why N-2 is ranked 🔴 rather than as tech debt: the harness is not merely *capable* of
-being stricter, it is currently green over 13 tests' worth of known-wrong values.
+being stricter, it is currently green over 13 tests' worth of uncompared values.
+
+#### ⚠️ Correction (2026-08-12): "13 red tests" is not "13 bugs"
+
+The findings were read one by one rather than counted. **The red list is dominated by test-data
+drift and by deliberate divergences — not product defects.** The earlier wording here implied
+otherwise and was wrong.
+
+| Category | What it is | Product bug? |
+|---|---|---|
+| **Environment-dependent** — `fullPath` (a temp dir), `loadedAt`, `ipAddress`, `userAgent` | Can never match a capture from another machine | **No.** Fixed by normalizing — see below. |
+| **Fixture drift** — `size` 4096 vs 1.2e8, `duration` 9975 vs 9975.480544, `publishedYear` `800` vs `800BC`, track titles, `timeBase`, `mediaItemId`, `itemsPerPage` | The synthetic test book is not the oracle's Odyssey capture | **No.** Fixed by aligning fixture data. |
+| **Deliberate divergence** — `user.type` `user` vs `root`; `Source` `audiobook-organizer` vs `docker` | `dto.go:275-277` states the reason: reporting `user` makes Absorb *hide the admin UI we do not implement* | **No — intentional.** Must be whitelisted, never "fixed". |
+| **Genuinely worth deciding** — `media.tracks[].title` (we send `The Odyssey: Book 06`, ABS sends the filename `odyssey_06_homer_butler_64kb.mp3`); author ordering in `/personalized` | A client renders these directly | **Maybe.** Needs a client-behaviour call. |
+
+**Acted on:** four keys added to `DefaultVolatileKeys` — `fullpath`, `loadedat`, `ipaddress`,
+`useragent`. `fullpath` was a plain oversight, sitting next to `path` in the same
+"host-dependent" group. Measured effect: **13 red → 12**, and a whole class of false positives
+gone. `useragent` normalization hides nothing — `me.go:127` populates it for real; the tests
+simply never set the header.
+
+**Deliberately NOT normalized:** `size`, `duration`, `progress`, `currentTime`, `startOffset`.
+`normalize.go:19-20` records that as an explicit decision — they are real playback data whose
+values matter — and normalizing them to force green would destroy exactly the signal N-2 exists
+to create. **Making the gate pass is not the goal; making it mean something is.**
+
+⇒ Remaining work to turn the gate on permanently is **fixture alignment**, not bug-fixing: seed
+the fake library from the oracle capture so sizes, durations, track lists and progress match.
+That is bounded but not small — `library_fake_test.go` is 767 lines.
 
 Normalization widens the blindness (`normalize.go:21-40`): ~25 volatile keys (`id`,
 `coverPath`, `contentUrl`, `lastUpdate`, `token`, `ino`, …) are canonicalized before
@@ -115,7 +150,42 @@ values are meant to be real, add coverage for the 4 orphan fixtures, and add a c
 > This is the "verify the instrument, not just the result" failure mode: the harness has been
 > green throughout, and green meant almost nothing.
 
-### 🔴 N-3. We advertise write permissions for routes that do not exist
+### ❌ N-3. ~~We advertise write permissions for routes that do not exist~~ — **RETRACTED 2026-08-12. This finding was WRONG.**
+
+> **Do not act on this section.** Acting on it would have broken progress sync and
+> bookmarks in both target clients.
+>
+> The finding scoped `LibraryStore` and item/library write routes, and concluded from their
+> absence that `Update: true` / `Delete: true` are dishonest. **It missed the entire
+> `/api/me/*` write surface**, which is nine real, working, registered routes:
+>
+> | Route | `handler.go` |
+> |---|---|
+> | `PATCH /api/me/progress/:id` | `:429` |
+> | `PATCH /api/me/progress/batch/update` | `:430` |
+> | `DELETE /api/me/progress/:id` | `:431` |
+> | `POST /api/me/progress/:id/remove-from-continue-listening` | `:456` |
+> | `POST /api/me/item/:id/remove-from-continue-listening` | `:457` |
+> | `POST /api/me/item/:id/bookmark` | `:479` |
+> | `PATCH /api/me/item/:id/bookmark` | `:480` |
+> | `DELETE /api/me/item/:id/bookmark/:time` | `:483` |
+> | `DELETE /api/me/sessions/:id` | `:374` |
+>
+> `Update: true` and `Delete: true` **honestly describe writes we serve.** The comment above
+> `defaultPermissions()` already said so — *"update/delete/download must be present and true
+> or the clients disable working features"* — and this audit contradicted a documented
+> decision without engaging with its stated reason.
+>
+> **Lesson, recorded because it generalises:** "there is no writer for X, therefore the write
+> permission is a lie" is only sound if X is the *only* thing the permission gates. Here it
+> gates progress and bookmark writes too, which are the single most important thing a
+> read-only-catalogue server can still do for an audiobook client. Enumerate what a flag
+> governs before calling it dishonest.
+
+<details>
+<summary>Original (incorrect) finding, kept for the record</summary>
+
+#### ~~N-3. We advertise write permissions for routes that do not exist~~
 
 | | |
 |---|---|
@@ -133,7 +203,16 @@ A client renders edit and delete affordances. Tapping one hits an unregistered
 `LibrariesAccessible: []` alongside `AccessAllLibraries: true` — that is the correct ABS
 idiom for "all libraries".
 
-### 🔴 N-4. Unimplemented `/api/…` paths **301 into `/api/v1/…`** instead of 404ing
+</details>
+
+### ✅ N-4. ~~Unimplemented `/api/…` paths **301 into `/api/v1/…`** instead of 404ing~~ — **FIXED 2026-08-12**
+
+> Six ABS namespaces — `/api/collections`, `/api/playlists`, `/api/authors`, `/api/series`,
+> `/api/users`, `/api/podcasts` — added to a new `absUnimplementedNamespaces` list in
+> `wire_abs_routes.go`, matched as exact path or subtree. They now 404 instead of redirecting.
+> Verified empirically before and after; the redirect still works for app-API paths
+> (`/api/audiobooks` → `/api/v1/audiobooks`), which is pinned by its own test. Regression test
+> verified by removal. Original finding below.
 
 | | |
 |---|---|
@@ -274,11 +353,14 @@ unauthenticated cover endpoint (gate 2.17.0) and `/public/session/:id/track/:ind
 ## 4. Recommended order
 
 1. **N-1** — one line in `nonSPAPrefixes`, plus a regression test. Highest value per byte.
-2. **N-2** — turn on the harness gates for value-real endpoints. This **has been measured**:
-   it goes red across 13 tests (§N-2), all on non-volatile fields. That red list *is* the
-   worklist — work it down rather than flipping the gate and reverting. Add the 4 orphan
-   fixtures. Without this, nothing below stays fixed.
-3. **N-3** and **N-4** — stop advertising what we cannot do; make unimplemented ABS paths 404.
+2. **N-2** — *partially done 2026-08-12.* Four environment-dependent keys are now normalized
+   (13 red → 12). The remainder is **fixture alignment**, not bug-fixing — see the correction
+   in §N-2. Do not chase green by normalizing `size`/`duration`/`progress`; that would delete
+   the signal. Add the 4 orphan fixtures.
+3. ~~**N-3**~~ — **RETRACTED, do not act on it.** It was wrong; see §N-3. `Update`/`Delete`
+   honestly describe the nine `/api/me/*` write routes.
+   **N-4** — *done 2026-08-12.* Six unimplemented ABS namespaces now 404 instead of 301ing into
+   the app API.
 4. **N-5**, **N-6** — contract-conformance and observability.
 5. **N-7 … N-10** — bookkeeping truth-ups.
 6. **N-11** — an operational decision, not a code change.

--- a/internal/server/wire_abs_routes.go
+++ b/internal/server/wire_abs_routes.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_abs_routes.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 9c6b13f8-40a2-4e57-b18d-72e0a5c4d396
-// last-edited: 2026-08-02
+// last-edited: 2026-08-12
 
 package server
 
@@ -66,6 +66,33 @@ var absReservedPathPrefixes = []string{
 	"/api/session/",
 }
 
+// absUnimplementedNamespaces are ABS endpoints we do NOT implement, reserved for the
+// opposite reason to the lists above: not to protect a route we serve, but to make sure
+// the ones we DON'T serve fail honestly.
+//
+// Without these, an ABS client probing /api/collections gets a 301 into
+// /api/v1/collections — the app API — and meets a different JSON shape or a 401. That is
+// the exact "looks implemented, behaves broken" failure the comment above warns about,
+// arrived at from the other direction. An honest 404 lets a client hide the feature;
+// a 301 into a foreign shape makes it look present and broken, and any non-2xx flips
+// AudioBooth's connection indicator.
+//
+// Matched as exact path OR subtree, so /api/authors and /api/authors/:id both 404.
+//
+// Safe because nothing in-repo requests these without the /v1 prefix — the SPA's only
+// bare /api/ call is /api/events (SSE), which is deliberately absent from this list.
+//
+// If one of these is ever implemented on the ABS surface, MOVE it to the lists above
+// rather than deleting it — it must stay excluded from the redirect either way.
+var absUnimplementedNamespaces = []string{
+	"/api/collections",
+	"/api/playlists",
+	"/api/authors",
+	"/api/series",
+	"/api/users",
+	"/api/podcasts",
+}
+
 // absReservedPath reports whether a request path belongs to the ABS surface and must
 // therefore skip the /api/* → /api/v1/* compatibility redirect.
 func absReservedPath(path string) bool {
@@ -76,6 +103,11 @@ func absReservedPath(path string) bool {
 	}
 	for _, prefix := range absReservedPathPrefixes {
 		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	for _, ns := range absUnimplementedNamespaces {
+		if path == ns || strings.HasPrefix(path, ns+"/") {
 			return true
 		}
 	}

--- a/internal/server/wire_abs_routes_test.go
+++ b/internal/server/wire_abs_routes_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_abs_routes_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 3ea1d764-95c8-4b02-8f31-6d70a5be2c49
-// last-edited: 2026-08-02
+// last-edited: 2026-08-12
 
 package server
 
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
 )
 
 // TestABSReservedPath_CoversTheABSSurfaceUnderAPI guards the /api/* → /api/v1/*
@@ -177,4 +178,50 @@ func TestWireABSRoutes_DisabledByDefaultRegistersNothing(t *testing.T) {
 	if n := len(s.router.Routes()); n != 0 {
 		t.Fatalf("expected no routes at all, got %d", n)
 	}
+}
+
+// An ABS endpoint we do NOT implement must 404, not 301 into the app API.
+//
+// The /api/* -> /api/v1/* compatibility redirect used to catch these: a client
+// probing /api/collections was sent to /api/v1/collections, met a different JSON
+// shape or a 401, and concluded the feature was present and broken rather than
+// absent. Contract §2.4 -- a misapplied non-404 silently disables a working client
+// feature, and any non-2xx flips AudioBooth's connection indicator.
+func TestUnimplementedABSNamespacesAre404NotRedirect(t *testing.T) {
+	s, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	for _, path := range []string{
+		"/api/collections",
+		"/api/playlists",
+		"/api/authors",
+		"/api/authors/aut_abc123",
+		"/api/series",
+		"/api/series/ser_abc123",
+		"/api/users",
+		"/api/podcasts",
+	} {
+		w := httptest.NewRecorder()
+		s.router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+
+		require.NotEqual(t, http.StatusMovedPermanently, w.Code,
+			"%s must not 301 into the /api/v1 app API — the client would meet a foreign shape", path)
+		require.Empty(t, w.Header().Get("Location"),
+			"%s must not send the client anywhere", path)
+		require.Equal(t, http.StatusNotFound, w.Code,
+			"%s is unimplemented on the ABS surface and must say so honestly", path)
+	}
+}
+
+// The redirect must still work for everything that is NOT an ABS namespace,
+// otherwise this fix has quietly broken /api/* compatibility for the app API.
+func TestNonABSPathsStillRedirect(t *testing.T) {
+	s, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	w := httptest.NewRecorder()
+	s.router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/audiobooks", nil))
+	require.Equal(t, http.StatusMovedPermanently, w.Code,
+		"/api/audiobooks is app-API surface and must keep redirecting to /api/v1")
+	require.Equal(t, "/api/v1/audiobooks", w.Header().Get("Location"))
 }

--- a/internal/syncapi/conformance/normalize.go
+++ b/internal/syncapi/conformance/normalize.go
@@ -1,7 +1,7 @@
 // file: internal/syncapi/conformance/normalize.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: ed9387e2-9e6a-46d7-912a-28c96d442d0d
-// last-edited: 2026-07-29
+// last-edited: 2026-08-12
 
 package conformance
 
@@ -28,9 +28,16 @@ func DefaultVolatileKeys() map[string]bool {
 		// timestamps
 		"createdat", "updatedat", "addedat", "lastupdate", "lastseen",
 		"startedat", "finishedat", "birthtimems", "mtimems", "ctimems",
-		"scanversion", "lastscan",
+		"scanversion", "lastscan", "loadedat",
 		// host-dependent
 		"path", "relpath", "contenturl", "coverpath", "metadatapath",
+		"fullpath",
+		// request-dependent: describe the CALLER, not the response format.
+		// A capture taken on the oracle's machine can never match ours, and
+		// nothing about ABS compatibility depends on reproducing its client.
+		// Note these are populated for real -- me.go:127 maps s.UserAgent --
+		// so normalizing them hides no gap; the tests just don't set headers.
+		"ipaddress", "useragent",
 	}
 	out := make(map[string]bool, len(keys))
 	for _, k := range keys {

--- a/todo.d/2026-08-12-abs-conformance-fixture-alignment.md
+++ b/todo.d/2026-08-12-abs-conformance-fixture-alignment.md
@@ -1,0 +1,29 @@
+## ABS
+
+- [ ] **Align the ABS conformance fixtures with the oracle capture so the value gate can be
+      turned on permanently.** `assertConformant` still runs with `CompareValues` off, so no test
+      compares a single value. Turning it on today reddens **12** tests — but reading the findings
+      rather than counting them shows they are mostly *not* defects:
+
+      - **Fixture drift (most of them).** The fake library seeds a synthetic book; the oracle is a
+        real capture of *The Odyssey*. So `size` is 4096 vs 1.20828875e8, `duration` 9975 vs
+        9975.480544, `publishedYear` `800` vs `800BC`, track titles `The Odyssey: Book 06` vs
+        `odyssey_06_homer_butler_64kb.mp3`, `timeBase` `1/1000` vs `1/14112000`.
+      - **Deliberate divergences** that must be whitelisted, never "fixed": `user.type` is `user`
+        not `root` (`dto.go:275-277` — it makes Absorb hide the admin UI we do not implement), and
+        `Source` is `audiobook-organizer` not `docker`.
+      - **Two worth an actual decision:** whether `media.tracks[].title` should be the filename
+        (as ABS sends) rather than a display title, and the author ordering in `/personalized`.
+
+      The work is to seed the fake library FROM the oracle fixture so the values match by
+      construction, then flip the gate on and keep it on. `library_fake_test.go` is 767 lines, so
+      this is bounded but not small.
+
+      ⚠️ **Do not chase green by normalizing `size`/`duration`/`progress`/`currentTime`/
+      `startOffset`.** `normalize.go:19-20` records keeping them comparable as an explicit
+      decision — they are real playback data. Normalizing them would make the suite pass while
+      deleting the exact signal the gate exists to produce. Four environment-dependent keys
+      (`fullpath`, `loadedat`, `ipaddress`, `useragent`) have already been normalized, which is
+      what took the count from 13 to 12; that is the end of what normalization can honestly fix.
+
+      Also still open from the same audit: 4 golden fixtures that no test ever loads.


### PR DESCRIPTION
Closes **N-4**, partially advances **N-2**, and **retracts N-3 as wrong** — from the [ABS coverage audit](https://github.com/falkcorp/audiobook-organizer/blob/main/docs/audits/2026-08-11-abs-coverage-gap-audit.md).

## N-4 — fixed

Six ABS endpoints we don't implement were caught by the `/api/*` → `/api/v1/*` compatibility redirect. Measured before the change:

```
/api/collections     -> 301  Location="/api/v1/collections"
/api/playlists       -> 301  Location="/api/v1/playlists"
/api/authors/abc     -> 301  Location="/api/v1/authors/abc"
/api/series/abc      -> 301  Location="/api/v1/series/abc"
/api/users           -> 301  Location="/api/v1/users"
/api/podcasts        -> 301  Location="/api/v1/podcasts"
/api/me/nope         -> 404          ← reserved prefixes were already correct
```

A client probing `/api/collections` followed the 301 into the **app API** and met a different JSON shape or a 401 — concluding the feature was *present and broken* rather than absent. That's the same "looks implemented, behaves broken" failure the comment above `absReservedPathPrefixes` already warns about, reached from the other direction: those lists protect routes we **do** serve, and nothing protected the ones we don't.

Added `absUnimplementedNamespaces`, matched as exact path **or** subtree so `/api/authors` and `/api/authors/:id` both 404.

**The redirect still works for app-API paths** — `/api/audiobooks` → `/api/v1/audiobooks` — pinned by its own new test so this fix can't silently widen. Safe because nothing in-repo requests these without `/v1` (the SPA's only bare `/api/` call is `/api/events`, deliberately excluded).

Both tests verified by removal: without the change, `TestUnimplementedABSNamespacesAre404NotRedirect` fails with *"Should not be: 301"*.

## N-3 — ❌ RETRACTED. I was wrong.

N-3 claimed `Update: true` / `Delete: true` in `defaultPermissions()` advertise writes we can't perform, because `LibraryStore` has no writer and no item/library write routes are registered.

**It missed the entire `/api/me/*` write surface** — nine real, registered, working routes:

| Route | `handler.go` |
|---|---|
| `PATCH /api/me/progress/:id` | `:429` |
| `PATCH /api/me/progress/batch/update` | `:430` |
| `DELETE /api/me/progress/:id` | `:431` |
| `POST /api/me/progress/:id/remove-from-continue-listening` | `:456` |
| `POST /api/me/item/:id/remove-from-continue-listening` | `:457` |
| `POST /api/me/item/:id/bookmark` | `:479` |
| `PATCH /api/me/item/:id/bookmark` | `:480` |
| `DELETE /api/me/item/:id/bookmark/:time` | `:483` |
| `DELETE /api/me/sessions/:id` | `:374` |

**Acting on N-3 would have advertised `update: false` and broken progress sync and bookmarks in both target clients.** The comment above `defaultPermissions()` already said so — *"update/delete/download must be present and true or the clients disable working features"* — and the audit contradicted a documented decision without engaging with its stated reason.

No code change; the audit now carries the retraction and the original text is preserved in a `<details>` block.

## N-2 — partially advanced, and its framing corrected

Four environment-dependent keys added to `DefaultVolatileKeys`: `fullPath`, `loadedAt`, `ipAddress`, `userAgent`. `fullPath` was a plain oversight — it sat next to `path` in the same *host-dependent* group and is exactly as machine-specific. **Measured: 13 red → 12.**

`userAgent` normalization hides nothing: `me.go:127` populates it for real; the tests simply never set the header.

**The audit's "13 red tests" framing was misleading and is corrected.** Reading the findings instead of counting them:

| Category | Product bug? |
|---|---|
| Environment-dependent (`fullPath`, `loadedAt`, `ipAddress`, `userAgent`) | **No** — fixed here |
| Fixture drift (`size` 4096 vs 1.2e8, `duration` 9975 vs 9975.480544, `publishedYear` `800` vs `800BC`, track titles, `timeBase`) | **No** — the fake book isn't the oracle's Odyssey capture |
| Deliberate divergence (`user.type` `user` not `root`; `Source`) | **No — intentional.** `dto.go:275-277`: reporting `user` makes Absorb hide the admin UI we don't implement |
| `media.tracks[].title`, author ordering | **Maybe** — needs a client-behaviour call |

**The value gate stays OFF.** I deliberately did *not* chase green by normalizing `size`/`duration`/`progress`/`currentTime`/`startOffset` — `normalize.go:19-20` records keeping those comparable as an explicit decision, and normalizing them would make the suite pass while deleting the exact signal the gate exists to produce. Making it pass isn't the goal; making it *mean* something is.

Remaining work is fixture alignment (seed the fake library from the oracle capture), filed in `todo.d` with the taxonomy above.

## Verification

- `internal/syncapi/conformance` ✅ · `internal/syncapi/progress` ✅ · `internal/server/handlers/abs` ✅
- N-4 tests verified by removal (fail without the fix)
- `go build ./...` clean, `go vet ./internal/server/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t