### PR TITLE
fix(database): serialise EmbeddingStore.Close against in-flight operations [skip changelog]

### DIFF
--- a/changelog.d/20260812_fix_embeddingstore_close_deadlock.md
+++ b/changelog.d/20260812_fix_embeddingstore_close_deadlock.md
@@ -1,0 +1,25 @@
+### Fixed
+
+#### `EmbeddingStore.Close()` could deadlock against in-flight operations
+
+Closing an `EmbeddingStore` that owns its PebbleDB while operations were still running
+could hang forever: writers already inside `db.Set` blocked on Pebble's commit-pipeline
+mutex and never woke. Pebble documents that calling `Close` concurrently with any other DB
+method is unsafe; the store now provides the guarantee Pebble does not.
+
+Every operation that touches the database holds a read lock for its whole duration and
+`Close` takes the write lock, so `Close` cannot begin until the last in-flight operation
+has returned.
+
+This was reached only by tests — the production constructor `NewEmbeddingStore` sets
+`owned: false`, so `Close()` returns immediately and never shuts the DB down. Its cost was
+paid in CI, where `TestChaos_MixedReadWriteDuringClose` hung for the full job timeout and
+reported only an unexplained "cancelled".
+
+The pre-existing `closed` flag could not have prevented this and was never going to: it is
+a check-then-act, and an operation already inside `db.Set` is past the check.
+
+Also bounded the three chaos tests' worker waits. A deadlock is not a panic, so the
+`recover()` in each of them could never catch this, and a bare `wg.Wait()` turned a
+regression into a silent 30-minute hang with no test named. A regression now fails in 30
+seconds and says which invariant broke.

--- a/internal/database/embedding_store.go
+++ b/internal/database/embedding_store.go
@@ -1,6 +1,6 @@
 // file: internal/database/embedding_store.go
-// version: 2.9.0
-// last-edited: 2026-07-17
+// version: 2.10.0
+// last-edited: 2026-08-12
 // guid: 7c4a9b2e-d831-4f5c-a07e-3b8d6e1f9c42
 
 package database
@@ -198,8 +198,20 @@ type EmbeddingHealthStats struct {
 // EmbeddingStore is a PebbleDB-backed store for vector embeddings, text-hash
 // cache, and dedup candidates. It replaces the former SQLite sidecar (embeddings.db).
 type EmbeddingStore struct {
-	db        *pebble.DB
-	owned     bool        // if true, Close() shuts down the DB
+	db    *pebble.DB
+	owned bool // if true, Close() shuts down the DB
+	// closeMu serialises every DB-touching operation against Close. Operations
+	// hold RLock for their whole duration; Close takes the write lock, so it
+	// cannot begin until the last in-flight operation has returned.
+	//
+	// This exists because Pebble documents that calling Close concurrently with
+	// any other DB method is unsafe, and doing so deadlocks for real: three
+	// writers inside db.Set blocked forever on commitPipeline.prepare and hung
+	// TestChaos_MixedReadWriteDuringClose for 29 minutes (CI run 31603570061).
+	// The pre-existing `closed` flag below cannot prevent that — it is a
+	// check-then-act, and a writer already inside db.Set is past the check.
+	// Only a lock held for the operation's DURATION closes that window.
+	closeMu   sync.RWMutex
 	mu        sync.Mutex  // serialises counter + pair-uniqueness operations
 	closeOnce sync.Once   // guards owned Close against double-call
 	closed    atomic.Bool // set on Close; makes post-close ops return errors, not panic
@@ -219,6 +231,15 @@ func (s *EmbeddingStore) Close() error {
 	}
 	var closeErr error
 	s.closeOnce.Do(func() {
+		// The write lock is the whole fix. It cannot be acquired until every
+		// in-flight operation has released its RLock, so db.Close() never runs
+		// concurrently with another Pebble method — which Pebble documents as
+		// unsafe and which deadlocks in practice (commitPipeline.prepare).
+		//
+		// closed is still set, and set BEFORE the DB goes away, so the cheap
+		// checkClosed fast path keeps working for callers that arrive later.
+		s.closeMu.Lock()
+		defer s.closeMu.Unlock()
 		s.closed.Store(true)
 		closeErr = s.db.Close()
 	})
@@ -301,6 +322,8 @@ func (s *EmbeddingStore) Get(entityType, entityID string) (*Embedding, error) {
 
 // Delete removes an embedding. It is a no-op if the entity does not exist.
 func (s *EmbeddingStore) Delete(entityType, entityID string) error {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	if err := s.checkClosed(); err != nil {
 		return err
 	}
@@ -309,6 +332,8 @@ func (s *EmbeddingStore) Delete(entityType, entityID string) error {
 
 // ListByType returns all embeddings for the given entity type.
 func (s *EmbeddingStore) ListByType(entityType string) ([]Embedding, error) {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	if err := s.checkClosed(); err != nil {
 		return nil, err
 	}
@@ -369,6 +394,8 @@ func (s *EmbeddingStore) FindSimilar(entityType string, query []float32, minSimi
 
 // CountByType returns the number of embeddings stored for the given entity type.
 func (s *EmbeddingStore) CountByType(entityType string) (int, error) {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	if err := s.checkClosed(); err != nil {
 		return 0, err
 	}
@@ -393,6 +420,8 @@ func (s *EmbeddingStore) CountByType(entityType string) (int, error) {
 // GetCachedEmbedding looks up a cached embedding by text hash and model.
 // Returns nil, nil on a cache miss.
 func (s *EmbeddingStore) GetCachedEmbedding(textHash, model string) ([]float32, error) {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	if textHash == "" || model == "" {
 		return nil, nil
 	}
@@ -415,6 +444,8 @@ func (s *EmbeddingStore) GetCachedEmbedding(textHash, model string) ([]float32, 
 // PutCachedEmbedding stores a vector keyed by text hash and model.
 // A write failure is never fatal — callers log and continue.
 func (s *EmbeddingStore) PutCachedEmbedding(textHash, model string, vector []float32) error {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	if textHash == "" || model == "" || len(vector) == 0 {
 		return nil
 	}
@@ -523,6 +554,8 @@ func (s *EmbeddingStore) UpsertCandidate(c DedupCandidate) error {
 // must never re-label an existing pair on a score update — should call this
 // instead of UpsertCandidate.
 func (s *EmbeddingStore) UpsertCandidateNew(c DedupCandidate) (id int64, isNew bool, err error) {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	if err := s.checkClosed(); err != nil {
 		return 0, false, err
 	}
@@ -715,6 +748,21 @@ const dedupCandidateStatusIndexBuiltFlagKey = "dedup_candidate_status_index_v1_d
 // today's full dedup:r: scan (fail-open — no candidate can ever be silently
 // dropped by an incomplete index).
 func (s *EmbeddingStore) IsCandidateStatusIndexBuilt() bool {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
+	return s.isCandidateStatusIndexBuiltLocked()
+}
+
+// isCandidateStatusIndexBuiltLocked is the body of IsCandidateStatusIndexBuilt
+// with NO lock of its own. It exists because ListCandidates — which already
+// holds closeMu.RLock — needs to consult the flag. Calling the exported method
+// from there would take RLock recursively, and sync.RWMutex does not permit
+// that: a writer (Close) blocking between the two acquisitions leaves the
+// second RLock waiting on a writer that is itself waiting on the first, which
+// is a guaranteed deadlock rather than the rare one this file is fixing.
+//
+// Callers MUST hold s.closeMu (read or write) for the duration of this call.
+func (s *EmbeddingStore) isCandidateStatusIndexBuiltLocked() bool {
 	if err := s.checkClosed(); err != nil {
 		return false
 	}
@@ -734,6 +782,8 @@ func (s *EmbeddingStore) IsCandidateStatusIndexBuilt() bool {
 // Called by the dedup.build-candidate-status-index op when its full scan
 // finishes.
 func (s *EmbeddingStore) SetCandidateStatusIndexBuilt() error {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	if err := s.checkClosed(); err != nil {
 		return err
 	}
@@ -760,6 +810,8 @@ func (s *EmbeddingStore) SetCandidateStatusIndexBuilt() error {
 // (a candidate can never legitimately have an empty status — UpsertCandidateNew
 // defaults it to "pending" — so this only guards against corrupt/legacy rows).
 func (s *EmbeddingStore) WriteCandidateStatusIndexRow(id int64, status string) error {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	if err := s.checkClosed(); err != nil {
 		return err
 	}
@@ -772,6 +824,8 @@ func (s *EmbeddingStore) WriteCandidateStatusIndexRow(id int64, status string) e
 // GetCandidateByID retrieves a single candidate by its ID.
 // Returns nil, nil when not found.
 func (s *EmbeddingStore) GetCandidateByID(id int64) (*DedupCandidate, error) {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	val, closer, err := s.db.Get(dedupRecKey(id))
 	if err == pebble.ErrNotFound {
 		return nil, nil
@@ -802,11 +856,15 @@ func (s *EmbeddingStore) GetCandidateByID(id int64) (*DedupCandidate, error) {
 // the REMAINING filters in Go, then the same sort + pagination tail. A
 // dangling index row (record missing) is skipped silently, never an error.
 func (s *EmbeddingStore) ListCandidates(f CandidateFilter) ([]DedupCandidate, int, error) {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	if err := s.checkClosed(); err != nil {
 		return nil, 0, err
 	}
 
-	if f.Status != "" && s.IsCandidateStatusIndexBuilt() {
+	// isCandidateStatusIndexBuiltLocked, not the exported method: we already
+	// hold closeMu.RLock, and recursive RLock deadlocks (see that method's doc).
+	if f.Status != "" && s.isCandidateStatusIndexBuiltLocked() {
 		all, err := s.listCandidatesByStatusIndex(f)
 		if err != nil {
 			return nil, 0, err
@@ -966,6 +1024,8 @@ func paginateCandidates(all []DedupCandidate, f CandidateFilter) ([]DedupCandida
 // entity on either side, using the "dedup:e:" secondary index for O(k) lookup
 // instead of a full-table scan. status="" returns all statuses.
 func (s *EmbeddingStore) ListCandidatesForEntity(entityType, entityID, status string) ([]DedupCandidate, error) {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	if err := s.checkClosed(); err != nil {
 		return nil, err
 	}
@@ -1014,6 +1074,8 @@ func (s *EmbeddingStore) ListCandidatesForEntity(entityType, entityID, status st
 // was stored before the entity index was introduced. Safe to call repeatedly —
 // writes are idempotent. Returns the number of candidates processed.
 func (s *EmbeddingStore) BackfillEntityIndex() (int, error) {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	if err := s.checkClosed(); err != nil {
 		return 0, err
 	}
@@ -1062,6 +1124,8 @@ func (s *EmbeddingStore) BackfillEntityIndex() (int, error) {
 // candidateWriteOpts (NoSync — see PR #1855 / candidateWriteOpts doc). No new
 // lock, no new commit beyond the single write this function already made.
 func (s *EmbeddingStore) UpdateCandidateStatus(id int64, status string) error {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	if err := s.checkClosed(); err != nil {
 		return err
 	}
@@ -1128,6 +1192,8 @@ func (s *EmbeddingStore) UpdateCandidateLLM(id int64, verdict, reason string) er
 }
 
 func (s *EmbeddingStore) updateCandidate(id int64, mutFn func(*candRec)) error {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	val, closer, err := s.db.Get(dedupRecKey(id))
 	if err == pebble.ErrNotFound {
 		return nil
@@ -1153,6 +1219,8 @@ func (s *EmbeddingStore) updateCandidate(id int64, mutFn func(*candRec)) error {
 
 // DeleteCandidate removes a single candidate row by ID.
 func (s *EmbeddingStore) DeleteCandidate(id int64) error {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	val, closer, err := s.db.Get(dedupRecKey(id))
 	if err == pebble.ErrNotFound {
 		return nil
@@ -1192,6 +1260,8 @@ func (s *EmbeddingStore) DeleteCandidate(id int64) error {
 //
 // Returns the number of rows whose status was newly changed.
 func (s *EmbeddingStore) MarkCandidatesAsMergedForEntity(entityType, entityID string) (int, error) {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	if entityType == "" || entityID == "" {
 		return 0, nil
 	}
@@ -1274,6 +1344,8 @@ func (s *EmbeddingStore) MarkCandidatesAsMergedForEntity(entityType, entityID st
 // RemoveCandidatesForEntity deletes all candidate rows that involve the given
 // entity (as either entity_a or entity_b). Returns the number of rows deleted.
 func (s *EmbeddingStore) RemoveCandidatesForEntity(entityType, entityID string) (int, error) {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	prefix := []byte(dedupRecPfx)
 	upper := prefixUpperBound(prefix)
 
@@ -1328,6 +1400,8 @@ func (s *EmbeddingStore) RemoveCandidatesForEntity(entityType, entityID string) 
 // exactly one entry with entity_a_id < entity_b_id lexicographically.
 // Returns (rewritten, deleted) counts for logging.
 func (s *EmbeddingStore) CanonicalizeCandidates() (rewritten, deleted int, err error) {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	prefix := []byte(dedupRecPfx)
 	upper := prefixUpperBound(prefix)
 
@@ -1414,6 +1488,8 @@ func (s *EmbeddingStore) CanonicalizeCandidates() (rewritten, deleted int, err e
 
 // GetCandidateStats returns row counts grouped by entity_type, layer, and status.
 func (s *EmbeddingStore) GetCandidateStats() ([]CandidateStat, error) {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	prefix := []byte(dedupRecPfx)
 	upper := prefixUpperBound(prefix)
 
@@ -1469,6 +1545,8 @@ func (s *EmbeddingStore) HealthStats() (EmbeddingHealthStats, error) {
 // ─── Internal helpers ─────────────────────────────────────────────────────────
 
 func (s *EmbeddingStore) getEmbRec(key []byte) (*embRec, error) {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	val, closer, err := s.db.Get(key)
 	if err == pebble.ErrNotFound {
 		return nil, nil
@@ -1486,6 +1564,8 @@ func (s *EmbeddingStore) getEmbRec(key []byte) (*embRec, error) {
 }
 
 func (s *EmbeddingStore) setJSON(key []byte, v any) error {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
 	data, err := json.Marshal(v)
 	if err != nil {
 		return fmt.Errorf("marshal: %w", err)

--- a/internal/database/embedding_store_chaos_test.go
+++ b/internal/database/embedding_store_chaos_test.go
@@ -1,6 +1,7 @@
 // file: internal/database/embedding_store_chaos_test.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c
+// last-edited: 2026-08-12
 //
 // Chaos tests for the EmbeddingStore under shutdown conditions.
 // Validates graceful behavior when the store is closed during or
@@ -28,6 +29,35 @@ func newOwnedEmbeddingStore(t *testing.T, dir string) *EmbeddingStore {
 	db, err := pebble.Open(dir, &pebble.Options{})
 	require.NoError(t, err)
 	return &EmbeddingStore{db: db, owned: true}
+}
+
+// waitForWorkers blocks until wg is done, or fails the test after a deadline.
+//
+// The chaos tests below deliberately race Close against in-flight operations.
+// When that deadlocked (three writers stuck forever on Pebble's
+// commitPipeline.prepare), a bare wg.Wait() produced NO test failure — it hung
+// until the CI job was killed, which surfaced as "Go Tests cancelled" with no
+// test named and no stack. One occurrence burned the whole job cap; see
+// todo.d/20260812-embeddingstore-close-deadlock.md.
+//
+// recover() cannot help here: a deadlock is not a panic. A bounded wait is what
+// turns a silent 30-minute hang into a 30-second named failure, so a regression
+// is reported instead of merely being expensive.
+func waitForWorkers(t *testing.T, wg *sync.WaitGroup, within time.Duration) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(within):
+		t.Fatalf("workers still running %v after Close returned: operations "+
+			"raced Close and deadlocked. EmbeddingStore.closeMu is supposed to "+
+			"make this impossible — Close must not start until every in-flight "+
+			"operation has released its read lock.", within)
+	}
 }
 
 // makeVector creates a random float32 vector of the given dimension.
@@ -146,7 +176,7 @@ func TestChaos_ConcurrentWritesDuringClose(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 	_ = store.Close()
 
-	wg.Wait()
+	waitForWorkers(t, &wg, 30*time.Second)
 }
 
 // TestChaos_ConcurrentReadsDuringClose simulates readers active when
@@ -179,7 +209,7 @@ func TestChaos_ConcurrentReadsDuringClose(t *testing.T) {
 	time.Sleep(2 * time.Millisecond)
 	_ = store.Close()
 
-	wg.Wait()
+	waitForWorkers(t, &wg, 30*time.Second)
 }
 
 // TestChaos_MixedReadWriteDuringClose simulates a realistic shutdown
@@ -241,7 +271,7 @@ func TestChaos_MixedReadWriteDuringClose(t *testing.T) {
 	time.Sleep(3 * time.Millisecond)
 	_ = store.Close()
 
-	wg.Wait()
+	waitForWorkers(t, &wg, 30*time.Second)
 }
 
 // TestChaos_DataDurabilityAfterGracefulClose verifies that data written

--- a/todo.d/20260812-embeddingstore-close-deadlock.md
+++ b/todo.d/20260812-embeddingstore-close-deadlock.md
@@ -1,4 +1,18 @@
-## 🐛 `EmbeddingStore.Close()` deadlocks against in-flight writes (~4–5% of CI runs)
+## ✅ FIXED — `EmbeddingStore.Close()` deadlocked against in-flight writes
+
+**Fixed by `fix/embeddingstore-close-lock`.** Every DB-touching method now holds
+`closeMu.RLock` for its whole duration and `Close` takes the write lock, so `Close` cannot
+begin until the last in-flight operation has returned and the Pebble UB is unreachable.
+The three chaos tests' worker waits are now bounded, so a regression fails in 30 seconds
+naming the broken invariant instead of hanging for the full job cap.
+
+The heading of this entry originally read "~4–5% of CI runs". That figure is **retracted**
+— see the rate section below. It was inferred from run history and then contradicted by
+the same branch hanging 2 out of 2 attempts.
+
+Everything below is the original diagnosis, kept because the mechanism is worth reading.
+
+---
 
 `TestChaos_MixedReadWriteDuringClose` hangs forever, burning the whole Go Tests job.
 This is the cause of the long-standing "Minimal CI / Go Tests cancelled with no reason"


### PR DESCRIPTION
Fixes the hang diagnosed in #2329. Closes out the "Minimal CI / Go Tests — cancelled, no reason given" runs.

## The bug

`pebble.DB.Close()` running while operations are in flight. Three writers already inside `db.Set` block on Pebble's commit-pipeline mutex and never wake:

```
goroutine 2261 [sync.WaitGroup.Wait, 29 minutes]   <- the test's wg.Wait()
3 x writer     [sync.Mutex.Lock,    29 minutes]
    pebble/v2.(*commitPipeline).prepare   commit.go:455
    pebble/v2.(*DB).Set                   db.go:646
    database.(*EmbeddingStore).setJSON
```

Pebble documents that calling `Close` concurrently with any other DB method is unsafe. This change makes `EmbeddingStore` provide the guarantee Pebble doesn't.

**Reached only by tests.** `NewEmbeddingStore` sets `owned: false`, so production's `Close()` returns on its first line and never touches Pebble. The cost was paid entirely in CI.

## Why the two existing defences could never work

- **`recover()`** is in all three chaos tests. A deadlock is not a panic — `recover()` cannot see it. That is why the tests looked adequately guarded for months.
- **`closed atomic.Bool`** is a check-then-act. A writer already inside `db.Set` is past the check. Only a lock held for the operation's **duration** closes that window.

## The change

Every method that touches `s.db` takes `closeMu.RLock` for its whole duration; `Close` takes the write lock, so it cannot begin until the last in-flight operation has returned. **21 methods guarded.** No `closed` check was added to them — Pebble already returns `ErrClosed` on a closed DB (which is why `TestChaos_OperationsAfterClose` passes today), so the lock only needs to provide exclusion, not error reporting. That kept the diff uniform instead of requiring 21 different zero-value returns.

Deliberate exceptions, derived from the internal call graph rather than assumed:

| method | treatment | why |
|---|---|---|
| `nextID` | unguarded | only caller `UpsertCandidateNew` already holds RLock |
| `listCandidatesByStatusIndex` | unguarded | only caller `ListCandidates` already holds RLock |
| `IsCandidateStatusIndexBuilt` | **split** into wrapper + `isCandidateStatusIndexBuiltLocked` | exported *and* called by `ListCandidates` under RLock |

That third one matters. `sync.RWMutex` does not permit recursive `RLock`: a writer blocking between the two acquisitions leaves the second waiting on a writer that is waiting on the first. Guarding it naively would have traded a rare deadlock for a **guaranteed** one — and would have passed every test that never calls `Close`.

`FindSimilar`, `UpsertCandidate` and `HealthStats` call other exported methods but touch no DB primitive themselves, so they correctly take no lock at all.

Lock ordering is consistent everywhere: `closeMu` first, then the pre-existing `mu`. Nothing takes them in the other order.

## Second layer: a hang now reports itself

The deadlock was one silent layer; **a hang producing no test failure at all** was the other. A bare `wg.Wait()` meant a regression showed up as a dead CI job with no test named and no stack. The three chaos tests now use a bounded `waitForWorkers`, so a regression fails in 30 seconds and says which invariant broke.

## Verification

**The guard was watched going red before being trusted green.** Injecting a worker that outlives the deadline:

```
--- FAIL: TestChaos_MixedReadWriteDuringClose (30.13s)
    workers still running 30s after Close returned: operations raced Close and
    deadlocked. EmbeddingStore.closeMu is supposed to make this impossible ...
```

Then removed (`grep -c NEGCTRL` = 0) and re-run clean.

- `go build` — exit 0
- `go vet` — exit 0
- `go test ./internal/database/ -run TestChaos -count=30 -race` — **exit 0, 66.0s**. This is the check that matters for the new lock: 30 consecutive runs with no recursive-`RLock` regression.
- Full `./internal/database/` suite with `-race` — running; will report the count before merge.

## What is NOT claimed

**The original hang was never reproduced locally — 0 of 50 runs on macOS with `-race`.** So this fix is justified *by construction* (the write lock makes concurrent `Close` impossible) and by no-regression evidence, **not** by observing the hang disappear. macOS scheduling does not produce the Linux + `-race` + parallel-package interleaving that CI does.

The rate remains unquantified. #2329's "4–5%" was retracted after the same branch hung 2 of 2 attempts; this PR also fixes the heading that still carried that number.

`PebbleDB()` still hands the raw handle to adjacent stores, which is outside this lock. Pre-existing, unchanged, and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp
