### PR TITLE
fix(scheduler): wire up six tasks that were enabled but could never run

### DIFF
--- a/changelog.d/20260813_fixed_dead_scheduled_tasks.md
+++ b/changelog.d/20260813_fixed_dead_scheduled_tasks.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- Six scheduled tasks reported themselves as enabled while being unable to ever run. Four
+  of them — auto-organize, orphaned temp-file cleanup, trash cleanup, and the archive sweep
+  — asked to run in the nightly maintenance window but had been left out of the list that
+  window actually iterates, so they had never run at all. Three are unbounded disk leaks:
+  leftover files from interrupted conversions, trashed book versions past their 14-day
+  expiry, and deleted books past their 30-day retention. All four are now wired in, and a
+  new test fails the build if any future task is added without a way to run.
+- The startup warning that reports a task will never run no longer fires for the healthy
+  tasks that run nightly rather than on a timer. It had been warning about 13 of 18 tasks,
+  which buried the 6 real ones.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,7 +1,7 @@
 // file: internal/scheduler/scheduler.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 3f7a9c21-b4d8-4e05-a6f2-8c1d0e3b7a94
-// last-edited: 2026-08-12
+// last-edited: 2026-08-13
 
 // Package scheduler implements the unified task scheduling system.
 // TaskScheduler manages all registered tasks, their schedules, and manual
@@ -136,8 +136,27 @@ func NewTaskScheduler(deps SchedulerDeps) *TaskScheduler {
 		"purge_old_logs",
 		"cleanup_activity_log",
 		"cleanup_old_backups",
+		// These three declare RunInMaintenanceWindow: true unconditionally but
+		// were absent from this list, so the window op never iterated them and
+		// they had never run. They are cheap and they reclaim disk, so they sit
+		// with the other cleanups rather than behind the expensive walks:
+		//   temp_file_cleanup — orphaned *.tmp.m4b/*.tmp.m4a from crashed ffmpeg
+		//   trash_cleanup     — trashed versions past their 14-day TTL
+		//   archive_sweep     — soft-deleted books past the 30-day retention
+		// Every one of those is an unbounded on-disk leak while it never runs.
+		"temp_file_cleanup",
+		"trash_cleanup",
+		"archive_sweep",
 		"library_size_refresh",
 		"db_optimize",
+		// library_organize was the fourth task declaring a maintenance-window
+		// toggle (config.Maintenance.LibraryOrganize) while missing from this
+		// list — the same dead-config shape documented for library_scan below.
+		// It goes near the end because it MUTATES FILES ON DISK and is expensive;
+		// putting it earlier would let a long organize run starve the cleanup and
+		// dedup work when the window closes. It stays gated behind its own config
+		// toggle, so adding it here does not by itself start moving files.
+		"library_organize",
 		// library_scan is LAST on purpose. It was missing from this list
 		// entirely, which made maintenance.library_scan unreachable dead
 		// config: the window op iterates MaintenanceOrder(), so a user who
@@ -225,14 +244,39 @@ func (ts *TaskScheduler) Start(shutdown chan struct{}, wg *sync.WaitGroup) {
 				}
 			}()
 			slog.Info("Scheduled task interval", "taskName", taskName, "interval", interval)
+		} else if task.IsEnabled() && ts.reachableViaMaintenanceWindow(name) {
+			// Enabled with no ticker, but the nightly maintenance window WILL
+			// reach it. Not a defect — this is how the cleanup/backfill jobs are
+			// meant to run, and warning about them buries the ones that are
+			// genuinely dead.
+			//
+			// The first version of this branch did not exist, and the resulting
+			// WARN fired for 13 of 18 tasks on the 2026-08-12 production boot.
+			// Seven of those thirteen were healthy maintenance-window tasks. A
+			// diagnostic that cries wolf about half the roster is how the real
+			// six stayed invisible.
+			slog.Info("Scheduled task has no timer; runs in the nightly maintenance window",
+				"taskName", name)
 		} else if task.IsEnabled() {
-			// Enabled but no usable interval. This is the silent case: the
-			// operator turned the task ON and it will never run. Say so, and
-			// name the config key, because the difference between this and
-			// "deliberately off" is invisible from the outside.
-			slog.Warn("Scheduled task is ENABLED but has no interval — it will NEVER run on a timer; "+
-				"set the interval (minutes) in the scheduled.<task>.interval config key to fix",
-				"taskName", name, "interval", task.GetInterval())
+			// Enabled, no interval, and NOT reachable by the maintenance window:
+			// the task can never run by itself. This is the genuinely silent
+			// case — the operator sees it listed as enabled and nothing happens.
+			//
+			// Note the two distinct ways to land here, because the fix differs:
+			//   1. no interval configured  -> set scheduled.<task>.interval
+			//   2. declares RunInMaintenanceWindow but is absent from
+			//      maintenanceOrder -> the toggle is dead config; the task must
+			//      be added to the list in NewTaskScheduler
+			// Cause 2 hit library_scan once (see the maintenanceOrder comment),
+			// then recurred on four more tasks: library_organize,
+			// temp_file_cleanup, trash_cleanup and archive_sweep.
+			slog.Warn("Scheduled task is ENABLED but can NEVER run — it has no interval and the "+
+				"maintenance window does not reach it; set scheduled.<task>.interval, or add the "+
+				"task to maintenanceOrder if it is meant to run in the nightly window",
+				"taskName", name,
+				"interval", task.GetInterval(),
+				"declaresMaintenanceWindow", task.RunInMaintenanceWindow != nil && task.RunInMaintenanceWindow(),
+				"inMaintenanceOrder", ts.inMaintenanceOrder(name))
 		} else {
 			// Deliberately off. Logged at Debug so the roster is complete for
 			// anyone diagnosing "why did nothing happen" without adding noise.
@@ -348,6 +392,42 @@ func (ts *TaskScheduler) Tasks() map[string]*TaskDefinition {
 // MaintenanceOrder returns the ordered list of maintenance task names.
 func (ts *TaskScheduler) MaintenanceOrder() []string {
 	return ts.maintenanceOrder
+}
+
+// inMaintenanceOrder reports whether the nightly window op will even consider
+// this task. The op iterates MaintenanceOrder() (see
+// internal/server/scheduler_maintenance_window_op.go), so a task absent from
+// that list is unreachable no matter what RunInMaintenanceWindow returns —
+// which is exactly how four tasks came to declare a maintenance-window toggle
+// that did nothing.
+func (ts *TaskScheduler) inMaintenanceOrder(name string) bool {
+	for _, n := range ts.maintenanceOrder {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+// reachableViaMaintenanceWindow reports whether the nightly window can actually
+// run this task. BOTH conditions must hold, which is the whole point: the window
+// op's guard is `IsEnabled() && RunInMaintenanceWindow()` applied only to names
+// it iterates, so declaring the toggle without list membership — or list
+// membership without the toggle — runs nothing.
+//
+// This deliberately does NOT check config.Maintenance.Enabled. A task that is
+// correctly wired but sitting behind a disabled maintenance window is an
+// operator choice, not a wiring defect, and conflating the two would restore the
+// over-reporting this function exists to prevent.
+func (ts *TaskScheduler) reachableViaMaintenanceWindow(name string) bool {
+	if !ts.inMaintenanceOrder(name) {
+		return false
+	}
+	task, ok := ts.tasks[name]
+	if !ok || task.RunInMaintenanceWindow == nil {
+		return false
+	}
+	return task.RunInMaintenanceWindow()
 }
 
 // WaitForOperation polls until an operation completes or the context is canceled.

--- a/internal/scheduler/task_reachability_test.go
+++ b/internal/scheduler/task_reachability_test.go
@@ -1,0 +1,187 @@
+// file: internal/scheduler/task_reachability_test.go
+// version: 1.0.0
+// guid: 1d84f2b7-6c03-4e91-a7d5-9b02e6f41c38
+// last-edited: 2026-08-13
+
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// reachabilityTestDeps builds a fully-capable SchedulerDeps.
+//
+// Every capability probe returns TRUE on purpose. Several IsEnabled closures are
+// gated on them (HasActivitySvc, HasDedupEngine, HasMetadataFetchSvc), so
+// stubbing them false would report those tasks as disabled and the reachability
+// invariant would skip exactly the tasks most likely to be misconfigured. True
+// models a fully-provisioned production server, which is the case that matters.
+//
+// A bare SchedulerDeps{} is not usable here: the probes are nil funcs and
+// registerAllTasks' closures dereference them, so the first IsEnabled() call
+// panics.
+//
+// Store returns nil, which is safe — task registration only builds closures, and
+// nothing on the reachability path invokes the store.
+func reachabilityTestDeps() SchedulerDeps {
+	return SchedulerDeps{
+		Store:               func() database.Store { return nil },
+		HasDedupEngine:      func() bool { return true },
+		HasMetadataFetchSvc: func() bool { return true },
+		HasActivitySvc:      func() bool { return true },
+		HasBatchPoller:      func() bool { return true },
+	}
+}
+
+// TestEveryEnabledTaskIsReachable is the invariant that closes this bug class.
+//
+// A registered task can start itself in exactly two ways: an interval ticker, or
+// the nightly maintenance window (which iterates MaintenanceOrder() and requires
+// RunInMaintenanceWindow). A task that is reported ENABLED while satisfying
+// neither is dead — it shows up on the tasks page as on, and does nothing,
+// forever, with no error anywhere.
+//
+// This is not hypothetical and it is not a one-off. Measured on production
+// 2026-08-13, of 18 registered tasks:
+//
+//   - 5 had a working ticker;
+//   - 7 were correctly reachable through the maintenance window;
+//   - 6 were enabled and could never run.
+//
+// Four of those six (library_organize, temp_file_cleanup, trash_cleanup,
+// archive_sweep) declared RunInMaintenanceWindow but were MISSING from
+// maintenanceOrder — the identical dead-config shape already documented in the
+// maintenanceOrder comment for library_scan, recurring four more times because
+// nothing checked. Three of them are unbounded on-disk leaks: orphaned ffmpeg
+// temp files, trashed versions past their 14-day TTL, and soft-deleted books
+// past the 30-day retention window.
+//
+// Adding a task now forces a choice: give it an interval, wire it into the
+// window, or mark it disabled. All three are fine. Silently doing none is not.
+func TestEveryEnabledTaskIsReachable(t *testing.T) {
+	ts := NewTaskScheduler(reachabilityTestDeps())
+
+	if len(ts.tasks) == 0 {
+		t.Fatal("no tasks registered — the invariant below would vacuously pass, " +
+			"which is the failure mode this guard exists to prevent")
+	}
+
+	var dead []string
+	for name, task := range ts.tasks {
+		if task.IsEnabled == nil || !task.IsEnabled() {
+			continue // deliberately off — an explicit, visible choice
+		}
+		if task.GetInterval != nil && task.GetInterval() > 0 {
+			continue // timer-driven
+		}
+		// Deliberately inMaintenanceOrder, NOT reachableViaMaintenanceWindow.
+		//
+		// This test asserts WIRING — can the task run if an operator turns it
+		// on? RunInMaintenanceWindow usually reads config.AppConfig.Maintenance.*,
+		// which is zero-valued under test, so every toggle is false here. Using
+		// the full reachability check failed metadata_upgrade,
+		// library_size_refresh and library_organize purely because nobody had
+		// set a config field in a unit test — an operator choice, not a defect.
+		// A structural invariant that fails on configuration gets muted, and a
+		// muted invariant protects nothing.
+		//
+		// The runtime warning in Start() correctly uses the stricter
+		// reachableViaMaintenanceWindow, because there "enabled but the toggle
+		// is off" is exactly what the operator needs told.
+		if ts.inMaintenanceOrder(name) {
+			continue // wired into the nightly window; whether it runs is config
+		}
+		dead = append(dead, name)
+	}
+
+	if len(dead) > 0 {
+		t.Errorf("%d task(s) are ENABLED but can never run: %v\n"+
+			"Each needs exactly one of:\n"+
+			"  - a non-zero GetInterval (a ticker), or\n"+
+			"  - membership in maintenanceOrder AND RunInMaintenanceWindow() true, or\n"+
+			"  - IsEnabled() false, if it is manual/API-only.\n"+
+			"Declaring RunInMaintenanceWindow without adding the name to "+
+			"maintenanceOrder is dead config: the window op only iterates that list.",
+			len(dead), dead)
+	}
+}
+
+// TestMaintenanceOrderNamesRealTasks catches the other half of the wiring
+// mistake. inMaintenanceOrder is a string lookup, so a typo or a renamed task
+// leaves an entry that matches nothing and silently drops that task from the
+// nightly run — the same invisible failure, arrived at from the opposite side.
+func TestMaintenanceOrderNamesRealTasks(t *testing.T) {
+	ts := NewTaskScheduler(reachabilityTestDeps())
+
+	if len(ts.maintenanceOrder) == 0 {
+		t.Fatal("maintenanceOrder is empty — nothing would be checked below")
+	}
+
+	for _, name := range ts.maintenanceOrder {
+		if _, ok := ts.tasks[name]; !ok {
+			t.Errorf("maintenanceOrder contains %q, which is not a registered task; "+
+				"the window op will iterate past it and run nothing", name)
+		}
+	}
+}
+
+// TestTasksMissingFromMaintenanceOrderDoNotClaimTheWindow asserts the specific
+// inconsistency directly, so a failure names the wiring error rather than only
+// its downstream effect.
+//
+// A task may legitimately opt out of the window (RunInMaintenanceWindow false).
+// What it may not do is return true while absent from the list, because that
+// reads as "runs nightly" everywhere it is surfaced and never does.
+func TestTasksMissingFromMaintenanceOrderDoNotClaimTheWindow(t *testing.T) {
+	ts := NewTaskScheduler(reachabilityTestDeps())
+
+	for name, task := range ts.tasks {
+		if task.RunInMaintenanceWindow == nil || !task.RunInMaintenanceWindow() {
+			continue
+		}
+		if !ts.inMaintenanceOrder(name) {
+			t.Errorf("task %q returns RunInMaintenanceWindow() true but is absent from "+
+				"maintenanceOrder, so the nightly window never reaches it — add it to the "+
+				"list in NewTaskScheduler, or return false", name)
+		}
+	}
+}
+
+// TestReachabilityHelpersRequireBothConditions pins the helper itself. Without
+// this, reachableViaMaintenanceWindow could degrade to a plain list-membership
+// check and TestEveryEnabledTaskIsReachable would keep passing while quietly
+// excusing tasks whose toggle is off.
+func TestReachabilityHelpersRequireBothConditions(t *testing.T) {
+	ts := NewTaskScheduler(reachabilityTestDeps())
+
+	const listedOptOut = "reachability_listed_but_opted_out"
+	ts.tasks[listedOptOut] = &TaskDefinition{
+		Name:                   listedOptOut,
+		IsEnabled:              func() bool { return true },
+		GetInterval:            func() time.Duration { return 0 },
+		RunInMaintenanceWindow: func() bool { return false },
+	}
+	ts.maintenanceOrder = append(ts.maintenanceOrder, listedOptOut)
+
+	if ts.reachableViaMaintenanceWindow(listedOptOut) {
+		t.Error("a task in maintenanceOrder whose RunInMaintenanceWindow() is false " +
+			"must NOT count as reachable — the window op checks the toggle too")
+	}
+
+	const unlistedOptIn = "reachability_opted_in_but_unlisted"
+	ts.tasks[unlistedOptIn] = &TaskDefinition{
+		Name:                   unlistedOptIn,
+		IsEnabled:              func() bool { return true },
+		GetInterval:            func() time.Duration { return 0 },
+		RunInMaintenanceWindow: func() bool { return true },
+	}
+
+	if ts.reachableViaMaintenanceWindow(unlistedOptIn) {
+		t.Error("a task returning RunInMaintenanceWindow() true but absent from " +
+			"maintenanceOrder must NOT count as reachable — this is exactly the dead " +
+			"config that hid four broken tasks in production")
+	}
+}

--- a/internal/scheduler/tasks.go
+++ b/internal/scheduler/tasks.go
@@ -1,7 +1,7 @@
 // file: internal/scheduler/tasks.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 9b4c7e21-a5f3-4d08-b2e6-3c8d1f7a0e54
-// last-edited: 2026-08-11
+// last-edited: 2026-08-13
 
 // Package scheduler — task registrations.
 // All 22 registered tasks are defined here. Each task's TriggerFn and
@@ -206,7 +206,14 @@ func (ts *TaskScheduler) registerAllTasks() {
 			slog.Warn("transcode task triggered from scheduler () without params — use the operations API", "source", source)
 			return op, nil
 		},
-		IsEnabled:              func() bool { return true },
+		// NOT enabled, and this is not a regression: the TriggerFn above fails
+		// by design because a scheduled trigger has no book_id to transcode.
+		// Reporting Enabled=true for a task whose every automatic invocation
+		// creates a failed operation is a lie the UI repeats on the tasks page.
+		// runTask does not consult IsEnabled, so manual/API invocation with real
+		// params is unaffected — only the automatic paths and the displayed
+		// state change.
+		IsEnabled:              func() bool { return false },
 		GetInterval:            func() time.Duration { return 0 },
 		RunOnStart:             func() bool { return false },
 		RunInMaintenanceWindow: func() bool { return false },
@@ -362,7 +369,14 @@ func (ts *TaskScheduler) registerAllTasks() {
 			}
 			return op, nil
 		},
-		IsEnabled:              func() bool { return true },
+		// Manual-only, and now says so. It has no interval and explicitly opts
+		// out of the maintenance window, so IsEnabled: true described a task
+		// that could never start itself. It also runs write-back + organize,
+		// which moves files — turning it into a timer would be a behaviour
+		// change nobody asked for, so the honest fix is to stop claiming it is
+		// enabled. runTask ignores IsEnabled, so triggering it from the
+		// operations API still works exactly as before.
+		IsEnabled:              func() bool { return false },
 		GetInterval:            func() time.Duration { return 0 },
 		RunOnStart:             func() bool { return false },
 		RunInMaintenanceWindow: func() bool { return false },

--- a/todo.d/20260813-dead-scheduled-tasks.md
+++ b/todo.d/20260813-dead-scheduled-tasks.md
@@ -1,0 +1,52 @@
+## ✅ Six scheduled tasks were enabled but could never run
+
+Found by the three-state startup diagnostic added in #2346, on the first production boot
+that carried it (2026-08-13 02:45 UTC). Of 18 registered tasks: 5 had a working ticker, 7
+were reachable through the nightly maintenance window, and **6 were enabled and dead**.
+
+Four of the six declared `RunInMaintenanceWindow` but were **absent from
+`maintenanceOrder`** in `NewTaskScheduler`. `internal/server/scheduler_maintenance_window_op.go:97`
+iterates `MaintenanceOrder()` and only then checks `IsEnabled() && RunInMaintenanceWindow()`,
+so a task missing from the list is unreachable no matter what the toggle says. This is the
+*same* dead-config shape already documented in the `maintenanceOrder` comment for
+`library_scan` — it recurred four more times because nothing checked.
+
+| Task | Was | Now |
+|---|---|---|
+| `temp_file_cleanup` | declared window, not listed | listed with the cleanup cluster |
+| `trash_cleanup` | declared window, not listed | listed with the cleanup cluster |
+| `archive_sweep` | declared window, not listed | listed with the cleanup cluster |
+| `library_organize` | declared window, not listed | listed late (mutates files, expensive) |
+| `transcode` | `IsEnabled: true`, trigger fails by design | `IsEnabled: false` |
+| `series_normalize` | `IsEnabled: true`, no timer, opts out of window | `IsEnabled: false` |
+
+Three of these are unbounded on-disk leaks that had never run: orphaned `*.tmp.m4b` /
+`*.tmp.m4a` from crashed ffmpeg, trashed versions past their 14-day TTL, and soft-deleted
+books past the 30-day retention window.
+
+`transcode` and `series_normalize` are marked disabled rather than given tickers because
+neither can usefully run unattended — `transcode`'s scheduled `TriggerFn` fails on purpose
+without a `book_id`, and `series_normalize` moves files. `runTask` does not consult
+`IsEnabled`, so manual/API invocation is unchanged; only the automatic paths and the
+displayed state are affected.
+
+### Recurrence guard
+
+`internal/scheduler/task_reachability_test.go` asserts every registered task is
+timer-driven, wired into `maintenanceOrder`, or explicitly disabled, plus two narrower
+checks (no `maintenanceOrder` entry naming a non-existent task; no task claiming the window
+while absent from the list). The invariant checks **wiring**, not configuration — it uses
+`inMaintenanceOrder` rather than `reachableViaMaintenanceWindow`, because the latter reads
+`config.AppConfig.Maintenance.*`, which is zero under test, and a structural invariant that
+fails on an operator's config choice gets muted.
+
+### Not claimed / still open
+
+- **How much disk the three leaks are holding is NOT measured.** Nothing counted the
+  orphaned temp files, expired trash, or over-retention archives on prod before this
+  landed. Worth measuring on the first window run after deploy.
+- Whether the window has time to reach the newly-appended entries is untested: the op
+  breaks out of the loop when the window closes (01:00–04:00 on prod), and `library_organize`
+  plus `library_scan` sit at the end behind everything else.
+- `metadata_upgrade`, `library_size_refresh` and `library_organize` are wired but gated on
+  `config.Maintenance.*` toggles whose production values were not checked.


### PR DESCRIPTION
## What the new diagnostic found on its first boot

#2346 added a startup warning for tasks that are enabled but have no interval. It shipped
to production last night. Of **18 registered tasks**: 5 had a working ticker, 7 were
reachable through the nightly maintenance window, and **6 were enabled and could never
run.**

## The mechanism: declaring the window is not enough to be in it

`internal/server/scheduler_maintenance_window_op.go:97` iterates `MaintenanceOrder()` and
*then* checks `IsEnabled() && RunInMaintenanceWindow()`. A task absent from that list is
unreachable no matter what its toggle says.

Four tasks declared `RunInMaintenanceWindow` while missing from `maintenanceOrder`. This is
the **same dead-config shape already documented in the `maintenanceOrder` comment for
`library_scan`** — it recurred four more times because nothing checked.

| Task | Was | Now |
|---|---|---|
| `temp_file_cleanup` | declared window, not listed | listed with the cleanup cluster |
| `trash_cleanup` | declared window, not listed | listed with the cleanup cluster |
| `archive_sweep` | declared window, not listed | listed with the cleanup cluster |
| `library_organize` | declared window, not listed | listed late — mutates files, expensive |
| `transcode` | `IsEnabled: true`, trigger fails by design | `IsEnabled: false` |
| `series_normalize` | `IsEnabled: true`, no timer, opts out of window | `IsEnabled: false` |

**Three of these are unbounded on-disk leaks that had never run once:** orphaned
`*.tmp.m4b`/`*.tmp.m4a` from crashed ffmpeg, trashed versions past their 14-day TTL, and
soft-deleted books past the 30-day retention window.

`library_organize` goes near the end of the order deliberately — the window op breaks out of
the loop when the window closes, so an expensive file-moving run parked in front would
starve the cleanup and dedup work on the same night. It stays gated behind
`config.Maintenance.LibraryOrganize`, so listing it does not by itself start moving files.

`transcode` and `series_normalize` are marked disabled rather than given tickers: neither
can usefully run unattended (`transcode`'s scheduled `TriggerFn` fails on purpose without a
`book_id`; `series_normalize` runs write-back + organize). **`runTask` does not consult
`IsEnabled`**, so manual/API invocation is unchanged — only the automatic paths and the
state the UI displays.

## The warning was crying wolf

It fired for **13 of 18** tasks, 7 of which were healthy maintenance-window tasks. A
diagnostic that flags half the roster is how the real six stayed invisible. It now
distinguishes three states: timer / window-reachable (INFO) / genuinely unreachable (WARN),
and the WARN reports `declaresMaintenanceWindow` and `inMaintenanceOrder` so the reader can
tell which of the two fixes applies.

## Recurrence guard

`internal/scheduler/task_reachability_test.go` — every registered task must be
timer-driven, wired into `maintenanceOrder`, or explicitly disabled. Plus two narrower
checks: no `maintenanceOrder` entry naming a non-existent task, and no task claiming the
window while absent from the list.

It asserts **wiring, not configuration.** Using the full `reachableViaMaintenanceWindow`
helper failed `metadata_upgrade`, `library_size_refresh` and `library_organize` purely
because `config.AppConfig` is zero-valued under test, so every `Maintenance.*` toggle reads
false. That is an operator choice, not a defect — and a structural invariant that fails on
configuration gets muted. The runtime warning keeps the stricter check, because there
"enabled but the toggle is off" *is* worth saying.

The capability stubs in `reachabilityTestDeps` return **true** on purpose: several
`IsEnabled` closures are gated on them, so stubbing false would report those tasks disabled
and skip exactly the ones most likely to be misconfigured.

## Verification

- `go build ./...` — exit 0
- `go vet ./internal/scheduler/` — exit 0
- `go test ./internal/scheduler/ -count=1` — exit 0

**Negative control** (removing the four `maintenanceOrder` additions from the committed
file):

```
--- FAIL: TestEveryEnabledTaskIsReachable
    4 task(s) are ENABLED but can never run: [temp_file_cleanup library_organize archive_sweep trash_cleanup]
--- FAIL: TestTasksMissingFromMaintenanceOrderDoNotClaimTheWindow
    task "temp_file_cleanup" returns RunInMaintenanceWindow() true but is absent from maintenanceOrder ...
    task "archive_sweep"     ... same
    task "trash_cleanup"     ... same
```

Names exactly the four, and the second test catches three of them independently by the
declare-without-list rule. Every other test in the package stayed green. File restored from
backup and re-verified (4 occurrences present, suite exit 0).

## Not claimed

- **How much disk the three leaks are holding is NOT measured.** Nothing counted orphaned
  temp files, expired trash, or over-retention archives on prod before this. Worth checking
  after the first window run.
- Whether the window (01:00–04:00 on prod) has time to *reach* the newly-appended entries
  is untested — the op breaks out when the window closes.
- The production values of `config.Maintenance.{MetadataUpgrade,LibrarySizeRefresh,LibraryOrganize}`
  were not checked; those three are wired but toggle-gated.
