### PR TITLE
docs(scheduler): correct the disk-leak claim for the three cleanup tasks [skip changelog]

### DIFF
--- a/changelog.d/20260813_fixed_dead_scheduled_tasks.md
+++ b/changelog.d/20260813_fixed_dead_scheduled_tasks.md
@@ -3,10 +3,10 @@
 - Six scheduled tasks reported themselves as enabled while being unable to ever run. Four
   of them — auto-organize, orphaned temp-file cleanup, trash cleanup, and the archive sweep
   — asked to run in the nightly maintenance window but had been left out of the list that
-  window actually iterates, so they had never run at all. Three are unbounded disk leaks:
-  leftover files from interrupted conversions, trashed book versions past their 14-day
-  expiry, and deleted books past their 30-day retention. All four are now wired in, and a
-  new test fails the build if any future task is added without a way to run.
+  window actually iterates, so they had never run at all. Between them they clear leftover
+  files from interrupted conversions, trashed book versions past their 14-day expiry, and
+  deleted books past their 30-day retention. All four are now wired in, and a new test
+  fails the build if any future task is added without a way to run.
 - The startup warning that reports a task will never run no longer fires for the healthy
   tasks that run nightly rather than on a timer. It had been warning about 13 of 18 tasks,
   which buried the 6 real ones.

--- a/todo.d/20260813-dead-scheduled-tasks.md
+++ b/todo.d/20260813-dead-scheduled-tasks.md
@@ -20,9 +20,21 @@ so a task missing from the list is unreachable no matter what the toggle says. T
 | `transcode` | `IsEnabled: true`, trigger fails by design | `IsEnabled: false` |
 | `series_normalize` | `IsEnabled: true`, no timer, opts out of window | `IsEnabled: false` |
 
-Three of these are unbounded on-disk leaks that had never run: orphaned `*.tmp.m4b` /
-`*.tmp.m4a` from crashed ffmpeg, trashed versions past their 14-day TTL, and soft-deleted
-books past the 30-day retention window.
+Three of these are retention/cleanup jobs that had never run once. **Correcting an
+overstatement in the merged PR body and changelog**, which called all three "unbounded
+on-disk leaks" — only one touches disk, and it is currently empty:
+
+| Task | Operates on | Measured on prod 2026-08-13 |
+|---|---|---|
+| `temp_file_cleanup` | disk — walks `config.AppConfig.RootDir` for `*.tmp.m4b`/`*.tmp.m4a` (`sweep.CleanupOrphanedTempFiles`) | **0 files, 0 bytes** |
+| `trash_cleanup` | database rows — `versions.CleanupTrashedVersions` | not measured |
+| `archive_sweep` | database rows — `sweep.SweepArchivedBooks` | not measured |
+
+The temp-file count was taken with `find` over the real root the op uses, so "0" is a
+measurement, not an assumption. It does mean the disk-leak framing was wrong: whatever
+these three were holding, it was not gigabytes of stranded audio. The two DB-side counts
+are still unknown and will be reported by the first window run, which logs
+`Trash cleanup: purged N versions` and `Archive sweep: cleaned N books`.
 
 `transcode` and `series_normalize` are marked disabled rather than given tickers because
 neither can usefully run unattended — `transcode`'s scheduled `TriggerFn` fails on purpose


### PR DESCRIPTION
#2360's body, changelog fragment and todo fragment all described `temp_file_cleanup`, `trash_cleanup` and `archive_sweep` as "three unbounded on-disk leaks". That was wrong on two counts, and the check was cheap.

| Task | Operates on | Measured on prod 2026-08-13 |
|---|---|---|
| `temp_file_cleanup` | **disk** — `sweep.CleanupOrphanedTempFiles` over `config.AppConfig.RootDir` | **0 files, 0 bytes** |
| `trash_cleanup` | **database rows** — `versions.CleanupTrashedVersions` | not measured |
| `archive_sweep` | **database rows** — `sweep.SweepArchivedBooks` | not measured |

Only one of the three touches disk, and that one is currently empty. The count was taken with `find` over the real root the op uses, so 0 is a measurement rather than an assumption.

**The defect and the fix stand** — those tasks were genuinely unreachable and are now wired in. What was wrong was the consequence: I wrote a more dramatic story than the evidence supported, having guessed at trash/archive directory paths instead of reading the two `Run` functions.

The two DB-side counts will be reported by the first maintenance-window run (01:00–04:00), which logs `Trash cleanup: purged N versions` and `Archive sweep: cleaned N books`.

Docs only — no code change.