### PR TITLE
feat(database): name the caller on every aggregate-recompute log line

### DIFF
--- a/changelog.d/20260812_changed_aggregate_recompute_caller_attribution.md
+++ b/changelog.d/20260812_changed_aggregate_recompute_caller_attribution.md
@@ -1,0 +1,8 @@
+### Changed
+
+- Aggregate-recomputation log lines now name the subsystem that triggered them. A
+  production sample counted 126,928 `RecomputeBookAggregates updated` lines across 5,595
+  books (worst book: 1,189 recomputes) with no way to tell which of thirteen possible
+  originators issued them. Each line now carries a `caller` field such as
+  `internal/merge.(*Service).mergeBooks:438`, which is the prerequisite for coalescing the
+  redundant work — and for measuring whether the coalescing helped.

--- a/internal/database/aggregate_caller.go
+++ b/internal/database/aggregate_caller.go
@@ -1,0 +1,112 @@
+// file: internal/database/aggregate_caller.go
+// version: 1.0.0
+// guid: 3c9e17ab-64d2-4f80-9153-8ad7be2f01c6
+// last-edited: 2026-08-12
+
+// Package database — caller attribution for aggregate recomputation.
+//
+// WHY this file exists:
+//
+//	A production log sample (2026-08-12) counted 126,928 "RecomputeBookAggregates
+//	updated" lines across 5,595 distinct books — worst single book recomputed
+//	1,189 times. Because each call re-reads every BookFile of the book, N
+//	sequential inserts cost 1+2+...+N reads: 5,430,858 implied reads for 126,928
+//	updates, a 42.8x amplification.
+//
+//	None of those 126,928 lines said WHO issued the write. There are thirteen
+//	possible originators — eight packages calling RecomputeBookAggregates
+//	directly, plus five BookFile mutators that reach it through
+//	notifyBookFileChange — and the obvious suspect was ruled OUT: the scanner
+//	writes via BatchUpsertBookFiles, which never calls notifyBookFileChange at
+//	all. Without attribution the coalescing fix cannot be aimed, and more
+//	importantly cannot be MEASURED afterwards.
+//
+// WHY a runtime stack walk instead of a caller parameter:
+//
+//	RecomputeBookAggregates is part of the BookWriter/BookStore/Store interfaces
+//	and is mocked in eight generated files. Threading a caller string through the
+//	signature would regenerate tens of thousands of lines of mock code for what is
+//	purely a diagnostic. The stack already holds the answer.
+//
+// COST: runtime.Callers over a small fixed frame budget, evaluated only at the
+// log sites that actually emit — roughly 1-2us per emitted line. Against the
+// 126,928 lines above that totals well under a second across a four-hour scan.
+package database
+
+import (
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+const (
+	// aggregateCallerDepth bounds the stack walk. The deepest real chain is
+	// caller -> UpdateBookFile -> notifyBookFileChange -> RecomputeBookAggregates
+	// -> log site, so 16 frames leaves generous headroom for wrappers and
+	// inlining boundaries without allocating a large array on every call.
+	aggregateCallerDepth = 16
+
+	// databasePkgMarker matches any function defined in this package. Function
+	// names from runtime look like
+	// "github.com/falkcorp/audiobook-organizer/internal/database.(*PebbleStore).UpdateBookFile",
+	// so the leading slash keeps this from matching a hypothetical
+	// "somethingdatabase." package elsewhere.
+	databasePkgMarker = "/internal/database."
+
+	// modulePrefix is trimmed from reported names so the log field stays short
+	// and greppable: "internal/scanner.(*Service).Process" rather than the full
+	// module path repeated on every one of 126,928 lines.
+	modulePrefix = "github.com/falkcorp/audiobook-organizer/"
+)
+
+// aggregateCaller returns "package.Func:line" for the nearest stack frame
+// OUTSIDE this package — the code that actually asked for the write.
+//
+// Frames inside internal/database are skipped deliberately: naming
+// notifyBookFileChange or UpdateBookFile as the caller would just restate what
+// the log line already says. The interesting question is which subsystem drove
+// the mutation, and that always lives one package up.
+//
+// When there is no in-repo caller the walk does NOT stop at the package
+// boundary — a goroutine stack never ends there. It continues into whatever sits
+// below, so the value degrades gracefully to a runtime frame rather than to
+// nothing:
+//
+//   - a bare `go store.UpdateBookFile(...)` reports "runtime.goexit:0", an
+//     honest bucket meaning "no in-repo caller was on the stack";
+//   - an in-package test reports a "testing." frame.
+//
+// The "database-internal" return is therefore a backstop that requires more than
+// aggregateCallerDepth consecutive frames in this package, which no current call
+// chain produces. It exists so the function can never return an empty string.
+// "unknown" is returned only if the stack cannot be walked at all.
+func aggregateCaller() string {
+	var pcs [aggregateCallerDepth]uintptr
+	// Skip 2: runtime.Callers itself and aggregateCaller.
+	n := runtime.Callers(2, pcs[:])
+	if n == 0 {
+		return "unknown"
+	}
+
+	frames := runtime.CallersFrames(pcs[:n])
+	for {
+		frame, more := frames.Next()
+		if frame.Function == "" {
+			break
+		}
+		if !strings.Contains(frame.Function, databasePkgMarker) {
+			return shortFuncName(frame.Function) + ":" + strconv.Itoa(frame.Line)
+		}
+		if !more {
+			break
+		}
+	}
+	return "database-internal"
+}
+
+// shortFuncName strips the module path prefix from a fully-qualified runtime
+// function name, leaving the repo-relative package path intact so the value is
+// still unambiguous and still greppable against real source paths.
+func shortFuncName(fn string) string {
+	return strings.TrimPrefix(fn, modulePrefix)
+}

--- a/internal/database/aggregate_caller_ext_test.go
+++ b/internal/database/aggregate_caller_ext_test.go
@@ -1,0 +1,72 @@
+// file: internal/database/aggregate_caller_ext_test.go
+// version: 1.0.0
+// guid: 8f31d62c-0b74-4e95-a1d8-73c6f905e2b4
+// last-edited: 2026-08-12
+
+// Package database_test holds the caller-attribution tests that CANNOT live in
+// package database — see the comment on AggCallerExportedForTest for why an
+// in-package test cannot observe the behaviour under test.
+package database_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// TestAggregateCallerNamesTheExternalCaller is the core assertion: a caller
+// outside package database is reported by name and line.
+func TestAggregateCallerNamesTheExternalCaller(t *testing.T) {
+	got := database.AggCallerExportedForTest()
+
+	const wantFunc = "internal/database_test.TestAggregateCallerNamesTheExternalCaller"
+	if !strings.HasPrefix(got, wantFunc+":") {
+		t.Fatalf("aggregateCaller() = %q, want it to start with %q — the nearest "+
+			"frame outside package database is this test function", got, wantFunc+":")
+	}
+	// A line number must be present and non-zero, otherwise the value is useless
+	// for locating the originator in source.
+	line := strings.TrimPrefix(got, wantFunc+":")
+	if line == "" || line == "0" {
+		t.Fatalf("aggregateCaller() = %q, want a non-zero source line after the colon", got)
+	}
+}
+
+// TestAggregateCallerSkipsIntermediateDatabaseFrames is the DISCRIMINATING case.
+//
+// The previous test would still pass if aggregateCaller simply reported
+// runtime.Caller(1) with no skip logic at all, because the test calls straight
+// into the package. This one routes through an extra in-package frame — the same
+// shape as the real notifyBookFileChange -> RecomputeBookAggregates chain — and
+// requires the answer to be UNCHANGED. Naive caller-reporting fails here.
+func TestAggregateCallerSkipsIntermediateDatabaseFrames(t *testing.T) {
+	got := database.AggCallerViaStoreFrameForTest()
+
+	const wantFunc = "internal/database_test.TestAggregateCallerSkipsIntermediateDatabaseFrames"
+	if !strings.HasPrefix(got, wantFunc+":") {
+		t.Fatalf("aggregateCaller() through an intermediate database frame = %q, "+
+			"want it to start with %q — every frame inside package database must be "+
+			"skipped so the reported caller is the subsystem that drove the write, "+
+			"not the store's own plumbing", got, wantFunc+":")
+	}
+	if strings.Contains(got, "/internal/database.") {
+		t.Fatalf("aggregateCaller() = %q, want no frame from package database itself", got)
+	}
+}
+
+// TestAggregateCallerReportsRepoRelativePackagePath pins the log-field shape.
+// The module prefix must be stripped (it repeats on every emitted line) but the
+// repo-relative package path must survive, or the value stops being greppable
+// against real source paths.
+func TestAggregateCallerReportsRepoRelativePackagePath(t *testing.T) {
+	got := database.AggCallerExportedForTest()
+
+	if strings.Contains(got, "github.com/falkcorp/audiobook-organizer/") {
+		t.Fatalf("aggregateCaller() = %q, want the module prefix trimmed", got)
+	}
+	if !strings.HasPrefix(got, "internal/") {
+		t.Fatalf("aggregateCaller() = %q, want a repo-relative package path "+
+			"beginning with \"internal/\"", got)
+	}
+}

--- a/internal/database/export_aggregate_caller_test.go
+++ b/internal/database/export_aggregate_caller_test.go
@@ -1,0 +1,98 @@
+// file: internal/database/export_aggregate_caller_test.go
+// version: 1.0.0
+// guid: 5a70c9d3-1e46-4b28-8f95-c2d0e6a3417b
+// last-edited: 2026-08-12
+
+package database
+
+import (
+	"strings"
+	"testing"
+)
+
+// AggCallerExportedForTest exposes the unexported aggregateCaller to the
+// EXTERNAL database_test package.
+//
+// WHY the indirection is necessary rather than merely convenient: aggregateCaller
+// skips every frame belonging to this package. A test written in `package
+// database` is itself such a frame, so calling it in-package always yields
+// "database-internal" — the test would pass while proving nothing about how real
+// callers are attributed. Only a test in `package database_test` (whose frames
+// read ".../internal/database_test.", which the marker deliberately does not
+// match) can observe the real behaviour.
+func AggCallerExportedForTest() string {
+	return aggregateCaller()
+}
+
+// AggCallerViaStoreFrameForTest calls aggregateCaller through an EXTRA frame in
+// this package, mimicking the real notifyBookFileChange -> RecomputeBookAggregates
+// chain. The external test asserts the answer is unchanged, which is what proves
+// intervening database frames are skipped rather than reported.
+func AggCallerViaStoreFrameForTest() string {
+	return aggCallerInnerStoreFrameForTest()
+}
+
+func aggCallerInnerStoreFrameForTest() string {
+	return aggregateCaller()
+}
+
+// TestAggregateCallerWalksPastDatabaseIntoTheRuntime pins what happens when
+// there is no in-repo caller: the walk does NOT stop at the package boundary, it
+// keeps going into whatever sits below.
+//
+// This test was originally written asserting "database-internal" and it FAILED,
+// returning "testing.tRunner:2036". That result is correct and worth pinning: a
+// goroutine stack never ends at a package boundary, so the "every frame in the
+// budget is database" fallback is effectively unreachable. The realistic
+// degenerate case in production is a bare `go store.UpdateBookFile(...)`, which
+// reports "runtime.goexit:0" — an honest bucket meaning "no in-repo caller on
+// the stack" rather than a filtered-away blank.
+func TestAggregateCallerWalksPastDatabaseIntoTheRuntime(t *testing.T) {
+	got := aggregateCaller()
+
+	if strings.Contains(got, databasePkgMarker) {
+		t.Fatalf("aggregateCaller() = %q, want no frame from package database itself", got)
+	}
+	// The nearest non-database frame above an in-package test is the testing
+	// harness. Matching on the package rather than the exact function keeps this
+	// from breaking if the Go runtime renames tRunner.
+	if !strings.HasPrefix(got, "testing.") {
+		t.Fatalf("aggregateCaller() from inside package database = %q, want a "+
+			"\"testing.\" frame — the walk continues past this package into whatever "+
+			"called it, and for an in-package test that is the test harness", got)
+	}
+}
+
+// TestShortFuncNameTrimsModulePrefix guards the log-field formatting. If the
+// module path ever changes, the prefix stops matching and every one of the
+// 126,928 lines/scan grows by the full module path; this fails loudly instead.
+func TestShortFuncNameTrimsModulePrefix(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "method on a store type in another package",
+			in:   "github.com/falkcorp/audiobook-organizer/internal/scanner.(*Service).ProcessBook",
+			want: "internal/scanner.(*Service).ProcessBook",
+		},
+		{
+			name: "plain function in a maintenance job",
+			in:   "github.com/falkcorp/audiobook-organizer/internal/maintenance/jobs.RunRecompute",
+			want: "internal/maintenance/jobs.RunRecompute",
+		},
+		{
+			name: "third-party frame keeps its full path",
+			in:   "github.com/cockroachdb/pebble.(*DB).Set",
+			want: "github.com/cockroachdb/pebble.(*DB).Set",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shortFuncName(tc.in); got != tc.want {
+				t.Fatalf("shortFuncName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/database/pebble_store_book_aggregates.go
+++ b/internal/database/pebble_store_book_aggregates.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_book_aggregates.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
-// last-edited: 2026-07-12
+// last-edited: 2026-08-12
 
 // Package database — book aggregate recomputation from BookFiles.
 //
@@ -129,7 +129,14 @@ func (p *PebbleStore) RecomputeBookAggregates(bookID string) error {
 		existingFileSize = *book.FileSize
 	}
 	if existingDuration == wantDuration && existingFileSize == wantFileSize {
-		slog.Debug("RecomputeBookAggregates: no change needed", "book_id", bookID)
+		// "caller" is the redundancy signal: a book recomputed many times from
+		// the same originator with no change to show for it is exactly what the
+		// coalescing fix is meant to eliminate. Debug-level, so this costs
+		// nothing in production until someone turns it on to look.
+		slog.Debug("RecomputeBookAggregates: no change needed",
+			"book_id", bookID,
+			"caller", aggregateCaller(),
+		)
 		return nil
 	}
 
@@ -141,8 +148,15 @@ func (p *PebbleStore) RecomputeBookAggregates(bookID string) error {
 		return fmt.Errorf("RecomputeBookAggregates UpdateBook %s: %w", bookID, err)
 	}
 
+	// "caller" names the subsystem that drove this write. This is the line the
+	// 126,928-sample production count was drawn from, so adding the field here
+	// (rather than at some new log site) keeps any future measurement directly
+	// comparable with that baseline. "total_files" is also the per-call read
+	// count — caller x total_files is the amplification attributable to each
+	// originator.
 	slog.Info("RecomputeBookAggregates updated",
 		"book_id", bookID,
+		"caller", aggregateCaller(),
 		"duration_sec", wantDuration,
 		"file_size_bytes", wantFileSize,
 		"files_with_duration", filesWithDuration,
@@ -165,6 +179,7 @@ func (p *PebbleStore) notifyBookFileChange(bookID string) {
 	if err := p.RecomputeBookAggregates(bookID); err != nil {
 		slog.Warn("notifyBookFileChange RecomputeBookAggregates failed (best-effort)",
 			"book_id", bookID,
+			"caller", aggregateCaller(),
 			"error", err,
 		)
 	}

--- a/todo.d/20260812-recompute-aggregates-n2-amplification.md
+++ b/todo.d/20260812-recompute-aggregates-n2-amplification.md
@@ -61,6 +61,31 @@ trigger). Neither is traced.
 or instrument `notifyBookFileChange` with a caller tag. Fixing before knowing the
 workload means the fix cannot be measured.
 
+#### ✅ Attribution shipped — awaiting a production sample
+
+`internal/database/aggregate_caller.go` adds a `caller` field naming the nearest stack
+frame outside `internal/database`, e.g. `internal/merge.(*Service).mergeBooks:438`. It is
+on all three aggregate log lines, including the `RecomputeBookAggregates updated` Info
+line the 126,928 baseline was counted from — so the next sample is directly comparable
+with it. A runtime stack walk was chosen over a signature change because
+`RecomputeBookAggregates` is mocked in eight generated files.
+
+**Still open — the numbers below cannot be produced until prod runs this build:**
+
+```
+# which subsystem drives the recomputes
+journalctl -u audiobook-organizer --since "..." \
+  | grep -o 'caller=[^ ]*' | sort | uniq -c | sort -rn
+
+# redundant recomputes per caller (requires log level debug)
+... | grep 'no change needed' | grep -o 'caller=[^ ]*' | sort | uniq -c | sort -rn
+```
+
+Degenerate values are meaningful, not noise: `runtime.goexit:0` means the write came from
+a bare `go store.…(…)` with no in-repo frame left on the stack. Expect `caller` to name
+the merge service, the five maintenance jobs, or the metadata write-back path — **not**
+the scanner, which writes via `BatchUpsertBookFiles` and never reaches this code.
+
 ### Fix direction, once attribution is known
 
 A coalescing scope on the store:


### PR DESCRIPTION
## What

Adds a `caller` field to the three aggregate-recomputation log lines, naming the nearest
stack frame outside `internal/database` — e.g. `internal/merge.(*Service).mergeBooks:438`.

**No behaviour change. Log fields only.**

## Why

The prior unit (#2357) measured, from a production log sample:

| Metric | Value |
|---|---|
| `RecomputeBookAggregates updated` lines | 126,928 |
| Distinct books | 5,595 |
| Worst single book | 1,189 recomputes |
| Implied BookFile reads | 5,430,858 (**42.8x** amplification) |
| Lines carrying an `opID` | **0 of 126,928** |

That last row is why this PR exists and why the coalescing fix was deliberately *not*
written yet. There are thirteen possible originators — eight packages calling
`RecomputeBookAggregates` directly, plus five `BookFile` mutators reaching it through
`notifyBookFileChange` — and the obvious suspect is already ruled out: the scanner writes
via `BatchUpsertBookFiles` (`internal/scanner/scanner.go:1544`), which never calls
`notifyBookFileChange` at all. Changing a core DB write path against an unidentified
workload means the change cannot be measured.

The field is added to the **same Info line the 126,928 baseline was counted from**, so the
next sample is directly comparable rather than a fresh unrelated measurement.

## Why a stack walk, not a caller parameter

`RecomputeBookAggregates` is on the `BookWriter` / `BookStore` / `Store` interfaces and is
mocked in **eight generated files**. Threading a `caller string` through the signature
would regenerate tens of thousands of lines of mockery output for a pure diagnostic. The
stack already holds the answer. Cost is ~1-2 µs per emitted line — under a second across a
four-hour scan.

## A test went red and changed the design

The in-package test was written asserting a `"database-internal"` fallback. It **failed**,
returning `testing.tRunner:2036`. A goroutine stack does not end at a package boundary, so
that fallback is effectively unreachable — the walk always finds some non-database frame.
The realistic degenerate value is `runtime.goexit:0`, from a bare
`go store.UpdateBookFile(...)` with no in-repo frame left on the stack. That is an honest,
aggregatable bucket meaning "no in-repo caller", so it is documented rather than filtered
away. The assertion and the doc comment now record the real behaviour.

## Verification

- `go build ./...` — exit 0
- `go vet ./internal/database/` — exit 0
- `go test ./internal/database/ -run 'AggregateCaller|ShortFuncName' -count=1` — **5/5 pass**, exit 0

**Negative control** (generated from the committed artifact, not a paraphrase): replacing
the skip condition with `if true` — naive caller reporting, no skip logic — gives
**3 FAIL / 2 PASS**:

| Test | Under negative control |
|---|---|
| `TestAggregateCallerNamesTheExternalCaller` | FAIL |
| `TestAggregateCallerSkipsIntermediateDatabaseFrames` | FAIL |
| `TestAggregateCallerWalksPastDatabaseIntoTheRuntime` | FAIL |
| `TestShortFuncNameTrimsModulePrefix` | PASS (pure formatting — correctly unaffected) |
| `TestAggregateCallerReportsRepoRelativePackagePath` | PASS (pure formatting — correctly unaffected) |

Discriminating, not blanket-red. File restored from backup afterwards and re-verified by
grep (0 occurrences of the control marker, skip condition present at line 97) and by a
re-run at exit 0.

## What this does NOT claim

- It does **not** identify the originator. That requires a production sample from a build
  containing this change. The `todo.d` entry carries the exact `journalctl` commands.
- It does **not** fix the amplification. The coalescing design (depth-counted,
  mutex-guarded, scoped **per book** so aggregates do not sit stale for a 4h15m run, and
  applied to `BatchUpsertBookFiles` too) is recorded in the same entry, unimplemented.
- The 42.8x figure is *implied* from `total_files` per line, not directly counted reads.
