### PR TITLE
fix(acoustid): gate the OOM-implicated backfill behind a flag that is actually read

### DIFF
--- a/changelog.d/20260812-acoustid-backfill-gate.md
+++ b/changelog.d/20260812-acoustid-backfill-gate.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- The nightly AcoustID fingerprint backfill is now gated behind
+  `maintenance.acoustid_backfill`, **default off**. Its load phase pulls the entire
+  book table into memory before it can start — roughly 862 MB of live heap in
+  production, implicated in three OOM kills in one night. Both automatic triggers
+  respect the flag: the unconditional enqueue at server startup, and the
+  `acoustid-backfill` child of the `library.optimize` sweep. Enqueuing the op
+  directly through the ops API is unchanged, so the deliberate opt-in path still
+  works.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,7 @@
 // file: internal/config/config.go
-// version: 1.75.1
+// version: 1.76.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
-// last-edited: 2026-08-11
+// last-edited: 2026-08-12
 
 package config
 
@@ -273,6 +273,10 @@ type MaintenanceConfig struct {
 	LibrarySizeRefresh   bool `json:"library_size_refresh"   mapstructure:"library_size_refresh"`
 	AcoustIDOnlineLookup bool `json:"acoustid_online_lookup" mapstructure:"acoustid_online_lookup"`
 	AcoustIDNightlyLimit int  `json:"acoustid_nightly_limit" mapstructure:"acoustid_nightly_limit"`
+	// AcoustIDBackfill gates the nightly acoustid.backfill op (local fpcalc/
+	// ffmpeg fingerprint generation). OFF by default — see the SetDefault
+	// comment for why.
+	AcoustIDBackfill bool `json:"acoustid_backfill" mapstructure:"acoustid_backfill"`
 }
 
 // MetadataScoringConfig holds settings for the AI-assisted metadata scoring pipeline.
@@ -1190,12 +1194,19 @@ func InitConfig() {
 	// AcoustID online lookup is OFF by default — uses third-party quota
 	viper.SetDefault("maintenance.acoustid_online_lookup", false)
 	viper.SetDefault("maintenance.acoustid_nightly_limit", 5000)
+	// AcoustID (local) fingerprint backfill is OFF by default as of 2026-08-11.
+	// The nightly op spawns fpcalc/ffmpeg per book file and loads the entire
+	// book table into memory before it can start; in production it held ~862 MB
+	// of live heap and was implicated in three OOM kills in one night. Opt in
+	// deliberately once the memory profile of the load phase is fixed.
+	viper.SetDefault("maintenance.acoustid_backfill", false)
 	// BindEnv maps env vars so MAINTENANCE_ENABLED etc. override even without AutomaticEnv.
 	viper.BindEnv("maintenance.enabled", "MAINTENANCE_ENABLED")                               //nolint:errcheck
 	viper.BindEnv("maintenance.window_start", "MAINTENANCE_WINDOW_START")                     //nolint:errcheck
 	viper.BindEnv("maintenance.window_end", "MAINTENANCE_WINDOW_END")                         //nolint:errcheck
 	viper.BindEnv("maintenance.acoustid_online_lookup", "MAINTENANCE_ACOUSTID_ONLINE_LOOKUP") //nolint:errcheck
 	viper.BindEnv("maintenance.acoustid_nightly_limit", "MAINTENANCE_ACOUSTID_NIGHTLY_LIMIT") //nolint:errcheck
+	viper.BindEnv("maintenance.acoustid_backfill", "MAINTENANCE_ACOUSTID_BACKFILL")           //nolint:errcheck
 
 	// Download client defaults
 	viper.SetDefault("download_client.torrent.type", "")

--- a/internal/plugins/maintenance/optimize.go
+++ b/internal/plugins/maintenance/optimize.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/optimize.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: d4e5f6a7-b8c9-0123-4567-890123456789
-// last-edited: 2026-07-12
+// last-edited: 2026-08-12
 
 package maintenance
 
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/logging"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
@@ -80,6 +81,31 @@ func (p *Plugin) runOptimize(ctx context.Context, _ json.RawMessage, reporter sd
 			defID:  "acoustid.backfill",
 			params: nil,
 		},
+	}
+
+	// maintenance.acoustid_backfill (default OFF as of 2026-08-11): the backfill's load
+	// phase pulls the whole book table into memory before it can start — ~862 MB of live
+	// heap in production, implicated in three OOM kills in one night. optimize is a broad
+	// "tidy everything" sweep rather than a request for this specific op, so it is an
+	// automatic trigger for the purposes of the flag and respects it. A direct
+	// EnqueueOp("acoustid.backfill") via the ops API stays ungated — that is the
+	// deliberate opt-in path. Filtering here rather than skipping mid-loop keeps `total`
+	// honest, so progress does not report a child it never intended to run.
+	if !config.AppConfig.Maintenance.AcoustIDBackfill {
+		kept := make([]childOp, 0, len(children))
+		for _, ch := range children {
+			if ch.defID == "acoustid.backfill" {
+				logging.Info(ctx, "library.optimize: acoustid-backfill excluded",
+					"operation_id", opID,
+					"reason", "maintenance.acoustid_backfill=false",
+				)
+				_ = reporter.Log(slog.LevelInfo,
+					"Skipping acoustid-backfill: disabled by maintenance.acoustid_backfill")
+				continue
+			}
+			kept = append(kept, ch)
+		}
+		children = kept
 	}
 
 	total := len(children)

--- a/internal/plugins/maintenance/optimize_backfill_gate_test.go
+++ b/internal/plugins/maintenance/optimize_backfill_gate_test.go
@@ -1,0 +1,101 @@
+// file: internal/plugins/maintenance/optimize_backfill_gate_test.go
+// version: 1.0.0
+// guid: 8e3a1c96-5b70-4d2f-9a41-c7f0d6b28e53
+// last-edited: 2026-08-12
+
+package maintenance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+)
+
+// optimizeGateDeps records which child ops the optimize sweep actually enqueues.
+// Named for this test specifically so it cannot collide with the shared fakeDeps.
+type optimizeGateDeps struct {
+	fakeDeps
+	enqueued []string
+}
+
+func (d *optimizeGateDeps) EnqueueOp(_ context.Context, defID string, _ any) (string, error) {
+	d.enqueued = append(d.enqueued, defID)
+	return "child-" + defID, nil
+}
+
+// The whole point of maintenance.acoustid_backfill is that the op's load phase pulls the
+// full book table into memory (~862 MB live heap in production, three OOM kills in one
+// night). A flag that is declared and defaulted but never read would report "backfill
+// disabled" while the sweep kept firing it — so this asserts on what was ENQUEUED, not on
+// the flag's value.
+func TestOptimize_AcoustIDBackfillRespectsTheFlag(t *testing.T) {
+	prev := config.AppConfig.Maintenance.AcoustIDBackfill
+	t.Cleanup(func() { config.AppConfig.Maintenance.AcoustIDBackfill = prev })
+
+	run := func(t *testing.T, enabled bool) (*optimizeGateDeps, *fakeReporter) {
+		t.Helper()
+		config.AppConfig.Maintenance.AcoustIDBackfill = enabled
+		deps := &optimizeGateDeps{}
+		rep := &fakeReporter{}
+		if err := New(deps).runOptimize(context.Background(), nil, rep); err != nil {
+			t.Fatalf("runOptimize: %v", err)
+		}
+		return deps, rep
+	}
+
+	contains := func(hay []string, needle string) bool {
+		for _, s := range hay {
+			if s == needle {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("disabled excludes the child", func(t *testing.T) {
+		deps, rep := run(t, false)
+		if contains(deps.enqueued, "acoustid.backfill") {
+			t.Fatalf("acoustid.backfill was enqueued with the flag OFF: %v", deps.enqueued)
+		}
+		// The other children must still run — this gates one op, it does not disable the sweep.
+		for _, want := range []string{"maintenance.temp-file-cleanup", "acoustid.fingerprint-rescan", "acoustid.scan"} {
+			if !contains(deps.enqueued, want) {
+				t.Errorf("%s should still run with the backfill gated off, got %v", want, deps.enqueued)
+			}
+		}
+		// A silent exclusion is the failure mode this whole track is about.
+		var announced bool
+		for _, msg := range rep.logs {
+			if strings.Contains(msg, "acoustid-backfill") && strings.Contains(msg, "Skipping") {
+				announced = true
+			}
+		}
+		if !announced {
+			t.Errorf("the exclusion must be reported to the operator, got logs %v", rep.logs)
+		}
+		// Progress totals must not count a child that was never going to run.
+		for _, msg := range rep.logs {
+			if strings.Contains(msg, "/4:") {
+				t.Errorf("progress still counts 4 children after excluding one: %q", msg)
+			}
+		}
+	})
+
+	t.Run("enabled includes the child", func(t *testing.T) {
+		deps, _ := run(t, true)
+		if !contains(deps.enqueued, "acoustid.backfill") {
+			t.Fatalf("acoustid.backfill must run with the flag ON, got %v", deps.enqueued)
+		}
+	})
+}
+
+// The default is the safety property: a fresh install must not fingerprint the whole
+// library on boot.
+func TestAcoustIDBackfillDefaultsOff(t *testing.T) {
+	var c config.MaintenanceConfig
+	if c.AcoustIDBackfill {
+		t.Fatal("zero value must be false")
+	}
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -995,8 +995,19 @@ func (s *Server) startBackfills() {
 	// that already have a fingerprint) and runs in the registry's own worker
 	// pool, so this is fire-and-forget — no bgWG enrollment (the op's lifecycle
 	// is owned by opRegistry, not the backfill WaitGroup).
+	// Gated by maintenance.acoustid_backfill (default OFF as of 2026-08-11): the op's
+	// load phase pulls the whole book table into memory before it starts and held
+	// ~862 MB of live heap in production, implicated in three OOM kills in one night.
+	// The startup enqueue is automatic and unattended, so it is the trigger that must
+	// respect the flag. A direct EnqueueOp("acoustid.backfill") via the ops API stays
+	// ungated — that is the deliberate opt-in path.
 	go func() {
 		if err := s.bgCtx.Err(); err != nil {
+			return
+		}
+		if !config.AppConfig.Maintenance.AcoustIDBackfill {
+			slog.Info("startup: acoustid.backfill skipped (maintenance.acoustid_backfill=false)",
+				"reason", "load phase holds the full book table in memory; see config.go")
 			return
 		}
 		if _, err := s.opRegistry.EnqueueOp(s.bgCtx, "acoustid.backfill", nil); err != nil {


### PR DESCRIPTION
## What

The nightly `acoustid.backfill` op loads the **entire book table into memory** before it can start. In production that held ~862 MB of live heap and was implicated in **three OOM kills in one night**. It is now gated behind `maintenance.acoustid_backfill`, default **off**.

## The part that mattered

The config field, its `SetDefault` and its `BindEnv` already existed as uncommitted work in a worktree — but **nothing anywhere read the value**:

```
$ grep -rn "AcoustIDBackfill" --include='*.go' . | grep -v _test
internal/config/config.go:279   AcoustIDBackfill bool `json:"acoustid_backfill" ...`
internal/config/config.go:1202  viper.SetDefault("maintenance.acoustid_backfill", false)
internal/config/config.go:1209  viper.BindEnv("maintenance.acoustid_backfill", ...)
```

Three declarations, zero reads. Shipped as-is that is a knob reading "backfill disabled" while the backfill keeps running — worse than no flag, because it stops anyone looking further.

## Both automatic triggers are gated

This is the part that needed enumerating rather than assuming:

| trigger | file | gated |
|---|---|---|
| unconditional enqueue on every boot | `internal/server/server_lifecycle.go` | ✅ |
| `acoustid-backfill` child of `library.optimize` | `internal/plugins/maintenance/optimize.go` | ✅ |
| direct `EnqueueOp("acoustid.backfill")` via ops API | — | ❌ by design |

Gating only the startup path would have left `optimize` firing the same 862 MB load phase while the flag claimed otherwise. The direct ops-API enqueue stays ungated deliberately: an operator asking for the op *by name* is not the unattended case this protects against, and removing that would leave no opt-in path at all.

`optimize` **filters** the child out of the list rather than skipping it mid-loop, so `total` stays honest and progress does not count a child it never intended to run. The exclusion is logged to the operator rather than silent.

## Verification

The test asserts on **what gets enqueued**, not on the flag's value — a flag-value test would have passed against the dead version. Confirmed by deleting the gate and re-running:

```
--- FAIL: TestOptimize_AcoustIDBackfillRespectsTheFlag/disabled_excludes_the_child
    acoustid.backfill was enqueued with the flag OFF:
    [maintenance.temp-file-cleanup acoustid.fingerprint-rescan acoustid.scan acoustid.backfill]
```

It also checks that the other three children still run (this gates one op, it does not disable the sweep), that the exclusion is announced, and that progress no longer reports `/4:`.

## Deployment note

Default-off means **production stops auto-fingerprinting at boot** once this ships. That is the intended trade against the OOM kills, but it is a behaviour change worth knowing before deploy: fingerprint coverage will only advance when someone opts in via `MAINTENANCE_ACOUSTID_BACKFILL=true` or runs the op directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t