### PR TITLE
test(abs): seed the conformance fixtures from the oracle, and bound the allowances

### DIFF
--- a/changelog.d/20260812-abs-conformance-reseed.md
+++ b/changelog.d/20260812-abs-conformance-reseed.md
@@ -1,0 +1,47 @@
+### Changed
+
+- **The ABS conformance fixtures are now seeded from the oracle, so they cannot drift
+  from it.** The fake library's two books were built from constants invented in the test
+  file: six identical 1662-second tracks of 2049–2054 bytes against a real *Odyssey*
+  capture with six distinct durations and 11–21 MB files, and a single-file book of 4096
+  bytes against a real 120 MB m4b. That drift is why twelve assertions could not compare
+  values at all. Per-track durations, sizes, filenames, tags and chapter boundaries now
+  come out of the fixture itself.
+
+  File sizes conform via sparse files: `mapper.go:225` stats every track and lets the
+  on-disk size override the recorded one, so `metadata.size` can only match if the file
+  really is that long — about 200 MB per run written as holes, costing no disk. Safe for
+  the Range assertions because they compare a suffix range against the response's own
+  tail rather than against a byte pattern.
+
+- **Allowances are now bounded, and an allowance that never fires fails the test.** A
+  blanket exemption at `media.duration` accepts any duration there forever; the day we
+  report half a book's length, a suite full of such exemptions says nothing. A bounded
+  allowance states the widest gap its stated cause can produce — 0.5 s for a rounded
+  track, 3.0 s for a six-track aggregate — and anything wider still fails as a different
+  defect.
+
+  This is not theoretical. The bound immediately caught `sixChapters()` returning flat
+  1662.5-second spans where the oracle's first chapter ends at 1386.057: a **276-second**
+  gap that a blanket "chapter bounds may differ" would have absorbed as the known
+  sub-second truncation. Those chapters are now seeded from the oracle and match exactly,
+  so they need no allowance at all.
+
+### Fixed
+
+- **`mediaItemId`, `bookId`, `date` and `dayOfWeek` are treated as volatile in
+  conformance comparisons.** The first two are the same minted sync ids as
+  `libraryItemId`, reached under a different name from the progress and playback bodies;
+  the last two are when a captured listening session happened. Four permanent
+  "mismatches" that no run could ever satisfy.
+
+### Added
+
+- **Five production findings surfaced by comparing values**, filed rather than fixed
+  alongside test work: `BookFile.Duration` is an `int` (2.431 s lost across six tracks,
+  `startOffset` drifting 2.200 s by track 6, ~0.4 s per track boundary);
+  `/api/me/sessions` reports `itemsPerPage` as the item count rather than the page size
+  where its siblings in `stats.go` get it right; `deviceInfo.deviceType` is never derived
+  from the User-Agent; `BookFile.BitrateKbps` is int-kbps so 96208 bps round-trips as
+  96000; and `publishedYear` renders `Book.PrintYear` as an int, so a raw `"800BC"` tag
+  comes back `"800"`. See `todo.d/20260812-bookfile-duration-integer-seconds.md`.

--- a/changelog.d/20260812-abs-conformance-values.md
+++ b/changelog.d/20260812-abs-conformance-values.md
@@ -18,14 +18,17 @@
   are enumerated in the source rather than in a tracking doc, and the count cannot drift
   upward quietly.
 
-  Their failures are not one problem. Eight are fixture drift: the fake library's
+  Their failures are not one problem. Most are fixture drift: the fake library's
   multi-file book is synthetic (six identical 1662 s tracks, 2049–2054 byte files,
   `timeBase 1/1000`) where the oracle captured a real recording of *The Odyssey* (six
   distinct durations summing to 9975.48, files of 11–21 MB, `timeBase 1/14112000`).
   Four are identity divergences we may well intend to keep — `user.type`, `Source`,
   `permissions.upload`, `permissions.createEreader`.
 
-  Two are neither, and would have stayed invisible under shape-only checking: we emit
-  the raw ID3 `TRCK` value `4/24` in `metaTags.tagTrack` where AudiobookShelf normalizes
-  it to `4`, and we send the tag title for an audio track where AudiobookShelf sends the
-  filename. Both are live mapper behaviour rather than test data.
+  One is neither, and would have stayed invisible under shape-only checking: for an
+  audio track we send the embedded tag title where AudiobookShelf sends the **filename**
+  (`media.tracks[].title` is `odyssey_01_homer_butler_64kb.mp3` in the oracle, while
+  `metaTags.tagTitle` separately carries `The Odyssey: Book 01`). `trackTitle()` prefers
+  `BookFile.Title` and falls back to the basename; ABS appears to use the basename
+  unconditionally. That is live mapper behaviour rather than test data, and whether it
+  matters depends on whether any client renders that field.

--- a/docs/audits/2026-08-11-abs-coverage-gap-audit.md
+++ b/docs/audits/2026-08-11-abs-coverage-gap-audit.md
@@ -393,10 +393,27 @@ unauthenticated cover endpoint (gate 2.17.0) and `/public/session/:id/track/:ind
 ## 4. Recommended order
 
 1. **N-1** — one line in `nonSPAPrefixes`, plus a regression test. Highest value per byte.
-2. **N-2** — *partially done 2026-08-12.* Four environment-dependent keys are now normalized
-   (13 red → 12). The remainder is **fixture alignment**, not bug-fixing — see the correction
-   in §N-2. Do not chase green by normalizing `size`/`duration`/`progress`; that would delete
-   the signal. Add the 4 orphan fixtures.
+2. **N-2** — *done 2026-08-12, across two PRs.* `CompareValues` is on for every assertion
+   (#2337), and the fake library's two books are now seeded **from the oracle fixture** —
+   per-track durations, sizes, filenames and tags — so the drift that made 12 assertions
+   uncheckable cannot recur by construction. Sizes conform via sparse files, because
+   `mapper.go:225` stats each track and lets the on-disk size win.
+
+   The standing advice above held and is worth restating: **nothing was made green by
+   normalizing `size`/`duration`/`progress`.** What could not be aligned is named in a
+   **bounded** allowance instead — the gap must be the known one, within a stated numeric
+   limit, so a duration that goes wrong by more than the truncation still fails. Two
+   volatile keys were added (`mediaItemId`/`bookId`, both minted sync ids reached by a
+   different name, plus the session's own `date`/`dayOfWeek`), which is normalization of
+   things no run could ever match rather than of signal.
+
+   Turning values on found five things nothing else had, all filed rather than fixed here:
+   `BookFile.Duration` is an `int` (2.431 s lost over six tracks, `startOffset` drifting
+   2.200 s by track 6), `/api/me/sessions` reports `itemsPerPage` as the item count,
+   `deviceType` is never derived, `publishedYear` loses its era, and `timeBase` is
+   hardcoded. See `todo.d/20260812-bookfile-duration-integer-seconds.md`.
+
+   Still open: add the 4 orphan fixtures.
 3. ~~**N-3**~~ — **RETRACTED, do not act on it.** It was wrong; see §N-3. `Update`/`Delete`
    honestly describe the nine `/api/me/*` write routes.
    **N-4** — *partially done 2026-08-12, after TWO regressions.* TWO namespaces

--- a/internal/server/handlers/abs/abs_test.go
+++ b/internal/server/handlers/abs/abs_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/abs/abs_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 2c07b5e9-4d16-48fa-b930-71e5c8a04f6d
 // last-edited: 2026-08-12
 
@@ -543,10 +543,8 @@ func TestRegisteredRoutesAreReal(t *testing.T) {
 func TestLogin_PasswordSuccessConformsToFixture(t *testing.T) {
 	h := newConformanceHarness(t)
 	body := h.login(t, "oracle", "pw-pw-pw-pw")
-	assertConformantPending(t, "post_login.json", body,
-		"identity divergence, not drift: we send user.type=user where ABS sends root, "+
-			"and permissions.upload/createEreader false where ABS sends true. Needs a "+
-			"product call on whether the ABS role model is one we adopt or translate")
+	assertConformantExcept(t, "post_login.json", body,
+		mergeAllowances(t, identityAllowances(), sourceAllowance()))
 }
 
 // TestLogin_UserDefaultLibraryIdIsNonNullString is a LOGIN BLOCKER (§1.8.2):
@@ -902,9 +900,8 @@ func TestRefresh_RotatesAndConformsToFixture(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("got %d: %s", w.Code, w.Body.String())
 	}
-	assertConformantPending(t, "post_auth_refresh.json", body,
-		"same identity divergence as post_login.json — this endpoint re-serves the user "+
-			"object, so it goes strict when login does")
+	assertConformantExcept(t, "post_auth_refresh.json", body,
+		mergeAllowances(t, identityAllowances(), sourceAllowance()))
 
 	u := userObj(t, body)
 	newAccess := str(t, u, "accessToken")
@@ -1179,9 +1176,7 @@ func TestMe_ConformsToFixture(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("got %d: %s", w.Code, w.Body.String())
 	}
-	assertConformantPending(t, "get_api_me.json", body,
-		"same identity divergence as post_login.json, plus Source=audiobook-organizer "+
-			"where the oracle captured docker — that one is ours to keep")
+	assertConformantExcept(t, "get_api_me.json", body, identityAllowances())
 }
 
 // TestMe_MediaProgressIsAlwaysAPresentArray is the DATA-LOSS guard of §1.8.1:
@@ -1326,9 +1321,16 @@ func TestSessions_ConformsToFixture(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("got %d: %s", w.Code, w.Body.String())
 	}
-	assertConformantPending(t, "get_api_me_sessions.json", body,
-		"fixture drift: listening sessions embed the synthetic book's duration and "+
-			"per-track values")
+	assertConformantExcept(t, "get_api_me_sessions.json", body, map[string]allowance{
+		// A real bug, deliberately not fixed here: me.go:132 sets ItemsPerPage to
+		// len(out) — the number of items on the page rather than the page size — where
+		// the sibling handlers at stats.go:108,133 correctly use
+		// queryInt(c, "itemsPerPage", 10). Fixing it changes pagination on a live
+		// endpoint, which has no business riding along with test-fixture work.
+		// Filed: todo.d/20260812-bookfile-duration-integer-seconds.md
+		"itemsPerPage": {Reason: "me.go:132 reports len(out) instead of the page size; " +
+			"oracle says 10 with total 3. Filed as a separate production fix"},
+	})
 
 	// total must be an INTEGER (§1.7.3 item 5: Dart throws on `42.0 as int?`).
 	total, ok := body["total"].(float64)

--- a/internal/server/handlers/abs/browse_test.go
+++ b/internal/server/handlers/abs/browse_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/abs/browse_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 8b3e10c4-6d97-4a52-bf08-2e4c95d7130a
 // last-edited: 2026-08-12
 
@@ -76,9 +76,10 @@ func TestLibraryItems_ConformsToOracle(t *testing.T) {
 	if code != http.StatusOK {
 		t.Fatalf("got %d want 200", code)
 	}
-	assertConformantPending(t, "get_api_libraries_id_items.json", body,
-		"fixture drift: the minified media block carries the synthetic book's flat 9975 "+
-			"duration and 2049-2054 byte sizes")
+	assertConformantExcept(t, "get_api_libraries_id_items.json", body, map[string]allowance{
+		"results[].media.duration":               {Reason: durationReason, Within: 3.0},
+		"results[].media.metadata.publishedYear": {Reason: publishedYearReason},
+	})
 }
 
 // TestLibraryItems_MinifiedDurationIsNonZero pins verified requirement 13: if
@@ -254,9 +255,16 @@ func TestPersonalized_ConformsToOracle(t *testing.T) {
 	if _, isObj := body.(map[string]any); isObj {
 		t.Fatal("/personalized must be a bare array, not an object (§1.8.6)")
 	}
-	assertConformantPending(t, "get_api_libraries_id_personalized.json", body,
-		"fixture drift: shelves embed the same minified media block as "+
-			"get_api_libraries_id_items.json")
+	assertConformantExcept(t, "get_api_libraries_id_personalized.json", body, map[string]allowance{
+		"[].entities[].media.duration":               {Reason: durationReason, Within: 3.0},
+		"[].entities[].media.metadata.publishedYear": {Reason: publishedYearReason},
+		// The authors shelf lists the same two authors in the opposite order. Ordering
+		// within a shelf is not pinned by the fixture format (each entity is compared
+		// positionally), and the seed's author ids drive ours.
+		"[].entities[].name": {Reason: "authors shelf ordering: the oracle lists " +
+			"\"transl. Samuel Butler Homer\" before \"Homer\"; our order follows the " +
+			"seeded author ids. Positional comparison makes this read as two mismatches"},
+	})
 }
 
 func TestSeries_ConformsToOracle(t *testing.T) {
@@ -332,9 +340,10 @@ func TestFilterData_AllEightKeys(t *testing.T) {
 	if code != http.StatusOK {
 		t.Fatalf("got %d want 200", code)
 	}
-	assertConformantPending(t, "get_api_libraries_id_filterdata.json", body,
-		"fixture drift: the oracle's filter facets were built from the real library's "+
-			"authors/narrators/genres, which the fake library does not reproduce verbatim")
+	assertConformantExcept(t, "get_api_libraries_id_filterdata.json", body, map[string]allowance{
+		"publishedDecades[]": {Reason: publishedYearReason + " — the decade facet is " +
+			"derived from that year, so it inherits the same loss"},
+	})
 
 	obj := body.(map[string]any)
 	for _, key := range []string{"authors", "genres", "tags", "series", "narrators", "languages", "publishers", "publishedDecades"} {
@@ -373,9 +382,29 @@ func TestSearch_ConformsToOracle(t *testing.T) {
 	// null here. Neither target client reads it. The fix belongs in the scanner.
 	const langGap = "audioFiles[].language is ffprobe stream data our scanner does not persist; " +
 		"read by neither AudioBooth nor Absorb — see mapper.go fileLanguage"
-	assertConformantExcept(t, "get_api_libraries_id_search.json", body, map[string]string{
-		"book[0].libraryItem.media.audioFiles[0].language": langGap,
-		"book[0].libraryItem.media.tracks[0].language":     langGap,
+	// Search returns BOTH books, so this list is the union of what each one diverges on.
+	// book[0] is the single-file m4b — its chapters and filename now come from the
+	// oracle, so its bounds and track title match exactly. book[1] is the six-mp3 copy,
+	// whose chapters are synthesized from the integer track durations and so inherit the
+	// truncation, and whose tracks carry tag titles.
+	assertConformantExcept(t, "get_api_libraries_id_search.json", body, map[string]allowance{
+		"book[].libraryItem.media.chapters[].start":      {Reason: durationReason + " (synthesized chapter bound, book[1])", Within: 3.0},
+		"book[].libraryItem.media.chapters[].end":        {Reason: durationReason + " (synthesized chapter bound, book[1])", Within: 3.0},
+		"book[].libraryItem.media.tracks[].title":        {Reason: trackTitleReason},
+		"book[].libraryItem.media.audioFiles[].language": {Reason: langGap},
+		"book[].libraryItem.media.tracks[].language":     {Reason: langGap},
+		"book[].libraryItem.media.audioFiles[].duration": {Reason: durationReason, Within: 0.5},
+		"book[].libraryItem.media.tracks[].duration":     {Reason: durationReason, Within: 0.5},
+		// book[1]'s total sums six roundings, so this one takes the aggregate bound.
+		"book[].libraryItem.media.duration":               {Reason: durationReason + " (summed over six tracks for book[1])", Within: 3.0},
+		"book[].libraryItem.media.tracks[].startOffset":   {Reason: durationReason + " (accumulated across tracks)", Within: 3.0},
+		"book[].libraryItem.media.audioFiles[].timeBase":  {Reason: timeBaseReason},
+		"book[].libraryItem.media.tracks[].timeBase":      {Reason: timeBaseReason},
+		"book[].libraryItem.media.metadata.publishedYear": {Reason: publishedYearReason},
+		// BitrateKbps is an int too, so 96208 bps can only come back as 96 * 1000.
+		// Same shape of loss as the duration truncation, bounded the same way.
+		"book[].libraryItem.media.audioFiles[].bitRate": {Reason: bitrateReason, Within: 999},
+		"book[].libraryItem.media.tracks[].bitRate":     {Reason: bitrateReason, Within: 999},
 	})
 }
 
@@ -410,11 +439,17 @@ func TestItem_ConformsToOracle(t *testing.T) {
 	if code != http.StatusOK {
 		t.Fatalf("got %d want 200: %#v", code, body)
 	}
-	assertConformantPending(t, "get_api_items_id.json", body,
-		"fixture drift on audioFiles/chapters, PLUS two genuine mapper questions this "+
-			"fixture is the only one to expose: metaTags.tagTrack (we pass raw ID3 TRCK "+
-			"'4/24' through where ABS normalizes to 4) and track title (we send the tag "+
-			"title, ABS sends the filename). Those two are behaviour, not seed data")
+	// metaTags.tagTrack is absent from these allowances on purpose. It looked like a
+	// mapper defect (we send "4/24" where the oracle says "4") until all six tracks were
+	// read: the oracle carries 1/24, 2/24, 3/24, 4, 5/24, none. ABS passes the raw ID3
+	// tag through exactly as mapper.go:758 does — track 4's real tag was a bare 4. The
+	// old seed's hardcoded "%d/24" manufactured the difference, and seeding from the
+	// oracle removed it. One row of a diff is one sample.
+	assertConformantExcept(t, "get_api_items_id.json", body,
+		mergeAllowances(t, bookBodyAllowances(), map[string]allowance{
+			"userMediaProgress.duration": {Reason: durationReason + " (summed over six tracks)", Within: 3.0},
+			"userMediaProgress.progress": {Reason: progressReason},
+		}))
 }
 
 // TestItem_LibraryItemIDIs36CharUUID pins §1.7.1, the single BREAKING id

--- a/internal/server/handlers/abs/library_fake_test.go
+++ b/internal/server/handlers/abs/library_fake_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/abs/library_fake_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 1d4a67f2-0c85-4f39-9b6e-3a71c5d0e824
 // last-edited: 2026-08-12
 
@@ -9,9 +9,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -609,8 +612,15 @@ func seedOracleLibrary(t *testing.T) *oracleSeed {
 	if err := os.MkdirAll(singleDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	m4b := filepath.Join(singleDir, "odyssey.m4b")
-	writeFakeAudio(t, m4b, 4096)
+	// Named as the oracle names it: the filename reaches clients through
+	// metadata.filename AND, via trackTitle's basename fallback, through tracks[].title.
+	m4b := filepath.Join(singleDir, "odyssey_complete.m4b")
+	// singleFileSize is what the oracle's m4b actually weighs. mapper.go stats the file
+	// and lets the on-disk size override the recorded one, so a 4096-byte stand-in made
+	// `size` unconformable everywhere this book appears — including two personalized
+	// shelves. Written sparse; see writeFakeAudioSized.
+	const singleFileSize = 120828875
+	writeFakeAudioSized(t, m4b, singleFileSize)
 	single := &database.Book{
 		ID: "01SINGLEFILEODYSSEYBOOK00", Title: "The Odyssey",
 		FilePath: m4b, Format: "QuickTime / MOV", Duration: intp(9975),
@@ -623,14 +633,16 @@ func seedOracleLibrary(t *testing.T) *oracleSeed {
 	// version of the mapper fabricated an index, which the conformance diff caught.
 	lib.addBook(single, []database.BookFile{{
 		ID: "f-m4b", BookID: single.ID, FilePath: m4b, Format: "QuickTime / MOV", Codec: "aac",
-		Duration: 9975, FileSize: 4096,
+		// The oracle reports 9975.480544; BookFile.Duration is an int, so 9975 is the
+		// closest the schema can hold. See todo.d/20260812-bookfile-duration-integer-seconds.
+		Duration: 9975, FileSize: singleFileSize,
 		BitrateKbps: 96, SampleRateHz: 22050, Channels: 1,
 		RawTags: map[string]string{
 			"album": "The Odyssey", "artist": "Homer", "date": "800BC",
 			"encoder": "Lavf62.3.100", "genre": "Audiobook", "title": "The Odyssey",
 		},
 		CreatedAt: created, UpdatedAt: created,
-	}}, sixChapters())
+	}}, sixChapters(t))
 
 	// ── book 2: six mp3 tracks, 6 synthesized chapters ──────────────────────
 	multiDir := filepath.Join(root, "Homer", "The Odyssey")
@@ -645,28 +657,35 @@ func seedOracleLibrary(t *testing.T) *oracleSeed {
 		LibraryState: organized, IsPrimaryVersion: primary,
 		CreatedAt: &createdMulti, UpdatedAt: &createdMulti,
 	}
+	// Every per-track value below comes from the ORACLE rather than from constants
+	// invented here. Hardcoding them is what made this book diverge from the fixture
+	// the conformance tests compare it against — six identical 1662s durations and
+	// 2049-2054 byte files against a real recording — and that drift is why twelve
+	// assertions could not check values at all until 2026-08-12.
+	//
+	// It also stops the seed from inventing facts. The old loop gave every track the
+	// same six tags and a "%d/24" track number; the real capture has track 4 tagged a
+	// bare "4", track 6 carrying no track tag AND no comment/encoder/genre at all.
+	// Reading it made one "mapper defect" evaporate: we do not differ from ABS on
+	// tagTrack, the seed was manufacturing the difference.
 	var mp3s []database.BookFile
-	for i := 1; i <= 6; i++ {
-		p := filepath.Join(multiDir, fmt.Sprintf("odyssey_%02d_homer_butler_64kb.mp3", i))
-		writeFakeAudio(t, p, 2048+i)
-		// Track 6 deliberately carries no "track" tag, mirroring the oracle: its
-		// trackNumFromFilename is 6 while its trackNumFromMeta is null. That asymmetry
-		// is the whole reason the two fields are not interchangeable.
-		rawTags := map[string]string{
-			"album": "The Odyssey", "artist": "Homer, transl. Samuel Butler",
-			"comment": "http://archive.org/details/odyssey_butler_librivox",
-			"encoder": "LAME 64bits version 3.98.4 (http://www.mp3dev.org/)",
-			"genre":   "Speech", "title": fmt.Sprintf("The Odyssey: Book %02d", i),
-		}
-		if i < 6 {
-			rawTags["track"] = fmt.Sprintf("%d/24", i)
-		}
+	for i, ot := range oracleAudioFiles(t) {
+		p := filepath.Join(multiDir, ot.Filename)
+		writeFakeAudioSized(t, p, ot.Size)
 		mp3s = append(mp3s, database.BookFile{
-			ID: fmt.Sprintf("f-mp3-%d", i), BookID: multi.ID, FilePath: p,
-			Format: "MP2/3 (MPEG audio layer 2/3)", Codec: "mp3", Duration: 1662, FileSize: int64(2048 + i),
-			TrackNumber: i, TrackCount: 24, Title: fmt.Sprintf("The Odyssey: Book %02d", i),
-			BitrateKbps: 64, SampleRateHz: 22050, Channels: 1,
-			RawTags:   rawTags,
+			ID: fmt.Sprintf("f-mp3-%d", i+1), BookID: multi.ID, FilePath: p,
+			Format: "MP2/3 (MPEG audio layer 2/3)", Codec: "mp3",
+			// BookFile.Duration is an INT: whole seconds is all the schema can hold, so
+			// the oracle's 1386.057143 necessarily becomes 1386. That truncation is a
+			// real production limitation, not a test artifact -- see the bounded
+			// duration allowances at the assertion sites.
+			Duration: int(math.Round(ot.Duration)),
+			FileSize: ot.Size,
+			// TrackNumber feeds trackNumFromFilename; trackNumFromMeta is derived from
+			// RawTags, so track 6's missing "track" tag yields null there on its own.
+			TrackNumber: i + 1, TrackCount: 24, Title: ot.Tags["title"],
+			BitrateKbps: ot.BitrateBps / 1000, SampleRateHz: 22050, Channels: ot.Channels,
+			RawTags:   ot.Tags,
 			CreatedAt: created, UpdatedAt: created,
 		})
 	}
@@ -679,15 +698,154 @@ func seedOracleLibrary(t *testing.T) *oracleSeed {
 	return &oracleSeed{lib: lib, root: root, singleID: single.ID, multiID: multi.ID}
 }
 
-func sixChapters() []database.Chapter {
-	out := make([]database.Chapter, 6)
-	start := 0.0
-	for i := range out {
-		end := start + 1662.5
-		out[i] = database.Chapter{ID: i, StartSec: start, EndSec: end, Title: fmt.Sprintf("Book %02d", i+1)}
-		start = end
+// sixChapters returns the single-file book's chapters as the ORACLE reported them.
+//
+// They used to be six flat 1662.5s spans, which is nothing like the real recording's
+// boundaries — the first chapter ends at 1386.057. Unlike the durations, this one is
+// fully fixable: database.Chapter holds StartSec/EndSec as float64, so the oracle's
+// values fit exactly and no allowance is needed. It was the BOUNDED duration allowance
+// that exposed this: a blanket "chapter bounds may differ" would have absorbed a 276s
+// gap as though it were the known sub-second truncation.
+func sixChapters(t *testing.T) []database.Chapter {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(fixturesDir(), "get_api_libraries_id_search.json"))
+	if err != nil {
+		t.Fatalf("read search oracle: %v", err)
+	}
+	var doc struct {
+		Response struct {
+			Body struct {
+				Book []struct {
+					LibraryItem struct {
+						Media struct {
+							Chapters []struct {
+								ID    int     `json:"id"`
+								Start float64 `json:"start"`
+								End   float64 `json:"end"`
+								Title string  `json:"title"`
+							} `json:"chapters"`
+						} `json:"media"`
+					} `json:"libraryItem"`
+				} `json:"book"`
+			} `json:"body"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("decode search oracle: %v", err)
+	}
+	if len(doc.Response.Body.Book) == 0 {
+		t.Fatal("search oracle has no book result; the single-file book would be seeded chapterless")
+	}
+	chs := doc.Response.Body.Book[0].LibraryItem.Media.Chapters
+	if len(chs) != 6 {
+		t.Fatalf("search oracle must yield 6 chapters, got %d", len(chs))
+	}
+	out := make([]database.Chapter, 0, len(chs))
+	for _, c := range chs {
+		out = append(out, database.Chapter{ID: c.ID, StartSec: c.Start, EndSec: c.End, Title: c.Title})
 	}
 	return out
+}
+
+// oracleTrack is one audioFile exactly as the reference server reported it.
+type oracleTrack struct {
+	Filename   string
+	Duration   float64
+	Size       int64
+	BitrateBps int
+	Channels   int
+	// Tags is metaTags translated back to the RawTags key space the importer uses
+	// (tagAlbum -> album, ...). A tag the oracle did not carry is ABSENT here, not
+	// empty: the difference is load-bearing, because trackNumFromMeta is derived
+	// from the presence of "track".
+	Tags map[string]string
+}
+
+// oracleAudioFiles reads the six tracks out of the item fixture so the fake library
+// is seeded from the same source the tests assert against. Anything hardcoded here
+// instead is free to drift, and did.
+func oracleAudioFiles(t *testing.T) []oracleTrack {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(fixturesDir(), "get_api_items_id.json"))
+	if err != nil {
+		t.Fatalf("read item oracle: %v", err)
+	}
+	var doc struct {
+		Response struct {
+			Body struct {
+				Media struct {
+					AudioFiles []struct {
+						BitRate  int            `json:"bitRate"`
+						Channels int            `json:"channels"`
+						Duration float64        `json:"duration"`
+						MetaTags map[string]any `json:"metaTags"`
+						Metadata struct {
+							Filename string `json:"filename"`
+							Size     int64  `json:"size"`
+						} `json:"metadata"`
+					} `json:"audioFiles"`
+				} `json:"media"`
+			} `json:"body"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("decode item oracle: %v", err)
+	}
+	files := doc.Response.Body.Media.AudioFiles
+	// Guard against a vacuous seed: an empty or restructured fixture would otherwise
+	// produce a book with no tracks, and every multi-file assertion would pass by
+	// having nothing to disagree about.
+	if len(files) != 6 {
+		t.Fatalf("item oracle must yield 6 audioFiles, got %d — the fixture changed shape "+
+			"and the fake library would be seeded empty", len(files))
+	}
+	tagKey := map[string]string{
+		"tagAlbum": "album", "tagArtist": "artist", "tagComment": "comment",
+		"tagDate": "date", "tagEncoder": "encoder", "tagGenre": "genre",
+		"tagTitle": "title", "tagTrack": "track",
+	}
+	out := make([]oracleTrack, 0, len(files))
+	for _, f := range files {
+		tags := map[string]string{}
+		for k, v := range f.MetaTags {
+			s, ok := v.(string)
+			if !ok || strings.TrimSpace(s) == "" {
+				continue // absent or null: must stay absent, see oracleTrack.Tags
+			}
+			if key, ok := tagKey[k]; ok {
+				tags[key] = s
+			}
+		}
+		out = append(out, oracleTrack{
+			Filename: f.Metadata.Filename, Duration: f.Duration, Size: f.Metadata.Size,
+			BitrateBps: f.BitRate, Channels: f.Channels, Tags: tags,
+		})
+	}
+	return out
+}
+
+// writeFakeAudioSized produces a file whose LENGTH matches the oracle without
+// writing the oracle's bytes. mapper.go stats every track and lets the on-disk size
+// override the recorded one, so `metadata.size` can only conform if the file really
+// is ~11-21 MB — 66 MB per run across six tracks if written out in full.
+//
+// The first 4 KiB carry the usual pattern and the rest is a hole, which costs no
+// disk. Safe for the Range assertions because they are self-referential: play_test.go
+// compares a suffix range against the full response's own tail rather than against a
+// hardcoded pattern, so zeroes satisfy them exactly as patterned bytes do.
+func writeFakeAudioSized(t *testing.T, path string, size int64) {
+	t.Helper()
+	const patterned = 4096
+	n := int64(patterned)
+	if size < n {
+		n = size
+	}
+	writeFakeAudio(t, path, int(n))
+	if size > n {
+		if err := os.Truncate(path, size); err != nil {
+			t.Fatalf("extend %s to %d: %v", path, size, err)
+		}
+	}
 }
 
 // writeFakeAudio writes deterministic bytes so Range assertions can name exact
@@ -725,61 +883,221 @@ func mustLoadFixture(t *testing.T, name string) *conformance.Fixture {
 	return f
 }
 
-// assertConformantPending is a SHAPE-ONLY check for a call site that cannot meet the
-// oracle's values yet. It is the debt list for the strictness flip of 2026-08-12.
+// assertConformantPending was the debt list for the strictness flip of 2026-08-12: a
+// shape-only check that each exempt call site had to justify in prose. It is gone
+// because the list is EMPTY — every one of the twelve now holds assertConformant or
+// assertConformantExcept with named allowances. A helper kept alive for a debt nobody
+// owes is just a softer gate waiting to be reached for.
 //
-// Every use is a promise to come back, so every use must say why in prose — an empty
-// reason fails the test rather than silently buying another release of weak checking.
-// Delete a call site from this helper the moment it can hold assertConformant; the
-// count of these IS the remaining N-2 work, so it must not be able to drift upward
-// quietly.
-func assertConformantPending(t *testing.T, fixture string, got any, reason string) {
+// ── the standing divergences ────────────────────────────────────────────────
+//
+// These are the same four wherever a book body appears, so they are written once and
+// merged per call site rather than restated. Three were owner decisions on 2026-08-12;
+// the fourth is a schema limit filed for separate work.
+
+const durationReason = "BookFile.Duration is an INT: the store holds whole seconds, so " +
+	"the oracle's 1386.057143 can only come back as 1386. Bounded, not blanket — a " +
+	"duration wrong by more than the truncation is a different bug and still fails. " +
+	"Filed: todo.d/20260812-bookfile-duration-integer-seconds.md"
+
+const timeBaseReason = "timeBase is hardcoded 1/1000 (mapper.go:645) where ffprobe " +
+	"reports 1/14112000. We do not capture stream time_base at import, so there is " +
+	"nothing to map from. Owner decision 2026-08-12: allow rather than add an ingest " +
+	"field and backfill for a value no client is known to divide by"
+
+const trackTitleReason = "we send the embedded tag title where ABS sends the filename. " +
+	"Owner decision 2026-08-12: keep ours deliberately — the tag title is the useful " +
+	"string and the filename is also available via metadata.filename"
+
+// bookBodyAllowances covers any response embedding a book's media block.
+//
+// The duration bounds are the arithmetic, not round numbers: a per-file duration is
+// rounded to whole seconds so it cannot be off by more than 0.5, and startOffset and
+// chapter bounds accumulate those roundings across six tracks, worst case 3.0.
+func bookBodyAllowances() map[string]allowance {
+	return map[string]allowance{
+		// A single track is rounded to whole seconds, so it cannot be off by more
+		// than 0.5. Anything wider is not this bug.
+		"*audioFiles[].duration": {Reason: durationReason, Within: 0.5},
+		"*tracks[].duration":     {Reason: durationReason, Within: 0.5},
+		// Aggregates aggregate the error: six roundings, worst case 3.0. Keeping this
+		// separate from the per-track bound is the point — one loose bound covering
+		// both would let a per-track duration be wrong by 3s and call it expected.
+		"*media.duration":   {Reason: durationReason + " (summed over six tracks)", Within: 3.0},
+		"*startOffset":      {Reason: durationReason + " (accumulated across tracks)", Within: 3.0},
+		"*chapters[].start": {Reason: durationReason + " (synthesized chapter bound)", Within: 3.0},
+		"*chapters[].end":   {Reason: durationReason + " (synthesized chapter bound)", Within: 3.0},
+		"*timeBase":         {Reason: timeBaseReason},
+		// Scoped to TRACK titles. A bare "*title" would also swallow
+		// media.metadata.title — the book's own title, which must stay compared.
+		"*tracks[].title": {Reason: trackTitleReason},
+	}
+}
+
+// identityAllowances covers the user object served by /login, /auth/refresh and /me.
+// Source is NOT included: /me does not carry it, and an allowance that cannot fire is
+// a test failure by design.
+func identityAllowances() map[string]allowance {
+	const roleReason = "our role model is not ABS's: the oracle captured its own root " +
+		"account, and upload/createEreader describe ABS features we do not implement. " +
+		"Reporting true would be a claim we cannot honour"
+	return map[string]allowance{
+		"*type":                      {Reason: roleReason},
+		"*permissions.upload":        {Reason: roleReason},
+		"*permissions.createEreader": {Reason: roleReason},
+	}
+}
+
+// sourceAllowance is separate because only the auth bodies carry Source.
+func sourceAllowance() map[string]allowance {
+	return map[string]allowance{
+		"Source": {Reason: "we identify as audiobook-organizer; the oracle was a docker install"},
+	}
+}
+
+// progressReason covers a progress fraction that reflects where the CAPTURE happened to
+// be paused. currentTime/duration at capture time is not something a test can align to,
+// and the normalizer deliberately does not treat progress as volatile because its value
+// does matter — so it is named here rather than hidden there.
+const progressReason = "progress is currentTime/duration at CAPTURE time; the oracle was " +
+	"recorded at a different playback position than this test sets"
+
+// bitrateReason is the duration truncation's twin one field over: BookFile.BitrateKbps
+// is an int in KILObits, so the oracle's 96208 bps can only come back as 96 * 1000.
+const bitrateReason = "BookFile.BitrateKbps is an int in kbps, so ffprobe's 96208 bps " +
+	"round-trips as 96000. Bounded below 1 kbps — a bitrate wrong by more than the " +
+	"rounding is a different bug"
+
+// publishedYearReason is the same shape of loss as the duration truncation: a typed
+// column cannot hold what the raw tag said. Book.PrintYear is an int, so the oracle's
+// "800BC" comes back "800" — ABS passes the raw date tag straight through.
+const publishedYearReason = "we render Book.PrintYear (an int) where ABS passes the raw " +
+	"date tag through, so the oracle's \"800BC\" loses its era and becomes \"800\""
+
+// mergeAllowances combines allowance sets, and refuses to let one silently replace a
+// key from another — a collision would mean two different reasons for one path, and
+// the loser's reason would be a lie in the source.
+func mergeAllowances(t *testing.T, sets ...map[string]allowance) map[string]allowance {
 	t.Helper()
-	if strings.TrimSpace(reason) == "" {
-		t.Fatalf("%s: assertConformantPending requires a reason — a call site that cannot say "+
-			"why it is exempt has no business being exempt", fixture)
-	}
-	f := mustLoadFixture(t, fixture)
-	t.Logf("%s: PENDING strict conformance (shape only) — %s", fixture, reason)
-	findings := f.CompareBody(got, conformance.Options{IgnoreExtra: true})
-	if len(findings) > 0 {
-		for _, fi := range findings {
-			t.Errorf("%s: %s", fixture, fi)
+	out := map[string]allowance{}
+	for _, s := range sets {
+		for k, v := range s {
+			if prev, dup := out[k]; dup {
+				t.Fatalf("allowance %q declared twice (%q vs %q)", k, prev.Reason, v.Reason)
+			}
+			out[k] = v
 		}
-		t.Fatalf("%s: %d SHAPE findings against the real ABS 2.36.0 response — these are not "+
-			"covered by the pending exemption, which is for values only", fixture, len(findings))
 	}
+	return out
+}
+
+// allowance is a divergence from the oracle that we accept.
+//
+// Where the divergence is numeric and its cause is known and bounded — integer-second
+// duration truncation, say — Within states the widest gap that cause can produce, and
+// anything wider still fails. That distinction matters: a blanket allowance at
+// media.duration accepts ANY duration there forever, so the day we start reporting
+// half the book's length the suite says nothing. Within keeps the field checked while
+// admitting the part we cannot fix.
+//
+// Within == 0 means blanket, which is only honest where the divergence is not numeric.
+type allowance struct {
+	Reason string
+	Within float64
+}
+
+// arrayIndex normalizes concrete element indices so one allowance can cover a whole
+// list. An allowance almost never applies to element 3 alone.
+var arrayIndex = regexp.MustCompile(`\[\d+\]`)
+
+// allowedAt resolves a finding's path against the allowance keys. Keys use [] for "any
+// index"; a leading * makes the remainder a suffix match, so a single entry covers
+// media.x, libraryItem.media.x and a bare x — the play body carries all three.
+func allowedAt(allowed map[string]allowance, path string) (string, allowance, bool) {
+	norm := arrayIndex.ReplaceAllString(path, "[]")
+	if a, ok := allowed[norm]; ok {
+		return norm, a, true
+	}
+	for key, a := range allowed {
+		suffix, isSuffix := strings.CutPrefix(key, "*")
+		if !isSuffix {
+			continue
+		}
+		if norm == suffix || strings.HasSuffix(norm, "."+suffix) {
+			return key, a, true
+		}
+	}
+	return "", allowance{}, false
+}
+
+// numericGap reports |want-got| when both sides parse as numbers.
+func numericGap(fi conformance.Finding) (float64, bool) {
+	want, err1 := strconv.ParseFloat(strings.TrimSpace(fi.Want), 64)
+	got, err2 := strconv.ParseFloat(strings.TrimSpace(fi.Got), 64)
+	if err1 != nil || err2 != nil {
+		return 0, false
+	}
+	return math.Abs(want - got), true
 }
 
 // assertConformantExcept is assertConformant with an explicit, named allowance list.
 //
-// It exists for exactly ONE situation and must not grow past it: a field where real
-// ABS reports data our pipeline genuinely does not collect, so no amount of mapping
-// work would close the gap. Each allowance names the JSON path AND the reason, so an
-// allowance can never quietly become a shape bug — a finding at any other path still
-// fails, and an allowance that stops firing is dead weight a reader can delete.
+// It exists for one situation and must not grow past it: a field where real ABS reports
+// something our pipeline genuinely cannot produce, so no amount of mapping work closes
+// the gap. Each allowance names the path AND the reason, so an allowance can never
+// quietly become a shape bug — a finding at any other path still fails.
 //
-// NOTE (2026-08-12): still shape-only while assertConformant went strict. Its one call
-// site (search) is in the pending-12 and its allowances are calibrated against
-// shape-level findings, so flipping CompareValues here without retriaging those
-// allowances would just relocate the failure. It goes strict with the rest in N-2.
-func assertConformantExcept(t *testing.T, fixture string, got any, allowed map[string]string) {
+// Two guards keep the list from rotting, because an allowance that protects nothing
+// reads exactly like one that protects something:
+//
+//   - An allowance that never fires FAILS the test. The old doc comment asked readers
+//     to notice and delete dead weight themselves; nobody was going to. A stale entry
+//     is either a divergence we already fixed or a path we typo'd, and the second one
+//     is a hole shaped like a safeguard.
+//   - A bounded allowance that fires OUTSIDE its bound fails too, reported as its own
+//     kind of finding rather than silently absorbed.
+func assertConformantExcept(t *testing.T, fixture string, got any, allowed map[string]allowance) {
 	t.Helper()
 	f := mustLoadFixture(t, fixture)
-	findings := f.CompareBody(got, conformance.Options{IgnoreExtra: true})
-	var unexpected []conformance.Finding
+	findings := f.CompareBody(got, conformance.Options{IgnoreExtra: true, CompareValues: true})
+	fired := make(map[string]bool, len(allowed))
+	var unexpected []string
 	for _, fi := range findings {
-		if reason, ok := allowed[fi.Path]; ok {
-			t.Logf("%s: ALLOWED deviation at %s (%s) — %s", fixture, fi.Path, fi.Kind, reason)
+		key, a, ok := allowedAt(allowed, fi.Path)
+		if !ok {
+			unexpected = append(unexpected, fi.String())
 			continue
 		}
-		unexpected = append(unexpected, fi)
+		if a.Within > 0 {
+			gap, numeric := numericGap(fi)
+			if !numeric {
+				unexpected = append(unexpected, fmt.Sprintf(
+					"%s — allowance %q is bounded (within %v) but this finding is not numeric",
+					fi, key, a.Within))
+				continue
+			}
+			if gap > a.Within {
+				unexpected = append(unexpected, fmt.Sprintf(
+					"%s — gap %v EXCEEDS the %v allowed by %q (%s). A known divergence got "+
+						"bigger, which makes it a different divergence",
+					fi, gap, a.Within, key, a.Reason))
+				continue
+			}
+		}
+		fired[key] = true
 	}
-	for _, fi := range unexpected {
-		t.Errorf("%s: %s", fixture, fi)
+	for _, msg := range unexpected {
+		t.Errorf("%s: %s", fixture, msg)
 	}
-	if len(unexpected) > 0 {
-		t.Fatalf("%s: %d unallowed conformance findings against the real ABS 2.36.0 response", fixture, len(unexpected))
+	for key, a := range allowed {
+		if !fired[key] {
+			t.Errorf("%s: allowance %q never fired — it is either a divergence that has "+
+				"been fixed (delete it) or a path that does not exist (a hole). Reason given: %s",
+				fixture, key, a.Reason)
+		}
+	}
+	if t.Failed() {
+		t.Fatalf("%s: %d unallowed findings; see above", fixture, len(unexpected))
 	}
 }
 

--- a/internal/server/handlers/abs/play_test.go
+++ b/internal/server/handlers/abs/play_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/abs/play_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 3e5c9b17-84d0-4f26-a1b9-70c8de4531f5
 // last-edited: 2026-08-12
 
@@ -43,10 +43,17 @@ func TestPlay_ConformsToOracle(t *testing.T) {
 		t.Fatalf("seed position: %v", err)
 	}
 	body := startSession(t, h, mustSyncID(t, seed, seed.multiID), tok)
-	assertConformantPending(t, "post_api_items_id_play.json", body,
-		"fixture drift: audioTracks carry the synthetic book's six identical 1662s durations, "+
-			"2049-2054 byte sizes and timeBase 1/1000 against the oracle's real per-track "+
-			"values and 1/14112000. Track startOffset accumulates the same error")
+	assertConformantExcept(t, "post_api_items_id_play.json", body,
+		mergeAllowances(t, bookBodyAllowances(), map[string]allowance{
+			// The play body carries the track list under audioTracks and the book's
+			// total under a bare `duration`, so neither is reached by the shared keys.
+			"duration":               {Reason: durationReason + " (summed over six tracks)", Within: 3.0},
+			"audioTracks[].duration": {Reason: durationReason, Within: 0.5},
+			"audioTracks[].title":    {Reason: trackTitleReason},
+			"deviceInfo.deviceType": {Reason: "the oracle was captured from a wearable; we " +
+				"do not derive deviceType from the User-Agent at all and report unknown. " +
+				"Unlike ipAddress/userAgent this is a real gap, not a caller artifact"},
+		}))
 }
 
 // TestPlay_CurrentTimeIsTrueLatestPosition pins verified requirement 16.

--- a/internal/server/handlers/abs/progress_write_test.go
+++ b/internal/server/handlers/abs/progress_write_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/abs/progress_write_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2b7f4e91-8a05-4c63-b1d8-70e396a5cf42
 // last-edited: 2026-08-12
 
@@ -701,10 +701,10 @@ func TestBookmarks_ListErrorIs5xxNotEmptyList(t *testing.T) {
 func TestMediaProgressGet_ConformsToOracle(t *testing.T) {
 	w := newWriteHarness(t)
 	w.patch(t, map[string]any{"currentTime": 42.0, "duration": 9975.48, "isFinished": false})
-	assertConformantPending(t, "get_api_me_progress_id.json", w.getRow(t),
-		"fixture drift: the oracle's duration 9975.48 is the sum of six REAL Odyssey track "+
-			"durations; the fake library seeds a flat 9975. Goes strict when the seed is "+
-			"derived from the oracle")
+	assertConformantExcept(t, "get_api_me_progress_id.json", w.getRow(t), map[string]allowance{
+		"duration": {Reason: durationReason, Within: 0.5},
+		"progress": {Reason: progressReason},
+	})
 }
 
 func TestMediaProgressList_ConformsToOracle(t *testing.T) {
@@ -714,8 +714,10 @@ func TestMediaProgressList_ConformsToOracle(t *testing.T) {
 	if code != http.StatusOK {
 		t.Fatalf("got %d %s", code, raw)
 	}
-	assertConformantPending(t, "get_api_me_progress.json", body,
-		"same synthetic-duration drift as get_api_me_progress_id.json")
+	assertConformantExcept(t, "get_api_me_progress.json", body, map[string]allowance{
+		"mediaProgress[].duration": {Reason: durationReason, Within: 0.5},
+		"mediaProgress[].progress": {Reason: progressReason},
+	})
 }
 
 func TestBookmarkCreate_ConformsToOracle(t *testing.T) {

--- a/internal/syncapi/conformance/normalize.go
+++ b/internal/syncapi/conformance/normalize.go
@@ -1,5 +1,5 @@
 // file: internal/syncapi/conformance/normalize.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: ed9387e2-9e6a-46d7-912a-28c96d442d0d
 // last-edited: 2026-08-12
 
@@ -23,12 +23,21 @@ func DefaultVolatileKeys() map[string]bool {
 		// identifiers
 		"id", "libraryid", "libraryitemid", "folderid", "userid", "sessionid",
 		"episodeid", "ino", "authorid", "seriesid", "collectionid",
+		// mediaitemid/bookid are the same minted sync ids as libraryitemid, reached
+		// by a different name from the progress and playback bodies. They were left
+		// off until 2026-08-12, so turning value comparison on reported four
+		// "mismatches" that no run could ever satisfy.
+		"mediaitemid", "bookid",
 		// secrets / tokens
 		"token", "refreshtoken", "accesstoken", "apikey", "password",
 		// timestamps
 		"createdat", "updatedat", "addedat", "lastupdate", "lastseen",
 		"startedat", "finishedat", "birthtimems", "mtimems", "ctimems",
 		"scanversion", "lastscan", "loadedat",
+		// A listening session records WHEN it happened. The capture's Thursday is not
+		// ours and never will be. Note these are the session's own date fields; the
+		// book's publication date is publishedDate/tagDate and stays compared.
+		"date", "dayofweek",
 		// host-dependent
 		"path", "relpath", "contenturl", "coverpath", "metadatapath",
 		"fullpath",

--- a/todo.d/20260812-abs-conformance-onefailure-unreproduced.md
+++ b/todo.d/20260812-abs-conformance-onefailure-unreproduced.md
@@ -1,0 +1,56 @@
+## ⚠️ `TestSearch_ConformsToOracle` failed once and has not reproduced in 27 runs
+
+Recording this because it was observed, not because it is understood. Do not treat the
+suite as proven stable until someone explains it or it recurs with a mechanism attached.
+
+On the very first execution of the reseeded ABS conformance suite (2026-08-12, before the
+work was committed), `TestSearch_ConformsToOracle` failed with six `value_mismatch`
+findings:
+
+```
+value_mismatch at book[1].libraryItem.media.duration:
+    want 9975.431111000002, got 9976 — gap 0.5688889999983076 EXCEEDS the 0.5 allowed by
+    "book[].libraryItem.media.duration"
+value_mismatch at book[1].libraryItem.media.tracks[1].startOffset: want 1386.057143, got 1386
+value_mismatch at book[1].libraryItem.media.tracks[2].startOffset: want 2788.702041, got 2789
+value_mismatch at book[1].libraryItem.media.tracks[3].startOffset: want 4309.211429, got 4310
+value_mismatch at book[1].libraryItem.media.tracks[4].startOffset: want 6928.9792290000005, got 6930
+value_mismatch at book[1].libraryItem.media.tracks[5].startOffset: want 8602.200453000001, got 8603
+```
+
+**The part that does not add up.** The message says a **0.5** bound was applied to
+`book[].libraryItem.media.duration`, but that key is declared in `browse_test.go` with
+`Within: 3.0`, and `book[].libraryItem.media.tracks[].startOffset` is declared `Within: 3.0`
+as well — so on the code as written, none of those six gaps (max 1.02) should have been
+findings at all. Either the run used a build that predated those two entries, or allowance
+selection can pick a different entry than the one intended.
+
+**Reproduction attempts, all clean:**
+
+| invocation | runs | failures |
+|---|---|---|
+| `-run TestSearch_ConformsToOracle` alone | 20 | 0 |
+| full `./internal/server/handlers/abs/` package | 2 | 0 |
+| `./internal/server/handlers/abs/ ./internal/syncapi/conformance/` (the exact original command) | 5 | 0 |
+
+27 runs, zero failures.
+
+**Hypothesis considered and NOT confirmed:** that allowance lookup ranges over the
+`map[string]allowance` and takes the first pattern that matches, making the chosen bound
+depend on Go's randomised map iteration order. That would make the suite flaky by
+construction and would explain a 0.5 bound being applied where 3.0 is declared. 20 runs of
+the isolated test did not produce it, so this is a lead, not a finding. If it recurs, look
+at the matcher first: check whether more than one declared pattern can match
+`book[].libraryItem.media.duration`, and whether selection is deterministic (most-specific
+wins) or iteration-order dependent.
+
+**Why it matters even though it passes now.** The whole point of the bounded-allowance
+design is that a bound states the widest gap its stated cause can produce. If which bound
+applies is nondeterministic, the design's guarantee does not hold — a too-wide bound could
+silently accept a real divergence on some runs. That is a worse failure than the one
+observed, because it is invisible.
+
+Related, and already filed separately:
+`todo.d/20260812-bookfile-duration-integer-seconds.md` — `BookFile.Duration` is an `int`,
+so the store holds whole seconds and per-track truncation accumulates across `startOffset`.
+That is the underlying product issue the allowances exist to bound.

--- a/todo.d/20260812-bookfile-duration-integer-seconds.md
+++ b/todo.d/20260812-bookfile-duration-integer-seconds.md
@@ -1,0 +1,66 @@
+- [ ] **`BookFile.Duration` is `int` seconds, so every per-track duration is truncated and
+  `startOffset` drift compounds through a book.** Found by turning on value comparison in
+  the ABS conformance suite (#2337), measured against the real *Odyssey* capture in
+  `testdata/abs-fixtures/get_api_items_id.json`:
+
+  ```
+  oracle sum(audioFiles.duration) : 9975.431111
+  int-truncated sum (ours)        : 9973          → 2.431 s short
+  oracle startOffsets : [0, 1386.06, 2788.70, 4309.21, 6928.98, 8602.20]
+  ours (int seconds)  : [0, 1386,    2788,    4308,    6927,    8600   ]
+                                                       ↑ 2.200 s drift by track 6
+  ```
+
+  `startOffset` is cumulative, so error accumulates at roughly 0.4 s per track boundary —
+  this item has 6 files but its own tags say the work is 24 parts, which would drift on
+  the order of 10 s by the final track. A client that seeks using `startOffset` lands
+  progressively further off the deeper into the book the listener is.
+
+  `internal/database/store.go:696` — `Duration int`. There is no millisecond field on
+  `BookFile` (`AcoustIDFingerprintDurationSec` immediately below it *is* `float64`, so
+  sub-second precision is already understood to matter elsewhere in the same struct).
+  `mapper.go:217` widens it back out with `DurationSec: float64(f.Duration)`, which cannot
+  recover what the store never held.
+
+  Not fixed alongside the conformance work by owner decision on 2026-08-12: changing a core
+  production field's type touches the store, the mappers, the importers and needs a
+  backfill, and had no business riding along with test-fixture changes. The affected
+  conformance assertions carry **bounded** allowances (they still fail if a duration is
+  wrong by more than the known truncation), so this stays visible rather than becoming
+  permanently accepted.
+
+- [ ] **`/api/me/sessions` reports `itemsPerPage` as the item count, not the page size.**
+  `internal/server/handlers/abs/me.go:132` sets `ItemsPerPage: len(out)` alongside
+  `NumPages: 1` — the endpoint does not paginate at all. The oracle returns
+  `itemsPerPage=10, total=3, numPages=1`, i.e. the default page size with a short page.
+  The sibling handlers in the same package get this right:
+  `stats.go:108` and `stats.go:133` both use `queryInt(c, "itemsPerPage", 10)`.
+
+  A client computing `numPages = ceil(total / itemsPerPage)` gets the right answer today
+  only by accident, because `total` is also `len(out)`. Any client that trusts
+  `itemsPerPage` as a page size — to decide whether to request a second page — is being
+  told the wrong number.
+
+  Not fixed with the conformance work because the honest fix is either to report the
+  requested page size while still returning everything (self-inconsistent) or to actually
+  paginate the endpoint (a live behaviour change for any user with more sessions than one
+  page). That is a product call, not a test-fixture call. Found by #2337's value gate.
+
+- [ ] **`deviceInfo.deviceType` is always `"unknown"`.** We never derive it from the
+  User-Agent; the oracle capture reported `wearable`. Unlike `ipAddress`/`userAgent` —
+  which the conformance normalizer treats as caller artifacts precisely because
+  `me.go:127` *does* populate them for real — this one is a genuine unimplemented field,
+  so it is named in an allowance rather than normalized away. Low priority; nothing is
+  known to read it.
+
+- [ ] **`publishedYear` loses the era: `Book.PrintYear` is an `int`, so the oracle's
+  `"800BC"` comes back `"800"`.** ABS passes the raw date tag through. Same shape of loss
+  as the duration truncation above — a typed column cannot hold what the tag said. The
+  `publishedDecades` filter facet inherits it. Only visible on pre-CE material, so this is
+  genuinely low priority, but it is the same class of bug and worth recording as such.
+
+- [ ] **`timeBase` is hardcoded `"1/1000"` at `internal/server/handlers/abs/mapper.go:645`**
+  where the oracle carries ffprobe's real stream `1/14112000`. We do not capture stream
+  `time_base` at import, so there is nothing to map from. Owner decision 2026-08-12: allow
+  it with a documented permanent allowance rather than add an ingest field and backfill for
+  a value no client is known to divide by. Revisit only if a client turns out to use it.


### PR DESCRIPTION
## What

#2337 turned value comparison on and found twelve endpoints that could not meet the oracle.
This closes them: the fake library's two books are now seeded **from the oracle fixture**, and
what genuinely cannot be aligned is named in a **bounded** allowance instead of being left
unchecked.

## The seed was inventing facts

The fake library was built from constants written in the test file. The multi-file book had
six identical 1662-second tracks of 2049–2054 bytes; the real capture has six distinct
durations and files of 11–21 MB. The single-file book was 4096 bytes against a real 120 MB
m4b, and was called `odyssey.m4b` where the oracle says `odyssey_complete.m4b` — a name that
reaches clients twice, through `metadata.filename` and through `trackTitle`'s basename
fallback.

Durations, sizes, filenames, per-track tags and chapter boundaries now come out of the
fixture. Drift is no longer a thing that can happen; it is the same single-source-of-truth
move as deriving the route check from `router.Routes()` in #2335.

Sizes conform via **sparse files**. `mapper.go:225` stats every track and lets the on-disk
size override the recorded one, so `metadata.size` can only match if the file really is that
long — ~200 MB per run, written as holes at no disk cost. Verified safe for the Range
assertions first: `play_test.go:263` compares a suffix range against `full.Body.Bytes()`'s own
tail, not against a byte pattern, so zeroes satisfy it identically.

## Bounded allowances, and the guard that made them necessary

A blanket allowance at `media.duration` accepts **any** duration there forever. A suite full
of those reports green while saying nothing. So an allowance now states the widest gap its
stated cause can produce — 0.5 s for one rounded track, 3.0 s for a six-track aggregate — and
anything wider fails as a different defect:

```
value_mismatch at book[0].libraryItem.media.tracks[0].chapters[0].end:
  want 1386.057, got 1662.5 — gap 276.443 EXCEEDS the 3 allowed by "*end"
```

That is not a hypothetical. `sixChapters()` was returning flat 1662.5-second spans where the
oracle's first chapter ends at 1386.057. A blanket "chapter bounds may differ" would have
absorbed a **276-second** error as the known sub-second truncation. Those chapters are now
seeded from the oracle and match exactly — `database.Chapter` holds float64, so no allowance
is needed at all.

The second guard: **an allowance that never fires fails the test.** The old doc comment asked
readers to notice and delete dead weight themselves; nobody was going to. It turned out to be
a design tool rather than a safety net — every "never fired" failure was the suite telling me
a divergence I had predicted did not exist, which is how `search` ended up with its own exact
list instead of inheriting the multi-file book's. I could not have written these lists
correctly by inspection.

## One correction carried over from #2337

That PR's description claimed **two** mapper defects. Only one was real, and it is corrected
here in the changelog fragment and at the call site.

`metaTags.tagTrack` is **not** a defect. I read one diff row (`want 4, got 4/24`) and inferred
a normalization rule. All six oracle tracks read `1/24, 2/24, 3/24, 4, 5/24, absent` — ABS
passes the raw ID3 tag through, track 4's real tag was a bare `4`, track 6 had none, and
`mapper.go:758` does exactly the same. The seed's hardcoded `"%d/24"` manufactured the
difference, and seeding from the oracle removed it. **One row of a diff is one sample.**

## Five production findings, all filed rather than fixed here

Comparing values surfaced these. None is fixed in this PR — per the standing rule that
production changes do not ride along with test-fixture work — and all are in
`todo.d/20260812-bookfile-duration-integer-seconds.md`:

| Finding | Measured |
|---|---|
| **`BookFile.Duration` is an `int`** | 2.431 s lost across six tracks; `startOffset` drifts 2.200 s by track 6, ~0.4 s per boundary. A client seeking by `startOffset` lands further off the deeper into the book it is |
| **`/api/me/sessions` `itemsPerPage`** | `me.go:132` reports `len(out)`, the item count, not the page size. `stats.go:108,133` get it right |
| **`deviceInfo.deviceType`** | never derived from the User-Agent; always `unknown` |
| **`BookFile.BitrateKbps` is int-kbps** | ffprobe's 96208 bps round-trips as 96000 |
| **`publishedYear`** | rendered from `Book.PrintYear` (int), so a raw `"800BC"` tag returns `"800"` |

Owner decisions taken on the first, third and fifth: file the duration schema change rather
than bundle it; keep our track title deliberately ("the file name is stupid"); allow the
hardcoded `timeBase` rather than add an ingest field for a value nothing is known to read.

## Also

`mediaItemId`, `bookId`, `date` and `dayOfWeek` are now volatile in conformance comparisons —
the first two are the same minted sync ids as `libraryItemId` under a different name, the last
two are when a captured session happened. Four permanent "mismatches" no run could satisfy.
Note this is normalizing things that carry **no signal**; nothing that carries signal was
normalized to chase green, which is what §N-2 of the audit warns against.

`assertConformantPending` is deleted. The debt list it existed for is empty, and a helper kept
alive for a debt nobody owes is a softer gate waiting to be reached for.

## Verification

`go vet` exit 0 · `gofmt` clean · full `internal/server/handlers/abs` and
`internal/syncapi/conformance` packages, **no `-run` filter**.

Every allowance in the suite is proven live by the never-fired guard: if any one of them
stopped describing a real divergence, this PR would not be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t
