### PR TITLE
fix(abs): three ABS namespaces I 404'd in #2332 are live app-API routes

### DIFF
--- a/changelog.d/20260812_120000_abs_namespace_collision.md
+++ b/changelog.d/20260812_120000_abs_namespace_collision.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **`/api/authors`, `/api/series` and `/api/playlists` 404'd instead of reaching the app
+  API.** The previous change (#2332) added six unimplemented Audiobookshelf namespaces to
+  the list of paths excluded from the `/api/*` → `/api/v1/*` compatibility redirect, so
+  they would answer an honest 404 to ABS clients instead of redirecting them into a
+  foreign JSON shape. Three of those six — authors, series and playlists — are namespaces
+  the **app API really serves** under `/api/v1` (19, 18 and 9 routes). For those the
+  redirect was not a lie, and excluding them 404'd 46 working routes' unversioned form.
+  Because the redirect middleware is not gated on `ABS_API_ENABLED`, this happened on
+  every deployment, including ones with the ABS surface switched off. The three colliding
+  namespaces now keep their redirect; `collections`, `users` and `podcasts` — which have
+  no `/api/v1` twin — still 404 honestly. No unversioned traffic to any of the six was
+  observed in 30 days of production logs, so no client is known to have been affected.

--- a/docs/audits/2026-08-11-abs-coverage-gap-audit.md
+++ b/docs/audits/2026-08-11-abs-coverage-gap-audit.md
@@ -1,5 +1,5 @@
 <!-- file: docs/audits/2026-08-11-abs-coverage-gap-audit.md -->
-<!-- version: 2.0.0 -->
+<!-- version: 2.1.0 -->
 <!-- guid: 8c4f2b19-5d73-46ea-b1c0-3f8a92d6e457 -->
 <!-- last-edited: 2026-08-12 -->
 
@@ -205,14 +205,34 @@ idiom for "all libraries".
 
 </details>
 
-### ✅ N-4. ~~Unimplemented `/api/…` paths **301 into `/api/v1/…`** instead of 404ing~~ — **FIXED 2026-08-12**
+### ⚠️ N-4. ~~Unimplemented `/api/…` paths **301 into `/api/v1/…`** instead of 404ing~~ — **PARTIALLY FIXED 2026-08-12, after a regression**
 
-> Six ABS namespaces — `/api/collections`, `/api/playlists`, `/api/authors`, `/api/series`,
-> `/api/users`, `/api/podcasts` — added to a new `absUnimplementedNamespaces` list in
-> `wire_abs_routes.go`, matched as exact path or subtree. They now 404 instead of redirecting.
-> Verified empirically before and after; the redirect still works for app-API paths
-> (`/api/audiobooks` → `/api/v1/audiobooks`), which is pinned by its own test. Regression test
-> verified by removal. Original finding below.
+> **Fixed for three namespaces, deliberately NOT fixed for three others.**
+>
+> `/api/collections`, `/api/users`, `/api/podcasts` now 404 (exact path or subtree) via
+> `absUnimplementedNamespaces` in `wire_abs_routes.go`.
+>
+> 🚨 **The first attempt (#2332) listed six and shipped a regression.** `/api/authors`,
+> `/api/series` and `/api/playlists` are ABS namespaces we lack, but they are *also* app-API
+> namespaces we serve — **19, 18 and 9 routes** under `/api/v1` (`wire_entities_routes.go`,
+> `wire_dedup_routes.go`). For those the 301 lands on a working handler, so excluding them
+> 404'd 46 live routes' unversioned form. Worse, the redirect middleware is **not** gated on
+> `ABSAPIEnabled` (`server_lifecycle.go:1219`), so this applied to every deployment, including
+> ABS-disabled ones. Reverted for those three the same day; they are now listed in
+> `absAppAPICollisions` and pinned by `TestCollidingNamespacesStillRedirect`, verified by
+> reintroducing the bug. 30 days of prod logs show **zero** unversioned requests to any of the
+> six, so no client is known to have been affected.
+>
+> **The reasoning error:** the original justification was "nothing in-repo requests these
+> without the `/v1` prefix" — which checks the *caller* side of the boundary and never the
+> *target* side. A compatibility shim exists precisely for callers that are not in the repo.
+> Rule going forward: before adding a namespace, grep for app-API routes of the same name.
+>
+> Residual gap: an ABS client probing `/api/authors/:id` still 301s into the app API. Fixing
+> that honestly requires gating the ABS surface's semantics on `ABSAPIEnabled` and registering
+> explicit 404 handlers inside the ABS group — a design change, not a list edit. Not done.
+>
+> Original finding below.
 
 | | |
 |---|---|
@@ -359,8 +379,10 @@ unauthenticated cover endpoint (gate 2.17.0) and `/public/session/:id/track/:ind
    the signal. Add the 4 orphan fixtures.
 3. ~~**N-3**~~ — **RETRACTED, do not act on it.** It was wrong; see §N-3. `Update`/`Delete`
    honestly describe the nine `/api/me/*` write routes.
-   **N-4** — *done 2026-08-12.* Six unimplemented ABS namespaces now 404 instead of 301ing into
-   the app API.
+   **N-4** — *partially done 2026-08-12.* THREE namespaces (`collections`, `users`, `podcasts`)
+   now 404 instead of 301ing into the app API. The first attempt listed six and broke 46 live
+   app routes; `authors`, `series` and `playlists` have `/api/v1` twins and keep their redirect.
+   See §N-4 for the reasoning error and the residual gap.
 4. **N-5**, **N-6** — contract-conformance and observability.
 5. **N-7 … N-10** — bookkeeping truth-ups.
 6. **N-11** — an operational decision, not a code change.

--- a/docs/executive-summaries/2026-08-12-checking-our-own-homework-executive-summary.md
+++ b/docs/executive-summaries/2026-08-12-checking-our-own-homework-executive-summary.md
@@ -1,0 +1,123 @@
+<!-- file: docs/executive-summaries/2026-08-12-checking-our-own-homework-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4f1c8e27-9db3-4a56-b0e8-6c395a71d2f4 -->
+<!-- last-edited: 2026-08-12 -->
+
+# Executive Summary: Checking Our Own Homework
+
+**Date:** 2026-08-12
+**Written for:** anyone who wants to know what changed and why it mattered, without
+needing to read code.
+
+---
+
+## In one paragraph
+
+This was a day of **checking claims** — most of them our own. A phone app was being told
+a feature existed when it didn't. Our documentation described dozens of things the server
+cannot do. A maintenance script reported success after doing nothing at all. Our to-do
+list said an important job had never run, when in fact it had finished cleanly weeks
+earlier. And two of the things we found and "fixed" turned out to be wrong — one was a
+mistaken accusation, the other actively broke something. Both were caught and undone the
+same day. The honest summary is not "we fixed eight things"; it is "we fixed eight
+things, got two of them wrong, and caught both before anyone was affected."
+
+---
+
+## 1. The app was told a feature existed
+
+Audiobook apps on a phone don't ask "what can you do?" — they *probe*. They send a
+request to a known address and treat any friendly answer as "yes, supported."
+
+Our server had a habit of being friendly to everything. Ask it for any address it doesn't
+recognise and it would hand back the web page — a perfectly valid response that, to a
+phone app, reads as **yes**. So when an app checked whether we supported live updates
+("this book just finished, refresh the screen"), it got a yes. We do not support live
+updates. The app then waited for updates that would never come.
+
+The server now says **no** to those questions, plainly. Saying no lets the app hide a
+feature it can't use. Saying yes made it look present and broken — which is worse,
+because a person then reports a bug against a feature that was never there.
+
+## 2. The manual described things that don't exist
+
+We keep a written specification of everything the server can do — the reference other
+tools and future work are built against. We had **two** of them. They had drifted apart
+over time until each described things the other didn't, and neither matched reality.
+
+They are now a single document, and it has been checked against the server's own list of
+what it actually answers. Along the way we found that **48 described features do not
+exist**. One of them had been copied out of a note in the code — a comment describing an
+idea, filed as though it were a working feature.
+
+Those 48 are now written down as a known problem rather than quietly presented as truth.
+Nothing was removed on a guess.
+
+## 3. A script that reported success after doing nothing
+
+A maintenance script would report a clean run when it had processed **zero** items. If
+the thing it was meant to read was empty or unreadable, it found nothing, had no errors
+to report, and said everything was fine.
+
+This is the most expensive kind of bug, because it doesn't look like one. It now stops
+and says exactly what it found and what it expected.
+
+## 4. The to-do list was wrong, not the job
+
+Our notes said a large cleanup job had never run. Production's own records show it ran,
+processed **7,891 items**, and finished with zero errors. The job was fine; the to-do
+list was stale.
+
+Checking that turned up something more useful than the original question: the backlog
+that job cleared has been **filling back up** — from about 1,300 items to nearly 6,000 in
+three and a half weeks. Running the cleanup again would clear it and it would refill.
+Something upstream is producing the work, and that is now the recorded problem.
+
+## 5. Two things we got wrong
+
+**A mistaken accusation.** We concluded the server was overstating what it lets apps do —
+claiming it accepts changes when nothing could be changed. That was wrong. It had been
+checked in one place only, and missed **nine** other places where the server genuinely
+does accept changes: saving your position in a book, and bookmarks. Acting on the finding
+would have told every app "we don't accept changes," turning off progress-saving and
+bookmarks — the two things that matter most to someone actually listening. The finding
+was withdrawn, and the wrong reasoning was kept on the record rather than deleted.
+
+**A fix that broke something.** Part of the work above made the server answer "no" to
+features it doesn't have. Six were listed. Three of them — authors, series and playlists
+— are things the server *does* have, under a slightly different address. The old
+behaviour quietly forwarded requests to the working version; the change replaced that
+with a flat "no", switching off **46 working functions** for anyone using the older
+address. It also did this on every installation, including ones with the phone-app
+support turned off entirely.
+
+This was caught the same day, before any release, and reversed for those three. Thirty
+days of production records show **no request from anyone** to the affected addresses, so
+no user is known to have been affected. A test now guards it, and that test was checked
+by deliberately reintroducing the bug to confirm it fails.
+
+---
+
+## Why the mistakes are in this summary
+
+They could have been left out. Both were found and fixed by us, on the same day, with no
+user impact — the kind of thing that never has to be mentioned.
+
+They are here because the pattern is the point. Both errors came from **checking one side
+of a question and concluding we had checked all of it**: one place that accepts changes,
+not nine; who *calls* an address, but not whether the address *works*. Every item in this
+summary is a version of the same failure — something that reported a state it had not
+actually verified. Leaving our own two out would have made the write-up an example of the
+problem it describes.
+
+---
+
+## Where this leaves things
+
+- The phone-app compatibility work has a verified test suite and a known, written list of
+  what is still missing.
+- The API specification is one document, valid, and honest about its 48 gaps.
+- Four decisions are waiting on the owner, all written up: a security question about a
+  key stored in the browser, what to do about those 48 phantom entries, a stale status
+  column in an older security review, and whether an unfinished redesign is still wanted.
+- Nothing in this summary is deployed to production yet.

--- a/internal/server/wire_abs_routes.go
+++ b/internal/server/wire_abs_routes.go
@@ -1,5 +1,5 @@
 // file: internal/server/wire_abs_routes.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: 9c6b13f8-40a2-4e57-b18d-72e0a5c4d396
 // last-edited: 2026-08-12
 
@@ -77,20 +77,45 @@ var absReservedPathPrefixes = []string{
 // a 301 into a foreign shape makes it look present and broken, and any non-2xx flips
 // AudioBooth's connection indicator.
 //
-// Matched as exact path OR subtree, so /api/authors and /api/authors/:id both 404.
+// Matched as exact path OR subtree, so /api/users and /api/users/:id both 404.
 //
-// Safe because nothing in-repo requests these without the /v1 prefix — the SPA's only
-// bare /api/ call is /api/events (SSE), which is deliberately absent from this list.
+// # Why this list is SHORTER than the set of ABS namespaces we lack
+//
+// A namespace only belongs here if the redirect leads nowhere. Three ABS namespaces —
+// authors, series, playlists — collide with namespaces the APP API really serves under
+// /api/v1 (19, 18 and 9 routes respectively, see wire_entities_routes.go and
+// wire_dedup_routes.go). For those, the 301 is not a lie: it lands on a working handler.
+// Listing them here 404s a live route to make an unimplemented one honest, which is a
+// strictly worse trade — and because this middleware is NOT gated on ABSAPIEnabled
+// (server_lifecycle.go:1219), it would do that on every deployment, including ones with
+// the ABS surface switched off.
+//
+// That is not hypothetical: they WERE listed here when this shipped in #2332, and the
+// original justification — "nothing in-repo requests these without the /v1 prefix" —
+// checked the CALLER side of the boundary and never the TARGET side. The compatibility
+// shim exists precisely for callers that are not in this repo.
+//
+// So the rule for adding a namespace here is: grep for app-API routes under the same
+// name first. No /api/v1 twin → honest 404 belongs here. A twin exists → leave it out
+// and let the redirect work; TestCollidingNamespacesStillRedirect pins that choice.
 //
 // If one of these is ever implemented on the ABS surface, MOVE it to the lists above
 // rather than deleting it — it must stay excluded from the redirect either way.
 var absUnimplementedNamespaces = []string{
 	"/api/collections",
-	"/api/playlists",
-	"/api/authors",
-	"/api/series",
 	"/api/users",
 	"/api/podcasts",
+}
+
+// absAppAPICollisions are ABS namespaces we do NOT implement but must NOT 404, because
+// the app API serves the same name under /api/v1 and the compatibility redirect is the
+// only way an unversioned caller reaches it. Declared as data rather than left implicit
+// so the regression test can iterate it, and so the next person to extend the list above
+// sees the exclusion instead of rediscovering it.
+var absAppAPICollisions = []string{
+	"/api/authors",
+	"/api/series",
+	"/api/playlists",
 }
 
 // absReservedPath reports whether a request path belongs to the ABS surface and must

--- a/internal/server/wire_abs_routes_test.go
+++ b/internal/server/wire_abs_routes_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/wire_abs_routes_test.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 3ea1d764-95c8-4b02-8f31-6d70a5be2c49
 // last-edited: 2026-08-12
 
@@ -193,12 +193,9 @@ func TestUnimplementedABSNamespacesAre404NotRedirect(t *testing.T) {
 
 	for _, path := range []string{
 		"/api/collections",
-		"/api/playlists",
-		"/api/authors",
-		"/api/authors/aut_abc123",
-		"/api/series",
-		"/api/series/ser_abc123",
+		"/api/collections/col_abc123",
 		"/api/users",
+		"/api/users/usr_abc123",
 		"/api/podcasts",
 	} {
 		w := httptest.NewRecorder()
@@ -224,4 +221,43 @@ func TestNonABSPathsStillRedirect(t *testing.T) {
 	require.Equal(t, http.StatusMovedPermanently, w.Code,
 		"/api/audiobooks is app-API surface and must keep redirecting to /api/v1")
 	require.Equal(t, "/api/v1/audiobooks", w.Header().Get("Location"))
+}
+
+// TestCollidingNamespacesStillRedirect is the regression guard for the bug #2332
+// introduced: authors, series and playlists are ABS namespaces we don't implement,
+// but they are ALSO app-API namespaces we do. 404ing them to be honest about the ABS
+// surface destroyed 46 working app routes' unversioned form on every deployment,
+// because the redirect middleware is not gated on ABSAPIEnabled.
+//
+// The earlier version of this suite missed it by checking only /api/audiobooks — a
+// path with no ABS meaning at all, so it could never have caught a collision. The
+// test has to be driven by the collision list itself to be worth anything.
+func TestCollidingNamespacesStillRedirect(t *testing.T) {
+	s, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	require.NotEmpty(t, absAppAPICollisions, "the collision list must not be silently emptied")
+
+	for _, base := range absAppAPICollisions {
+		for _, path := range []string{base, base + "/123"} {
+			w := httptest.NewRecorder()
+			s.router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+
+			require.Equal(t, http.StatusMovedPermanently, w.Code,
+				"%s has a live /api/v1 twin — 404ing it breaks a working app route to make an "+
+					"unimplemented ABS one honest, on every deployment including ABS-disabled ones", path)
+			require.Equal(t, strings.Replace(path, "/api/", "/api/v1/", 1), w.Header().Get("Location"))
+		}
+	}
+}
+
+// A namespace must never appear in both lists: one says 404, the other says redirect,
+// and absReservedPath consults only the first — so a duplicate would silently win as a
+// 404 while the collision list claimed otherwise.
+func TestNamespaceListsAreDisjoint(t *testing.T) {
+	for _, u := range absUnimplementedNamespaces {
+		for _, c := range absAppAPICollisions {
+			require.NotEqual(t, u, c, "%s is in both absUnimplementedNamespaces and absAppAPICollisions", u)
+		}
+	}
 }


### PR DESCRIPTION
## What broke

#2332 added six unimplemented Audiobookshelf namespaces to the set excluded from the `/api/*` → `/api/v1/*` compatibility redirect, so an ABS client probing them would get an honest 404 instead of being redirected into a foreign JSON shape.

**Three of the six were wrong.** `authors`, `series` and `playlists` are namespaces the **app API really serves** under `/api/v1`:

| namespace | app routes under `/api/v1` | verdict |
|---|---|---|
| `authors` | **19** (`wire_entities_routes.go`, `wire_dedup_routes.go`) | ❌ redirect was correct |
| `series` | **18** | ❌ redirect was correct |
| `playlists` | **9** | ❌ redirect was correct |
| `collections` | 0 | ✅ 404 correct |
| `users` | 0 | ✅ 404 correct |
| `podcasts` | 0 | ✅ 404 correct |

For those three the 301 is not a lie — it lands on a working handler. Excluding them 404'd **46 live routes'** unversioned form. And because the redirect middleware is **not gated on `ABSAPIEnabled`** (`server_lifecycle.go:1219`), it did so on every deployment, including ones with the ABS surface switched off.

## The reasoning error

The justification in the original comment was:

> Safe because nothing in-repo requests these without the `/v1` prefix

That checks the **caller** side of the boundary and never the **target** side. A compatibility shim exists precisely for callers that are *not* in this repo. The rule is now written into the code: before adding a namespace, grep for app-API routes of the same name.

## Blast radius: none observed

30 days of production logs show **zero** unversioned requests to any of the six namespaces.

The instrument was checked rather than trusted — the same journal query returns real traffic for `/api/items/` (56), `/api/session/` (28), `/api/me/item/` (28), `/api/libraries/`, so the null is real and not a broken grep.

Not deployed to production.

## Tests

`TestCollidingNamespacesStillRedirect` is driven by the collision list itself, and asserts both the bare path and a subtree path still 301 to the `/api/v1` form. `TestNamespaceListsAreDisjoint` stops a namespace appearing in both lists, where the 404 would silently win.

Both were **verified by reintroducing the bug** — with `authors`/`series`/`playlists` put back into `absUnimplementedNamespaces`, both fail; with the fix, all 7 tests in the file pass.

The prior suite missed this because `TestNonABSPathsStillRedirect` only checked `/api/audiobooks` — a path with no ABS meaning, so it could never have caught a collision.

## Residual gap

An ABS client probing `/api/authors/:id` still 301s into the app API. Closing that honestly requires gating the ABS surface's semantics on `ABSAPIEnabled` and registering explicit 404 handlers inside the ABS group — a design change, not a list edit. Recorded in the audit, not attempted here.

## Also

- `docs/audits/2026-08-11-abs-coverage-gap-audit.md` → N-4 downgraded from ✅ FIXED to ⚠️ PARTIALLY FIXED, with the regression and the reasoning error on the record.
- Adds the executive summary for the whole 2026-08-12 sweep (8 PRs), which this regression is part of — including the two findings that turned out wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t
