### PR TITLE
ci(deps): stop Dependency Review blocking golang.org/x/* on Go's PATENTS grant

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,6 +1,7 @@
 # file: .github/dependency-review-config.yml
-# version: 1.1.0
+# version: 1.2.0
 # guid: dep-review-cfg-2025-12-07
+# last-edited: 2026-08-12
 
 # Dependency Review Configuration
 # This file configures the dependency-review-action for automated security scanning
@@ -22,9 +23,37 @@ allow-licenses:
   - LGPL-2.1
   - LGPL-3.0
 
-# Allow specific packages even if they have denied licenses
-# allow-dependencies-licenses:
-#   - pkg:npm/some-package@1.0.0
+# Allow specific packages even if they have denied licenses.
+#
+# The golang.org/x/* modules are BSD-3-Clause — which IS in allow-licenses above — plus
+# Go's standard PATENTS file, an ADDITIONAL grant of patent rights that makes them
+# strictly more permissive than BSD-3-Clause alone. ScanCode reports the pair as the
+# compound expression:
+#
+#   BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang
+#
+# allow-licenses matches the WHOLE SPDX expression, not each term, so the compound
+# string fails the policy even though both halves are acceptable. Adding
+# LicenseRef-scancode-google-patent-license-golang to allow-licenses would not fix it
+# either — the expression still would not equal any single allowed entry — and it would
+# quietly widen the policy for every ecosystem. Naming the packages is the narrow fix.
+#
+# Listed WITHOUT versions so the entry matches any version. Dependency Review only
+# reviews CHANGED dependencies, so this failure appears the moment any one of these is
+# bumped and not before: it first blocked #2305, where bytedance/sonic 1.15.1 → 1.15.2
+# pulled golang.org/x/arch. All nine are listed rather than just that one, because the
+# other eight are the same license under the same policy and would each have produced an
+# identical surprise on their next bump.
+allow-dependencies-licenses:
+  - pkg:golang/golang.org/x/arch
+  - pkg:golang/golang.org/x/crypto
+  - pkg:golang/golang.org/x/exp
+  - pkg:golang/golang.org/x/net
+  - pkg:golang/golang.org/x/oauth2
+  - pkg:golang/golang.org/x/sync
+  - pkg:golang/golang.org/x/sys
+  - pkg:golang/golang.org/x/text
+  - pkg:golang/golang.org/x/time
 
 # Deny specific packages
 # deny-packages:

--- a/changelog.d/20260812-dep-review-go-patents.md
+++ b/changelog.d/20260812-dep-review-go-patents.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **Dependency Review blocked every `golang.org/x/*` bump on a licence that is not a
+  problem.** Those modules are BSD-3-Clause — already allowed — plus Go's standard
+  `PATENTS` file, an *additional* grant of patent rights that makes them strictly more
+  permissive than BSD-3-Clause alone. ScanCode reports the pair as the single compound
+  expression `BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang`, and
+  `allow-licenses` matches the whole expression rather than each term, so the compound
+  string failed the policy with both halves acceptable.
+
+  It surfaced on #2305, where `bytedance/sonic 1.15.1 → 1.15.2` pulled
+  `golang.org/x/arch`. Dependency Review only reviews *changed* dependencies, which is
+  why nine modules with this licence sat in `go.mod` for months without tripping it —
+  and why each of the other eight was one Dependabot PR away from an identical surprise.
+  All nine are listed, without versions.
+
+  Named as packages rather than widened in `allow-licenses`: adding the `LicenseRef-`
+  term there would not have fixed it (the compound expression still equals no single
+  allowed entry) and would have loosened the policy for every ecosystem at once.


### PR DESCRIPTION
## The failure

#2305 is blocked by **one** dependency:

```
go.mod » golang.org/x/arch@0.29.0
  License: BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang
```

`golang.org/x/*` modules are BSD-3-Clause — **already in `allow-licenses`** — plus Go's standard `PATENTS` file, an *additional* grant of patent rights that makes them strictly **more** permissive than BSD-3-Clause alone. ScanCode reports the pair as one compound SPDX expression, and `allow-licenses` matches the **whole expression** rather than each term. So a policy that accepts both halves rejects their conjunction.

## Why now, and why it will keep happening

Dependency Review only reviews **changed** dependencies. Nine `golang.org/x/*` modules have sat in `go.mod` for months without tripping this; it fired the moment `bytedance/sonic 1.15.1 → 1.15.2` pulled `golang.org/x/arch` in. Each of the other eight was one Dependabot PR away from an identical surprise, so all nine are listed, without versions.

## Why packages, not a wider licence list

Adding `LicenseRef-scancode-google-patent-license-golang` to `allow-licenses` **would not have fixed it** — the compound expression still equals no single allowed entry — and it would have loosened the policy for every ecosystem at once. `allow-dependencies-licenses` is the narrow instrument; the config already had the stanza, commented out.

## How this nearly got fixed in the wrong file

Grepping this repo for `.github/dependency-review-config.yml` returns **only the file's own header line**. It reads exactly like an orphaned config that governs nothing, and I was one commit from saying so.

It is not orphaned. The reusable workflow probes for it **by path**:

```yaml
if [ -f ".github/dependency-review-config.yml" ]; then ...
```

— in `falkcorp/github-common`'s `reusable-security.yml`. The reference is a string in a *different repository*, so no search of this one can see it. Same blind spot as a gin-composed route path, one repo over. That reasoning is in the commit message so the next person doesn't re-derive it.

## Verification

This PR changes no dependencies, so its own Dependency Review passes trivially — that is **not** the test. The real check is #2305: once this lands, `@dependabot rebase` picks up the config from the head ref and its Dependency Review should go green on the same dependency set. I'll drive that and report the result rather than assume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t
