### PR TITLE
fix(abs): /api/users 404'd — seven live app routes, missed by the #2333 fix

### DIFF
--- a/changelog.d/20260812_140000_abs_users_namespace_collision.md
+++ b/changelog.d/20260812_140000_abs_users_namespace_collision.md
@@ -1,0 +1,29 @@
+### Fixed
+
+- **`/api/users` 404'd instead of reaching its seven live app-API routes.** A second
+  instance of the `#2332` namespace-collision regression that `#2333` was supposed to
+  close. `/api/users` was left in `absUnimplementedNamespaces`, so the `/api/*` →
+  `/api/v1/*` compatibility redirect skipped it and `NoRoute` answered 404 — on every
+  deployment, including ones with the ABS surface disabled, since the middleware is not
+  gated on `ABSAPIEnabled`. The seven routes behind it include
+  `POST /api/v1/users/:id/reset-password`. Moved to `absAppAPICollisions`.
+
+  `#2333` missed it because it prescribed grepping the source for `/api/v1` twins, and
+  grep cannot answer that question: gin composes a route's path from its `RouterGroup` at
+  registration time, so a grouped route (`protected.Group("/users")` → `users.GET("", …)`)
+  has its final path written nowhere in the source. Six prefixed groups register that way.
+
+### Added
+
+- **`TestUnimplementedNamespacesHaveNoAppAPITwin` / `TestCollisionNamespacesAreStillColliding`**
+  replace that grep with a check derived from `router.Routes()`, the flattened table gin
+  actually matches against and the only complete oracle for which paths exist. The first
+  fails if a namespace marked unimplemented has a live `/api/v1` twin; the second fails if
+  a collision entry's twin ever disappears, so the list cannot rot into a lie. Both were
+  verified by reintroducing the bug in each direction, and the first guards against a
+  vacuous pass by asserting the route table is populated before trusting any negative
+  result.
+
+30 days of production logs show zero unversioned requests to any of the six namespaces —
+validated method-agnostically against a query shape that does return traffic for the
+`/api/v1` forms — so no client is known to have been affected by either regression.

--- a/docs/audits/2026-08-11-abs-coverage-gap-audit.md
+++ b/docs/audits/2026-08-11-abs-coverage-gap-audit.md
@@ -1,5 +1,5 @@
 <!-- file: docs/audits/2026-08-11-abs-coverage-gap-audit.md -->
-<!-- version: 2.1.0 -->
+<!-- version: 2.2.0 -->
 <!-- guid: 8c4f2b19-5d73-46ea-b1c0-3f8a92d6e457 -->
 <!-- last-edited: 2026-08-12 -->
 
@@ -207,9 +207,9 @@ idiom for "all libraries".
 
 ### ⚠️ N-4. ~~Unimplemented `/api/…` paths **301 into `/api/v1/…`** instead of 404ing~~ — **PARTIALLY FIXED 2026-08-12, after a regression**
 
-> **Fixed for three namespaces, deliberately NOT fixed for three others.**
+> **Fixed for two namespaces, deliberately NOT fixed for four others.**
 >
-> `/api/collections`, `/api/users`, `/api/podcasts` now 404 (exact path or subtree) via
+> `/api/collections` and `/api/podcasts` now 404 (exact path or subtree) via
 > `absUnimplementedNamespaces` in `wire_abs_routes.go`.
 >
 > 🚨 **The first attempt (#2332) listed six and shipped a regression.** `/api/authors`,
@@ -220,13 +220,33 @@ idiom for "all libraries".
 > `ABSAPIEnabled` (`server_lifecycle.go:1219`), so this applied to every deployment, including
 > ABS-disabled ones. Reverted for those three the same day; they are now listed in
 > `absAppAPICollisions` and pinned by `TestCollidingNamespacesStillRedirect`, verified by
-> reintroducing the bug. 30 days of prod logs show **zero** unversioned requests to any of the
-> six, so no client is known to have been affected.
+> reintroducing the bug.
 >
-> **The reasoning error:** the original justification was "nothing in-repo requests these
+> 🚨 **The fix (#2333) then missed a FOURTH: `/api/users`.** It has **7 live app routes**
+> (`wire_library_routes.go:88`), including `POST /api/v1/users/:id/reset-password` — account
+> recovery. Caught 2026-08-12 and moved to `absAppAPICollisions`. Prod logs show 5 calls to
+> `/api/v1/users` in 30 days, so it is admin-path traffic, not a hot path.
+>
+> **The reasoning error, twice.** #2332's justification was "nothing in-repo requests these
 > without the `/v1` prefix" — which checks the *caller* side of the boundary and never the
 > *target* side. A compatibility shim exists precisely for callers that are not in the repo.
-> Rule going forward: before adding a namespace, grep for app-API routes of the same name.
+> #2333 then fixed that but prescribed the wrong instrument: *"grep for app-API routes of the
+> same name."* **Grep cannot answer this question.** gin composes a route's path from its
+> `RouterGroup` at registration time, so a grouped route — `users := protected.Group("/users")`
+> then `users.GET("", …)` — has its final path written nowhere in the source. `/api/users` was
+> invisible to every pattern for exactly that reason, and this codebase registers routes both
+> directly and through groups.
+>
+> The check is now mechanical and derived from the flattened router
+> (`s.router.Routes()`), which is the only complete oracle:
+> `TestUnimplementedNamespacesHaveNoAppAPITwin` fails if any listed namespace has a live
+> `/api/v1` twin, and `TestCollisionNamespacesAreStillColliding` fails if a collision entry's
+> twin ever disappears. Both verified by reintroducing the bug in each direction. Nobody has
+> to remember the right grep again.
+>
+> 30 days of prod logs show **zero** unversioned requests to any of the six namespaces
+> (validated method-agnostically, against a query shape that *does* return traffic for the
+> `/api/v1` forms), so no client is known to have been affected by either regression.
 >
 > Residual gap: an ABS client probing `/api/authors/:id` still 301s into the app API. Fixing
 > that honestly requires gating the ABS surface's semantics on `ABSAPIEnabled` and registering
@@ -379,10 +399,12 @@ unauthenticated cover endpoint (gate 2.17.0) and `/public/session/:id/track/:ind
    the signal. Add the 4 orphan fixtures.
 3. ~~**N-3**~~ — **RETRACTED, do not act on it.** It was wrong; see §N-3. `Update`/`Delete`
    honestly describe the nine `/api/me/*` write routes.
-   **N-4** — *partially done 2026-08-12.* THREE namespaces (`collections`, `users`, `podcasts`)
-   now 404 instead of 301ing into the app API. The first attempt listed six and broke 46 live
-   app routes; `authors`, `series` and `playlists` have `/api/v1` twins and keep their redirect.
-   See §N-4 for the reasoning error and the residual gap.
+   **N-4** — *partially done 2026-08-12, after TWO regressions.* TWO namespaces
+   (`collections`, `podcasts`) now 404 instead of 301ing into the app API. The first attempt
+   listed six and broke 46 live app routes; the fix for that missed a seventh route set under
+   `/api/users`. `authors`, `series`, `playlists` and `users` all have `/api/v1` twins and keep
+   their redirect. The twin check is now a router-derived test, not a grep. See §N-4 for both
+   reasoning errors and the residual gap.
 4. **N-5**, **N-6** — contract-conformance and observability.
 5. **N-7 … N-10** — bookkeeping truth-ups.
 6. **N-11** — an operational decision, not a code change.

--- a/docs/executive-summaries/2026-08-12-checking-our-own-homework-executive-summary.md
+++ b/docs/executive-summaries/2026-08-12-checking-our-own-homework-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-08-12-checking-our-own-homework-executive-summary.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 4f1c8e27-9db3-4a56-b0e8-6c395a71d2f4 -->
 <!-- last-edited: 2026-08-12 -->
 
@@ -17,10 +17,11 @@ This was a day of **checking claims** — most of them our own. A phone app was 
 a feature existed when it didn't. Our documentation described dozens of things the server
 cannot do. A maintenance script reported success after doing nothing at all. Our to-do
 list said an important job had never run, when in fact it had finished cleanly weeks
-earlier. And two of the things we found and "fixed" turned out to be wrong — one was a
-mistaken accusation, the other actively broke something. Both were caught and undone the
-same day. The honest summary is not "we fixed eight things"; it is "we fixed eight
-things, got two of them wrong, and caught both before anyone was affected."
+earlier. And some of what we found and "fixed" turned out to be wrong — one was a
+mistaken accusation, one actively broke something, and the repair for *that* missed a
+piece. All three were caught and undone the same day. The honest summary is not "we fixed
+eight things"; it is "we fixed eight things, got three of them wrong, and caught all
+three before anyone was affected."
 
 ---
 
@@ -73,7 +74,7 @@ that job cleared has been **filling back up** — from about 1,300 items to near
 three and a half weeks. Running the cleanup again would clear it and it would refill.
 Something upstream is producing the work, and that is now the recorded problem.
 
-## 5. Two things we got wrong
+## 5. Three things we got wrong
 
 **A mistaken accusation.** We concluded the server was overstating what it lets apps do —
 claiming it accepts changes when nothing could be changed. That was wrong. It had been
@@ -83,32 +84,48 @@ would have told every app "we don't accept changes," turning off progress-saving
 bookmarks — the two things that matter most to someone actually listening. The finding
 was withdrawn, and the wrong reasoning was kept on the record rather than deleted.
 
-**A fix that broke something.** Part of the work above made the server answer "no" to
-features it doesn't have. Six were listed. Three of them — authors, series and playlists
-— are things the server *does* have, under a slightly different address. The old
-behaviour quietly forwarded requests to the working version; the change replaced that
-with a flat "no", switching off **46 working functions** for anyone using the older
-address. It also did this on every installation, including ones with the phone-app
-support turned off entirely.
+**A fix that broke something — and the repair that missed a piece.** Part of the work
+above made the server answer "no" to features it doesn't have. Six were listed. Three of
+them — authors, series and playlists — are things the server *does* have, under a
+slightly different address. The old behaviour quietly forwarded requests to the working
+version; the change replaced that with a flat "no", switching off **46 working
+functions** for anyone using the older address. It also did this on every installation,
+including ones with the phone-app support turned off entirely.
 
-This was caught the same day, before any release, and reversed for those three. Thirty
-days of production records show **no request from anyone** to the affected addresses, so
-no user is known to have been affected. A test now guards it, and that test was checked
-by deliberately reintroducing the bug to confirm it fails.
+That was caught the same day and reversed for those three. But the repair checked the
+list by searching the source code for each address — and **some addresses cannot be found
+that way at all.** Most are written out plainly in the code, but six groups of them are
+assembled from pieces when the server starts, so the finished address appears nowhere to
+be searched for. User management is one of those six. It stayed broken because of it —
+including the password-reset page.
+
+The check no longer works that way. Instead of searching the code, the test now asks the
+running server for its own list of addresses, which is the only version that is
+guaranteed complete. It fails if any address we've marked "we don't have this" turns out
+to exist, and also if one we've marked "keep this working" ever disappears. Both
+directions were confirmed by deliberately reintroducing each bug.
+
+Thirty days of production records show **no request from anyone** to any of the affected
+addresses, so no user is known to have been affected by either mistake. Nothing had been
+released.
 
 ---
 
 ## Why the mistakes are in this summary
 
-They could have been left out. Both were found and fixed by us, on the same day, with no
+They could have been left out. All were found and fixed by us, on the same day, with no
 user impact — the kind of thing that never has to be mentioned.
 
-They are here because the pattern is the point. Both errors came from **checking one side
-of a question and concluding we had checked all of it**: one place that accepts changes,
-not nine; who *calls* an address, but not whether the address *works*. Every item in this
-summary is a version of the same failure — something that reported a state it had not
-actually verified. Leaving our own two out would have made the write-up an example of the
-problem it describes.
+They are here because the pattern is the point. All three came from **concluding we had
+checked something when the check could not have seen the answer**: one place that accepts
+changes, not nine; who *calls* an address, but not whether the address *works*; and then
+a search of the code that structurally cannot find half the addresses it was searching
+for. That third one is the sharpest, because it was the *fix* for the second — the
+correction repeated the original shape of the mistake, one level down.
+
+Every item in this summary is a version of that failure: something reporting a state it
+had not actually verified. Leaving our own three out would have made the write-up an
+example of the problem it describes.
 
 ---
 

--- a/internal/server/wire_abs_routes.go
+++ b/internal/server/wire_abs_routes.go
@@ -1,5 +1,5 @@
 // file: internal/server/wire_abs_routes.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 9c6b13f8-40a2-4e57-b18d-72e0a5c4d396
 // last-edited: 2026-08-12
 
@@ -77,7 +77,7 @@ var absReservedPathPrefixes = []string{
 // a 301 into a foreign shape makes it look present and broken, and any non-2xx flips
 // AudioBooth's connection indicator.
 //
-// Matched as exact path OR subtree, so /api/users and /api/users/:id both 404.
+// Matched as exact path OR subtree, so /api/collections and /api/collections/:id both 404.
 //
 // # Why this list is SHORTER than the set of ABS namespaces we lack
 //
@@ -95,15 +95,29 @@ var absReservedPathPrefixes = []string{
 // checked the CALLER side of the boundary and never the TARGET side. The compatibility
 // shim exists precisely for callers that are not in this repo.
 //
-// So the rule for adding a namespace here is: grep for app-API routes under the same
-// name first. No /api/v1 twin → honest 404 belongs here. A twin exists → leave it out
-// and let the redirect work; TestCollidingNamespacesStillRedirect pins that choice.
+// So the rule for adding a namespace here is: no /api/v1 twin → honest 404 belongs
+// here; a twin exists → leave it out and let the redirect work, which
+// TestCollidingNamespacesStillRedirect pins.
+//
+// # Do NOT check for a twin with grep — it cannot see one
+//
+// The #2333 fix said "grep for app-API routes under the same name first", and that
+// advice was itself wrong: it missed /api/users, which has SEVEN live app routes
+// (wire_library_routes.go:88). gin composes a route's path from its RouterGroup at
+// registration time, so a grouped route's final path — `users := protected.Group("/users")`
+// then `users.GET("", ...)` — exists as a literal NOWHERE in the source. Any text search
+// for a route path is structurally blind to grouped registrations, and this codebase
+// registers both ways: six prefixed groups today (/auth, /bench, /deluge, /itunes,
+// /plugins, /users), everything else direct. Six is enough — /users was one of them.
+//
+// The only complete oracle is the flattened router: s.router.Routes(). That is what
+// TestUnimplementedNamespacesHaveNoAppAPITwin walks, so the check no longer depends on
+// anyone remembering to run the right grep.
 //
 // If one of these is ever implemented on the ABS surface, MOVE it to the lists above
 // rather than deleting it — it must stay excluded from the redirect either way.
 var absUnimplementedNamespaces = []string{
 	"/api/collections",
-	"/api/users",
 	"/api/podcasts",
 }
 
@@ -116,6 +130,12 @@ var absAppAPICollisions = []string{
 	"/api/authors",
 	"/api/series",
 	"/api/playlists",
+	// Added 2026-08-12, a second instance of the same defect: #2332 404'd this too and
+	// #2333 did not catch it, because its twin is registered through a RouterGroup
+	// (`protected.Group("/users")`, wire_library_routes.go:88) and the grep used only
+	// matched direct registrations. Seven routes, including reset-password — an
+	// account-recovery path.
+	"/api/users",
 }
 
 // absReservedPath reports whether a request path belongs to the ABS surface and must

--- a/internal/server/wire_abs_routes_test.go
+++ b/internal/server/wire_abs_routes_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/wire_abs_routes_test.go
-// version: 1.5.0
+// version: 1.7.0
 // guid: 3ea1d764-95c8-4b02-8f31-6d70a5be2c49
 // last-edited: 2026-08-12
 
@@ -191,13 +191,18 @@ func TestUnimplementedABSNamespacesAre404NotRedirect(t *testing.T) {
 	s, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	for _, path := range []string{
-		"/api/collections",
-		"/api/collections/col_abc123",
-		"/api/users",
-		"/api/users/usr_abc123",
-		"/api/podcasts",
-	} {
+	// Derived from absUnimplementedNamespaces rather than restated. The hardcoded copy
+	// this replaces went stale the moment /api/users moved to absAppAPICollisions, and
+	// failed CI asserting a 404 the fix had deliberately removed — a duplicated list is
+	// a second source of truth that only ever disagrees with the first.
+	require.NotEmpty(t, absUnimplementedNamespaces, "the unimplemented list must not be silently emptied")
+
+	var paths []string
+	for _, ns := range absUnimplementedNamespaces {
+		paths = append(paths, ns, ns+"/abc123")
+	}
+
+	for _, path := range paths {
 		w := httptest.NewRecorder()
 		s.router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
 
@@ -259,5 +264,80 @@ func TestNamespaceListsAreDisjoint(t *testing.T) {
 		for _, c := range absAppAPICollisions {
 			require.NotEqual(t, u, c, "%s is in both absUnimplementedNamespaces and absAppAPICollisions", u)
 		}
+	}
+}
+
+// TestUnimplementedNamespacesHaveNoAppAPITwin is the mechanical form of the check that
+// has now failed BY HAND twice — in #2332 (authors/series/playlists) and again in #2333,
+// whose fix missed /api/users.
+//
+// Both misses came from searching the SOURCE for route paths. gin builds a route's path
+// from its RouterGroup at registration time, so a grouped route
+// (`users := protected.Group("/users")`; `users.GET("", ...)`) has no literal "/users"
+// path anywhere in the file — grep cannot see it, no matter how the pattern is written.
+// This codebase registers both directly and through groups, so the source is simply not
+// a sound oracle for "does /api/v1/<ns> exist".
+//
+// router.Routes() is: it returns the flattened, fully-resolved table gin will actually
+// match against. Walking it means nobody has to remember the right grep again.
+func TestUnimplementedNamespacesHaveNoAppAPITwin(t *testing.T) {
+	s, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	routes := s.router.Routes()
+
+	// Guard against a VACUOUS pass. If this server were wired without the app API,
+	// every assertion below would succeed by finding nothing, and the test would read
+	// as protection while providing none.
+	var versioned int
+	for _, r := range routes {
+		if strings.HasPrefix(r.Path, "/api/v1/") {
+			versioned++
+		}
+	}
+	require.Greater(t, versioned, 50,
+		"the route table has only %d /api/v1 routes — the app API is not wired into this "+
+			"test server, so the twin checks below would pass by finding nothing", versioned)
+
+	for _, ns := range absUnimplementedNamespaces {
+		twin := strings.Replace(ns, "/api/", "/api/v1/", 1)
+		var found []string
+		for _, r := range routes {
+			if r.Path == twin || strings.HasPrefix(r.Path, twin+"/") {
+				found = append(found, r.Method+" "+r.Path)
+			}
+		}
+		require.Empty(t, found,
+			"%s is listed as unimplemented, so absReservedPath makes it 404 — but the app API "+
+				"serves %d live route(s) under %s: %s.\nThat 404 applies on EVERY deployment, "+
+				"including ABS-disabled ones, because the redirect middleware is not gated on "+
+				"ABSAPIEnabled. Move %s to absAppAPICollisions.",
+			ns, len(found), twin, strings.Join(found, ", "), ns)
+	}
+}
+
+// TestCollisionNamespacesAreStillColliding is the inverse guard, and it exists so the
+// collision list cannot rot into a lie. Each entry claims "we must not 404 this, because
+// a live app-API twin exists" — if that twin is ever deleted or renamed, the entry stops
+// describing reality and the honest-404 we gave up buying is no longer bought.
+func TestCollisionNamespacesAreStillColliding(t *testing.T) {
+	s, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	routes := s.router.Routes()
+
+	for _, ns := range absAppAPICollisions {
+		twin := strings.Replace(ns, "/api/", "/api/v1/", 1)
+		var found int
+		for _, r := range routes {
+			if r.Path == twin || strings.HasPrefix(r.Path, twin+"/") {
+				found++
+			}
+		}
+		require.Greater(t, found, 0,
+			"%s is excluded from the honest-404 list because %s was supposed to be live, but the "+
+				"router has no route under it any more. Either the app route moved (update this "+
+				"list) or it is gone (move %s to absUnimplementedNamespaces so it 404s honestly).",
+			ns, twin, ns)
 	}
 }


### PR DESCRIPTION
## What

`/api/users` was left in `absUnimplementedNamespaces`, so the `/api/*` → `/api/v1/*`
compatibility redirect skipped it and `NoRoute` answered **404** — on every deployment,
including ABS-disabled ones, since the middleware is not gated on `ABSAPIEnabled`.

Behind it are **seven live app-API routes** (`wire_library_routes.go:88`):

```
GET    /api/v1/users
GET    /api/v1/users/invites
POST   /api/v1/users/invite
POST   /api/v1/users/:id/deactivate
POST   /api/v1/users/:id/reactivate
POST   /api/v1/users/:id/reset-password
DELETE /api/v1/users/invites/:token
```

This is the **same defect as #2332**, which #2333 was supposed to close.

## Why #2333 missed it

#2333's rule was *"grep for app-API routes under the same name first."* **Grep cannot
answer that question.** gin composes a route's path from its `RouterGroup` at registration
time, so a grouped route —

```go
users := protected.Group("/users")
users.GET("", s.perm("users.manage"), userH.ListUsers)
```

— has its final path (`/api/v1/users`) written **nowhere** in the source. Six prefixed
groups register this way (`/auth`, `/bench`, `/deluge`, `/itunes`, `/plugins`, `/users`);
everything else registers directly, which is why `authors`/`series`/`playlists` surfaced
in #2333 and `users` did not. That was luck, not coverage.

## The fix that isn't a list edit

The twin check is now derived from `router.Routes()` — the flattened table gin actually
matches against, and the only complete oracle for which paths exist:

- **`TestUnimplementedNamespacesHaveNoAppAPITwin`** — fails if any namespace marked
  unimplemented has a live `/api/v1` twin, and names the offending routes in the failure.
- **`TestCollisionNamespacesAreStillColliding`** — the inverse: fails if a collision
  entry's twin ever disappears, so the list cannot rot into a lie.

Nobody has to remember the right grep again.

## Verification

Both guards verified **by reintroducing the bug in each direction** — not by observing a
green run:

```
--- FAIL: TestUnimplementedNamespacesHaveNoAppAPITwin
    Should be empty, but was [GET /api/v1/users GET /api/v1/users/invites
    POST /api/v1/users/invite POST /api/v1/users/:id/reactivate
    POST /api/v1/users/:id/reset-password POST /api/v1/users/:id/deactivate
    DELETE /api/v1/users/invites/:token]
--- FAIL: TestCollisionNamespacesAreStillColliding
```

`TestUnimplementedNamespacesHaveNoAppAPITwin` also guards against a **vacuous pass**: it
asserts the route table actually contains app-API routes before trusting any "no twin
found" result. Without that, unwiring the app API from the test server would make every
assertion succeed by finding nothing, and the test would read as protection while
providing none.

### The first push failed CI, and the failure was the same bug one level down

`TestUnimplementedABSNamespacesAre404NotRedirect` — **my own test from #2333** — restated
the namespace list as a hardcoded array instead of reading it. Moving `/api/users` to the
collision list made that test fail, asserting a 404 this change deliberately removed. It
was right to fail; it was just a second source of truth, and a duplicated list can only
ever come to disagree with the first.

It now derives its paths from `absUnimplementedNamespaces` as well. **Those namespaces are
written down in exactly one place in the repo** (`wire_abs_routes.go:120-121,138`), and all
four tests read from it.

I missed this locally because I verified with `go test -run '<subset>'` and the filter did
not match that test name — the same shape of error as the rest of this PR: a check that
could not see the thing it was checking for.

Final verification: `go build ./...` exit 0 · `go vet ./internal/server/` exit 0 ·
**`go test ./internal/server/ -short -count=1` → `ok 523.666s`** — the whole package, no
`-run` filter.

## Blast radius

30 days of production logs show **zero** unversioned requests to any of the six
namespaces. That null was re-validated method-agnostically against a query shape that
*does* return traffic for the `/api/v1` forms (`/api/v1/users` appears 5×, including one
`reset-password`), so the zero is a real absence and not a pattern that never matched.
No client is known to have been affected by either regression, and nothing was released.

## Docs

- Audit §N-4 → both reasoning errors and the corrected instrument.
- 2026-08-12 executive summary → now "three things we got wrong", including that the
  *repair* repeated the shape of the mistake it was repairing. An "about half of
  addresses" figure in the draft was measured and corrected to six groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t
