### PR TITLE
chore(lint): wave 0 of the silent-failure sweep — errcheck config and primitives

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,124 @@
+# file: .golangci.yml
+# version: 1.0.0
+# guid: 8d2a1f47-6c93-4b0e-a15d-7f3e28c9b604
+# last-edited: 2026-08-11
+
+# Wave 0 of the silent-failure sweep.
+# See docs/audits/2026-08-11-silent-failure-error-discards.md
+#
+# Scope: this file enables EXACTLY ONE linter (errcheck). It is deliberately
+# not a general-purpose lint config — `linters.default: none` keeps the
+# reported number an errcheck number, so the before/after counts in the Wave 0
+# PR stay attributable. Adding more linters here is a separate decision.
+#
+# WHY check-blank IS ON:
+#   errcheck's default ignores `_ = f()`. That single form is 100% of the
+#   1,125 statement-position discards the audit measured, i.e. every silent
+#   failure waves 4-13 exist to fix. Without check-blank this linter is inert
+#   for its entire purpose. It is on, and that is the point of the file.
+#
+# WHY THERE IS AN EXCLUDE LIST:
+#   Un-exempted, this config reports 2,326 findings. 54% of the audit's
+#   population is progress/log reporting whose only failure mode is "the
+#   progress bar didn't update" — handling it would mean logging about a
+#   failure to log. A linter that reports 2,326 findings gets switched off by
+#   whoever sees it next, so bucket (f) is exempted BY NAME, before the linter
+#   was ever wired up.
+#
+# HOW TO ADD AN EXEMPTION:
+#   errcheck matches the FULLY-QUALIFIED name (`(module/path.Type).Method`),
+#   never the variable name at the call site. `reporter.Log` as written below
+#   would silently match nothing. Always confirm a new entry by delta: run
+#   `make lint-errcheck-full`, add the line, re-run, and check the count
+#   actually dropped. A non-matching pattern is indistinguishable from a
+#   matching one if you only measure once.
+
+version: "2"
+
+run:
+  # The audit's population is non-test files. Test files have their own
+  # error-handling conventions and are out of scope for the sweep.
+  tests: false
+  timeout: 15m
+
+linters:
+  default: none
+  enable:
+    - errcheck
+
+  settings:
+    errcheck:
+      # See "WHY check-blank IS ON" above. Do not turn this off.
+      check-blank: true
+      # Type assertions are a different defect class; not part of this sweep.
+      check-type-assertions: false
+
+      exclude-functions:
+        # ---------------------------------------------------------------
+        # Bucket (f): progress / log reporting.
+        # Audit: 606 of 1,125 statement-position discards (53.9%).
+        # Only failure mode is a missed progress-bar tick.
+        # sdk.Reporter is a type ALIAS for registry.Reporter, so the two
+        # entries below cover the plugin SDK as well.
+        # ---------------------------------------------------------------
+        - (github.com/falkcorp/audiobook-organizer/internal/operations/registry.Reporter).Log
+        - (github.com/falkcorp/audiobook-organizer/internal/operations/registry.Reporter).UpdateProgress
+        - (github.com/falkcorp/audiobook-organizer/internal/operations.ProgressReporter).Log
+        - (github.com/falkcorp/audiobook-organizer/internal/operations.ProgressReporter).UpdateProgress
+        - (github.com/falkcorp/audiobook-organizer/internal/dedup.ProgressReporter).Log
+        - (github.com/falkcorp/audiobook-organizer/internal/dedup.ProgressReporter).UpdateProgress
+        # Concrete adapters that wrap a Reporter; same benign shape.
+        - (github.com/falkcorp/audiobook-organizer/internal/scheduler.extraOpsProgressAdapter).Log
+        - (github.com/falkcorp/audiobook-organizer/internal/scheduler.extraOpsProgressAdapter).UpdateProgress
+        - (github.com/falkcorp/audiobook-organizer/internal/server.registryProgressAdapter).Log
+        - (github.com/falkcorp/audiobook-organizer/internal/server.registryProgressAdapter).UpdateProgress
+
+        # ---------------------------------------------------------------
+        # Bucket (f): Close on READ handles and iterators.
+        #
+        # ⚠️ DELIBERATELY NOT EXEMPTED: (*os.File).Close, and any
+        # gzip/zip/bufio writer Close. A Close error on a handle you just
+        # WROTE is exactly where a delayed-write failure surfaces — the
+        # audit flags this and did not classify the 54 Close sites into
+        # read vs write. errcheck cannot express "read handle", so the
+        # split below is by TYPE: types that can only be read or whose
+        # Close is a pure resource release are exempt; file writers are
+        # left visible on purpose and are a candidate for a later wave.
+        # ---------------------------------------------------------------
+        - (io.Closer).Close
+        - (io.ReadCloser).Close
+        - (net.Conn).Close
+        - (net.Listener).Close
+        # Pebble iterators are read handles. Pebble Batch.Close is a resource
+        # release — per the audit, the error that actually matters on a batch
+        # is on Commit, which is NOT exempted.
+        - (*github.com/cockroachdb/pebble/v2.Iterator).Close
+        - (*github.com/cockroachdb/pebble/v2.Batch).Close
+        - (*github.com/cockroachdb/pebble/v2.Snapshot).Close
+
+        # ---------------------------------------------------------------
+        # Bucket (f): HTTP response writes. A failed response write means
+        # the client disconnected; there is nobody left to tell.
+        # ---------------------------------------------------------------
+        - (*encoding/json.Encoder).Encode
+
+        # ---------------------------------------------------------------
+        # Bucket (f): temp-file cleanup.
+        # Caveat from the audit: internal/itunes/itl_safe_write.go removes a
+        # staged .itl.new on a rejected write. A leaked .itl.new next to a
+        # live library is confusing but not destructive (rated 🟢 Low), so it
+        # rides along with this exemption rather than blocking Wave 0.
+        # ---------------------------------------------------------------
+        - os.Remove
+        - os.RemoveAll
+
+  exclusions:
+    generated: lax
+    paths:
+      - web/
+
+issues:
+  # Report every finding. Defaults cap at 50/linter and 3/identical, which
+  # would make the before/after counts meaningless.
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # file: Makefile
-# version: 2.16.0
+# version: 2.17.0
 # guid: c1d2e3f4-g5h6-7890-ijkl-m1234567890n
-# last-edited: 2026-08-10
+# last-edited: 2026-08-12
 
 BINARY := audiobook-organizer
 ROOT_DIR := $(shell git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -494,3 +494,14 @@ t: test
 c: coverage
 b: build
 v: version
+
+# Wave 0 of the silent-failure sweep. See .golangci.yml for why this enables
+# exactly one linter, and docs/audits/2026-08-11-silent-failure-error-discards.md
+# for the population it measures. Deliberately NOT wired into `make ci`: 922
+# findings is a backlog to burn down over waves 4-13, not a gate to fail on today.
+.PHONY: lint-errcheck lint-errcheck-full
+lint-errcheck: ## Run the Wave 0 errcheck config (exclusions applied)
+	golangci-lint run ./...
+
+lint-errcheck-full: ## Same, with a count — use this to verify a new exclusion actually matched
+	@golangci-lint run ./... 2>&1 | tail -3

--- a/changelog.d/20260812-wave0-errcheck-primitives.md
+++ b/changelog.d/20260812-wave0-errcheck-primitives.md
@@ -1,0 +1,10 @@
+### Added
+
+- Wave 0 of the silent-failure sweep: a single-linter `.golangci.yml` (errcheck with
+  `check-blank: true`, which is the whole point — errcheck's default ignores `_ = f()`,
+  the exact form of every discard the sweep exists to fix), plus `internal/errhandling`
+  providing the two primitives waves 4–13 need: `MustLog` for a deliberate one-off
+  discard that leaves an auditable WARN, and `SkipCounter` for loops that `continue`
+  on error and silently report a wrong denominator. Added `make lint-errcheck` and
+  `make lint-errcheck-full`. Not wired into `make ci` — 922 findings is a backlog to
+  burn down, not a gate to fail on today.

--- a/internal/errhandling/errhandling.go
+++ b/internal/errhandling/errhandling.go
@@ -1,0 +1,146 @@
+// file: internal/errhandling/errhandling.go
+// version: 1.0.0
+// guid: 525ad74d-d188-4d2f-9a1a-7806ac7599fc
+// last-edited: 2026-08-11
+
+// Package errhandling provides the two primitives the silent-failure sweep
+// needs, so that waves 4-13 do not each invent their own.
+//
+// The problem this package exists to solve is documented in
+// docs/audits/2026-08-11-silent-failure-error-discards.md: the backend has
+// ~1,125 statement-position error discards, and the ones that matter are
+// indistinguishable from the ones that don't because BOTH look like `_ = f()`.
+//
+// The two primitives:
+//
+//   - [MustLog] — "we looked at this error and chose to continue." One call
+//     instead of five lines, and crucially it leaves a WARN in the log, so the
+//     discard is auditable after the fact instead of invisible.
+//
+//   - [SkipCounter] — for bucket (d): loops that `continue` on error with no
+//     counter and no log, so the loop reports "processed 4,812" and the
+//     denominator is silently wrong. A SkipCounter makes the skipped count a
+//     first-class number and emits exactly one summary line at loop exit.
+//
+// # Choosing between them
+//
+// Use [MustLog] for a one-off discard. Use [SkipCounter] inside a loop — one
+// MustLog per iteration turns a 300-item skip into 300 log lines, which is its
+// own kind of invisible.
+//
+// # What this package is NOT for
+//
+// It is not a way to keep discarding errors with a clearer conscience. If the
+// error should abort the operation, return it. MustLog is for the case where
+// continuing is genuinely the right call and the only defect is that nobody
+// can tell it happened.
+package errhandling
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// logger holds the slog.Logger used by this package. It is nil until
+// [SetLogger] is called, in which case [activeLogger] falls back to
+// slog.Default().
+//
+// This indirection exists so tests can observe what was logged. A helper whose
+// output cannot be observed cannot be tested — a "does not panic" test would
+// pass with the body deleted.
+var (
+	loggerMu sync.RWMutex
+	logger   *slog.Logger
+)
+
+// SetLogger overrides the logger used by this package and returns a function
+// that restores the previous one. It is intended for tests and for wiring at
+// startup; production code should normally leave it alone and let the package
+// use slog.Default().
+//
+// The returned restore function makes it safe to use with defer:
+//
+//	defer errhandling.SetLogger(testLogger)()
+func SetLogger(l *slog.Logger) (restore func()) {
+	loggerMu.Lock()
+	prev := logger
+	logger = l
+	loggerMu.Unlock()
+	return func() {
+		loggerMu.Lock()
+		logger = prev
+		loggerMu.Unlock()
+	}
+}
+
+// activeLogger returns the logger to use for this call.
+func activeLogger() *slog.Logger {
+	loggerMu.RLock()
+	l := logger
+	loggerMu.RUnlock()
+	if l == nil {
+		return slog.Default()
+	}
+	return l
+}
+
+// MustLog records an error that the caller has deliberately chosen not to
+// propagate. It is a no-op when err is nil, so it is safe to call
+// unconditionally:
+//
+//	errhandling.MustLog(store.SaveCheckpoint(ctx, cp), "checkpoint not saved",
+//	    "op_id", opID)
+//
+// The message should say what the consequence is ("checkpoint not saved"), not
+// what the call was ("SaveCheckpoint failed") — the error already carries the
+// latter. kv is a slog-style alternating key/value list.
+//
+// Logged at WARN. A discard that deserves ERROR is probably not a discard;
+// return the error instead.
+func MustLog(err error, msg string, kv ...any) {
+	MustLogContext(context.Background(), err, msg, kv...)
+}
+
+// MustLogContext is [MustLog] with a context, so the record participates in
+// whatever the active slog handler extracts from it. Prefer this inside code
+// that already has a ctx in scope.
+func MustLogContext(ctx context.Context, err error, msg string, kv ...any) {
+	if err == nil {
+		return
+	}
+	// Parse the caller's key/value list FIRST, then append the error.
+	// Order matters: if the error attr were appended before parsing, a caller
+	// who passed an odd number of kv args would have their dangling key
+	// consume the error as its value — losing the error inside the helper
+	// whose entire job is to not lose the error.
+	attrs := append(toAttrs(kv), slog.Any("error", err))
+	activeLogger().LogAttrs(ctx, slog.LevelWarn, msg, attrs...)
+}
+
+// toAttrs converts a slog-style alternating key/value list into []slog.Attr.
+// A trailing key with no value is preserved as a "!BADKEY" attr rather than
+// dropped, matching slog's own behaviour — losing the operand would hide the
+// very information the caller was trying to record.
+func toAttrs(args []any) []slog.Attr {
+	attrs := make([]slog.Attr, 0, len(args))
+	for i := 0; i < len(args); {
+		switch v := args[i].(type) {
+		case slog.Attr:
+			attrs = append(attrs, v)
+			i++
+		case string:
+			if i+1 < len(args) {
+				attrs = append(attrs, slog.Any(v, args[i+1]))
+				i += 2
+			} else {
+				attrs = append(attrs, slog.String("!BADKEY", v))
+				i++
+			}
+		default:
+			attrs = append(attrs, slog.Any("!BADKEY", v))
+			i++
+		}
+	}
+	return attrs
+}

--- a/internal/errhandling/errhandling_test.go
+++ b/internal/errhandling/errhandling_test.go
@@ -1,0 +1,162 @@
+// file: internal/errhandling/errhandling_test.go
+// version: 1.0.0
+// guid: 21b860a5-1a53-4ed1-8cc2-d62c8862bea9
+// last-edited: 2026-08-11
+
+package errhandling
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// captureLogs installs a JSON logger over a buffer and returns a function that
+// decodes whatever was written. Tests assert on the DECODED RECORDS, not on
+// "it didn't panic" — a test that cannot see the output would pass with the
+// function body deleted.
+func captureLogs(t *testing.T) func() []map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	restore := SetLogger(slog.New(h))
+	t.Cleanup(restore)
+
+	return func() []map[string]any {
+		t.Helper()
+		var out []map[string]any
+		for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+			if line == "" {
+				continue
+			}
+			var rec map[string]any
+			if err := json.Unmarshal([]byte(line), &rec); err != nil {
+				t.Fatalf("undecodable log line %q: %v", line, err)
+			}
+			out = append(out, rec)
+		}
+		return out
+	}
+}
+
+func TestMustLog_NilErrorIsNoOp(t *testing.T) {
+	// Every wave will call MustLog unconditionally on a call that usually
+	// succeeds. If nil produced a log line, the sweep would bury production
+	// logs in noise — this is the most likely real-world bug in the helper.
+	records := captureLogs(t)
+
+	MustLog(nil, "should not appear", "key", "value")
+
+	if got := records(); len(got) != 0 {
+		t.Fatalf("MustLog(nil) emitted %d record(s), want 0: %v", len(got), got)
+	}
+}
+
+func TestMustLog_LogsErrorAtWarnWithFields(t *testing.T) {
+	records := captureLogs(t)
+	sentinel := errors.New("disk on fire")
+
+	MustLog(sentinel, "checkpoint not saved", "op_id", "op-123", "attempt", 2)
+
+	got := records()
+	if len(got) != 1 {
+		t.Fatalf("got %d records, want exactly 1: %v", len(got), got)
+	}
+	rec := got[0]
+
+	if rec["level"] != "WARN" {
+		t.Errorf("level = %v, want WARN", rec["level"])
+	}
+	if rec["msg"] != "checkpoint not saved" {
+		t.Errorf("msg = %v, want %q", rec["msg"], "checkpoint not saved")
+	}
+	// The error text must survive. This is the whole reason the helper exists:
+	// a discard that loses the error is the defect being fixed.
+	if rec["error"] != "disk on fire" {
+		t.Errorf("error = %v, want %q", rec["error"], "disk on fire")
+	}
+	if rec["op_id"] != "op-123" {
+		t.Errorf("op_id = %v, want op-123", rec["op_id"])
+	}
+	if rec["attempt"] != float64(2) {
+		t.Errorf("attempt = %v, want 2", rec["attempt"])
+	}
+}
+
+func TestMustLogContext_UsesContextAndLogs(t *testing.T) {
+	records := captureLogs(t)
+
+	MustLogContext(context.Background(), errors.New("boom"), "undo entry not written", "book_id", "b-9")
+
+	got := records()
+	if len(got) != 1 {
+		t.Fatalf("got %d records, want 1", len(got))
+	}
+	if got[0]["error"] != "boom" {
+		t.Errorf("error = %v, want boom", got[0]["error"])
+	}
+	if got[0]["book_id"] != "b-9" {
+		t.Errorf("book_id = %v, want b-9", got[0]["book_id"])
+	}
+}
+
+func TestMustLog_DanglingKeyIsPreservedNotDropped(t *testing.T) {
+	// A caller who miscounts arguments should still get their data. Silently
+	// dropping the operand would be a silent failure inside the silent-failure
+	// helper.
+	records := captureLogs(t)
+
+	MustLog(errors.New("x"), "msg", "lonely_key")
+
+	got := records()
+	if len(got) != 1 {
+		t.Fatalf("got %d records, want 1", len(got))
+	}
+	if got[0]["!BADKEY"] != "lonely_key" {
+		t.Errorf("!BADKEY = %v, want lonely_key", got[0]["!BADKEY"])
+	}
+	// The error must survive a malformed kv list. If the dangling key were
+	// paired with the error attr, the error would vanish — the exact defect
+	// this package exists to prevent, reintroduced inside the fix.
+	if got[0]["error"] != "x" {
+		t.Errorf("error = %v, want %q — a dangling key swallowed the error", got[0]["error"], "x")
+	}
+}
+
+func TestSetLogger_RestoresPrevious(t *testing.T) {
+	var buf bytes.Buffer
+	first := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	restore := SetLogger(first)
+	if activeLogger() != first {
+		t.Fatal("SetLogger did not install the logger")
+	}
+	restore()
+	if activeLogger() == first {
+		t.Fatal("restore() did not put the previous logger back")
+	}
+}
+
+func TestMustLog_ConcurrentUseIsSafe(t *testing.T) {
+	// Waves 4-13 will call this from inside bounded worker pools.
+	records := captureLogs(t)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			MustLog(errors.New("concurrent"), "parallel discard")
+		}()
+	}
+	wg.Wait()
+
+	if n := len(records()); n != 50 {
+		t.Fatalf("got %d records, want 50", n)
+	}
+}

--- a/internal/errhandling/skipcounter.go
+++ b/internal/errhandling/skipcounter.go
@@ -1,0 +1,226 @@
+// file: internal/errhandling/skipcounter.go
+// version: 1.0.0
+// guid: ed47a1ef-7722-4c13-8cc7-48e09d29d4ae
+// last-edited: 2026-08-11
+
+package errhandling
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+)
+
+// SkipCounter records how many items a loop skipped and why, and emits exactly
+// one summary log line at loop exit.
+//
+// It exists for bucket (d) of the silent-failure audit: 78 loops that
+// `continue` on error with no counter and no log. The defining defect is not
+// that the item was skipped — skipping is often correct — it is that the loop
+// reports "processed 4,812 books" and that number is indistinguishable from
+// "processed 4,812 books and silently skipped 300."
+//
+// A SkipCounter makes the denominator honest:
+//
+//	skips := errhandling.NewSkipCounter("auto-organize")
+//	defer skips.LogSummary(ctx)
+//
+//	for i := range books {
+//	    dbBook, err := store.GetBookByFilePath(books[i].FilePath)
+//	    if err != nil {
+//	        skips.Skip("store lookup failed", err)
+//	        continue
+//	    }
+//	    if dbBook == nil {
+//	        skips.Skip("book not in store", nil)
+//	        continue
+//	    }
+//	    // ... do the work ...
+//	    skips.Processed()
+//	}
+//
+// Note the two Skip calls. Splitting "the lookup broke" from "the row isn't
+// there" is the point: they need opposite responses, and the audit's anchor
+// site collapses them into one branch.
+//
+// # Reasons
+//
+// reason must be a small, bounded set of literal strings — it is a grouping
+// key, not a message. Do not interpolate an item ID into it; pass the ID as a
+// field on the error or leave it to the per-reason sample.
+//
+// # Concurrency
+//
+// A SkipCounter is safe for concurrent use, so it can be shared across a
+// bounded worker pool (see the concurrency rules in CLAUDE.md) without extra
+// locking. The zero value is not usable; call [NewSkipCounter].
+type SkipCounter struct {
+	// name identifies the loop in the summary log, e.g. "auto-organize".
+	name string
+
+	mu        sync.Mutex
+	processed int
+	byReason  map[string]int
+	// firstErr keeps one representative error per reason. Logging every
+	// error would reproduce the 300-log-lines problem; logging none would
+	// lose the ability to diagnose. One sample per reason is the compromise.
+	firstErr map[string]error
+	// order preserves first-seen order of reasons for stable output when
+	// counts tie.
+	order []string
+}
+
+// NewSkipCounter returns a SkipCounter for a loop identified by name. name
+// appears in the summary log and should describe the loop, not the package.
+func NewSkipCounter(name string) *SkipCounter {
+	return &SkipCounter{
+		name:     name,
+		byReason: make(map[string]int),
+		firstErr: make(map[string]error),
+	}
+}
+
+// Skip records that one item was skipped for the given reason. err may be nil
+// when the skip is not caused by an error (a legitimately absent row, say);
+// the reason is what gets counted either way.
+func (c *SkipCounter) Skip(reason string, err error) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, seen := c.byReason[reason]; !seen {
+		c.order = append(c.order, reason)
+	}
+	c.byReason[reason]++
+	if err != nil {
+		if _, have := c.firstErr[reason]; !have {
+			c.firstErr[reason] = err
+		}
+	}
+}
+
+// Processed records that one item was handled successfully. Calling it is what
+// makes the summary's ratio meaningful; a loop that only calls Skip still
+// reports a correct skipped count but a processed count of zero.
+func (c *SkipCounter) Processed() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.processed++
+	c.mu.Unlock()
+}
+
+// Add records n successfully processed items at once, for loops that batch.
+func (c *SkipCounter) Add(n int) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.processed += n
+	c.mu.Unlock()
+}
+
+// Skipped returns the total number of skipped items across all reasons.
+func (c *SkipCounter) Skipped() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, v := range c.byReason {
+		n += v
+	}
+	return n
+}
+
+// ProcessedCount returns the number of successfully processed items.
+func (c *SkipCounter) ProcessedCount() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.processed
+}
+
+// ByReason returns a copy of the per-reason skip counts.
+func (c *SkipCounter) ByReason() map[string]int {
+	if c == nil {
+		return map[string]int{}
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]int, len(c.byReason))
+	for k, v := range c.byReason {
+		out[k] = v
+	}
+	return out
+}
+
+// LogSummary emits exactly one log line describing the loop's outcome. Call it
+// once, at loop exit — `defer skips.LogSummary(ctx)` immediately after
+// [NewSkipCounter] is the intended usage.
+//
+// Level is INFO when nothing was skipped and WARN when anything was, so a
+// silently-shrunk denominator is visible at default log levels rather than
+// buried at DEBUG.
+func (c *SkipCounter) LogSummary(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	processed := c.processed
+	reasons := make([]string, len(c.order))
+	copy(reasons, c.order)
+	counts := make(map[string]int, len(c.byReason))
+	for k, v := range c.byReason {
+		counts[k] = v
+	}
+	samples := make(map[string]error, len(c.firstErr))
+	for k, v := range c.firstErr {
+		samples[k] = v
+	}
+	c.mu.Unlock()
+
+	skipped := 0
+	for _, v := range counts {
+		skipped += v
+	}
+
+	// Highest count first; first-seen order breaks ties so output is stable.
+	pos := make(map[string]int, len(reasons))
+	for i, r := range reasons {
+		pos[r] = i
+	}
+	sort.SliceStable(reasons, func(i, j int) bool {
+		if counts[reasons[i]] != counts[reasons[j]] {
+			return counts[reasons[i]] > counts[reasons[j]]
+		}
+		return pos[reasons[i]] < pos[reasons[j]]
+	})
+
+	attrs := []slog.Attr{
+		slog.String("loop", c.name),
+		slog.Int("processed", processed),
+		slog.Int("skipped", skipped),
+		slog.Int("total", processed+skipped),
+	}
+	for _, r := range reasons {
+		attrs = append(attrs, slog.Int("skipped."+r, counts[r]))
+		if err := samples[r]; err != nil {
+			attrs = append(attrs, slog.String("sample."+r, err.Error()))
+		}
+	}
+
+	level := slog.LevelInfo
+	msg := fmt.Sprintf("%s complete: %d processed, %d skipped", c.name, processed, skipped)
+	if skipped > 0 {
+		level = slog.LevelWarn
+	}
+	activeLogger().LogAttrs(ctx, level, msg, attrs...)
+}

--- a/internal/errhandling/skipcounter_test.go
+++ b/internal/errhandling/skipcounter_test.go
@@ -1,0 +1,175 @@
+// file: internal/errhandling/skipcounter_test.go
+// version: 1.0.0
+// guid: 0910fd4e-59de-4348-9e4b-e02e31fcff50
+// last-edited: 2026-08-11
+
+package errhandling
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestSkipCounter_CountsProcessedAndSkipped(t *testing.T) {
+	c := NewSkipCounter("auto-organize")
+
+	c.Processed()
+	c.Processed()
+	c.Skip("store lookup failed", errors.New("pebble io"))
+	c.Skip("store lookup failed", errors.New("pebble io again"))
+	c.Skip("book not in store", nil)
+
+	if got := c.ProcessedCount(); got != 2 {
+		t.Errorf("ProcessedCount = %d, want 2", got)
+	}
+	if got := c.Skipped(); got != 3 {
+		t.Errorf("Skipped = %d, want 3", got)
+	}
+	by := c.ByReason()
+	if by["store lookup failed"] != 2 {
+		t.Errorf("byReason[store lookup failed] = %d, want 2", by["store lookup failed"])
+	}
+	if by["book not in store"] != 1 {
+		t.Errorf("byReason[book not in store] = %d, want 1", by["book not in store"])
+	}
+}
+
+func TestSkipCounter_SummaryLogCarriesTheRealNumbers(t *testing.T) {
+	// The point of the type: the summary must state the skipped count, so
+	// "processed 2" can never again be mistaken for "there were only 2".
+	records := captureLogs(t)
+
+	c := NewSkipCounter("auto-organize")
+	c.Processed()
+	c.Processed()
+	c.Skip("store lookup failed", errors.New("pebble io"))
+	c.Skip("book not in store", nil)
+	c.LogSummary(context.Background())
+
+	got := records()
+	if len(got) != 1 {
+		t.Fatalf("got %d records, want exactly 1 summary line: %v", len(got), got)
+	}
+	rec := got[0]
+
+	if rec["level"] != "WARN" {
+		t.Errorf("level = %v, want WARN when items were skipped", rec["level"])
+	}
+	if rec["loop"] != "auto-organize" {
+		t.Errorf("loop = %v, want auto-organize", rec["loop"])
+	}
+	if rec["processed"] != float64(2) {
+		t.Errorf("processed = %v, want 2", rec["processed"])
+	}
+	if rec["skipped"] != float64(2) {
+		t.Errorf("skipped = %v, want 2", rec["skipped"])
+	}
+	if rec["total"] != float64(4) {
+		t.Errorf("total = %v, want 4", rec["total"])
+	}
+	if rec["skipped.store lookup failed"] != float64(1) {
+		t.Errorf("per-reason count = %v, want 1", rec["skipped.store lookup failed"])
+	}
+	// One representative error per reason, so the skip is diagnosable.
+	if rec["sample.store lookup failed"] != "pebble io" {
+		t.Errorf("sample = %v, want %q", rec["sample.store lookup failed"], "pebble io")
+	}
+}
+
+func TestSkipCounter_CleanRunLogsAtInfo(t *testing.T) {
+	records := captureLogs(t)
+
+	c := NewSkipCounter("clean-loop")
+	c.Add(10)
+	c.LogSummary(context.Background())
+
+	got := records()
+	if len(got) != 1 {
+		t.Fatalf("got %d records, want 1", len(got))
+	}
+	if got[0]["level"] != "INFO" {
+		t.Errorf("level = %v, want INFO when nothing was skipped", got[0]["level"])
+	}
+	if got[0]["skipped"] != float64(0) {
+		t.Errorf("skipped = %v, want 0", got[0]["skipped"])
+	}
+	if got[0]["processed"] != float64(10) {
+		t.Errorf("processed = %v, want 10", got[0]["processed"])
+	}
+}
+
+func TestSkipCounter_EmitsExactlyOneLineNotOnePerSkip(t *testing.T) {
+	// A per-iteration log would reproduce the problem in a different shape:
+	// 300 lines is as unreadable as 0.
+	records := captureLogs(t)
+
+	c := NewSkipCounter("noisy")
+	for i := 0; i < 300; i++ {
+		c.Skip("bad row", errors.New("decode"))
+	}
+	c.LogSummary(context.Background())
+
+	got := records()
+	if len(got) != 1 {
+		t.Fatalf("got %d records, want exactly 1", len(got))
+	}
+	if got[0]["skipped"] != float64(300) {
+		t.Errorf("skipped = %v, want 300", got[0]["skipped"])
+	}
+}
+
+func TestSkipCounter_ConcurrentUseIsSafe(t *testing.T) {
+	// CLAUDE.md mandates bounded worker pools for library-scale loops, so the
+	// counter must be shareable across workers without extra locking.
+	c := NewSkipCounter("parallel")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				c.Processed()
+			} else {
+				c.Skip("odd", errors.New("odd item"))
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if got := c.ProcessedCount(); got != 50 {
+		t.Errorf("ProcessedCount = %d, want 50", got)
+	}
+	if got := c.Skipped(); got != 50 {
+		t.Errorf("Skipped = %d, want 50", got)
+	}
+}
+
+func TestSkipCounter_NilReceiverIsSafe(t *testing.T) {
+	// Callers may hold an optional counter; a nil one must not panic mid-loop.
+	var c *SkipCounter
+	c.Skip("reason", errors.New("x"))
+	c.Processed()
+	c.Add(3)
+	c.LogSummary(context.Background())
+	if got := c.Skipped(); got != 0 {
+		t.Errorf("Skipped on nil = %d, want 0", got)
+	}
+	if got := c.ProcessedCount(); got != 0 {
+		t.Errorf("ProcessedCount on nil = %d, want 0", got)
+	}
+}
+
+func TestSkipCounter_ByReasonIsACopy(t *testing.T) {
+	c := NewSkipCounter("copy")
+	c.Skip("r", nil)
+
+	m := c.ByReason()
+	m["r"] = 999
+
+	if c.ByReason()["r"] != 1 {
+		t.Error("ByReason returned a live map; mutating it corrupted the counter")
+	}
+}


### PR DESCRIPTION
## What

Groundwork for waves 4–13 of the silent-failure sweep. **Nothing here changes runtime behaviour.**

- `.golangci.yml` — exactly one linter (errcheck), `check-blank: true`
- `internal/errhandling` — the two primitives the later waves need
- `make lint-errcheck` / `make lint-errcheck-full`

This was sitting uncommitted in a worktree. Memory flagged it as "still undone, everything depends on it."

## Why check-blank is the whole point

errcheck's default **ignores `_ = f()`** — which is the exact form of every statement-position discard the sweep exists to fix. Without `check-blank: true` this linter is inert for its purpose.

## The numbers, measured today

| config | findings |
|---|---|
| with the exclude list | **922** |
| without it | **2,373** |
| exclusions remove | 1,451 |

The exclude list exempts bucket (f) — progress/log reporting, whose only failure mode is a missed progress-bar tick — **by name, before the linter was ever wired up**. A linter that greets you with 2,373 findings gets switched off by whoever sees it next.

⚠️ The config's own comment says **2,326** un-exempted. The real number today is **2,373** — drifted by 47 since 2026-08-11. I left the comment as written rather than quietly correcting it, because the drift is the useful signal.

I also got this measurement wrong the first time and caught it: truncating the file at `exclude-functions:` also deleted the `issues:` block below it, including `max-issues-per-linter: 0`. The run came back "50 issues" — golangci-lint's *default cap*, not a real count. Exclusions reducing findings from 922 to 50 is impossible on its face, which is what prompted the recheck.

## Two primitives

- **`MustLog`** — "we looked at this error and chose to continue." One call instead of five lines, and it leaves a WARN, so the discard is auditable after the fact instead of invisible.
- **`SkipCounter`** — for loops that `continue` on error with no counter and no log, so the loop reports "processed 4,812" and the denominator is silently wrong. Makes the skipped count first-class and emits one summary line at loop exit.

Not a way to keep discarding errors with a clearer conscience — if the error should abort the operation, return it.

## Safety

- **No CI workflow invokes golangci-lint**, so adding this file changes no existing job. Verified: `grep -rln golangci .github/workflows/` returns nothing.
- **Deliberately not wired into `make ci`.** 922 findings is a backlog to burn down over waves 4–13, not a gate to fail on today. Wiring it in is a separate decision and yours to make.
- `go test ./internal/errhandling/` passes.

## Note

The config's instructions told people to run `make lint-errcheck-full` to verify a new exclusion actually matched — and **no such target existed**. Added, because errcheck matches fully-qualified names (`(module/path.Type).Method`) and a non-matching pattern is indistinguishable from a matching one if you only measure once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t