### PR TITLE
fix(scheduler): an enabled task with no interval was dropped silently — nothing had been scanning

### DIFF
--- a/changelog.d/20260812_fix_scheduler_silent_task_skip.md
+++ b/changelog.d/20260812_fix_scheduler_silent_task_skip.md
@@ -1,0 +1,21 @@
+### Fixed
+
+#### The scheduler dropped enabled tasks without a word — and nothing had been scanning
+
+A task only got a timer when it was both enabled and had a non-zero interval. When it
+was enabled but its interval resolved to zero, it got no timer, no log line, and no
+other trace. From the outside that is indistinguishable from a task somebody turned off
+on purpose.
+
+That is how automatic library scanning stayed off without anyone noticing. The periodic
+scan ships enabled with a six-hour interval, but a stored zero was overriding that
+default, so the one job responsible for noticing newly added books was never scheduled —
+and the only symptom was a log line that was not there. Four unrelated jobs were
+scheduled normally, so the scheduler looked healthy.
+
+The scheduler now says which task it dropped and why, and names the setting to change.
+Correctly configured tasks log as before, and tasks that are off on purpose stay quiet —
+so "off deliberately" and "on but broken" no longer look the same.
+
+The underlying cause, where stored zero values permanently shadow shipped defaults, is
+written up with the measurements and the options for fixing it properly.

--- a/docs/design/2026-08-12-unified-settings-architecture.md
+++ b/docs/design/2026-08-12-unified-settings-architecture.md
@@ -1,0 +1,198 @@
+<!-- file: docs/design/2026-08-12-unified-settings-architecture.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6d2f8a41-93cb-47e5-b0a2-5c7e1d94f38b -->
+<!-- last-edited: 2026-08-12 -->
+
+# Unified settings architecture — why viper/cobra did not prevent this
+
+## The question
+
+> "How does this keep happening? We have viper and cobra, which is supposed to give
+> us one working settings system via config file or env var. Why does this keep
+> happening?"
+
+Fair question, and the answer is not "viper is bad" or "we configured it wrong".
+Viper is doing exactly what it promises. It is simply **not in the path** where the
+bug happens.
+
+## What viper actually guarantees
+
+Viper resolves a key through a precedence chain:
+
+```
+explicit Set()  >  flag  >  env  >  config file  >  key/value store  >  default
+```
+
+That guarantee applies **only to values read through viper**, at the moment you call
+`viper.GetInt("scheduled.library_scan.interval")`. It is a property of the *read*, not
+a property of the value.
+
+## What this codebase actually does
+
+```
+                    ┌─────────────────────────────────────────┐
+   viper defaults ──┤                                         │
+   config.yaml    ──┤  viper.GetX(...)  ──►  config.AppConfig │   ← read ONCE, at boot
+   env vars       ──┤                        (plain Go struct)│
+   flags (cobra)  ──┘                                         │
+                    └─────────────────────────────────────────┘
+                                                  │
+                                                  ▼
+                    ┌─────────────────────────────────────────┐
+   DB settings   ───┤  LoadConfigFromDatabase → applySetting   │   ← MUTATES the same
+   rows             │  c.Scheduled.LibraryScan.Enabled = b     │     struct, afterwards
+                    └─────────────────────────────────────────┘
+                                                  │
+                                                  ▼
+                              every consumer reads config.AppConfig
+```
+
+There are **two writers to one struct and no precedence rule between them.** The DB
+writer runs second, so the DB always wins — regardless of whether the operator set a
+flag, an env var, or a config-file value. Cobra and viper never get a say, because by
+the time the DB loader runs, viper is out of the picture entirely.
+
+This is the whole bug class. It is not specific to the scheduler.
+
+## Why it is silent
+
+The second mechanism is Go's zero value.
+
+`ScheduledTaskConfig{Enabled bool, Interval int, OnStartup bool}` cannot represent
+"not set". `false` and `0` are simultaneously:
+
+- a legitimate operator choice ("off", "never"), and
+- what a field gets when nobody filled it in.
+
+So when `PUT /api/v1/config` serialises the entire struct — including fields the UI
+form never populated — it writes `false`/`0` for them. Those are stored as explicit
+settings. Forever after, `applySetting` finds the key present and overwrites the viper
+default with it.
+
+**Measured consequence (2026-08-12, production):** every key under `scheduled.*` had
+`interval: 0`, including `library_scan`, whose shipped default is `enabled: true,
+interval: 360`. `library_scan` is the only unattended discovery path for new books, so
+nothing had scanned automatically since the setting was last saved. PR #2315 shipped
+that default and is deployed; the stored zeros defeated it. Raising a default cannot
+affect any install that has ever saved settings.
+
+This is the same shape as the other silent-success defects on the backlog: a code path
+that cannot distinguish "no value" from "a value that happens to be zero", and answers
+confidently either way.
+
+## Why "just use viper harder" is not the fix
+
+Two tempting non-fixes:
+
+- **"Read through viper everywhere at runtime."** Viper's global is not safe for the
+  hot read paths here, and it loses the typed struct that the whole codebase already
+  depends on. It also does not solve the zero-value problem: `viper.GetInt` on a key
+  explicitly stored as `0` still returns `0`.
+- **"Stop saving settings we did not change."** Correct instinct, but as a convention
+  it is unenforceable — it re-breaks the first time someone adds a field to the struct
+  and a form that does not populate it.
+
+The fix has to make the *illegal state unrepresentable*, or make viper the single
+arbiter. Below are the three real options.
+
+---
+
+## Option A — Make the DB a viper layer (recommended)
+
+Stop having two writers. Feed the DB settings **into viper** before the struct is
+built, so viper's existing precedence chain does the arbitration:
+
+```go
+// after viper defaults/file/env are established, BEFORE building AppConfig
+stored, err := loadSettingsAsMap(store)   // {"scheduled.library_scan.interval": 360, ...}
+if err == nil {
+    _ = viper.MergeConfigMap(stored)
+}
+cfg := buildAppConfigFromViper()          // the ONLY writer to the struct
+```
+
+**Wins:** one reader, one precedence chain, one place to reason about. Flags and env
+vars start working for every key, which is what was expected all along. `config.AppConfig`
+becomes write-once and can be made effectively read-only.
+
+**Costs:** the DB layer sits at a fixed precedence position, so decide deliberately
+where it goes. Recommended: **above** config file, **below** env and flags — so an
+operator can always override a bad stored value with `ABK_SCHEDULED_LIBRARY_SCAN_INTERVAL=360`
+without touching the DB. That property alone would have made the current outage a
+one-line recovery.
+
+**Does not, by itself, fix the zero-value problem** — a stored explicit `0` still wins
+over the default. Pair with Option B.
+
+## Option B — Make "unset" representable
+
+Store settings as a **delta from default**, not as a full snapshot:
+
+- On save, compare each field against its default. Write a row **only when it differs**;
+  **delete** the row when it returns to the default.
+- Or change the persisted shape to pointers (`*int`, `*bool`) so `nil` means unset, and
+  only non-nil values are applied.
+
+The delta form is preferable: it is self-healing (a default change propagates to every
+install that never overrode it — exactly what was expected of #2315), the settings table
+stays small and readable, and "what has this operator actually customised?" becomes
+answerable by looking at it.
+
+**This is the option that actually stops the recurrence.** Option A alone routes the
+values correctly; Option B is what makes a changed default reach an existing install.
+
+## Option C — One registry, generated accessors
+
+The "central package with getters/setters" shape:
+
+```go
+settings.Register(settings.Def{
+    Key:     "scheduled.library_scan.interval",
+    Default: 360,
+    Env:     "ABK_SCHEDULED_LIBRARY_SCAN_INTERVAL",
+    Flag:    "scheduled-library-scan-interval",
+    Doc:     "Minutes between automatic library scans. 0 disables the timer.",
+})
+```
+
+with every consumer reading `settings.Int("scheduled.library_scan.interval")` and no
+direct struct access anywhere.
+
+**Wins:** a single registration point means the default, env var, flag, docs and
+validation cannot drift apart; `--help` and the settings UI can both be generated from
+it; an unknown key becomes an error instead of a silent zero.
+
+**Costs:** this is a large migration — 114 top-level config keys and hundreds of read
+sites. Realistically an incremental target, not a single change.
+
+---
+
+## Recommendation
+
+Do **A + B** now, treat **C** as the direction of travel.
+
+A and B together are a contained change to `internal/config` plus the settings write
+path, and they fix the actual failure mode: stored values would be routed through one
+precedence chain, and unset would stop masquerading as zero. C is where this should end
+up, but it should be approached one subsystem at a time rather than as a big-bang
+rewrite.
+
+## Guardrails to add regardless of which option is chosen
+
+These are cheap, and each one would independently have caught this outage:
+
+1. **Log the effective config for anything that gates unattended work.** Already done
+   for the scheduler in this PR: a task that is enabled but has no usable interval now
+   WARNs and names the config key, instead of being dropped silently.
+2. **A startup assertion for defaults that matter.** If `library_scan` resolves to
+   "will never run", say so loudly at boot. The absence of a log line is not something
+   anyone can grep for.
+3. **A test that runs against a *persisted* config, not just a fresh default one.**
+   `TestLibraryScanIsScheduledUnderDefaultConfig` passes and always did — it builds a
+   default config, which is precisely the case that was never broken. The gap was
+   "default config + a settings save". Any new default-on feature needs that second test.
+4. **Reject unknown setting keys on write** rather than storing them, so a renamed key
+   fails loudly instead of becoming a permanent invisible zero.
+
+Guardrail 3 is the one that generalises: **a config test that never persists anything
+cannot see this entire bug class.**

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,7 +1,7 @@
 // file: internal/scheduler/scheduler.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 3f7a9c21-b4d8-4e05-a6f2-8c1d0e3b7a94
-// last-edited: 2026-08-11
+// last-edited: 2026-08-12
 
 // Package scheduler implements the unified task scheduling system.
 // TaskScheduler manages all registered tasks, their schedules, and manual
@@ -186,7 +186,23 @@ func (ts *TaskScheduler) Start(shutdown chan struct{}, wg *sync.WaitGroup) {
 			}()
 		}
 
-		// Start scheduled ticker if interval > 0 and enabled
+		// Start scheduled ticker if interval > 0 and enabled.
+		//
+		// The `else` arms below exist because this condition used to fail
+		// SILENTLY. A task that was enabled but whose interval resolved to 0
+		// got no ticker, no log line, and no other trace — from the outside it
+		// was indistinguishable from a task deliberately turned off.
+		//
+		// That is not hypothetical. Measured on production 2026-08-12: every
+		// task in the `scheduled.*` config block had interval 0, including
+		// library_scan, whose shipped defaults are enabled=true / interval=360.
+		// Stored zero values were overriding the viper defaults, so the ONLY
+		// unattended discovery path for newly added books had never run — and
+		// the only evidence was the absence of a log line, which nobody can
+		// grep for. Four unrelated tasks did get tickers, which made the
+		// scheduler look healthy.
+		//
+		// A scheduler that drops a task must say which task and why.
 		if task.IsEnabled() && task.GetInterval() > 0 {
 			interval := task.GetInterval()
 			taskName := name
@@ -209,6 +225,18 @@ func (ts *TaskScheduler) Start(shutdown chan struct{}, wg *sync.WaitGroup) {
 				}
 			}()
 			slog.Info("Scheduled task interval", "taskName", taskName, "interval", interval)
+		} else if task.IsEnabled() {
+			// Enabled but no usable interval. This is the silent case: the
+			// operator turned the task ON and it will never run. Say so, and
+			// name the config key, because the difference between this and
+			// "deliberately off" is invisible from the outside.
+			slog.Warn("Scheduled task is ENABLED but has no interval — it will NEVER run on a timer; "+
+				"set the interval (minutes) in the scheduled.<task>.interval config key to fix",
+				"taskName", name, "interval", task.GetInterval())
+		} else {
+			// Deliberately off. Logged at Debug so the roster is complete for
+			// anyone diagnosing "why did nothing happen" without adding noise.
+			slog.Debug("Scheduled task disabled", "taskName", name)
 		}
 	}
 

--- a/internal/scheduler/silent_task_skip_test.go
+++ b/internal/scheduler/silent_task_skip_test.go
@@ -1,0 +1,136 @@
+// file: internal/scheduler/silent_task_skip_test.go
+// version: 1.0.0
+// guid: 7c4e1b93-2a86-4d0f-9e57-3b1a8f6c204d
+// last-edited: 2026-08-12
+
+// Regression test for a scheduler that dropped tasks without saying so.
+//
+// Start() creates a ticker only when `IsEnabled() && GetInterval() > 0`. There
+// was no else branch, so a task that was ENABLED but whose interval resolved to
+// 0 produced no ticker, no log line, and no other evidence. From the outside it
+// was identical to a task deliberately switched off.
+//
+// Measured on production 2026-08-12: every task under the `scheduled.*` config
+// block had interval 0 — including library_scan, whose shipped defaults are
+// enabled=true / interval=360 — because stored zero values were shadowing the
+// viper defaults. library_scan is the only unattended discovery path for newly
+// added books, so nothing had scanned automatically, and the sole symptom was a
+// log line that was absent. Four unrelated tasks did get tickers, which made the
+// scheduler look healthy.
+//
+// The test asserts the WARN names the task, so the next occurrence is greppable.
+
+package scheduler
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// captureLogs swaps the default slog logger for one writing into a buffer, and
+// restores it when the test ends.
+func captureLogs(t *testing.T, level slog.Level) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: level})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf
+}
+
+// startScheduler runs Start() with only the given tasks registered and returns
+// the captured log output. Start spawns goroutines; shutting down immediately
+// keeps the test fast and deterministic because every ticker branch logs
+// synchronously before its goroutine does any work.
+func startScheduler(t *testing.T, level slog.Level, defs ...TaskDefinition) string {
+	t.Helper()
+	buf := captureLogs(t, level)
+
+	ts := &TaskScheduler{
+		// Store must be non-nil: Start -> loadLastMaintenanceRun calls it
+		// unconditionally. Returning a nil Store is the supported "DB not ready"
+		// path and makes loadLastMaintenanceRun return early.
+		deps:    SchedulerDeps{Store: func() database.Store { return nil }},
+		tasks:   make(map[string]*TaskDefinition),
+		lastRun: make(map[string]time.Time),
+	}
+	for _, d := range defs {
+		ts.RegisterTask(d)
+	}
+
+	shutdown := make(chan struct{})
+	var wg sync.WaitGroup
+	ts.Start(shutdown, &wg)
+	close(shutdown)
+	wg.Wait()
+
+	return buf.String()
+}
+
+// TestEnabledTaskWithZeroIntervalIsReported is the core regression: an enabled
+// task with no usable interval must produce a WARN naming it, not silence.
+func TestEnabledTaskWithZeroIntervalIsReported(t *testing.T) {
+	out := startScheduler(t, slog.LevelInfo, TaskDefinition{
+		Name:        "library_scan",
+		Description: "the only unattended discovery path for new books",
+		IsEnabled:   func() bool { return true },
+		GetInterval: func() time.Duration { return 0 },
+		RunOnStart:  func() bool { return false },
+	})
+
+	if !strings.Contains(out, "library_scan") {
+		t.Fatalf("an enabled task that will NEVER run must be named in the logs; "+
+			"this is the silent-skip defect. got:\n%s", out)
+	}
+	if !strings.Contains(out, "level=WARN") {
+		t.Errorf("a task that is on but can never fire is a misconfiguration and "+
+			"belongs at WARN, not below it; got:\n%s", out)
+	}
+	// The operator needs to know what to change, not merely that something is wrong.
+	if !strings.Contains(out, "interval") {
+		t.Errorf("the warning must point at the interval setting; got:\n%s", out)
+	}
+}
+
+// TestScheduledTaskWithIntervalStillLogsNormally guards against the fix turning
+// every healthy task into a warning — the discriminating half of the control.
+func TestScheduledTaskWithIntervalStillLogsNormally(t *testing.T) {
+	out := startScheduler(t, slog.LevelInfo, TaskDefinition{
+		Name:        "purge_deleted",
+		IsEnabled:   func() bool { return true },
+		GetInterval: func() time.Duration { return 6 * time.Hour },
+		RunOnStart:  func() bool { return false },
+	})
+
+	if !strings.Contains(out, "Scheduled task interval") {
+		t.Errorf("a correctly configured task should still log its interval; got:\n%s", out)
+	}
+	if strings.Contains(out, "level=WARN") {
+		t.Errorf("a correctly configured task must NOT warn; got:\n%s", out)
+	}
+}
+
+// TestDisabledTaskDoesNotWarn pins the distinction the defect erased: OFF on
+// purpose and ON-but-broken must not look the same, and OFF must stay quiet.
+func TestDisabledTaskDoesNotWarn(t *testing.T) {
+	out := startScheduler(t, slog.LevelDebug, TaskDefinition{
+		Name:        "db_optimize",
+		IsEnabled:   func() bool { return false },
+		GetInterval: func() time.Duration { return 0 },
+		RunOnStart:  func() bool { return false },
+	})
+
+	if strings.Contains(out, "level=WARN") {
+		t.Errorf("a deliberately disabled task must not warn; got:\n%s", out)
+	}
+	if !strings.Contains(out, "db_optimize") {
+		t.Errorf("the roster should still account for a disabled task at Debug "+
+			"so 'why did nothing happen' is answerable; got:\n%s", out)
+	}
+}

--- a/todo.d/20260812-scheduled-config-zeros-shadow-defaults.md
+++ b/todo.d/20260812-scheduled-config-zeros-shadow-defaults.md
@@ -1,0 +1,73 @@
+## 🔴 Stored ZERO values shadow every `scheduled.*` default — nothing has been scanning
+
+Measured on production 2026-08-12 via `GET /api/v1/config`:
+
+```
+scheduled.library_scan   = {enabled: false, interval: 0, on_startup: false}
+scheduled.dedup_refresh  = {enabled: true,  interval: 0, on_startup: false}
+scheduled.author_split   = {enabled: true,  interval: 0, on_startup: false}
+scheduled.db_optimize    = {enabled: false, interval: 0, on_startup: false}
+scheduled.label_refinement = {enabled: false, interval: 0, on_startup: false}
+```
+
+Compare the shipped viper defaults (`internal/config/config.go` ~line 1100):
+
+| key | default | on prod |
+|---|---|---|
+| `scheduled.library_scan.enabled` | **true** | false |
+| `scheduled.library_scan.interval` | **360** | 0 |
+| `scheduled.dedup_refresh.interval` | 360 | 0 |
+| `scheduled.db_optimize.interval` | 1440 | 0 |
+| `scheduled.label_refinement.interval` | 10080 | 0 |
+
+**Every interval in the block is 0.** Not one default survived.
+
+### Consequence
+
+`library_scan` is the only unattended discovery path for newly added books. With
+`interval: 0` it never gets a ticker, so **nothing has been scanning automatically**.
+PR #2315 shipped the periodic scan enabled-by-default and is deployed — the code is
+right, the stored config defeats it. A book copied into an import path is still never
+noticed until somebody presses Scan by hand, which is the exact bug #2315 set out to fix.
+
+Only four tasks got tickers at the last restart (`tombstone_cleanup`, `purge_deleted`,
+`isbn_enrichment`, `cleanup_activity_log`) — they read their intervals from config
+fields outside the `scheduled.*` block, which is why the scheduler looked healthy.
+
+### Mechanism
+
+Viper's precedence chain (flag > env > file > default) only arbitrates values read
+*through* viper. This codebase reads viper **once** into a plain Go struct
+(`config.AppConfig`), and then a second, independent loader
+(`LoadConfigFromDatabase` → `applySetting`) mutates that same struct from DB rows.
+Two writers, one struct, no precedence rule between them — and the DB writer runs last.
+
+`persistence.go` has a comment asserting this is safe: *"an absent stored setting must
+leave the viper default alone. That holds here because applySetting is a per-leaf-key
+switch: a key that was never stored is simply never seen."* The reasoning is correct;
+the premise is not. The keys **were** stored. The tell is `dedup_refresh.enabled: true`
+and `author_split.enabled: true` when both default to `false` — something wrote explicit
+values for the whole block. That is the signature of a full-struct save (`PUT /config`
+serialises every field), where fields the caller never populated are written as their Go
+zero value.
+
+**In Go, `0` and `false` are indistinguishable from "unset".** Once a whole-struct save
+lands, the default is dead permanently — no later default change can ever take effect.
+That is why raising a default (as #2315 did) had no effect on an existing install, and
+it will happen again to the next default anyone changes.
+
+### Immediate repair (one API call, no code change)
+
+```
+PUT /api/v1/config   scheduled.library_scan = {enabled: true, interval: 360}
+```
+
+⚠️ Owner call, not applied: a full library scan is expensive on this library (see the
+open "prod scans take hours" item), so turning on a 6-hourly scan has a real cost.
+Decide the interval before enabling.
+
+### Durable fix — see the settings-architecture design
+
+The repair above fixes one key on one host. It does not stop the next default from being
+shadowed. The structural options are in
+`docs/design/2026-08-12-unified-settings-architecture.md`.


### PR DESCRIPTION
## The finding: nothing on this server has been scanning for new books

`library_scan` is the only unattended discovery path for newly added books. PR #2315 shipped it enabled-by-default at a 6h interval and **is deployed**. It has never run.

Measured on production via `GET /api/v1/config`:

| key | shipped default | on prod |
|---|---|---|
| `scheduled.library_scan.enabled` | **true** | `false` |
| `scheduled.library_scan.interval` | **360** | `0` |
| `scheduled.dedup_refresh.interval` | 360 | `0` |
| `scheduled.db_optimize.interval` | 1440 | `0` |
| `scheduled.label_refinement.interval` | 10080 | `0` |

**Every interval under `scheduled.*` is 0.** Not one default survived.

## Why nobody caught it

`Start()` created a ticker only under `IsEnabled() && GetInterval() > 0` — **no else branch, no log**. An enabled task with interval 0 got no ticker and left no trace, so it was indistinguishable from a task deliberately switched off. The only symptom was a log line that was *absent*, which nobody can grep for.

Four unrelated tasks (`tombstone_cleanup`, `purge_deleted`, `isbn_enrichment`, `cleanup_activity_log`) did get tickers — they read intervals from config fields outside the `scheduled.*` block — so the scheduler looked healthy.

## Root cause: viper was never in the path

Viper's precedence chain (flag > env > file > default) governs values read **through viper**. This codebase reads viper **once** into `config.AppConfig`, then `LoadConfigFromDatabase` -> `applySetting` **mutates that same struct afterwards**. Two writers, one struct, no precedence rule between them — and the DB writer runs last.

`persistence.go` asserts this is safe because "a key that was never stored is simply never seen". The reasoning is right; the premise is wrong. The keys **were** stored — the tell is `dedup_refresh.enabled: true` and `author_split.enabled: true` when both default to `false`. That is the signature of a whole-struct save (`PUT /config` serialises every field), writing Go zero values for fields the caller never populated.

**In Go, `0`/`false` are indistinguishable from "unset".** Once a whole-struct save lands, the default is dead permanently — which is why raising a default (as #2315 did) had no effect on an existing install, and why it will happen to the next default anyone changes.

## What this PR changes

Observability only — **no behaviour change, nothing starts running**:

- **WARN** when a task is enabled but has no usable interval, naming the task *and* the config key to set.
- **Debug** roster line for deliberately-disabled tasks, so "why did nothing happen" is answerable.
- Correctly configured tasks log exactly as before.

## Verification

3 regression tests, and the negative control is **discriminating** — reverting the fix reddens the two silent-skip tests while leaving the healthy-task test green:

```
--- FAIL: TestEnabledTaskWithZeroIntervalIsReported
--- PASS: TestScheduledTaskWithIntervalStillLogsNormally   <-- unaffected
--- FAIL: TestDisabledTaskDoesNotWarn
```

Full package green with the fix in place: `ok internal/scheduler 0.629s`.

## Not done here — two owner calls

1. **Turning the scan on.** One API call fixes prod (`PUT /api/v1/config` with `scheduled.library_scan = {enabled: true, interval: 360}`), but a full scan is expensive on this library (see the open "prod scans take hours" item). Pick the interval first.
2. **The structural fix.** `docs/design/2026-08-12-unified-settings-architecture.md` lays out why "use viper harder" doesn't work and what does: (A) merge DB settings **into** viper so one precedence chain arbitrates — placed below env/flags so a bad stored value is always overridable; (B) store settings as a **delta from default** so unset stops masquerading as zero and default changes reach existing installs; (C) a single registration module with generated accessors, as the long-term direction.

**A+B is what stops the recurrence.** Also flagged: `TestLibraryScanIsScheduledUnderDefaultConfig` passes and always did — it builds a *default* config, the one case that was never broken. A config test that never persists anything cannot see this bug class.
