### PR TITLE
fix(scanner): a failed metadata pass no longer files books under placeholder names

### DIFF
--- a/changelog.d/20260812-scan-metadata-failure-no-organize.md
+++ b/changelog.d/20260812-scan-metadata-failure-no-organize.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- A scan whose metadata pass failed logged the error and then **carried on into
+  auto-organize anyway**. Those books still held whatever title/author the scan
+  started with — frequently empty — so organizing them expanded the naming pattern
+  over blank fields and sent them all to the same degenerate path. In the 4h15m
+  production scan of 2026-08-11, 848 books collided on
+  `Unknown Author/Unknown Title/Unknown Title - Unknown Author.mp3`. The failure now
+  skips auto-organize for that folder and returns, so the folder is also no longer
+  counted as a successful scan.

--- a/changelog.d/20260812_fix_scan_ctx_and_unprocessed_organize.md
+++ b/changelog.d/20260812_fix_scan_ctx_and_unprocessed_organize.md
@@ -1,0 +1,21 @@
+### Fixed
+
+#### A cancelled scan kept going, and filed books whose details were never read
+
+Two faults on the scan path, found while measuring why a full scan takes over four hours.
+
+**Cancelling a scan did not stop it.** The scan checked its own stop button but never
+the request's cancellation signal. When that signal fired, the scan carried on into
+every remaining folder — 2,406 of them in a single production run — failing to read
+details for each one and then reporting overall success.
+
+**Books were filed even when their details could not be read.** When reading a folder's
+audiobook details failed, the failure was written to the log and then the books were
+organized anyway. A book whose title and author were never read has no title and no
+author, so the naming pattern produced the same placeholder name for all of them and
+they were all filed to the same destination — where every one after the first failed as
+"already occupied". The same run recorded 7,561 refusals to overwrite an existing
+destination and 3,481 duplicate candidates, with 848 books aimed at one placeholder path.
+
+A cancelled scan now stops and says it was cancelled, and a folder whose details could
+not be read is no longer organized or counted as successful.

--- a/internal/scanner/scan_cancel_test.go
+++ b/internal/scanner/scan_cancel_test.go
@@ -1,0 +1,87 @@
+// file: internal/scanner/scan_cancel_test.go
+// version: 1.0.0
+// guid: 4f6a2d81-95e3-4c07-b1a8-6d20c9f3e574
+// last-edited: 2026-08-12
+
+// Regression tests for a scan that ignored its context.
+//
+// PerformScan's folder loop checked only log.IsCanceled() — the operation's own
+// stop flag — and never ctx.Err(). A cancelled CONTEXT therefore did not stop
+// the walk: the loop carried on into every remaining folder, each one failed its
+// metadata pass with "context canceled", and the scan still reported success.
+//
+// Measured on production during the 4h15m scan of 2026-08-11: 2,406 folders were
+// processed that way inside a single run.
+//
+// The second half of the defect lived in scanFolder: when ProcessBooksParallel
+// returned an error it was logged and then execution FELL THROUGH to
+// AutoOrganizeFn, so books whose metadata had never been extracted were filed
+// anyway — with whatever title/author the scan started with, frequently empty.
+// The same production run logged 7,561 "safeRename refusing to overwrite" and
+// 3,481 organize-collision candidates, with 848 books landing on the single path
+// "Unknown Author/Unknown Title/Unknown Title - Unknown Author.mp3".
+
+package scanner
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/logger"
+)
+
+// TestPerformScanStopsOnCanceledContext pins the loop guard. With a cancelled
+// context the scan must abort and say so, not walk every folder.
+func TestPerformScanStopsOnCanceledContext(t *testing.T) {
+	mockDB := &database.MockStore{
+		GetAllImportPathsFunc: func() ([]database.ImportPath, error) {
+			return []database.ImportPath{
+				{Path: "/nonexistent/one", Enabled: true},
+				{Path: "/nonexistent/two", Enabled: true},
+				{Path: "/nonexistent/three", Enabled: true},
+			}, nil
+		},
+	}
+
+	ss := NewScanService(mockDB)
+
+	organizeCalls := 0
+	ss.AutoOrganizeFn = func(_ context.Context, _ []Book, _ logger.Logger) {
+		organizeCalls++
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled before the scan even starts
+
+	err := ss.PerformScan(ctx, &ScanRequest{}, logger.New("test"))
+
+	if err == nil {
+		t.Fatal("a scan run under a cancelled context must report an error, not success — " +
+			"reporting success is what let 2,406 folders fail their metadata pass unnoticed")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "cancel") {
+		t.Errorf("the error should identify cancellation as the cause; got %v", err)
+	}
+	if organizeCalls != 0 {
+		t.Errorf("auto-organize must not run for a cancelled scan; ran %d times", organizeCalls)
+	}
+}
+
+// TestPerformScanRunsWhenContextIsLive is the discriminating half: the new guard
+// must not abort a healthy scan. Without this, a fix that returned an error
+// unconditionally would look identical on the test above.
+func TestPerformScanRunsWhenContextIsLive(t *testing.T) {
+	mockDB := &database.MockStore{
+		GetAllImportPathsFunc: func() ([]database.ImportPath, error) {
+			return []database.ImportPath{}, nil
+		},
+	}
+
+	ss := NewScanService(mockDB)
+
+	if err := ss.PerformScan(context.Background(), &ScanRequest{}, logger.New("test")); err != nil {
+		t.Fatalf("a live context with nothing to scan must still succeed; got %v", err)
+	}
+}

--- a/internal/scanner/service.go
+++ b/internal/scanner/service.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/service.go
-// version: 1.11.0
+// version: 1.12.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-// last-edited: 2026-08-11
+// last-edited: 2026-08-12
 package scanner
 
 import (
@@ -174,6 +174,19 @@ func (ss *ScanService) performScanInternal(ctx context.Context, opID string, req
 	var processedFiles atomic.Int32
 
 	for folderIdx, folderPath := range foldersToScan {
+		// Both cancellation channels have to be checked here. log.IsCanceled()
+		// is the operation's own stop flag; ctx is the request/server one. Only
+		// the former was checked, so a cancelled CONTEXT did not stop the walk —
+		// the loop carried on into every remaining folder and each one failed
+		// its metadata pass with "context canceled".
+		//
+		// Production, 2026-08-11: 2,406 folders were processed that way inside a
+		// single scan, each logging the failure and continuing. The scan then
+		// reported success.
+		if err := ctx.Err(); err != nil {
+			log.Info("Scan canceled (context): %v", err)
+			return fmt.Errorf("scan canceled: %w", err)
+		}
 		if log.IsCanceled() {
 			log.Info("Scan canceled")
 			return fmt.Errorf("scan canceled")
@@ -374,10 +387,30 @@ func (ss *ScanService) scanFolder(ctx context.Context, folderIdx int, folderPath
 
 		log.Info("Processing metadata for %d books using %d workers", len(books), workers)
 		if err := ProcessBooksParallel(ctx, books, workers, progressCallback, log.With("scanner")); err != nil {
+			// Do NOT fall through to auto-organize. These books did not get
+			// their metadata extracted, so their title/author are whatever the
+			// scan started with — frequently empty. Organizing them anyway
+			// expands the naming pattern over blank fields and sends every one
+			// of them to the same degenerate path, where all but the first fail
+			// as "target already occupied".
+			//
+			// That is not a theoretical risk. In the 4h15m production scan of
+			// 2026-08-11 this branch fired 2,406 times with "context canceled",
+			// and the same run logged 7,561 "safeRename refusing to overwrite
+			// existing destination" and 3,481 organize-collision candidates.
+			// 848 books collided on one path,
+			// "Unknown Author/Unknown Title/Unknown Title - Unknown Author.mp3".
+			//
+			// Returning the error also stops this folder being counted as a
+			// success: scanFolder used to log here and then `return nil`, so a
+			// folder whose metadata pass failed outright was indistinguishable
+			// from one that worked.
 			log.Error("Failed to process books: %v", err)
-		} else {
-			log.Info("Successfully processed %d books", len(books))
+			return fmt.Errorf("metadata processing failed for %s (%d books), "+
+				"skipping auto-organize so unprocessed books are not filed under "+
+				"placeholder names: %w", folderPath, len(books), err)
 		}
+		log.Info("Successfully processed %d books", len(books))
 
 		// Auto-organize if enabled (via server-layer hook to avoid import cycle)
 		if ss.AutoOrganizeFn != nil {


### PR DESCRIPTION
## What

`scanFolder` logged `"Failed to process books"` and then **fell straight through into auto-organize**.

Those books never got their metadata extracted, so title/author were whatever the scan started with — frequently empty. Organizing them expands the naming pattern over blank fields, sending every one to the same degenerate destination, where all but the first fail as "target already occupied".

## Production evidence — 4h15m scan of 2026-08-11

| signal | count |
|---|---|
| this branch firing with `context canceled` | 2,406 |
| `safeRename refusing to overwrite existing destination` | 7,561 |
| organize-collision candidates | 3,481 |
| books collided on **one** path | **848** |

That path being `Unknown Author/Unknown Title/Unknown Title - Unknown Author.mp3`.

## Also fixed: the folder was counted as a success

The old code logged and then `return nil`. A folder whose metadata pass failed **outright** was indistinguishable from one that worked — the same silent-failure shape as the rest of the sweep.

## Blast radius

One folder, not the scan. The caller handles it:

```go
err := ss.scanFolder(...)   // service.go:195
if err != nil {
    log.Error("Error scanning folder %s: %v", folderPath, err)
    continue
}
```

That is the behaviour we want: a cancelled scan should skip its remaining folders rather than file them under placeholder names.

## Verification

`go build ./...`, `go vet ./internal/scanner/` and `go test ./internal/scanner/` all pass.

This was uncommitted work found in a worktree during a sweep for unlanded changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t