### PR TITLE
perf(database): guard the debug caller walk behind slog.Enabled [skip changelog]

### DIFF
--- a/internal/database/pebble_store_book_aggregates.go
+++ b/internal/database/pebble_store_book_aggregates.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_book_aggregates.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 // last-edited: 2026-08-12
 
@@ -26,6 +26,7 @@
 package database
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
@@ -131,12 +132,22 @@ func (p *PebbleStore) RecomputeBookAggregates(bookID string) error {
 	if existingDuration == wantDuration && existingFileSize == wantFileSize {
 		// "caller" is the redundancy signal: a book recomputed many times from
 		// the same originator with no change to show for it is exactly what the
-		// coalescing fix is meant to eliminate. Debug-level, so this costs
-		// nothing in production until someone turns it on to look.
-		slog.Debug("RecomputeBookAggregates: no change needed",
-			"book_id", bookID,
-			"caller", aggregateCaller(),
-		)
+		// coalescing fix is meant to eliminate.
+		//
+		// The Enabled guard is NOT redundant with slog's own level check. Go
+		// evaluates arguments before the call, so an unguarded
+		// slog.Debug(..., "caller", aggregateCaller()) would walk the stack on
+		// every no-change return regardless of log level — and this is the
+		// hottest path in the function: the maintenance backfill sweeps the whole
+		// library and most books have nothing to update. That would add an
+		// unconditional stack walk to a full-library loop inside the very
+		// function this instrumentation exists to make cheaper.
+		if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
+			slog.Debug("RecomputeBookAggregates: no change needed",
+				"book_id", bookID,
+				"caller", aggregateCaller(),
+			)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Follow-up to #2358, which merged with an eager-evaluation bug.

Go evaluates arguments before the call:

```go
slog.Debug("...", "caller", aggregateCaller())
```

slog's own level check happens *inside* the call — too late. So `aggregateCaller()` walks
the stack on **every** no-change return regardless of log level. The code comment claimed
the opposite.

That is the **hottest path in the function**:
`internal/maintenance/jobs/recompute_book_aggregates.go` sweeps the whole library and most
of ~63,870 books have nothing to update. #2358 as merged therefore added an unconditional
stack walk to a full-library loop, inside the very function the instrumentation exists to
make cheaper.

Wrapped in `slog.Default().Enabled(ctx, slog.LevelDebug)`.

The **Info-line call is deliberately left unguarded** — INFO is on in production and that
is the intended, priced cost (~1-2 µs across 126,928 lines, well under a second per scan).
Guarding it would defeat the purpose of #2358.

## Verification

- `go build ./...` — exit 0
- `go vet ./internal/database/` — exit 0
- `go test ./internal/database/ -run 'AggregateCaller|ShortFuncName' -count=1` — 5/5 pass, exit 0

Caught in review of #2358 before deploy; no production build ever ran the eager version.
