### PR TITLE
test(abs): derive the reserved-path guard from what the CLIENT requests

### DIFF
--- a/changelog.d/20260812-abs-reserved-path-client-derived-guard.md
+++ b/changelog.d/20260812-abs-reserved-path-client-derived-guard.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **ABS surface: guard the `/api` → `/api/v1` redirect against endpoints we have not built
+  yet.** Every existing check on this surface derives from `absRouteList()` — from what we
+  *implement* — so an endpoint the real client requests but we have not written is absent
+  from that list and nothing checks it. If its sub-tree is not reserved, the call 301s into
+  the app API and answers `200` in the app's shape: implemented-looking and broken, the exact
+  failure mode that produced #2332, #2333 and #2335. The new guard derives instead from the
+  golden fixtures' recorded `request.path`, which is the only in-repo record of what the
+  client *asks for*, so a newly captured endpoint is covered the moment its fixture lands.
+  All 28 captured paths are reserved today; this is a ratchet, not a bug report. Confirmed
+  by removing a reserved prefix and watching it fail on the exact fixture and path.

--- a/internal/server/wire_abs_routes_test.go
+++ b/internal/server/wire_abs_routes_test.go
@@ -1,13 +1,16 @@
 // file: internal/server/wire_abs_routes_test.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 3ea1d764-95c8-4b02-8f31-6d70a5be2c49
 // last-edited: 2026-08-12
 
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -340,4 +343,66 @@ func TestCollisionNamespacesAreStillColliding(t *testing.T) {
 				"list) or it is gone (move %s to absUnimplementedNamespaces so it 404s honestly).",
 			ns, twin, ns)
 	}
+}
+
+// TestABSReservedPath_CoversEveryPathTheRealClientRequested closes the one direction
+// the tests above structurally cannot.
+//
+// Every other guard on this surface derives from absRouteList() — that is, from what we
+// IMPLEMENT. An endpoint the client actually requests but we have not built yet is
+// absent from that list, so nothing checks it. If its prefix is not reserved it 301s
+// into the app API and answers 200 in the app's shape, which is the failure mode this
+// whole file exists to prevent: implemented-looking and broken.
+//
+// The golden fixtures are captures of a real Audiobookshelf answering the real target
+// clients, so request.path is the only record in this repo of what the client ASKS FOR,
+// independent of what we chose to build. Deriving from them means a newly captured
+// endpoint is covered the moment its fixture lands, with no list to remember to update.
+//
+// This passes today — all 28 captured paths are reserved. It is a ratchet, not a bug
+// report: it fails the day someone captures a fixture for an endpoint outside the four
+// reserved sub-trees and does not reserve it.
+func TestABSReservedPath_CoversEveryPathTheRealClientRequested(t *testing.T) {
+	files, err := filepath.Glob(filepath.Join("..", "..", "testdata", "abs-fixtures", "*.json"))
+	require.NoError(t, err)
+	require.Greater(t, len(files), 20,
+		"found only %d fixtures — the capture directory moved or the glob is wrong, and this "+
+			"test would pass by checking nothing", len(files))
+
+	checked := 0
+	for _, file := range files {
+		raw, err := os.ReadFile(file)
+		require.NoError(t, err)
+
+		var fx struct {
+			Request struct {
+				Method string `json:"method"`
+				Path   string `json:"path"`
+			} `json:"request"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &fx), "%s", file)
+		require.NotEmpty(t, fx.Request.Path, "%s: fixture records no request path", file)
+
+		reqPath := fx.Request.Path
+		if q := strings.IndexByte(reqPath, '?'); q >= 0 {
+			reqPath = reqPath[:q]
+		}
+
+		// Captures also include the login/probe endpoints and raw audio fetches, which
+		// live outside /api entirely and are never seen by the /api → /api/v1 redirect.
+		if !strings.HasPrefix(reqPath, "/api/") {
+			continue
+		}
+		checked++
+
+		require.True(t, absReservedPath(reqPath),
+			"%s: the real client requested %s %s, but absReservedPath does not cover it, so the "+
+				"/api → /api/v1 redirect swallows the call. Add its sub-tree to "+
+				"absReservedPathPrefixes (or the exact path to absReservedPaths).",
+			filepath.Base(file), fx.Request.Method, reqPath)
+	}
+
+	require.Greater(t, checked, 15,
+		"only %d of %d fixtures had an /api path — the fixture shape changed and this test is "+
+			"no longer reading what it thinks it is", checked, len(files))
 }


### PR DESCRIPTION
## What

Adds `TestABSReservedPath_CoversEveryPathTheRealClientRequested`, which derives the ABS reserved-path check from the **golden fixtures' recorded `request.path`** instead of from `absRouteList()`.

## Why this direction was unguarded

Every existing check on this surface derives from `absRouteList()` — from what we **implement**. An endpoint the real client requests but we have not built yet is absent from that list, so nothing checks it. If its sub-tree is not reserved, the call 301s into the app API and answers `200` in the app's shape: implemented-looking and broken. That is the exact failure mode behind #2332, #2333 and #2335.

The fixtures are captures of a real Audiobookshelf answering the real target clients, so `request.path` is the only record in this repo of what the client **asks for**, independent of what we chose to build.

## This passes on arrival — it is a ratchet, not a bug report

All 28 captured paths are reserved today. Verified red by removing `"/api/me/"` from `absReservedPathPrefixes`:

```
delete_api_me_item_id_bookmark_time.json: the real client requested
DELETE /api/me/item/689…/bookmark/100, but absReservedPath does not cover it,
so the /api → /api/v1 redirect swallows the call.
```

Both vacuity guards are present: the glob must find >20 fixtures and >15 must carry an `/api` path.

## N-4 is closed by evidence, not by this change

This branch started as N-4 ("`/api/authors/:id` still 301s into the app API"). Probing the wired router rather than reading it falsified the recorded harm:

| Claim | Verdict |
|---|---|
| ABS probes 301 into the app API | ✅ true |
| …and hit a 401, flipping the connection indicator | ❌ **false** — they 404 (`{"error":"endpoint not found"…}`); the JWT middleware is group-level, so `NoRoute` never enters it |
| …the *list* routes answer 200 with app-API JSON | ✅ true, and would blank a tab per §6.1 of the client contract |
| …but the target clients call those top-level paths | ❌ **false** |

Every authors/series call in the 28 captures is **library-scoped** (`/api/libraries/:id/authors?sort=name&minified=1&limit=100&page=0`), and `/api/libraries/` is already reserved. There are zero recorded requests to top-level `/api/authors`, `/api/series`, `/api/playlists` or `/api/users` — consistent with the 30-day production logs showing no traffic to any of them.

Rewriting engine-level middleware that has broken 46 live routes twice, to fix a path no client calls, is a bad trade. The gap worth closing was the missing *behavioural* guard, which is what this adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t