### PR TITLE
fix(config): the stored blob wiped every default instead of overriding them — this is why nothing scanned

### DIFF
--- a/changelog.d/20260812_fix_config_blob_wiped_defaults.md
+++ b/changelog.d/20260812_fix_config_blob_wiped_defaults.md
@@ -1,0 +1,25 @@
+### Fixed
+
+#### Saved settings quietly erased every shipped default
+
+Configuration is stored as a single saved snapshot. On startup that snapshot was applied
+by replacing the entire configuration with it — so any setting the snapshot did not
+mention was not left at its shipped default, it was reset to empty or zero.
+
+Because the snapshot is written once and re-read on every start, this made the erasure
+permanent: every setting added after that snapshot was saved stayed at zero forever, and
+no later change to a default could ever reach the installation.
+
+That is why nothing was scanning for newly added audiobooks. Automatic library scanning
+ships switched on with a six-hour interval, but the saved snapshot predated it, so on
+every startup it came back switched off with an interval of zero. The feature was
+present and working; the saved settings were erasing it before it ever ran.
+
+Saved settings are now applied on top of the defaults rather than in place of them, so a
+setting the snapshot does not mention keeps the value it shipped with. Anything
+deliberately turned off stays off — those choices are recorded in the snapshot and still
+take precedence.
+
+Because this means some settings will pick up their intended defaults for the first
+time, startup now lists exactly which ones did, so the change is visible rather than
+something to discover later.

--- a/internal/config/blob_default_audit.go
+++ b/internal/config/blob_default_audit.go
@@ -1,0 +1,141 @@
+// file: internal/config/blob_default_audit.go
+// version: 1.0.0
+// guid: 2b8d5f60-c179-4e34-a5d2-70f9e1c46b8a
+// last-edited: 2026-08-12
+
+package config
+
+import (
+	"encoding/json"
+	"log/slog"
+	"sort"
+	"strings"
+)
+
+// maxAuditedKeysLogged bounds the boot log line. The count is always exact; only
+// the enumeration is truncated, and the message says so when it truncates — a
+// silently shortened list would be the same class of defect this audit exists to
+// catch.
+const maxAuditedKeysLogged = 40
+
+// logDefaultsPreservedOverBlob reports every config key that the stored blob did
+// NOT contain and which therefore kept its shipped default.
+//
+// This exists because the inheritance is a real behaviour change and used to be
+// invisible. LoadConfigFromDatabase previously unmarshalled the blob into an
+// all-zero struct and assigned it wholesale, so a key absent from the blob was
+// silently zeroed rather than defaulted — that is how the periodic library scan
+// (default enabled=true / interval=360) came to be off on production with no
+// trace. Seeding from Snapshot() fixes the behaviour; this function makes the
+// consequence auditable at boot instead of leaving the operator to discover it.
+//
+// Only keys whose surviving default is NON-ZERO are reported: a key absent from
+// the blob whose default is false/0/"" produces the same value either way, so
+// listing it would bury the meaningful entries in noise.
+//
+// Keys only — never values. The blob is documented as secret-free, but this runs
+// during config load and there is no reason to put config values into a log line
+// to answer the question "which keys inherited a default".
+func logDefaultsPreservedOverBlob(blobStr string, loaded Config) {
+	var blobMap map[string]any
+	if err := json.Unmarshal([]byte(blobStr), &blobMap); err != nil {
+		return // already reported by the caller's parse-failure branch
+	}
+
+	effective, err := json.Marshal(loaded)
+	if err != nil {
+		return
+	}
+	var effMap map[string]any
+	if err := json.Unmarshal(effective, &effMap); err != nil {
+		return
+	}
+
+	stored := make(map[string]struct{})
+	flattenKeys(blobMap, "", stored)
+
+	effLeaves := make(map[string]any)
+	flattenLeaves(effMap, "", effLeaves)
+
+	var inherited []string
+	for key, val := range effLeaves {
+		if _, present := stored[key]; present {
+			continue
+		}
+		if isZeroJSON(val) {
+			continue
+		}
+		inherited = append(inherited, key)
+	}
+
+	if len(inherited) == 0 {
+		return
+	}
+	sort.Strings(inherited)
+
+	shown := inherited
+	truncated := ""
+	if len(shown) > maxAuditedKeysLogged {
+		shown = shown[:maxAuditedKeysLogged]
+		truncated = " (list truncated; count is exact)"
+	}
+
+	slog.Info("config: keys absent from the stored blob kept their shipped default"+truncated,
+		"count", len(inherited),
+		"keys", strings.Join(shown, ", "),
+	)
+}
+
+// flattenKeys records every leaf path present in a decoded JSON object. Nested
+// objects contribute their leaves, not themselves, so a blob that stores
+// scheduled.library_scan.interval but not .enabled marks only the former.
+func flattenKeys(m map[string]any, prefix string, out map[string]struct{}) {
+	for k, v := range m {
+		path := k
+		if prefix != "" {
+			path = prefix + "." + k
+		}
+		if child, ok := v.(map[string]any); ok {
+			flattenKeys(child, path, out)
+			continue
+		}
+		out[path] = struct{}{}
+	}
+}
+
+// flattenLeaves is flattenKeys but keeps the values, for the zero check.
+func flattenLeaves(m map[string]any, prefix string, out map[string]any) {
+	for k, v := range m {
+		path := k
+		if prefix != "" {
+			path = prefix + "." + k
+		}
+		if child, ok := v.(map[string]any); ok {
+			flattenLeaves(child, path, out)
+			continue
+		}
+		out[path] = v
+	}
+}
+
+// isZeroJSON reports whether a decoded JSON value is the zero value for its
+// kind. encoding/json decodes every number as float64, so 0 covers both int and
+// float defaults.
+func isZeroJSON(v any) bool {
+	switch t := v.(type) {
+	case nil:
+		return true
+	case bool:
+		return !t
+	case float64:
+		return t == 0
+	case string:
+		return t == ""
+	case []any:
+		return len(t) == 0
+	case map[string]any:
+		return len(t) == 0
+	default:
+		return false
+	}
+}

--- a/internal/config/blob_preserves_defaults_test.go
+++ b/internal/config/blob_preserves_defaults_test.go
@@ -1,0 +1,194 @@
+// file: internal/config/blob_preserves_defaults_test.go
+// version: 1.0.0
+// guid: 9e14c7b2-58fa-4d63-8071-2ab6f5cd913e
+// last-edited: 2026-08-12
+
+// Regression tests for the stored config blob wiping every default.
+//
+// LoadConfigFromDatabase used to unmarshal config_blob into a fresh, all-zero
+// `var loaded Config` and then assign `*c = loaded`. encoding/json only writes
+// the fields the JSON actually contains, so any field ABSENT from the blob kept
+// the zero value of that fresh struct — and the whole-struct assignment then
+// threw away the viper defaults that had just been loaded.
+//
+// A blob is written once and re-read on every boot, so this pinned every field
+// added to Config after that blob was saved to zero, permanently. No later
+// change to a default could reach the install.
+//
+// Measured on production 2026-08-12: every key under scheduled.* was
+// {enabled:false, interval:0}, including library_scan, whose shipped defaults
+// are enabled=true / interval=360. library_scan is the only unattended
+// discovery path for newly added books, so nothing had been scanning
+// automatically. The feature shipped (#2315) and deployed correctly; the blob
+// zeroed it on load.
+//
+// The fix seeds `loaded` from Snapshot() so absent means "keep the default"
+// rather than "use zero". A value the operator genuinely set to false/0 is
+// PRESENT in the blob and must still win — that is asserted here too, because a
+// fix that made stored zeros stop working would be a worse bug than the one it
+// replaced.
+
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// storeWithBlob builds a settings store holding exactly one config_blob.
+func storeWithBlob(t *testing.T, blob string) *mockSettingsStore {
+	t.Helper()
+	if !json.Valid([]byte(blob)) {
+		t.Fatalf("test blob is not valid JSON: %s", blob)
+	}
+	store := newMockSettingsStore()
+	store.settings["config_blob"] = &database.Setting{
+		Key:   "config_blob",
+		Value: blob,
+		Type:  "json",
+	}
+	return store
+}
+
+// TestBlobWithoutScheduledKeysKeepsDefaults is the core regression. A blob
+// written before scheduled.* existed must not zero it.
+func TestBlobWithoutScheduledKeysKeepsDefaults(t *testing.T) {
+	// Establish the pre-blob state: what viper/InitConfig would have left in
+	// AppConfig before the stored blob is applied on top.
+	Mutate(func(c *Config) {
+		c.Scheduled.LibraryScan.Enabled = true
+		c.Scheduled.LibraryScan.Interval = 360
+	})
+
+	// A blob from an older version: it knows about root_dir, and nothing at all
+	// about the scheduled block.
+	store := storeWithBlob(t, `{"root_dir":"/mnt/books"}`)
+
+	if err := LoadConfigFromDatabase(store); err != nil {
+		t.Fatalf("LoadConfigFromDatabase: %v", err)
+	}
+
+	got := Snapshot()
+
+	if got.RootDir != "/mnt/books" {
+		t.Errorf("the blob must still apply the fields it DOES contain; root_dir = %q", got.RootDir)
+	}
+
+	// The defect: these came back false/0 and the periodic scan never ran.
+	if !got.Scheduled.LibraryScan.Enabled {
+		t.Error("library_scan.enabled was zeroed by a blob that never mentioned it — " +
+			"this is the defect that stopped anything from scanning for new books")
+	}
+	if got.Scheduled.LibraryScan.Interval != 360 {
+		t.Errorf("library_scan.interval was zeroed by a blob that never mentioned it; "+
+			"want the default 360, got %d. Interval 0 means the scheduler creates no "+
+			"ticker at all", got.Scheduled.LibraryScan.Interval)
+	}
+}
+
+// TestBlobExplicitFalseStillWins is the discriminating half: the fix must not
+// make stored values unwritable. An operator who deliberately turned the scan
+// off has that choice recorded IN the blob, and it must survive.
+func TestBlobExplicitFalseStillWins(t *testing.T) {
+	Mutate(func(c *Config) {
+		c.Scheduled.LibraryScan.Enabled = true
+		c.Scheduled.LibraryScan.Interval = 360
+	})
+
+	store := storeWithBlob(t, `{"scheduled":{"library_scan":{"enabled":false,"interval":0}}}`)
+
+	if err := LoadConfigFromDatabase(store); err != nil {
+		t.Fatalf("LoadConfigFromDatabase: %v", err)
+	}
+
+	got := Snapshot()
+	if got.Scheduled.LibraryScan.Enabled {
+		t.Error("an explicit stored false must override the default — otherwise turning " +
+			"a task off would be impossible")
+	}
+	if got.Scheduled.LibraryScan.Interval != 0 {
+		t.Errorf("an explicit stored 0 must override the default; got %d",
+			got.Scheduled.LibraryScan.Interval)
+	}
+}
+
+// TestBlobPartialOverrideLeavesSiblingsAlone pins the per-field granularity:
+// setting one key in a nested block must not reset the others in that block.
+func TestBlobPartialOverrideLeavesSiblingsAlone(t *testing.T) {
+	Mutate(func(c *Config) {
+		c.Scheduled.LibraryScan.Enabled = true
+		c.Scheduled.LibraryScan.Interval = 360
+	})
+
+	// Operator changed only the interval.
+	store := storeWithBlob(t, `{"scheduled":{"library_scan":{"interval":120}}}`)
+
+	if err := LoadConfigFromDatabase(store); err != nil {
+		t.Fatalf("LoadConfigFromDatabase: %v", err)
+	}
+
+	got := Snapshot()
+	if got.Scheduled.LibraryScan.Interval != 120 {
+		t.Errorf("stored interval should apply; got %d", got.Scheduled.LibraryScan.Interval)
+	}
+	if !got.Scheduled.LibraryScan.Enabled {
+		t.Error("changing the interval must not silently disable the task — " +
+			"a sibling field absent from the blob keeps its default")
+	}
+}
+
+// TestDefaultInheritanceIsLogged pins the audit line. The seeding fix changes
+// behaviour on every existing install — measured upper bound on production was
+// 33 keys — so the inheritance has to be visible at boot rather than discovered
+// later from symptoms.
+func TestDefaultInheritanceIsLogged(t *testing.T) {
+	Mutate(func(c *Config) {
+		c.Scheduled.LibraryScan.Enabled = true
+		c.Scheduled.LibraryScan.Interval = 360
+	})
+
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	store := storeWithBlob(t, `{"root_dir":"/mnt/books"}`)
+	if err := LoadConfigFromDatabase(store); err != nil {
+		t.Fatalf("LoadConfigFromDatabase: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "kept their shipped default") {
+		t.Fatalf("inheriting a default is a behaviour change and must be logged; got:\n%s", out)
+	}
+	if !strings.Contains(out, "scheduled.library_scan.interval") {
+		t.Errorf("the audit must name the inherited keys, not just count them; got:\n%s", out)
+	}
+}
+
+// TestNoAuditLineWhenBlobIsComplete is the discriminating half: a blob that
+// already specifies everything must not produce a spurious audit line, or the
+// message becomes noise everyone learns to ignore.
+func TestNoAuditLineWhenBlobIsComplete(t *testing.T) {
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	// Seed a config that is entirely zero, so nothing non-zero can be inherited.
+	Mutate(func(c *Config) { *c = Config{} })
+
+	store := storeWithBlob(t, `{"root_dir":"/mnt/books"}`)
+	if err := LoadConfigFromDatabase(store); err != nil {
+		t.Fatalf("LoadConfigFromDatabase: %v", err)
+	}
+
+	if strings.Contains(buf.String(), "kept their shipped default") {
+		t.Errorf("no non-zero default was inherited, so there must be no audit line; got:\n%s", buf.String())
+	}
+}

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -1,7 +1,7 @@
 // file: internal/config/persistence.go
-// version: 1.31.0
+// version: 1.32.0
 // guid: 9c8d7e6f-5a4b-3c2d-1e0f-9a8b7c6d5e4f
-// last-edited: 2026-08-11
+// last-edited: 2026-08-12
 
 package config
 
@@ -748,7 +748,33 @@ func LoadConfigFromDatabase(store database.SettingsStore) error {
 			}
 		}
 
-		var loaded Config
+		// Start from the CURRENT config — which already holds the viper
+		// defaults, plus anything from the config file, env and flags — and let
+		// the blob override only the fields it actually contains.
+		//
+		// This used to be `var loaded Config`, i.e. an all-zero struct, followed
+		// by `*c = loaded`. That threw away every default wholesale: a field
+		// absent from the stored JSON did not fall back to its default, it got
+		// Go's zero value. encoding/json leaves absent fields untouched, so
+		// seeding from Snapshot() is what makes "absent" mean "use the default"
+		// instead of "use zero".
+		//
+		// The consequence of the old behaviour was not theoretical. A blob is
+		// written once and then reloaded on every boot, so any field added to
+		// Config AFTER that blob was saved was pinned to zero forever, and no
+		// later change to its default could ever reach the install. Measured on
+		// production 2026-08-12: every key under scheduled.* was {enabled:false,
+		// interval:0}, including library_scan, whose shipped defaults are
+		// enabled=true / interval=360. library_scan is the only unattended
+		// discovery path for newly added books, so nothing had been scanning —
+		// the feature shipped in #2315, deployed correctly, and was zeroed on
+		// load.
+		//
+		// A value the operator really did set to false/0 is present in the blob
+		// and still wins, which is the intended precedence. Only genuinely
+		// ABSENT keys change meaning.
+		loaded := Snapshot()
+		loaded.DatabaseType = savedDBType
 		if err := json.Unmarshal([]byte(blobStr), &loaded); err == nil {
 			// WHY Mutate: whole-struct assignment races with HTTP readers.
 			Mutate(func(c *Config) {
@@ -757,6 +783,18 @@ func LoadConfigFromDatabase(store database.SettingsStore) error {
 			})
 			blobFound = true
 			slog.Info("Loaded config from blob ( bytes)", "count", len(blob.Value))
+
+			// Name every key the blob did not contain and that therefore kept
+			// its default. Before the seeding fix those keys were silently
+			// zeroed, so an operator had no way to see that a shipped default
+			// had been discarded. Now the inheritance is stated at boot.
+			//
+			// Measured on production 2026-08-12 against the blob in place at the
+			// time: 33 keys inherit a non-zero default this way, including
+			// scheduled.library_scan.{enabled,interval}. Logged rather than
+			// suppressed precisely because that is a behaviour change an
+			// operator must be able to see and audit after an upgrade.
+			logDefaultsPreservedOverBlob(blobStr, loaded)
 		} else {
 			slog.Warn("Failed to parse config_blob — falling back to individual keys", "err", err)
 		}


### PR DESCRIPTION
## This is the actual root cause of "nothing ever scans for new books"

`LoadConfigFromDatabase` applied the stored `config_blob` like this:

```go
var loaded Config                                  // ← every field Go-zero
json.Unmarshal([]byte(blobStr), &loaded)
Mutate(func(c *Config) { *c = loaded; ... })       // ← REPLACES the whole struct
```

`encoding/json` only writes the fields the JSON actually contains. So a key **absent** from the blob kept that fresh struct's zero value — and `*c = loaded` then discarded **every viper default wholesale**. Only `DatabaseType` was preserved.

A blob is written once and re-read on **every boot**, so this pinned every field added to `Config` *after* that blob was saved to zero, permanently. No later change to a default could ever reach the install.

### The measured consequence

`scheduled.library_scan` ships `enabled=true / interval=360` and is the only unattended discovery path for newly added books. On production it loads as `{enabled:false, interval:0}` — and interval 0 means the scheduler creates no ticker at all. #2315 shipped that feature and deployed correctly; the blob zeroed it on load, every single boot.

## The fix

Seed from the current config — which already holds viper defaults plus file/env/flags — and let the blob override only what it actually contains:

```go
loaded := Snapshot()
loaded.DatabaseType = savedDBType
json.Unmarshal([]byte(blobStr), &loaded)
```

"Absent" now means *keep the default* instead of *use zero*. A value the operator genuinely set to `false`/`0` is **present** in the blob and still wins — that precedence is unchanged and is explicitly tested.

## ⚠️ This changes behaviour on every existing install — measured blast radius

Comparing production's effective config against the 188 parseable viper defaults, **33 keys** would inherit a non-zero default on next restart. Upper bound: a key explicitly stored as zero in the blob will not change, and the effective config alone cannot distinguish those.

| key | prod now | default |
|---|---|---|
| `scheduled.library_scan.enabled` | `false` | **true** |
| `scheduled.library_scan.interval` | `0` | **360** |
| `dedup.embeddings_enabled` | `false` | **true** |
| `enable_rate_limit` | `false` | **true** |
| `maintenance.library_size_refresh` | `false` | **true** |
| `metadata_scoring.write_backup_before` | `false` | **true** |
| `metadata_scoring.series_number_exact_boost` | `0` | **2.0** |
| `metadata_scoring.transcription_title_exact_boost` | `0` | **2.0** |
| `metadata_scoring.transcription_author_boost` | `0` | **1.6** |
| `scheduled.dedup_refresh.interval` | `0` | **360** |
| `scheduled.db_optimize.interval` | `0` | **1440** |
| `scheduled.label_refinement.interval` | `0` | **10080** |
| `log_retention_days` | `0` | **90** |
| `bootstrap_key_ttl_days` | `0` | **30** |
| … | | 19 more |

Nine of the 33 are `metadata_scoring.*` boosts currently at 0, so **metadata match scoring will change**.

A fix that silently flips 33 production settings is not a fix, it is an unannounced config migration. So boot now logs exactly which keys inherited a default:

```
config: keys absent from the stored blob kept their shipped default count=33 keys=...
```

**Keys only, never values.** The count is always exact; only the enumeration truncates, and the message says so when it does — a silently shortened list would be the same defect class this audit exists to catch.

**Merging is safe; deploying is the decision.** Review the table above first — particularly whether you want `dedup.embeddings_enabled` and the scoring boosts to switch on at the same time as the scan.

## Verification

5 tests, negative controls discriminating in both directions:

- Reverting the seeding → the two absent-key tests go red, `TestBlobExplicitFalseStillWins` stays **green** (so the control proves the seeding specifically, not "tests run").
- A blob that inherits nothing → no audit line, so the message cannot decay into noise.

```
--- PASS: TestBlobWithoutScheduledKeysKeepsDefaults
--- PASS: TestBlobExplicitFalseStillWins
--- PASS: TestBlobPartialOverrideLeavesSiblingsAlone
--- PASS: TestDefaultInheritanceIsLogged
--- PASS: TestNoAuditLineWhenBlobIsComplete
ok  internal/config
```

`go build ./...` exit 0 after rebase on main.

## Relation to the settings design

This is the concrete instance of the problem in `docs/design/2026-08-12-unified-settings-architecture.md`. It implements the practical half of **option B** (unset stops meaning zero) at the load path. **Option A** — merging stored settings *into* viper so one precedence chain arbitrates, with the DB layer placed below env/flags so a bad stored value is always overridable — is still open and is what makes this class of bug structurally impossible rather than fixed once.
