### PR TITLE
fix(filters): reject empty filter values instead of matching every book

### DIFF
--- a/changelog.d/20260813_fixed_empty_filter_matches_whole_library.md
+++ b/changelog.d/20260813_fixed_empty_filter_matches_whole_library.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- A filter with an empty value silently matched every book instead of narrowing anything.
+  Filtering the library by, say, title with the box left empty returned the entire library
+  rather than an error or an empty result — and the same filters are used to pick which
+  books a background metadata operation runs against, so an empty value could quietly point
+  a targeted job at the whole collection. Empty filter values are now rejected with a clear
+  message explaining that omitting the filter is how you ask for everything.

--- a/internal/audiobooks/empty_field_filter_test.go
+++ b/internal/audiobooks/empty_field_filter_test.go
@@ -1,0 +1,128 @@
+// file: internal/audiobooks/empty_field_filter_test.go
+// version: 1.0.0
+// guid: 4e8b1a37-9d52-4c06-b3f8-27a1d0e5c964
+// last-edited: 2026-08-13
+
+package audiobooks
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// emptyFilterTestBook builds a book with a known title/narrator so the tests
+// below can distinguish "matched because the filter is satisfied" from "matched
+// because the filter constrained nothing".
+func emptyFilterTestBook(title string) database.Book {
+	n := "Some Narrator"
+	return database.Book{
+		ID:       "b1",
+		Title:    title,
+		Narrator: &n,
+	}
+}
+
+// TestEmptyFilterValueDoesNotMatchEveryBook is the regression for the defect.
+//
+// strings.Contains(anything, "") is true in Go, so before the fix an empty
+// filter value silently matched every book. Measured on production 2026-08-13:
+// title="" returned all 63,870 books while title="zzqqxx" returned 0 — the
+// filter worked, and only the empty value widened it to everything.
+func TestEmptyFilterValueDoesNotMatchEveryBook(t *testing.T) {
+	book := emptyFilterTestBook("The Hobbit")
+
+	if matchesFieldFilters(book, []FieldFilter{{Field: "title", Value: ""}}) {
+		t.Error("an empty filter value matched a book; it must fail closed, because " +
+			"strings.Contains(x, \"\") is always true and would match the whole library")
+	}
+}
+
+// TestEmptyFilterValueFailsClosedEvenWhenNegated pins the negated case
+// separately. `title != ""` is no more a real constraint than `title == ""`, and
+// leaving Negated to fall through would give the two an inconsistent answer.
+func TestEmptyFilterValueFailsClosedEvenWhenNegated(t *testing.T) {
+	book := emptyFilterTestBook("The Hobbit")
+
+	if matchesFieldFilters(book, []FieldFilter{{Field: "title", Value: "", Negated: true}}) {
+		t.Error("a negated empty filter value matched a book; neither == \"\" nor != \"\" " +
+			"is a constraint a caller can have meant")
+	}
+}
+
+// TestNonEmptyFiltersStillWork is the discriminating control. Without it, the
+// two tests above would pass just as happily against a matcher that rejected
+// EVERYTHING — which would be a far worse bug than the one being fixed.
+func TestNonEmptyFiltersStillWork(t *testing.T) {
+	book := emptyFilterTestBook("The Hobbit")
+
+	cases := []struct {
+		name   string
+		filter FieldFilter
+		want   bool
+	}{
+		{"substring match", FieldFilter{Field: "title", Value: "Hobbit"}, true},
+		{"case-insensitive", FieldFilter{Field: "title", Value: "hobbit"}, true},
+		{"non-matching value", FieldFilter{Field: "title", Value: "zzqqxx"}, false},
+		{"negated non-match keeps the book", FieldFilter{Field: "title", Value: "zzqqxx", Negated: true}, true},
+		{"negated match drops the book", FieldFilter{Field: "title", Value: "Hobbit", Negated: true}, false},
+		{"other field still matches", FieldFilter{Field: "narrator", Value: "Narrator"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := matchesFieldFilters(book, []FieldFilter{tc.filter}); got != tc.want {
+				t.Errorf("matchesFieldFilters(%+v) = %v, want %v", tc.filter, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEmptyValueRejectsTheWholeFilterSet checks the AND semantics: one empty
+// value must sink the whole set, not just its own clause. A caller sending
+// [title="Hobbit", narrator=""] would otherwise still get everything the first
+// clause allowed while believing the second had narrowed it further.
+func TestEmptyValueRejectsTheWholeFilterSet(t *testing.T) {
+	book := emptyFilterTestBook("The Hobbit")
+
+	filters := []FieldFilter{
+		{Field: "title", Value: "Hobbit"}, // would match
+		{Field: "narrator", Value: ""},    // must sink the set
+	}
+	if matchesFieldFilters(book, filters) {
+		t.Error("a filter set containing one empty value matched; all filters are ANDed, " +
+			"so an unusable clause must reject the set rather than be ignored")
+	}
+}
+
+// TestFirstEmptyFilterValue covers the helper the two validation layers call.
+func TestFirstEmptyFilterValue(t *testing.T) {
+	t.Run("reports the offending field", func(t *testing.T) {
+		field, empty := FirstEmptyFilterValue([]FieldFilter{
+			{Field: "title", Value: "Hobbit"},
+			{Field: "narrator", Value: ""},
+		})
+		if !empty {
+			t.Fatal("FirstEmptyFilterValue did not flag an empty value")
+		}
+		if field != "narrator" {
+			t.Errorf("FirstEmptyFilterValue reported field %q, want %q — the message shown "+
+				"to the caller names this field", field, "narrator")
+		}
+	})
+
+	t.Run("clean filter set passes", func(t *testing.T) {
+		if _, empty := FirstEmptyFilterValue([]FieldFilter{
+			{Field: "title", Value: "Hobbit"},
+			{Field: "narrator", Value: "Someone"},
+		}); empty {
+			t.Error("FirstEmptyFilterValue flagged a filter set with no empty values")
+		}
+	})
+
+	t.Run("no filters at all is not an empty value", func(t *testing.T) {
+		if _, empty := FirstEmptyFilterValue(nil); empty {
+			t.Error("FirstEmptyFilterValue flagged an absent filter set; omitting filters " +
+				"legitimately means 'no constraint' and must stay allowed")
+		}
+	})
+}

--- a/internal/audiobooks/service_filtering.go
+++ b/internal/audiobooks/service_filtering.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_filtering.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: b4e8c3d2-e5f6-7a80-9b0c-1d2e3f4a5b6c
-// last-edited: 2026-07-18
+// last-edited: 2026-08-13
 
 package audiobooks
 
@@ -211,10 +211,57 @@ func matchesAllPerUserFilters(state *database.UserBookState, filters []FieldFilt
 	return true
 }
 
+// FirstEmptyFilterValue returns the field name of the first filter carrying an
+// empty value, and whether one was found.
+//
+// WHY this exists: the comparison at the bottom of fieldMatchesValue is
+//
+//	strings.Contains(strings.ToLower(bookValue), strings.ToLower(value))
+//
+// and strings.Contains(anything, "") is ALWAYS TRUE in Go. So a filter with an
+// empty value does not narrow anything — it silently matches every book.
+//
+// Measured on production 2026-08-13, and the filter is otherwise working:
+//
+//	title=""       -> 63,870 books (the entire library)
+//	title="zzqqxx" ->      0 books
+//	title="Skills" ->     25 books
+//
+// That is not merely a confusing read. FieldFilters also reach
+// Server.resolveFilterToBookIDs, which resolves a FilterSpec into concrete book
+// IDs for BACKGROUND OPERATIONS at a limit of 100,000 — so an empty value there
+// silently targets the whole library. That is the same failure shape as the
+// base64 op-params defect (#2309), where organize defaulted to every book.
+//
+// Callers use this to reject the input loudly. matchesFieldFilters below also
+// fails closed as a last line of defence, so a filter that somehow evades
+// validation matches nothing rather than everything.
+func FirstEmptyFilterValue(filters []FieldFilter) (string, bool) {
+	for _, f := range filters {
+		if f.Value == "" {
+			return f.Field, true
+		}
+	}
+	return "", false
+}
+
 // matchesFieldFilters returns true if a book matches all the given field filters.
 // All filters are ANDed: every filter must match for the book to be included.
 func matchesFieldFilters(book database.Book, filters []FieldFilter) bool {
 	for _, f := range filters {
+		// Fail CLOSED on an empty value. Falling through would reach
+		// strings.Contains(x, "") == true and match every book — see
+		// FirstEmptyFilterValue. Matching nothing is visibly wrong and harmless;
+		// matching everything is invisibly wrong and, on the background-op path,
+		// destructive. Negated is deliberately not consulted: neither `f == ""`
+		// nor `f != ""` is a constraint anyone can have meant.
+		//
+		// No in-repo code builds a filter with an empty value (the list warmer's
+		// constructions all carry real values), so this only ever fires on input
+		// that the boundary validation should already have rejected.
+		if f.Value == "" {
+			return false
+		}
 		matches := fieldMatchesValue(book, f.Field, f.Value)
 		if f.Negated && matches {
 			return false // NOT filter: exclude if matches

--- a/internal/server/handlers/audiobooks/handler.go
+++ b/internal/server/handlers/audiobooks/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 51fac747-9478-4075-8621-9da4bbdedc37
-// last-edited: 2026-08-11
+// last-edited: 2026-08-13
 
 // Package audiobookshandler hosts the main library list / CRUD HTTP handlers
 // extracted from the server package's audiobooks_handlers.go: book listing
@@ -455,6 +455,20 @@ func (h *Handler) ListAudiobooks(c *gin.Context) {
 		var fieldFilters []audiobookspkg.FieldFilter
 		if err := json.Unmarshal([]byte(filtersJSON), &fieldFilters); err != nil {
 			httputil.RespondWithBadRequest(c, "invalid filters parameter: "+err.Error())
+			return
+		}
+		// Reject empty filter values at the boundary. strings.Contains(x, "")
+		// is always true, so an empty value silently matches EVERY book instead
+		// of narrowing anything — measured on production as title="" returning
+		// all 63,870 books while title="zzqqxx" correctly returned 0. A caller
+		// that sends an empty value has a bug (usually a cleared UI field that
+		// was submitted anyway), and answering it with the whole library is the
+		// worst possible response. See audiobooks.FirstEmptyFilterValue.
+		if field, empty := audiobookspkg.FirstEmptyFilterValue(fieldFilters); empty {
+			httputil.RespondWithBadRequest(c,
+				"filter on \""+field+"\" has an empty value; an empty value matches every "+
+					"book rather than narrowing the results. Omit the filter to list everything, "+
+					"or supply a value to filter by.")
 			return
 		}
 		for _, ff := range fieldFilters {

--- a/internal/server/metadata_ops.go
+++ b/internal/server/metadata_ops.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_ops.go
-// version: 1.5.1
+// version: 1.6.0
 // guid: fba55738-5898-4950-8e79-3ee008ad0c70
-// last-edited: 2026-07-16
+// last-edited: 2026-08-13
 //
 // Async-operation machinery for the metadata domain, relocated verbatim from
 // metadata_handlers.go (ADR-003 Phase 4) when the 19 metadata HTTP handlers
@@ -466,6 +466,17 @@ func (s *Server) resolveFilterToBookIDs(ctx context.Context, f operations.Filter
 	for _, ff := range f.FieldFilters {
 		if IsPerUserField(ff.Field) {
 			continue
+		}
+		// Refuse an empty value rather than resolving it. strings.Contains(x, "")
+		// is always true, so an empty-valued filter matches EVERY book — and this
+		// function resolves to concrete book IDs for a BACKGROUND OPERATION with
+		// a limit of 100,000. Silently widening a targeted op to the whole
+		// library is exactly the base64 op-params defect (#2309) one level down,
+		// and unlike the list endpoint there is no HTTP boundary here to catch
+		// it: params arrive already deserialized from the operation queue.
+		if ff.Value == "" {
+			return nil, fmt.Errorf("filter on %q has an empty value, which would match every "+
+				"book and target the entire library; refusing to resolve it", ff.Field)
 		}
 		filters.FieldFilters = append(filters.FieldFilters, FieldFilter{
 			Field:   ff.Field,

--- a/todo.d/20260813-empty-field-filter-matches-everything.md
+++ b/todo.d/20260813-empty-field-filter-matches-everything.md
@@ -1,0 +1,49 @@
+## ✅ An empty `FieldFilter` value matched the WHOLE LIBRARY (fixed)
+
+`fieldMatchesValue` ends in:
+
+```go
+return strings.Contains(strings.ToLower(bookValue), strings.ToLower(value))
+```
+
+`strings.Contains(anything, "")` is **always true** in Go, so a filter whose value is empty
+constrains nothing. Measured live on prod 2026-08-13 (post-deploy build), and the filter is
+otherwise healthy — this is specific to the empty value:
+
+| `filters=[{"field":"title","value":X}]` | total |
+|---|---|
+| `X = ""` | **63,870 — the entire library** |
+| `X = "zzqqxx"` | 0 |
+| `X = "Skills"` | 25 |
+
+### Why this was more than a confusing read
+
+`FieldFilters` also flow into `Server.resolveFilterToBookIDs`
+(`internal/server/metadata_ops.go:458`), which resolves a `FilterSpec` into concrete book
+IDs **for background operations** with `limit=100000` — used by
+`metadata_batch_candidates.go:59` and the bulk metadata fetch op. An empty value there
+silently retargets a scoped job at the whole library. That is the **base64 op-params defect
+(#2309) one level down**: same shape, same whole-library default, different entry point.
+
+### Fixed in all three layers that were silent
+
+1. **HTTP boundary** (`handlers/audiobooks/handler.go`) — 400 naming the offending field.
+2. **Background-op path** (`metadata_ops.go`) — `resolveFilterToBookIDs` returns an error;
+   params arrive already deserialized from the queue, so there is no HTTP boundary here.
+3. **Matcher** (`service_filtering.go`) — `matchesFieldFilters` fails **closed** on an empty
+   value. Matching nothing is visibly wrong and harmless; matching everything is invisibly
+   wrong and, on the op path, destructive. `Negated` is deliberately not consulted —
+   neither `f == ""` nor `f != ""` is a constraint anyone can have meant.
+
+No in-repo code constructs an empty-value filter (checked: the list warmer's ~20
+constructions all carry real values), so layer 3 only fires on input the boundary should
+already have rejected.
+
+### Not addressed
+
+- **The frontend was not changed.** Whatever sends an empty value will now get a 400
+  instead of the whole library. That is the intended, safe direction, but the UI path that
+  produces it has not been traced — worth doing so the user sees a sensible message rather
+  than a raw error.
+- Whether any *stored* smart playlist or saved filter contains an empty value was not
+  checked; such a filter now returns nothing instead of everything.


### PR DESCRIPTION
## The bug

`fieldMatchesValue` ends in:

```go
return strings.Contains(strings.ToLower(bookValue), strings.ToLower(value))
```

**`strings.Contains(anything, "")` is always true in Go**, so a filter whose value is empty
constrains nothing — it matches every book.

Measured live on production 2026-08-13 against the current deployed build. The filter is
otherwise healthy; this is specific to the empty value:

| `filters=[{"field":"title","value":X}]` | total returned |
|---|---|
| `X = ""` | **63,870 — the entire library** |
| `X = "zzqqxx"` | 0 |
| `X = "Skills"` | 25 |

## Why this is more than a confusing list

`FieldFilters` also flow into `Server.resolveFilterToBookIDs`
(`internal/server/metadata_ops.go:458`), which resolves a `FilterSpec` into **concrete book
IDs for background operations** at `limit=100000` — used by
`metadata_batch_candidates.go:59` and the bulk metadata fetch op.

An empty value there silently retargets a scoped job at the whole library. That is the
**base64 op-params defect (#2309) one level down**: same shape, same whole-library default,
different entry point.

## Fixed in all three layers that were silent

| Layer | File | Behaviour |
|---|---|---|
| HTTP boundary | `handlers/audiobooks/handler.go` | 400 naming the offending field |
| Background op | `metadata_ops.go` | `resolveFilterToBookIDs` returns an error — params arrive already deserialized from the queue, so there is no HTTP boundary here |
| Matcher | `service_filtering.go` | `matchesFieldFilters` fails **closed** |

Layer 3 fails closed rather than open because **matching nothing is visibly wrong and
harmless; matching everything is invisibly wrong and, on the op path, destructive.**
`Negated` is deliberately not consulted — neither `f == ""` nor `f != ""` is a constraint a
caller can have meant, and letting them disagree would be its own trap.

No in-repo code constructs an empty-value filter (checked: the list warmer's ~20
constructions all carry real values), so layer 3 only ever fires on input the boundary
should already have rejected.

## Verification

- `go build ./...` — exit 0
- `go vet ./internal/audiobooks/ ./internal/server/handlers/audiobooks/` — exit 0
- `go test ./internal/audiobooks/ -count=1` — **whole package**, exit 0 (39s)

**Negative control** — removing only the layer-3 guard from the committed file:

| Test | Under negative control |
|---|---|
| `TestEmptyFilterValueDoesNotMatchEveryBook` | FAIL |
| `TestEmptyValueRejectsTheWholeFilterSet` | FAIL |
| `TestEmptyFilterValueFailsClosedEvenWhenNegated` | PASS (negation already excluded it by a different route) |
| `TestNonEmptyFiltersStillWork` (6 cases) | PASS |
| `TestFirstEmptyFilterValue` (3 cases) | PASS |

Discriminating, not blanket-red. `TestNonEmptyFiltersStillWork` is the control that matters:
without it, the two failing tests would pass equally well against a matcher that rejected
*everything*, which would be a worse bug than the one being fixed.

## Not addressed

- **The frontend was not traced.** Whatever sends an empty value now gets a 400 instead of
  the whole library — the safe direction, but the UI path producing it is unidentified, so
  a user may see a raw error.
- **Stored filters were not checked.** A saved smart playlist containing an empty-value
  filter would now return nothing instead of everything.
