### PR TITLE
test(abs): conformance suite checked shape but never values

### DIFF
--- a/changelog.d/20260812-abs-conformance-values.md
+++ b/changelog.d/20260812-abs-conformance-values.md
@@ -1,0 +1,31 @@
+### Changed
+
+- **The ABS conformance suite now checks values, not just shape.** All 22 golden-fixture
+  assertions ran with `conformance.Options{IgnoreExtra: true}` and no `CompareValues`,
+  which compared key presence and type and nothing else — a handler that returned every
+  correct key with entirely wrong data passed. The suite read as a conformance gate and
+  gated almost nothing.
+
+  Ten endpoints already met the oracle exactly and are now pinned to it: ping, status,
+  libraries, series, authors, narrators, paginated authors, and the three bookmark
+  routes.
+
+- **Strictness is now the default, and weakening it is what costs effort.** The previous
+  arrangement had this backwards: a newly added endpoint got the weak check for free and
+  turning it up required someone to remember. The twelve call sites that cannot meet the
+  oracle yet must now name themselves via `assertConformantPending` **and give a written
+  reason** — an empty reason fails the test. Those twelve are the remaining work, they
+  are enumerated in the source rather than in a tracking doc, and the count cannot drift
+  upward quietly.
+
+  Their failures are not one problem. Eight are fixture drift: the fake library's
+  multi-file book is synthetic (six identical 1662 s tracks, 2049–2054 byte files,
+  `timeBase 1/1000`) where the oracle captured a real recording of *The Odyssey* (six
+  distinct durations summing to 9975.48, files of 11–21 MB, `timeBase 1/14112000`).
+  Four are identity divergences we may well intend to keep — `user.type`, `Source`,
+  `permissions.upload`, `permissions.createEreader`.
+
+  Two are neither, and would have stayed invisible under shape-only checking: we emit
+  the raw ID3 `TRCK` value `4/24` in `metaTags.tagTrack` where AudiobookShelf normalizes
+  it to `4`, and we send the tag title for an audio track where AudiobookShelf sends the
+  filename. Both are live mapper behaviour rather than test data.

--- a/internal/server/handlers/abs/abs_test.go
+++ b/internal/server/handlers/abs/abs_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/abs_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2c07b5e9-4d16-48fa-b930-71e5c8a04f6d
-// last-edited: 2026-08-02
+// last-edited: 2026-08-12
 
 package abs_test
 
@@ -455,14 +455,23 @@ func str(t *testing.T, m map[string]any, key string) string {
 }
 
 // assertConformant diffs a response body against the golden ABS fixture, checking
-// presence and type of every field the real server returned.
+// presence, type AND VALUE of every field the real server returned.
+//
+// CompareValues was off until 2026-08-12, which made this a shape check: a handler
+// that returned every correct key with entirely wrong data passed. Twenty-two call
+// sites read as a conformance suite and gated almost nothing.
+//
+// Strictness is now the DEFAULT, and weakening it is what costs effort — a call site
+// that cannot meet the oracle yet must say so by name via assertConformantPending.
+// The old arrangement had that backwards: a new endpoint got the weak gate for free,
+// and turning it up required someone to remember. Nobody was going to.
 func assertConformant(t *testing.T, fixture string, got any) {
 	t.Helper()
 	f, err := conformance.LoadFixture(filepath.Join(fixturesDir(), fixture))
 	if err != nil {
 		t.Fatalf("LoadFixture(%s): %v", fixture, err)
 	}
-	findings := f.CompareBody(got, conformance.Options{IgnoreExtra: true})
+	findings := f.CompareBody(got, conformance.Options{IgnoreExtra: true, CompareValues: true})
 	if len(findings) > 0 {
 		for _, fi := range findings {
 			t.Errorf("%s: %s", fixture, fi)
@@ -534,7 +543,10 @@ func TestRegisteredRoutesAreReal(t *testing.T) {
 func TestLogin_PasswordSuccessConformsToFixture(t *testing.T) {
 	h := newConformanceHarness(t)
 	body := h.login(t, "oracle", "pw-pw-pw-pw")
-	assertConformant(t, "post_login.json", body)
+	assertConformantPending(t, "post_login.json", body,
+		"identity divergence, not drift: we send user.type=user where ABS sends root, "+
+			"and permissions.upload/createEreader false where ABS sends true. Needs a "+
+			"product call on whether the ABS role model is one we adopt or translate")
 }
 
 // TestLogin_UserDefaultLibraryIdIsNonNullString is a LOGIN BLOCKER (§1.8.2):
@@ -890,7 +902,9 @@ func TestRefresh_RotatesAndConformsToFixture(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("got %d: %s", w.Code, w.Body.String())
 	}
-	assertConformant(t, "post_auth_refresh.json", body)
+	assertConformantPending(t, "post_auth_refresh.json", body,
+		"same identity divergence as post_login.json — this endpoint re-serves the user "+
+			"object, so it goes strict when login does")
 
 	u := userObj(t, body)
 	newAccess := str(t, u, "accessToken")
@@ -1165,7 +1179,9 @@ func TestMe_ConformsToFixture(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("got %d: %s", w.Code, w.Body.String())
 	}
-	assertConformant(t, "get_api_me.json", body)
+	assertConformantPending(t, "get_api_me.json", body,
+		"same identity divergence as post_login.json, plus Source=audiobook-organizer "+
+			"where the oracle captured docker — that one is ours to keep")
 }
 
 // TestMe_MediaProgressIsAlwaysAPresentArray is the DATA-LOSS guard of §1.8.1:
@@ -1310,7 +1326,9 @@ func TestSessions_ConformsToFixture(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("got %d: %s", w.Code, w.Body.String())
 	}
-	assertConformant(t, "get_api_me_sessions.json", body)
+	assertConformantPending(t, "get_api_me_sessions.json", body,
+		"fixture drift: listening sessions embed the synthetic book's duration and "+
+			"per-track values")
 
 	// total must be an INTEGER (§1.7.3 item 5: Dart throws on `42.0 as int?`).
 	total, ok := body["total"].(float64)

--- a/internal/server/handlers/abs/browse_test.go
+++ b/internal/server/handlers/abs/browse_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/browse_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8b3e10c4-6d97-4a52-bf08-2e4c95d7130a
-// last-edited: 2026-07-30
+// last-edited: 2026-08-12
 
 package abs_test
 
@@ -76,7 +76,9 @@ func TestLibraryItems_ConformsToOracle(t *testing.T) {
 	if code != http.StatusOK {
 		t.Fatalf("got %d want 200", code)
 	}
-	assertConformant(t, "get_api_libraries_id_items.json", body)
+	assertConformantPending(t, "get_api_libraries_id_items.json", body,
+		"fixture drift: the minified media block carries the synthetic book's flat 9975 "+
+			"duration and 2049-2054 byte sizes")
 }
 
 // TestLibraryItems_MinifiedDurationIsNonZero pins verified requirement 13: if
@@ -252,7 +254,9 @@ func TestPersonalized_ConformsToOracle(t *testing.T) {
 	if _, isObj := body.(map[string]any); isObj {
 		t.Fatal("/personalized must be a bare array, not an object (§1.8.6)")
 	}
-	assertConformant(t, "get_api_libraries_id_personalized.json", body)
+	assertConformantPending(t, "get_api_libraries_id_personalized.json", body,
+		"fixture drift: shelves embed the same minified media block as "+
+			"get_api_libraries_id_items.json")
 }
 
 func TestSeries_ConformsToOracle(t *testing.T) {
@@ -328,7 +332,9 @@ func TestFilterData_AllEightKeys(t *testing.T) {
 	if code != http.StatusOK {
 		t.Fatalf("got %d want 200", code)
 	}
-	assertConformant(t, "get_api_libraries_id_filterdata.json", body)
+	assertConformantPending(t, "get_api_libraries_id_filterdata.json", body,
+		"fixture drift: the oracle's filter facets were built from the real library's "+
+			"authors/narrators/genres, which the fake library does not reproduce verbatim")
 
 	obj := body.(map[string]any)
 	for _, key := range []string{"authors", "genres", "tags", "series", "narrators", "languages", "publishers", "publishedDecades"} {
@@ -404,7 +410,11 @@ func TestItem_ConformsToOracle(t *testing.T) {
 	if code != http.StatusOK {
 		t.Fatalf("got %d want 200: %#v", code, body)
 	}
-	assertConformant(t, "get_api_items_id.json", body)
+	assertConformantPending(t, "get_api_items_id.json", body,
+		"fixture drift on audioFiles/chapters, PLUS two genuine mapper questions this "+
+			"fixture is the only one to expose: metaTags.tagTrack (we pass raw ID3 TRCK "+
+			"'4/24' through where ABS normalizes to 4) and track title (we send the tag "+
+			"title, ABS sends the filename). Those two are behaviour, not seed data")
 }
 
 // TestItem_LibraryItemIDIs36CharUUID pins §1.7.1, the single BREAKING id

--- a/internal/server/handlers/abs/library_fake_test.go
+++ b/internal/server/handlers/abs/library_fake_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/library_fake_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 1d4a67f2-0c85-4f39-9b6e-3a71c5d0e824
-// last-edited: 2026-08-02
+// last-edited: 2026-08-12
 
 package abs_test
 
@@ -725,6 +725,32 @@ func mustLoadFixture(t *testing.T, name string) *conformance.Fixture {
 	return f
 }
 
+// assertConformantPending is a SHAPE-ONLY check for a call site that cannot meet the
+// oracle's values yet. It is the debt list for the strictness flip of 2026-08-12.
+//
+// Every use is a promise to come back, so every use must say why in prose — an empty
+// reason fails the test rather than silently buying another release of weak checking.
+// Delete a call site from this helper the moment it can hold assertConformant; the
+// count of these IS the remaining N-2 work, so it must not be able to drift upward
+// quietly.
+func assertConformantPending(t *testing.T, fixture string, got any, reason string) {
+	t.Helper()
+	if strings.TrimSpace(reason) == "" {
+		t.Fatalf("%s: assertConformantPending requires a reason — a call site that cannot say "+
+			"why it is exempt has no business being exempt", fixture)
+	}
+	f := mustLoadFixture(t, fixture)
+	t.Logf("%s: PENDING strict conformance (shape only) — %s", fixture, reason)
+	findings := f.CompareBody(got, conformance.Options{IgnoreExtra: true})
+	if len(findings) > 0 {
+		for _, fi := range findings {
+			t.Errorf("%s: %s", fixture, fi)
+		}
+		t.Fatalf("%s: %d SHAPE findings against the real ABS 2.36.0 response — these are not "+
+			"covered by the pending exemption, which is for values only", fixture, len(findings))
+	}
+}
+
 // assertConformantExcept is assertConformant with an explicit, named allowance list.
 //
 // It exists for exactly ONE situation and must not grow past it: a field where real
@@ -732,6 +758,11 @@ func mustLoadFixture(t *testing.T, name string) *conformance.Fixture {
 // work would close the gap. Each allowance names the JSON path AND the reason, so an
 // allowance can never quietly become a shape bug — a finding at any other path still
 // fails, and an allowance that stops firing is dead weight a reader can delete.
+//
+// NOTE (2026-08-12): still shape-only while assertConformant went strict. Its one call
+// site (search) is in the pending-12 and its allowances are calibrated against
+// shape-level findings, so flipping CompareValues here without retriaging those
+// allowances would just relocate the failure. It goes strict with the rest in N-2.
 func assertConformantExcept(t *testing.T, fixture string, got any, allowed map[string]string) {
 	t.Helper()
 	f := mustLoadFixture(t, fixture)

--- a/internal/server/handlers/abs/play_test.go
+++ b/internal/server/handlers/abs/play_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/play_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3e5c9b17-84d0-4f26-a1b9-70c8de4531f5
-// last-edited: 2026-07-30
+// last-edited: 2026-08-12
 
 package abs_test
 
@@ -43,7 +43,10 @@ func TestPlay_ConformsToOracle(t *testing.T) {
 		t.Fatalf("seed position: %v", err)
 	}
 	body := startSession(t, h, mustSyncID(t, seed, seed.multiID), tok)
-	assertConformant(t, "post_api_items_id_play.json", body)
+	assertConformantPending(t, "post_api_items_id_play.json", body,
+		"fixture drift: audioTracks carry the synthetic book's six identical 1662s durations, "+
+			"2049-2054 byte sizes and timeBase 1/1000 against the oracle's real per-track "+
+			"values and 1/14112000. Track startOffset accumulates the same error")
 }
 
 // TestPlay_CurrentTimeIsTrueLatestPosition pins verified requirement 16.

--- a/internal/server/handlers/abs/progress_write_test.go
+++ b/internal/server/handlers/abs/progress_write_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/progress_write_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2b7f4e91-8a05-4c63-b1d8-70e396a5cf42
-// last-edited: 2026-08-02
+// last-edited: 2026-08-12
 
 package abs_test
 
@@ -689,15 +689,22 @@ func TestBookmarks_ListErrorIs5xxNotEmptyList(t *testing.T) {
 // ── conformance against the real ABS 2.36.0 captures ────────────────────────
 
 // These diff our bodies against fixtures captured from the reference server on
-// 2026-08-02, field by field, checking PRESENCE and TYPE rather than values. A
-// missing field is the highest-severity finding on this surface: a client that
-// hard-requires it fails its whole decode, and for a progress body that failure
-// looks to the user like the book losing its place.
+// 2026-08-02, field by field. A missing field is the highest-severity finding on
+// this surface: a client that hard-requires it fails its whole decode, and for a
+// progress body that failure looks to the user like the book losing its place.
+//
+// Values are checked too as of 2026-08-12 — except where a call site below is still
+// on assertConformantPending. Wrong values are not a harmless second tier here: a
+// progress body with the right keys and a wrong currentTime does not fail a decode,
+// it silently sends the listener to the wrong place in the book.
 
 func TestMediaProgressGet_ConformsToOracle(t *testing.T) {
 	w := newWriteHarness(t)
 	w.patch(t, map[string]any{"currentTime": 42.0, "duration": 9975.48, "isFinished": false})
-	assertConformant(t, "get_api_me_progress_id.json", w.getRow(t))
+	assertConformantPending(t, "get_api_me_progress_id.json", w.getRow(t),
+		"fixture drift: the oracle's duration 9975.48 is the sum of six REAL Odyssey track "+
+			"durations; the fake library seeds a flat 9975. Goes strict when the seed is "+
+			"derived from the oracle")
 }
 
 func TestMediaProgressList_ConformsToOracle(t *testing.T) {
@@ -707,7 +714,8 @@ func TestMediaProgressList_ConformsToOracle(t *testing.T) {
 	if code != http.StatusOK {
 		t.Fatalf("got %d %s", code, raw)
 	}
-	assertConformant(t, "get_api_me_progress.json", body)
+	assertConformantPending(t, "get_api_me_progress.json", body,
+		"same synthetic-duration drift as get_api_me_progress_id.json")
 }
 
 func TestBookmarkCreate_ConformsToOracle(t *testing.T) {


### PR DESCRIPTION
## What

The 22 ABS golden-fixture assertions ran with `conformance.Options{IgnoreExtra: true}` and
**no `CompareValues`**. That compares key presence and type. A handler returning every
correct key with entirely wrong data passed every one of them.

`CompareValues: true` is now on by default. **Ten endpoints already met the oracle exactly**
and are pinned to it from this commit: ping, status, libraries, series, authors, narrators,
paginated authors, and the three bookmark routes.

## The part that isn't the one-line flip

Strictness was opt-in, so a newly added endpoint got the weak check **for free** and turning
it up required someone to remember. That is the same shape of defect as #2333's "grep for
`/api/v1` twins" rule: a correct instruction whose enforcement is a human habit.

Inverted. Strict is the default; weakening it costs effort and leaves evidence. The twelve
call sites that cannot meet the oracle yet must name themselves via `assertConformantPending`
**and supply a written reason** — an empty reason fails the test rather than silently buying
another release of weak checking:

```go
if strings.TrimSpace(reason) == "" {
    t.Fatalf("%s: assertConformantPending requires a reason — a call site that cannot say "+
        "why it is exempt has no business being exempt", fixture)
}
```

The remaining N-2 work is therefore enumerated **in the source**, not in a tracking doc, and
the count cannot drift upward quietly.

Note that `assertConformantPending` is shape-only for **values**. Shape findings still fail
it — the exemption is narrow on purpose, so a pending call site cannot also start returning
the wrong keys.

## The twelve are not one problem

Measured by flipping both helpers and running the whole package:

| Pile | Count | What it is |
|---|---|---|
| Fixture drift | 8 | The fake library's multi-file book is synthetic — six identical 1662 s tracks, 2049–2054 byte files, `timeBase 1/1000` — where the oracle captured a real *Odyssey* recording: six distinct durations summing to 9975.48, files of 11–21 MB, `timeBase 1/14112000` |
| Identity divergence | 4 | `user.type` root/user · `Source` docker/audiobook-organizer · `permissions.upload` and `.createEreader` want true, got false. Plausibly ours to keep |
| **Genuine mapper behaviour** | **2** | `metaTags.tagTrack` — we pass raw ID3 `TRCK` `4/24` through where ABS normalizes to `4` · audio-track `title` — we send the tag title, ABS sends the filename |

The last two are the reason this was worth doing. They are **live mapper behaviour on a
client-facing surface**, they are not test data, and shape-only checking could not see them:
both fields were present and both were strings.

## Verification

The gate was watched going **red**, not merely observed green — a green conformance run is
exactly what the old shape-only suite produced for two years.

Corrupting one seeded author name (`"Homer"` → `"Homerr"`) turns the strict authors
assertions red and names the field. Restored before commit.

`go vet ./internal/server/handlers/abs/` exit 0 · full package `ok 23.743s`, **no `-run`
filter** — the #2335 CI failure was a test my filter did not match.

## Not in this PR

- **Reseeding the fake library from the oracle** so drift becomes structurally impossible.
  That is the follow-up, and it is what retires most of the twelve.
- **The two mapper questions**, which need a call on real client behaviour rather than a
  reading of our code.
- **N-4's residual `/api/authors/:id` redirect.** Closing it means gating the ABS surface on
  `ABSAPIEnabled` with explicit 404 handlers inside the group — a routing change with
  production blast radius that has no business riding along with test-fixture work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t
