### PR TITLE
fix(abs): report itemsPerPage as a page size and actually paginate sessions

### DIFF
--- a/changelog.d/20260812-abs-sessions-pagination.md
+++ b/changelog.d/20260812-abs-sessions-pagination.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **`GET /api/me/sessions` reported `itemsPerPage` as the number of items on the page
+  rather than the page size, and did not paginate at all.** The oracle capture answers
+  `itemsPerPage=10` with `total=3`; we answered `3` for both, making a page size and an
+  item count indistinguishable — and answering `0` on an empty result, which is a divide
+  by zero for any client deriving a page count from it. The endpoint now honours
+  `?itemsPerPage=` and `?page=` with the same defaults and clamping as the sibling
+  handlers in `stats.go`, so the number it reports is one a client can act on. The
+  conformance allowance covering this is removed; the assertion was confirmed to catch the
+  old behaviour (`value_mismatch at itemsPerPage: want 10, got 3`) before being trusted.

--- a/internal/server/handlers/abs/abs_test.go
+++ b/internal/server/handlers/abs/abs_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/abs/abs_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 2c07b5e9-4d16-48fa-b930-71e5c8a04f6d
 // last-edited: 2026-08-12
 
@@ -1321,16 +1321,10 @@ func TestSessions_ConformsToFixture(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("got %d: %s", w.Code, w.Body.String())
 	}
-	assertConformantExcept(t, "get_api_me_sessions.json", body, map[string]allowance{
-		// A real bug, deliberately not fixed here: me.go:132 sets ItemsPerPage to
-		// len(out) — the number of items on the page rather than the page size — where
-		// the sibling handlers at stats.go:108,133 correctly use
-		// queryInt(c, "itemsPerPage", 10). Fixing it changes pagination on a live
-		// endpoint, which has no business riding along with test-fixture work.
-		// Filed: todo.d/20260812-bookfile-duration-integer-seconds.md
-		"itemsPerPage": {Reason: "me.go:132 reports len(out) instead of the page size; " +
-			"oracle says 10 with total 3. Filed as a separate production fix"},
-	})
+	// No allowance any more: me.go now reports itemsPerPage as a page size (default 10,
+	// as the oracle answers) and paginates on ?page=/?itemsPerPage= rather than
+	// returning everything under a page-size that was really an item count.
+	assertConformant(t, "get_api_me_sessions.json", body)
 
 	// total must be an INTEGER (§1.7.3 item 5: Dart throws on `42.0 as int?`).
 	total, ok := body["total"].(float64)

--- a/internal/server/handlers/abs/me.go
+++ b/internal/server/handlers/abs/me.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/me.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 63b8c105-2f74-4ea9-8d16-947c0be5a2f3
-// last-edited: 2026-07-30
+// last-edited: 2026-08-12
 
 package abs
 
@@ -128,12 +128,47 @@ func (h *Handler) Sessions(c *gin.Context) {
 		})
 	}
 
+	// itemsPerPage is a PAGE SIZE, not the number of items on the page. The oracle
+	// capture answers itemsPerPage=10 with total=3, so reporting len(out) made those
+	// two indistinguishable — and reported 0 on an empty result, which is a divide by
+	// zero for any client deriving a page count from it.
+	//
+	// Paginating for real rather than only correcting the number, because reporting a
+	// page size while still returning everything and ignoring ?page= is a different
+	// lie: a client that reads numPages > 1 and asks for page 1 would be handed the
+	// same full list again. Defaults and clamping follow the sibling handlers at
+	// stats.go:108,133, and queryInt already falls back to the default on a negative
+	// or unparseable value.
+	perPage := queryInt(c, "itemsPerPage", 10)
+	if perPage == 0 {
+		perPage = 10
+	}
+	page := queryInt(c, "page", 0)
+
+	total := len(out)
+	numPages := (total + perPage - 1) / perPage
+	if numPages < 1 {
+		// The oracle has three sessions, so it cannot say whether real ABS reports 0
+		// or 1 numPages for an empty list. Holding this at 1 leaves the empty case
+		// answering exactly as it always has rather than guessing at a change.
+		numPages = 1
+	}
+
+	start := page * perPage
+	if start > total {
+		start = total
+	}
+	end := start + perPage
+	if end > total {
+		end = total
+	}
+
 	respondJSON(c, http.StatusOK, sessionsResponse{
-		ItemsPerPage: len(out),
-		NumPages:     1,
-		Page:         0,
-		Sessions:     out,
-		Total:        len(out),
+		ItemsPerPage: perPage,
+		NumPages:     numPages,
+		Page:         page,
+		Sessions:     out[start:end],
+		Total:        total,
 	})
 }
 

--- a/todo.d/20260812-bookfile-duration-integer-seconds.md
+++ b/todo.d/20260812-bookfile-duration-integer-seconds.md
@@ -29,29 +29,20 @@
   wrong by more than the known truncation), so this stays visible rather than becoming
   permanently accepted.
 
-- [ ] **`/api/me/sessions` reports `itemsPerPage` as the item count, not the page size.**
-  `internal/server/handlers/abs/me.go:132` sets `ItemsPerPage: len(out)` alongside
-  `NumPages: 1` — the endpoint does not paginate at all. The oracle returns
-  `itemsPerPage=10, total=3, numPages=1`, i.e. the default page size with a short page.
-  The sibling handlers in the same package get this right:
-  `stats.go:108` and `stats.go:133` both use `queryInt(c, "itemsPerPage", 10)`.
+- [ ] **`deviceInfo.deviceType` is always `"unknown"`, and the capture cannot tell us what
+  it should be.** `play.go:307` defaults it to `"unknown"` and then echoes whatever the
+  client sent (`play.go:315`), so a client that supplies `deviceType` is already handled —
+  the gap is only that we never *derive* it. Real ABS derives it from the User-Agent, and
+  the oracle answered `"wearable"` for a request whose body carried only `clientName` and
+  `deviceId`.
 
-  A client computing `numPages = ceil(total / itemsPerPage)` gets the right answer today
-  only by accident, because `total` is also `len(out)`. Any client that trusts
-  `itemsPerPage` as a page size — to decide whether to request a second page — is being
-  told the wrong number.
-
-  Not fixed with the conformance work because the honest fix is either to report the
-  requested page size while still returning everything (self-inconsistent) or to actually
-  paginate the endpoint (a live behaviour change for any user with more sessions than one
-  page). That is a product call, not a test-fixture call. Found by #2337's value gate.
-
-- [ ] **`deviceInfo.deviceType` is always `"unknown"`.** We never derive it from the
-  User-Agent; the oracle capture reported `wearable`. Unlike `ipAddress`/`userAgent` —
-  which the conformance normalizer treats as caller artifacts precisely because
-  `me.go:127` *does* populate them for real — this one is a genuine unimplemented field,
-  so it is named in an allowance rather than normalized away. Low priority; nothing is
-  known to read it.
+  **Blocked on evidence, not effort: 0 of 28 fixtures record request headers at all**, so
+  the User-Agent that produced `"wearable"` is not preserved anywhere. Inferring a
+  UA→deviceType rule from one output with no recorded input is exactly the single-sample
+  mistake that produced the retracted `tagTrack` finding. Unblocking this means teaching
+  the capture harness in `testdata/abs-oracle/` to record request headers and re-capturing;
+  the derivation is then a small, testable mapping. Low priority regardless — nothing in
+  the client contract reads `deviceType`; it is diagnostic, shown in the sessions list.
 
 - [ ] **`publishedYear` loses the era: `Book.PrintYear` is an `int`, so the oracle's
   `"800BC"` comes back `"800"`.** ABS passes the raw date tag through. Same shape of loss


### PR DESCRIPTION
## The bug

`GET /api/me/sessions` set `ItemsPerPage: len(out)` — the number of items on the page rather than the page size — alongside `NumPages: 1`, while not paginating at all.

```
oracle:  itemsPerPage=10  total=3   numPages=1
ours:    itemsPerPage=3   total=3   numPages=1
```

A page size and an item count were indistinguishable, and on an empty result we answered `itemsPerPage: 0` — a divide by zero for any client deriving a page count from it.

## Why paginate rather than just correct the number

Reporting a page size while still returning everything and ignoring `?page=` is a different lie: a client that reads `numPages > 1` and asks for page 1 would be handed the same full list again. The endpoint now honours `?itemsPerPage=` and `?page=`, with the defaults and clamping already used by the sibling handlers at `stats.go:108,133`.

`numPages` is held at a floor of 1 rather than allowed to fall to 0 on an empty list. The oracle has three sessions, so it cannot say which real ABS reports; holding the floor leaves the empty case answering exactly as it always has instead of guessing at a change.

## Verified red first

The conformance allowance for `itemsPerPage` is removed. Restoring `len(out)` fails:

```
--- FAIL: TestSessions_ConformsToFixture
    get_api_me_sessions.json: value_mismatch at itemsPerPage: want 10, got 3
```

Full `internal/server/handlers/abs` package green.

## Also: what the deviceType finding is really blocked on

The filed `deviceInfo.deviceType` item implied the derivation was merely unwritten. It isn't — **0 of 28 fixtures record request headers**, so the User-Agent that made real ABS answer `"wearable"` is preserved nowhere. `play.go:315` already echoes a client-supplied `deviceType`; only the derivation is missing, and inferring a UA→type rule from one output with no recorded input is the same single-sample error as the retracted `tagTrack` finding. The fragment now names the capture-harness change as the prerequisite.

## Not in this PR, and why

`BookFile.Duration` (int seconds), `BookFile.BitrateKbps` (int kbps) and `Book.PrintYear` (int) are one class: each is a schema addition **plus a full-library backfill** against a live ~30k-book production DB, since a new exact field only helps newly-probed files. `probe.go:230` confirms the exact bps exists and is discarded by `int(bps / 1000)`, so the code half is small — the data half is not. The owner already ruled this class "file it, don't fix it here" for `Duration`; these stay filed with bounded allowances so they cannot quietly become accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t