### PR TITLE
docs(organize): answer the target-path collision question with measured data [skip changelog]

### DIFF
--- a/internal/organizer/organizer_test.go
+++ b/internal/organizer/organizer_test.go
@@ -1,7 +1,7 @@
 // file: internal/organizer/organizer_test.go
-// version: 1.8.0
+// version: 1.8.1
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
-// last-edited: 2026-08-11
+// last-edited: 2026-08-12
 
 package organizer
 
@@ -623,8 +623,25 @@ func TestExpandPattern_EmptyNarrator(t *testing.T) {
 
 // TestExpandPattern_EmptySegmentDropsConnectorWords covers the production bug
 // where a book with no narrator was organized to a path containing the literal
-// word "narrator" (measured 2026-08-11: 2,611 of 3,194 occupied-path organize
-// failures contained "read by narrator").
+// word "narrator".
+//
+// CORRECTION (2026-08-12): this comment used to cite "2,611 of 3,194
+// occupied-path organize failures contained 'read by narrator'", which reads as
+// if the narrator literal CAUSED those collisions. It did not. Comparing the
+// same colliding target across the fix on production shows the pileup unchanged:
+//
+//	pre-fix   .../Unknown Title - Unknown Author - read by narrator.mp3   x852
+//	post-fix  .../Unknown Title - Unknown Author.mp3                      x848
+//
+// The literal was correlated with the collisions only because both are symptoms
+// of the same missing metadata. The collisions are distinct books (128 rows
+// share the title "Clarke, Susanna", 176 share "nobody103 (Jack Voraces)")
+// expanding to one identical path, and they need their own fix — see
+// todo.d/20260812-organize-collision-anatomy.md. Neither the 3,194 nor the 2,611
+// could be reproduced from the logs; do not reuse those numbers.
+//
+// This test is still correct and still worth keeping: a path containing the
+// literal word "narrator" is wrong on its own terms.
 //
 // The requirement is stronger than "don't substitute a default": with the
 // default pattern `{title} - {author} - read by {narrator}`, blanking the

--- a/todo.d/20260812-activity-channel-full-drops-records.md
+++ b/todo.d/20260812-activity-channel-full-drops-records.md
@@ -1,0 +1,38 @@
+## ⚠️ The activity channel overflows during organize and DROPS records
+
+While accounting for organize failure logs on production, 1,000 of the 19,519 matching
+lines since 2026-08-10 turned out not to be organize failures at all:
+
+```
+[WARN] activity channel full, dropped: operation: …
+```
+
+They cluster tightly — 44–70 per second during the Aug 11 22:35–22:36 organize run — i.e.
+the activity pipeline saturates precisely when an operation is producing the most activity
+worth recording. Every dropped line is an activity record that no longer exists anywhere.
+
+**Why it matters.** The drop is announced only in the process log, at WARN. Nothing in the
+API, the activity feed, or the operation summary tells a user their activity history has
+holes in it, or where. Anyone reading the activity log for "what did this organize run
+do?" gets a silently truncated answer that looks complete — the same shape as the other
+silent-success defects on this list.
+
+**What is NOT measured:** whether the drops are uniform or biased toward a particular
+activity type; whether an operation's own change rows (`organize_failed` /
+`organize_summary`) go through this channel and are therefore also lossy, or use a
+different, durable path. Establish that first — if operation changes are lossy, then the
+per-book error detail an organize run is supposed to leave behind is unreliable, which
+undermines using it as evidence for anything else.
+
+**Fix directions, cheapest first:**
+
+1. **Count and surface.** Keep a dropped-record counter and report it on the operation and
+   in the activity feed ("N activity records dropped during this run"). Turns an invisible
+   loss into a visible one. Does not fix the loss.
+2. **Back-pressure instead of drop** for operation-scoped activity, so a burst slows the
+   producer rather than discarding history. Needs care: organize's worker pool must not
+   deadlock behind a full channel.
+3. **Resize / batch** the channel. Simplest, but only moves the threshold — a large enough
+   library will always outrun a fixed buffer, so do this *with* (1), never instead of it.
+
+Whatever is chosen, (1) is non-negotiable: a queue that drops data must say how much.

--- a/todo.d/20260812-empty-fieldfilter-returns-whole-library.md
+++ b/todo.d/20260812-empty-fieldfilter-returns-whole-library.md
@@ -1,0 +1,40 @@
+## 🔴 An empty `FieldFilter` value silently returns the WHOLE library
+
+Measured against production 2026-08-12 on `GET /api/v1/audiobooks?filters=…`:
+
+| `filters` value | `count` returned |
+|---|---|
+| `[{"field":"title","value":"Hyperion"}]` | 4 |
+| `[{"field":"title","value":"zzzzz-no-such-title-exists"}]` | 0 |
+| `[{"field":"title","value":""}]` | **63,870 — the entire library** |
+
+The filter works. An **empty value is dropped**, and the request degrades to an unfiltered
+list. The response carries no indication that a filter was discarded: the caller asked
+"which books have a blank title?" and got back every book in the library, including ones
+whose titles are plainly non-blank (`The Awakened Spark`, `Hyperion`).
+
+**Why this is worse than a plain bug.** The failure is indistinguishable from a legitimate
+answer. Anyone measuring "how many books are missing field X" gets the library size and
+may well believe it — the number is large, which is exactly what a "lots of books are
+missing metadata" hypothesis predicts. It is a filter that answers "everything" when it
+means "I ignored you", and it will silently corrupt any audit built on it. It blocked a
+real measurement while investigating the organize target-path collisions.
+
+The same silent drop applies to the flat `?title=` query parameter, which is not a
+supported parameter at all — passing it returns the unfiltered first page rather than an
+"unknown parameter" error. Two separate paths, both answering confidently to a question
+they never applied.
+
+**Fix direction.** Decide explicitly what an empty value means and make the code say so:
+
+- If empty means "match rows where this field is empty" — implement it, and it becomes the
+  natural way to audit missing metadata.
+- If empty is not a supported query — reject the request with 400 and name the offending
+  filter. Never silently widen the result set.
+
+Either is fine. Silently returning everything is not. Add a test that pins the chosen
+behaviour, because both alternatives look identical from the outside today.
+
+Related: this is the same family as the search post-filter pagination defect and the
+"fallback that triggers only on ZERO results" — a code path that cannot distinguish
+"no constraint" from "constraint I could not apply".

--- a/todo.d/20260812-organize-collision-anatomy.md
+++ b/todo.d/20260812-organize-collision-anatomy.md
@@ -1,0 +1,122 @@
+## ✅ ANSWERED — the organize target-path collisions are DISTINCT BOOKS, not one book's files
+
+This closes the "are the 3,194 collisions distinct books or one book's files?" question.
+**They are distinct book rows, confirmed by ID.** But the headline number was wrong in a
+way that matters, and the shape of the collision is not what the earlier note implied.
+
+### How it was measured
+
+Every `target path already occupied by a different file` line on the production host
+since 2026-08-10: **19,519 lines, fully accounted for** —
+
+| bucket | lines |
+|---|---|
+| `operation: Organize failed for <title>: …` | (parsed) |
+| `operation: Failed to organize <title>: …`  | (parsed) |
+| **both shapes together** | **18,519** |
+| `[WARN] activity channel full, dropped: operation: …` | 1,000 |
+
+Two different phrasings for the identical failure means **two emit sites**. Any grep that
+matches only one of them under-reports by ~40%. That is how the first pass at this
+counted 12,213 and thought it had everything.
+
+### Per-run breakdown (runs split on a >300s gap between failures)
+
+| run | window (Aug 11) | failures | distinct titles | distinct targets | contain "read by narrator" |
+|---|---|---|---|---|---|
+| 0 | 02:00:30 → 02:01:00 | 1,098 | 837 | 874 | 827 |
+| 1 | 02:17:18 → 02:34:07 | 782 | 735 | 743 | 750 |
+| 2 | 06:36:18 → 06:36:22 | 1,098 | 837 | 874 | 827 |
+| 3 | 06:53:15 → 08:41:12 | 6,514 | 2,702 | 3,418 | 5,956 |
+| 4 | 09:09:14 → 10:04:15 | 4,736 | 4,703 | 4,716 | 4,184 |
+| 5 | 10:25:23 → 10:44:50 | 1,636 | 971 | 1,005 | 1,258 |
+| 6 | 22:34:02 → 22:37:16 | 2,655 | 475 | 478 | **0** |
+
+### Finding 1 — the collisions are distinct books, verified against the DB
+
+The top colliding target in run 6 is hit **848 times by a single title** (the empty
+string). A title alone cannot distinguish "848 distinct books that all have a blank
+title" from "one book logged 848 times", so the log was not sufficient. Querying the
+API by exact title settles it:
+
+| title | books in DB with that exact title | times it collides in run 6 |
+|---|---|---|
+| `Clarke, Susanna` | **128** (distinct IDs) | 120 |
+| `nobody103 (Jack Voraces)` | **176** (distinct IDs) | 84 |
+
+Distinct book IDs, same title, same author → **identical expanded target path**. Every
+book after the first finds the path occupied. This is a stampede of distinct books onto
+one name, and it is the dominant failure mode.
+
+Note what those two titles are: an **author name** (`Clarke, Susanna`) and a
+**narrator credit** (`nobody103 (Jack Voraces)`) sitting in the *title* field. The
+collision is downstream of the metadata-parser contamination already tracked elsewhere —
+fixing the titles would dissolve most of these collisions without touching the organizer.
+
+### Finding 2 — the "read by narrator" fix was ORTHOGONAL to the collisions
+
+Run 3 (pre-fix, paths contain the literal) and run 6 (post-fix, zero occurrences) show
+the same pileup on the same degenerate name:
+
+```
+run 3:  .../Unknown Author/Unknown Title/Unknown Title - Unknown Author - read by narrator.mp3   x852
+run 6:  .../Unknown Author/Unknown Title/Unknown Title - Unknown Author.mp3                       x848
+```
+
+852 → 848 across the fix. **The narrator literal never caused these collisions.** It was
+correlated with them only because both are symptoms of the same missing metadata. The
+comment in `internal/organizer/organizer_test.go` that read "2,611 of 3,194 occupied-path
+organize failures contained 'read by narrator'" invited exactly the wrong inference and
+is corrected in the same PR as this fragment.
+
+### Finding 3 — the mode is not constant across runs, and that is unexplained
+
+Run 4 is 4,736 failures over 4,716 distinct targets — essentially **1:1, no stampede at
+all** — while runs 3 and 6, on the same day and the same library, are heavily stamped.
+Whatever distinguishes run 4 (a different book population, a filter, a different entry
+path into organize) is **not measured**. Do not assume a single cause for all seven runs.
+
+### ⚠️ The 3,194 figure is not reproduced by this data
+
+No run produced 3,194 failures, and no run produced 2,611 narrator-literal lines. The
+closest candidates are run 6 (2,655) and run 5 (1,636). The original 3,194/2,611 pair
+came from some other source — most likely one operation's `stats.Failed`, which counts
+*all* failures rather than only occupied-target ones, or a run before the 2026-08-10 log
+horizon. **Treat 3,194 as unverified** until whoever recorded it says where it came from.
+The per-run table above is the measured replacement.
+
+### What is NOT claimed
+
+- How many books have a genuinely blank title. The obvious query for it is broken — see
+  the sibling fragment on empty `FieldFilter` values returning the whole library.
+- Whether the occupying file at each target is a real organized book (case 3) or an
+  orphan from a partial organize (case 4). `organizer.go` distinguishes these internally
+  but logs both identically.
+- Why run 4 shows no stampede.
+
+### 🔴 OWNER DECISION — do not pick this unilaterally
+
+`generateTargetPath` has **no uniqueness guarantee**. When the naming pattern expands to
+the same string for N books, all N target one path and N−1 fail. The existing empty-stem
+fallback in `generateTargetPath` makes this worse in a specific way: it was added because
+an empty stem produced a bare `.m4b` that "EVERY such book collides on", and it falls
+back to `defaultTitle` — *a constant*. That trades a collision on one name for a
+collision on another name. It is working exactly as written.
+
+Three ways out, and the choice changes what lands on disk in a 63,870-row production
+library, so it is yours:
+
+1. **Refuse** to organize a book whose expanded path is degenerate (title and author both
+   defaulted), reporting "insufficient metadata to name a unique file" instead of a
+   collision. Honest, but it is a real behaviour change: the *first* such book currently
+   succeeds and would stop succeeding.
+2. **Disambiguate** — append the book ID or the source filename stem when the expanded
+   path is already claimed. Nothing stops being organized, but ~848 files get names with
+   an ID in them.
+3. **Leave it** and fix the upstream metadata instead. Given that 128 books are titled
+   with an author's name and 176 with a narrator credit, this may dissolve the problem at
+   the source — but it is the slowest of the three.
+
+A detection-only counter (report "N books have insufficient metadata to name a unique
+file" at the end of an organize run, changing nothing on disk) is safe to add ahead of
+this decision and would give a real number for option 3.


### PR DESCRIPTION
## What this answers

The open question was: **are the organize target-path collisions distinct books, or one book's files?**

**They are distinct books.** Verified against the DB by ID, not inferred from logs:

| title | book rows with that exact title | collisions on its target |
|---|---|---|
| `Clarke, Susanna` | **128** distinct IDs | 120 |
| `nobody103 (Jack Voraces)` | **176** distinct IDs | 84 |

Same title + same author → one identical expanded path → every book after the first fails as occupied. Note what those titles *are*: an author name and a narrator credit sitting in the title field. The collision is downstream of the metadata-parser contamination, not an organizer bug in its own right.

## Evidence base

All 19,519 `target path already occupied` lines on production since 2026-08-10, **fully accounted for**: 18,519 organize failures + 1,000 activity-drop warnings. The failures use **two different message phrasings** (`Organize failed for X` and `Failed to organize X`) from two emit sites — a grep matching only one under-reports by ~40%, which is how the first pass counted 12,213 and believed it was complete.

## Three things this corrects or flags

1. **The narrator-literal fix was orthogonal to the collisions.** Same target, across the fix: `x852` before, `x848` after. It was correlated only because both are symptoms of the same missing metadata. The comment in `organizer_test.go` citing "2,611 of 3,194" invited the opposite inference and is corrected here.
2. **The 3,194 / 2,611 figures are not reproducible** from the logs — no run produced either number. Marked unverified; the per-run table replaces them.
3. **Run 4 shows no stampede at all** (4,736 failures / 4,716 distinct targets) on the same day and library as heavily-stamped runs. Unexplained, and recorded as unexplained — do not assume one cause for all seven runs.

## Two new defects found while measuring

- **An empty `FieldFilter` value silently returns the whole library** (63,870 rows) instead of matching-empty or erroring. It blocked the obvious "how many books have a blank title?" query, and would silently corrupt any missing-metadata audit built on it.
- **1,000 activity records dropped** during organize (`activity channel full`), announced only at WARN, with nothing in the API or operation summary indicating the history has holes.

## 🔴 Owner decision, deliberately not made here

`generateTargetPath` has no uniqueness guarantee, and its existing empty-stem fallback falls back to a **constant** — trading a collision on one name for a collision on another. The fix options (refuse / disambiguate with book ID / fix upstream metadata) each change what lands on disk in a 63,870-row production library, so the fragment states them and leaves the choice open rather than picking one.

## Scope

Docs + one test comment + version header. **No behaviour change.** `go test ./internal/organizer/ -run TestExpandPattern` exit 0.
