### PR TITLE
feat(maintenance): backfill embedded chapters for single-file books

### DIFF
--- a/changelog.d/20260813_094500_feat_chapters_backfill_op.md
+++ b/changelog.d/20260813_094500_feat_chapters_backfill_op.md
@@ -1,0 +1,38 @@
+### Added
+
+#### Chapter backfill op — single-file audiobooks were all serving one chapter
+
+Every audiobook that predates 2026-07-30 has been served over the ABS API with a
+**single chapter spanning the entire file**. Measured on production before the
+fix: 500 sampled library items all had `numChapters == numAudioFiles`, and all
+213 single-file containers longer than 10,000 s reported exactly 1 chapter — a
+24-hour audiobook delivered as one unnavigable block titled with the book's own
+name. Meanwhile 19 of 40 randomly probed `.m4b`/`.m4a` files on disk carry real
+embedded markers, 16 to 118 chapters each.
+
+Root cause: chapter extraction is a write-path-only feature.
+`SaveChaptersForBook` has exactly one non-test caller,
+`scanner.PersistChaptersForBook`, reached only from the `saveBook` success
+branch. The feature shipped after the library was scanned, and incremental scans
+skip unchanged files via the scan cache, so no pre-existing book was ever probed
+and none ever would be. Production logs show zero extraction warnings across 14
+days — it was not failing, it was never running.
+
+The failure stayed invisible because the read path has a fallback: with nothing
+persisted, the ABS mapper synthesizes chapters from the track list. For a
+multi-file book that yields one chapter per file, which looks right. For a
+single-file book it yields one chapter for the whole book, which looks like a
+book that simply has no chapters.
+
+New op `maintenance.chapters-backfill` probes single-file books with no persisted
+chapters and writes the real timeline. Dry run unless `{"apply": true}`, refuses
+to start without `ffprobe`, bounded worker pool at `runtime.NumCPU()`, and
+`{"bookIds": [...]}` restricts a run to an explicit cohort. It writes only the
+`chapters:` keyspace — no book row is touched, so the write-back-wipe class does
+not apply, and `DeleteChaptersForBook` reverts a book to today's behaviour.
+
+Multi-file books are skipped deliberately: their persisted form is byte-identical
+to the mapper's live synthesis, so writing it changes no response while creating
+a staleness hazard the read path cannot detect (`len(stored) > 0` short-circuits
+the live synthesis, so a stale persisted list would silently win after a book
+gains or loses a file).

--- a/internal/plugins/maintenance/chapters_backfill.go
+++ b/internal/plugins/maintenance/chapters_backfill.go
@@ -1,0 +1,339 @@
+// file: internal/plugins/maintenance/chapters_backfill.go
+// version: 1.0.0
+// guid: 5d3b7e14-9c62-4a8f-b0d7-2e6194af8c35
+// last-edited: 2026-08-13
+
+// Package maintenance — op maintenance.chapters-backfill.
+//
+// 🔴 THE PROBLEM THIS EXISTS TO CLOSE. Chapter extraction is a WRITE-PATH-ONLY
+// feature. database.SaveChaptersForBook has exactly one non-test caller —
+// scanner.PersistChaptersForBook (internal/scanner/process_file.go:259) — and
+// that is reached only from the saveBook success branch (scanner.go:851,
+// scanner.go:1035). The feature landed 2026-07-30; the library predates it, and
+// an incremental scan skips unchanged files via the scan cache. So no book that
+// already existed has ever been probed, and none ever will be.
+//
+// The failure is SILENT because the read path has a fallback. When no chapters
+// are persisted, handlers/abs/mapper.go:243 calls audioutil.SynthesizeChapters
+// over the track list. For a multi-file book that is one chapter per file, which
+// looks plausible. For a SINGLE-FILE book it is ONE CHAPTER SPANNING THE WHOLE
+// CONTAINER — a 24-hour audiobook served as one unnavigable block, titled with
+// the book's own name. A missing chapter list would have rendered blank and been
+// reported; a plausible wrong one was not.
+//
+// Measured on production 2026-08-13, before this op existed:
+//
+//	500 ABS items sampled  → numChapters == numAudioFiles in 500/500
+//	213 of them single-file containers over 10,000s → ALL reported exactly 1 chapter
+//	40 random .m4b/.m4a on disk → 19 carry real embedded markers (16–118 each)
+//	14 days of logs → 0 PersistChaptersForBook warnings (it is not failing; it never runs)
+//
+// SINGLE-FILE ONLY, DELIBERATELY. Multi-file books are out of scope and skipped.
+// Their persisted form (one chapter per file, synthesized from BookFile
+// durations) is byte-identical to what the mapper already computes at request
+// time, so persisting it changes no API response — while introducing a staleness
+// hazard the read path cannot detect: len(stored) > 0 short-circuits the live
+// synthesis, so a persisted list would silently win over the correct one after a
+// book gains or loses a file. There is no invalidation hook for that today. The
+// bug is entirely in the single-file population, and that is what this op fixes.
+//
+// 🔴 "PROBED, FOUND NONE" IS NOT REPRESENTABLE, SO THIS OP RE-PROBES.
+// SaveChaptersForBook deletes the key on an empty slice
+// (pebble_store_chapters.go:63), so a book with no embedded markers is
+// byte-identical to a book that was never examined. Every run therefore
+// re-ffprobes that population — roughly half of single-file containers, on the
+// 40-file sample. That is accepted rather than fixed here: the only durable
+// marker available is internal/operations/freshness, which today has ZERO
+// non-test callers and would need a new ServerDeps accessor plus server wiring
+// to reach an op. That plumbing is a wider change than this op's benefit
+// justifies while the op is MANUAL-TRIGGER ONLY. `-show_chapters` reads the
+// container header, so a re-probe is cheap. If this op is ever given a Schedule,
+// wire the freshness stamp FIRST — a nightly re-probe of every markerless
+// container is a different cost profile than an occasional manual run.
+//
+// DATA-LOSS SAFETY. There is no UpdateBook call in this file, and that is
+// structural rather than a promise: this repo's dominant incident class is the
+// write-back wipe, where a bare whole-row UpdateBook clears AcoustIDFingerprint
+// or Author. The only write here is SaveChaptersForBook, which touches one
+// dedicated Pebble keyspace (chapters:<bookID>) and no book row. Reverting a
+// book is DeleteChaptersForBook, which restores exactly the state production is
+// in today.
+//
+// DRY RUN BY DEFAULT, matching probe_directory_books.go: nothing is written
+// unless the caller passes {"apply": true}.
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/audioutil"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// chaptersBackfillParams configures the op.
+type chaptersBackfillParams struct {
+	// Apply gates every write. False (the default) makes this a pure reporter
+	// that measures what WOULD be persisted.
+	Apply bool `json:"apply"`
+	// Limit caps how many books are WRITTEN this run (0 = no cap). Probing
+	// always covers the whole library, mirroring probe-directory-books: a
+	// capped run must never look like a clean bill of health, so the cap
+	// applies to the writes and never to the measurement.
+	Limit int `json:"limit"`
+	// BookIDs restricts the run to an explicit set. Used to exercise the op
+	// against a bounded cohort before a whole-library pass.
+	BookIDs []string `json:"bookIds,omitempty"`
+}
+
+// chapterProbeTimeout bounds one ffprobe invocation. Mirrors
+// probe_directory_books.go's probeFileTimeout: ffprobe reads only the container
+// header, so this exists for a wedged mount, not a slow file.
+const chaptersBackfillProbeTimeout = 20 * time.Second
+
+// minPersistableChapters is the threshold below which a probe result is NOT
+// written.
+//
+// One chapter is exactly what the mapper already synthesizes for a single-file
+// book, so persisting it changes no response — it only converts "we never
+// looked" into "we looked and found nothing", which the store cannot represent
+// anyway (an empty save is a delete). Writing it would fabricate a row that is
+// indistinguishable from a measured one. Two is the smallest count that makes a
+// book navigable.
+const minPersistableChapters = 2
+
+// probeChaptersFn is the injection seam for tests, wired to the real
+// implementation in production. Tests that swap it must not run in parallel and
+// must restore via t.Cleanup — it is process-global. Mirrors the seam
+// probe_directory_books.go establishes for ProbeDurationSeconds.
+var probeChaptersFn = audioutil.ProbeChapters
+
+// chapterPersister is the narrow slice of the store this op needs beyond the
+// Store interface. Declared as an assertion target rather than requiring
+// *database.PebbleStore so a future backend that implements the same two
+// methods works unchanged — and so a backend that does NOT gets a clear refusal
+// instead of a nil-pointer panic.
+type chapterPersister interface {
+	GetChaptersForBook(bookID string) ([]database.Chapter, error)
+	SaveChaptersForBook(bookID string, chapters []database.Chapter) error
+}
+
+func (p *Plugin) chaptersBackfillDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "maintenance.chapters-backfill",
+		Plugin:      "maintenance",
+		DisplayName: "Backfill embedded chapters (single-file books)",
+		Description: "Extracts the embedded chapter timeline from single-file audiobook containers that have none " +
+			"persisted, so the ABS API stops falling back to a one-chapter-spans-the-whole-book synthesis. Chapter " +
+			"extraction only ever ran on the scanner's new-book save path, so every book predating 2026-07-30 was " +
+			"never probed. Multi-file books are skipped deliberately: their persisted form is identical to the " +
+			"live synthesis and would go stale undetectably. Refuses to run when ffprobe is unavailable. " +
+			"DRY RUN unless {\"apply\": true}.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityLow,
+		// Shares the ffprobe lane with the other whole-library probe op so the
+		// two cannot saturate every core at once.
+		ConcurrencyKey: "maintenance.probe-directory-books",
+		Cancellable:    true,
+		Isolate:        false,
+		Timeout:        24 * time.Hour,
+		// No Writes resources declared: this op writes only the chapters:
+		// keyspace, never a Book or BookFile row, so the dispatcher's write-set
+		// gate has nothing to serialize it against. Declaring ResBooks here
+		// would misdescribe it and needlessly block it behind every book writer.
+		Capabilities: []sdk.Capability{
+			sdk.CapLibraryRead,
+			sdk.CapLibraryWrite,
+			sdk.CapFilesRead,
+			sdk.CapFilesExecute,
+			sdk.CapSubprocessSpawn,
+		},
+		Run: p.runChaptersBackfill,
+	}
+}
+
+// chaptersBackfillCounters is the run tally. Every field is touched from
+// multiple RunItems workers, so all of them are atomic rather than
+// mutex-guarded — there is no invariant spanning two counters that would need
+// them to move together.
+type chaptersBackfillCounters struct {
+	examined       atomic.Int64
+	skipMultiFile  atomic.Int64
+	skipHasStored  atomic.Int64
+	skipNoPath     atomic.Int64
+	probeFailed    atomic.Int64
+	noChapters     atomic.Int64
+	wouldPersist   atomic.Int64
+	persisted      atomic.Int64
+	persistFailed  atomic.Int64
+	chaptersWorked atomic.Int64
+}
+
+func (c *chaptersBackfillCounters) summary(apply bool) string {
+	verb := "would persist"
+	n := c.wouldPersist.Load()
+	if apply {
+		verb = "persisted"
+		n = c.persisted.Load()
+	}
+	return fmt.Sprintf(
+		"examined=%d %s=%d (%d chapters) | skipped: multi-file=%d already-had=%d no-path=%d | "+
+			"no-markers=%d probe-failed=%d persist-failed=%d",
+		c.examined.Load(), verb, n, c.chaptersWorked.Load(),
+		c.skipMultiFile.Load(), c.skipHasStored.Load(), c.skipNoPath.Load(),
+		c.noChapters.Load(), c.probeFailed.Load(), c.persistFailed.Load(),
+	)
+}
+
+func (p *Plugin) runChaptersBackfill(ctx context.Context, raw json.RawMessage, reporter sdk.Reporter) error {
+	params := chaptersBackfillParams{}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return fmt.Errorf("invalid params: %w", err)
+		}
+	}
+
+	// ── refuse to run without ffprobe ────────────────────────────────────────
+	//
+	// First, before anything else. Every probe would fail and the op would
+	// report the same "no markers found" summary it reports against a library
+	// that genuinely has none. Those two states must not look alike.
+	ffprobePath, err := lookupFFprobeFn()
+	if err != nil {
+		return fmt.Errorf("cannot run: this op extracts real chapter markers and has no fallback — %w", err)
+	}
+	_ = reporter.Log(slog.LevelInfo, fmt.Sprintf("using ffprobe at %s", ffprobePath))
+
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	persister, ok := store.(chapterPersister)
+	if !ok {
+		return fmt.Errorf("cannot run: store is %T, which does not persist chapters", store)
+	}
+	if !params.Apply {
+		_ = reporter.Log(slog.LevelInfo, "DRY RUN — no chapters will be written")
+	}
+
+	ids := params.BookIDs
+	if len(ids) == 0 {
+		_ = reporter.UpdateProgress(0, 0, "Enumerating library…")
+		ids, err = store.ListBookIDs()
+		if err != nil {
+			return fmt.Errorf("ListBookIDs: %w", err)
+		}
+	} else {
+		_ = reporter.Log(slog.LevelInfo, fmt.Sprintf("restricted to %d explicit book IDs", len(ids)))
+	}
+
+	var c chaptersBackfillCounters
+
+	// CONCURRENCY (CLAUDE.md mandate): a whole-library loop doing one subprocess
+	// call per item is exactly the shape that hung dedup.full-scan for 3+ hours
+	// on a single core. Every worker touches a disjoint book, and the only
+	// shared state is the atomic counter block, so the pool needs no lock.
+	runErr := registry.RunItems(ctx, reporter, ids, func(ctx context.Context, id string) error {
+		c.examined.Add(1)
+
+		// Already extracted — idempotent, the same rule the scanner applies.
+		// Checked BEFORE the file read so a re-run over a mostly-done library
+		// costs one Pebble get per book and nothing more.
+		if stored, err := persister.GetChaptersForBook(id); err == nil && len(stored) > 0 {
+			c.skipHasStored.Add(1)
+			return nil
+		}
+
+		files, ferr := store.GetBookFiles(id)
+		if ferr != nil {
+			c.skipNoPath.Add(1)
+			return nil // a book that vanished mid-run is not this op's problem
+		}
+		if len(files) > 1 {
+			c.skipMultiFile.Add(1)
+			return nil
+		}
+
+		path := ""
+		if len(files) == 1 {
+			path = strings.TrimSpace(files[0].FilePath)
+		}
+		if path == "" {
+			b, berr := store.GetBookByID(id)
+			if berr != nil || b == nil {
+				c.skipNoPath.Add(1)
+				return nil
+			}
+			path = strings.TrimSpace(b.FilePath)
+		}
+		if path == "" {
+			c.skipNoPath.Add(1)
+			return nil
+		}
+
+		probeCtx, cancel := context.WithTimeout(ctx, chaptersBackfillProbeTimeout)
+		defer cancel()
+		chs, perr := probeChaptersFn(probeCtx, ffprobePath, path)
+		if perr != nil {
+			// Swallowed per file, never fatal to the run — but COUNTED, so a
+			// run where every probe failed cannot be mistaken for a library
+			// with no markers.
+			c.probeFailed.Add(1)
+			_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("ProbeChapters(%s): %v", path, perr))
+			return nil
+		}
+		if len(chs) < minPersistableChapters {
+			c.noChapters.Add(1)
+			return nil
+		}
+
+		c.chaptersWorked.Add(int64(len(chs)))
+		if !params.Apply {
+			c.wouldPersist.Add(1)
+			return nil
+		}
+		if params.Limit > 0 && c.persisted.Load() >= int64(params.Limit) {
+			c.wouldPersist.Add(1)
+			return nil
+		}
+
+		dbChapters := make([]database.Chapter, len(chs))
+		for i, ch := range chs {
+			dbChapters[i] = database.Chapter{
+				ID: ch.ID, StartSec: ch.StartSec, EndSec: ch.EndSec, Title: ch.Title,
+			}
+		}
+		if serr := persister.SaveChaptersForBook(id, dbChapters); serr != nil {
+			c.persistFailed.Add(1)
+			_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("SaveChaptersForBook(%s): %v", id, serr))
+			return nil
+		}
+		c.persisted.Add(1)
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency:   runtime.NumCPU(),
+		ProgressTotal: len(ids),
+		ErrMode:       registry.ErrModeCollect,
+		Label: func(i, total int) string {
+			return fmt.Sprintf("Books %d/%d (persist=%d markers=%d)",
+				i+1, total, c.persisted.Load(), c.chaptersWorked.Load())
+		},
+	})
+
+	summary := c.summary(params.Apply)
+	if params.Limit > 0 && c.wouldPersist.Load() > 0 && params.Apply {
+		summary += fmt.Sprintf(" | ⚠️ write cap %d reached — %d eligible books left unwritten",
+			params.Limit, c.wouldPersist.Load())
+	}
+	_ = reporter.Log(slog.LevelInfo, summary)
+	_ = reporter.UpdateProgress(len(ids), len(ids), summary)
+	return runErr
+}

--- a/internal/plugins/maintenance/chapters_backfill_test.go
+++ b/internal/plugins/maintenance/chapters_backfill_test.go
@@ -1,0 +1,356 @@
+// file: internal/plugins/maintenance/chapters_backfill_test.go
+// version: 1.0.0
+// guid: 8a41c0e6-52b7-4d93-9f18-7c3ea05b61d4
+// last-edited: 2026-08-13
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/audioutil"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+//
+// Helper names are prefixed chbf* because this package's tests share one
+// namespace and a generic name (seedBook, fakeProbe) collides with a sibling
+// file's helper the moment two are added in the same week.
+
+// chbfChapters is the probe result the fake returns for a book WITH markers.
+// Six chapters on a cumulative timeline, mirroring the shape a real m4b yields.
+func chbfChapters() []audioutil.Chapter {
+	out := make([]audioutil.Chapter, 6)
+	var start float64
+	for i := range out {
+		end := start + float64(600+i*30)
+		out[i] = audioutil.Chapter{
+			ID: i, StartSec: start, EndSec: end, Title: fmt.Sprintf("Chapter %d", i+1),
+		}
+		start = end
+	}
+	return out
+}
+
+// chbfProbeSpy replaces probeChaptersFn and records what it was asked to probe.
+// Counting is atomic because RunItems fans out over runtime.NumCPU() workers.
+type chbfProbeSpy struct {
+	calls  atomic.Int64
+	result []audioutil.Chapter
+	err    error
+}
+
+func (s *chbfProbeSpy) install(t *testing.T) {
+	t.Helper()
+	prev := probeChaptersFn
+	probeChaptersFn = func(_ context.Context, _, _ string) ([]audioutil.Chapter, error) {
+		s.calls.Add(1)
+		return s.result, s.err
+	}
+	t.Cleanup(func() { probeChaptersFn = prev })
+}
+
+// chbfStubFFprobe makes lookupFFprobeFn succeed without a real binary on PATH,
+// so these tests do not depend on the host having ffmpeg installed.
+func chbfStubFFprobe(t *testing.T) {
+	t.Helper()
+	prev := lookupFFprobeFn
+	lookupFFprobeFn = func() (string, error) { return "/usr/bin/ffprobe", nil }
+	t.Cleanup(func() { lookupFFprobeFn = prev })
+}
+
+// chbfSeedBook creates a book with nFiles book_file rows and returns its ID.
+func chbfSeedBook(t *testing.T, s *database.PebbleStore, title string, nFiles int) string {
+	t.Helper()
+	bk, err := s.CreateBook(&database.Book{Title: title, FilePath: "/lib/" + title})
+	if err != nil {
+		t.Fatalf("CreateBook(%s): %v", title, err)
+	}
+	for i := 0; i < nFiles; i++ {
+		bf := &database.BookFile{
+			BookID:   bk.ID,
+			FilePath: fmt.Sprintf("/lib/%s/track%02d.m4b", title, i),
+		}
+		if err := s.CreateBookFile(bf); err != nil {
+			t.Fatalf("CreateBookFile(%s/%d): %v", title, i, err)
+		}
+	}
+	return bk.ID
+}
+
+// chbfRun executes the op against store with the given params.
+func chbfRun(t *testing.T, s *database.PebbleStore, params chaptersBackfillParams) error {
+	t.Helper()
+	raw, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	p := &Plugin{deps: fakeDeps{store: s}}
+	return p.runChaptersBackfill(context.Background(), raw, &fakeReporter{})
+}
+
+func chbfStore(t *testing.T) *database.PebbleStore {
+	t.Helper()
+	s, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	s.WaitForWarmup()
+	return s
+}
+
+// ── case 1: the happy path, asserted by VALUE not by count ──────────────────
+//
+// Asserting only len(chapters) > 1 would pass against a handler that wrote six
+// zero-length chapters, which is the exact class of "plausible but wrong" this
+// op exists to remove. Every field of every chapter is compared to what the
+// probe returned.
+func TestChaptersBackfill_SingleFileWithMarkers_PersistsVerbatim(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	chbfStubFFprobe(t)
+	spy := &chbfProbeSpy{result: chbfChapters()}
+	spy.install(t)
+
+	s := chbfStore(t)
+	id := chbfSeedBook(t, s, "Deadly Jobs", 1)
+
+	if err := chbfRun(t, s, chaptersBackfillParams{Apply: true}); err != nil {
+		t.Fatalf("runChaptersBackfill: %v", err)
+	}
+
+	got, err := s.GetChaptersForBook(id)
+	if err != nil {
+		t.Fatalf("GetChaptersForBook: %v", err)
+	}
+	want := chbfChapters()
+	if len(got) != len(want) {
+		t.Fatalf("persisted %d chapters, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].ID != want[i].ID ||
+			got[i].StartSec != want[i].StartSec ||
+			got[i].EndSec != want[i].EndSec ||
+			got[i].Title != want[i].Title {
+			t.Fatalf("chapter %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+	// The timeline must be cumulative and gapless — a chapter list that does not
+	// chain is unnavigable even when every individual row looks reasonable.
+	for i := 1; i < len(got); i++ {
+		if got[i].StartSec != got[i-1].EndSec {
+			t.Fatalf("chapter %d starts at %v but %d ended at %v — timeline has a gap",
+				i, got[i].StartSec, i-1, got[i-1].EndSec)
+		}
+	}
+}
+
+// ── case 2: dry run writes NOTHING ──────────────────────────────────────────
+func TestChaptersBackfill_DryRunPersistsNothing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	chbfStubFFprobe(t)
+	spy := &chbfProbeSpy{result: chbfChapters()}
+	spy.install(t)
+
+	s := chbfStore(t)
+	id := chbfSeedBook(t, s, "Dry Run Book", 1)
+
+	if err := chbfRun(t, s, chaptersBackfillParams{Apply: false}); err != nil {
+		t.Fatalf("runChaptersBackfill: %v", err)
+	}
+
+	// The probe MUST have run — a dry run that silently skipped the measurement
+	// would report "0 would persist" and look identical to a clean library.
+	if spy.calls.Load() == 0 {
+		t.Fatal("dry run never probed anything, so its report measures nothing")
+	}
+	got, err := s.GetChaptersForBook(id)
+	if err != nil {
+		t.Fatalf("GetChaptersForBook: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("dry run persisted %d chapters; it must write nothing", len(got))
+	}
+}
+
+// ── case 3: already-extracted books are not re-probed ───────────────────────
+//
+// Asserted on the PROBE COUNT, not on the stored value. Checking only that the
+// chapters are unchanged would also pass if the op re-probed every book on
+// every run and happened to write the same bytes back — which is the expensive
+// bug, not the cheap one.
+func TestChaptersBackfill_AlreadyPersisted_SkipsWithoutProbing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	chbfStubFFprobe(t)
+	spy := &chbfProbeSpy{result: chbfChapters()}
+	spy.install(t)
+
+	s := chbfStore(t)
+	id := chbfSeedBook(t, s, "Already Done", 1)
+	seeded := []database.Chapter{{ID: 0, StartSec: 0, EndSec: 42, Title: "pre-existing"}}
+	if err := s.SaveChaptersForBook(id, seeded); err != nil {
+		t.Fatalf("SaveChaptersForBook: %v", err)
+	}
+
+	if err := chbfRun(t, s, chaptersBackfillParams{Apply: true}); err != nil {
+		t.Fatalf("runChaptersBackfill: %v", err)
+	}
+
+	if n := spy.calls.Load(); n != 0 {
+		t.Fatalf("probed %d times for a book that already had chapters; want 0", n)
+	}
+	got, err := s.GetChaptersForBook(id)
+	if err != nil {
+		t.Fatalf("GetChaptersForBook: %v", err)
+	}
+	if len(got) != 1 || got[0].Title != "pre-existing" {
+		t.Fatalf("existing chapters were overwritten: %+v", got)
+	}
+}
+
+// ── case 4: no markers → nothing written, AND the re-probe is pinned ────────
+//
+// The second half of this test documents an accepted trade-off rather than a
+// desirable behaviour: SaveChaptersForBook deletes on an empty slice, so
+// "probed, found none" is byte-identical to "never probed" and a second run
+// pays the probe again. If someone later wires a durable freshness stamp, this
+// assertion is the one that must change — and it will fail loudly rather than
+// letting the stamp go silently unused.
+func TestChaptersBackfill_NoMarkers_WritesNothingAndReprobes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	chbfStubFFprobe(t)
+	spy := &chbfProbeSpy{result: nil} // a container with no embedded markers
+	spy.install(t)
+
+	s := chbfStore(t)
+	id := chbfSeedBook(t, s, "No Markers", 1)
+
+	if err := chbfRun(t, s, chaptersBackfillParams{Apply: true}); err != nil {
+		t.Fatalf("run 1: %v", err)
+	}
+	got, err := s.GetChaptersForBook(id)
+	if err != nil {
+		t.Fatalf("GetChaptersForBook: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("persisted %d chapters for a book with no markers; want 0", len(got))
+	}
+	if spy.calls.Load() != 1 {
+		t.Fatalf("run 1 probed %d times, want exactly 1", spy.calls.Load())
+	}
+
+	if err := chbfRun(t, s, chaptersBackfillParams{Apply: true}); err != nil {
+		t.Fatalf("run 2: %v", err)
+	}
+	if n := spy.calls.Load(); n != 2 {
+		t.Fatalf("after a second run the probe count is %d, want 2 — the accepted "+
+			"re-probe of markerless books is no longer happening; if a durable "+
+			"'probed, found none' marker was added, update this test to assert it", n)
+	}
+}
+
+// ── case 5: multi-file books are skipped entirely ───────────────────────────
+//
+// Pins the scoping decision. A multi-file book's persisted chapters would be
+// byte-identical to the mapper's live synthesis, so writing them changes no
+// response while creating a staleness hazard the read path cannot detect.
+// Asserted on the probe count so a future change that merely declines to WRITE
+// (while still paying the ffprobe) also fails here.
+func TestChaptersBackfill_MultiFileBook_NeverProbedOrWritten(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	chbfStubFFprobe(t)
+	spy := &chbfProbeSpy{result: chbfChapters()}
+	spy.install(t)
+
+	s := chbfStore(t)
+	multi := chbfSeedBook(t, s, "Multi File", 6)
+	// A single-file control in the same run: without it, a bug that skipped
+	// EVERY book would pass this test.
+	single := chbfSeedBook(t, s, "Single Control", 1)
+
+	if err := chbfRun(t, s, chaptersBackfillParams{Apply: true}); err != nil {
+		t.Fatalf("runChaptersBackfill: %v", err)
+	}
+
+	if got, _ := s.GetChaptersForBook(multi); len(got) != 0 {
+		t.Fatalf("multi-file book got %d persisted chapters; want 0", len(got))
+	}
+	if got, _ := s.GetChaptersForBook(single); len(got) != 6 {
+		t.Fatalf("single-file control got %d chapters, want 6 — the op skipped "+
+			"everything, so the multi-file assertion above proves nothing", len(got))
+	}
+	if n := spy.calls.Load(); n != 1 {
+		t.Fatalf("probe ran %d times; want exactly 1 (the single-file control only) "+
+			"— the multi-file book is paying for an ffprobe it never uses", n)
+	}
+}
+
+// ── case 6: a missing ffprobe is a hard failure, not a clean run ────────────
+func TestChaptersBackfill_NoFFprobe_RefusesToRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	prev := lookupFFprobeFn
+	lookupFFprobeFn = func() (string, error) { return "", audioutil.ErrFFprobeNotAvailable }
+	t.Cleanup(func() { lookupFFprobeFn = prev })
+
+	spy := &chbfProbeSpy{result: chbfChapters()}
+	spy.install(t)
+
+	s := chbfStore(t)
+	chbfSeedBook(t, s, "Unreachable", 1)
+
+	err := chbfRun(t, s, chaptersBackfillParams{Apply: true})
+	if err == nil {
+		t.Fatal("op reported success without ffprobe — a run that could not measure " +
+			"anything must not look like a library with no markers")
+	}
+	if spy.calls.Load() != 0 {
+		t.Fatalf("probed %d times after the ffprobe lookup failed", spy.calls.Load())
+	}
+}
+
+// ── case 7: BookIDs restricts the run to an explicit cohort ─────────────────
+//
+// This is how the op is exercised against the 'job' test cohort before any
+// whole-library pass, so the restriction is asserted rather than assumed.
+func TestChaptersBackfill_BookIDsRestrictsScope(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	chbfStubFFprobe(t)
+	spy := &chbfProbeSpy{result: chbfChapters()}
+	spy.install(t)
+
+	s := chbfStore(t)
+	inScope := chbfSeedBook(t, s, "In Cohort", 1)
+	outOfScope := chbfSeedBook(t, s, "Out Of Cohort", 1)
+
+	if err := chbfRun(t, s, chaptersBackfillParams{
+		Apply: true, BookIDs: []string{inScope},
+	}); err != nil {
+		t.Fatalf("runChaptersBackfill: %v", err)
+	}
+
+	if got, _ := s.GetChaptersForBook(inScope); len(got) != 6 {
+		t.Fatalf("in-scope book got %d chapters, want 6", len(got))
+	}
+	if got, _ := s.GetChaptersForBook(outOfScope); len(got) != 0 {
+		t.Fatalf("out-of-scope book got %d chapters; the BookIDs restriction leaked", len(got))
+	}
+}

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/plugin.go
-// version: 1.16.0
+// version: 1.17.0
 // guid: b2c3d4e5-f6a7-8901-bcde-123456789012
-// last-edited: 2026-08-10
+// last-edited: 2026-08-13
 
 package maintenance
 
@@ -88,6 +88,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		// folder (1,019 of them). This op re-runs the same classifier over just
 		// that flagged set with real ffprobe durations filled in.
 		p.probeDirectoryBooksDef(),
+		p.chaptersBackfillDef(),
 		p.itunesHealDef(),
 		p.introTranscribeDef(),
 		p.repairTranscribeStatusDef(),

--- a/todo.d/2026-08-13-chapters-backfill-followups.md
+++ b/todo.d/2026-08-13-chapters-backfill-followups.md
@@ -1,0 +1,41 @@
+- [ ] 🎧 **Run `maintenance.chapters-backfill` against production.** The op ships
+      dry-run-by-default and has never been run on the real library. Sequence:
+      (1) dry run over the `job (chapter-backfill test cohort)` static playlist
+      (id `01KZXMN8F8ZEXVQQPZ2SF74T0A`, 77 books, 58 single-file) via
+      `{"bookIds": [...]}`; (2) apply over that cohort and verify against the
+      ffprobe oracle — `Deadly Jobs` must report **231** chapters, `The Icarus Job`
+      **28**, `The Colchis Job` **20**, and the two markerless files
+      (`132 132 - Job.m4b`, `Delve 132 - Chapter 132 - Job.m4b`) must stay at the
+      synthesized single chapter; (3) only then a whole-library apply. Expect
+      roughly 14,600 single-file candidates of which about half carry markers.
+
+- [ ] 🔁 **Wire a durable "probed, found none" marker before this op is ever
+      scheduled.** `SaveChaptersForBook` deletes its key on an empty slice, so a
+      book with no embedded markers is byte-identical to one that was never
+      examined, and every run re-ffprobes that whole population (~half of
+      single-file containers). That is acceptable for a manual op and NOT
+      acceptable nightly. `internal/operations/freshness` already provides
+      `Stamp`/`ClearStamps` but has **zero non-test callers** — reaching it from an
+      op needs a new `ServerDeps` accessor plus server wiring. Adding a `Schedule`
+      to the op without doing this first is the bug.
+      `TestChaptersBackfill_NoMarkers_WritesNothingAndReprobes` pins the current
+      behaviour and will fail loudly when the marker lands.
+
+- [ ] 🔍 **Index track names so smart playlists can match them.** The Bleve
+      `BookDocument` (`internal/search/document.go:19`) carries only book-level
+      fields — title, author, narrator, series, publisher, description, file_path.
+      Track names live in `BookFile.FilePath` / `BookFile.Title` and are never
+      indexed, and smart playlists evaluate exclusively through Bleve, so **no
+      dynamic playlist can match a track name**. Verified: three copies of the
+      Scourby Bible readings have a track literally named `Job` and appear in zero
+      search results for "job". Needs a `TrackNames []string` field on
+      `BookDocument`, a text field mapping, and a full reindex. Until then,
+      track-name cohorts must be built as static playlists.
+
+- [ ] 🧩 **Investigate per-chapter split files standing as their own books.** While
+      probing, item `97e56ed2` turned out to be a 463 s fragment
+      (`01 Angel in the Whirlwind - 1 - The.m4b`) registered as a standalone book,
+      and several sampled "single-file" books are per-chapter splits mis-grouped
+      the same way. Unrelated to chapter extraction — those files genuinely have no
+      markers — but it inflates the single-file population and produces 8-minute
+      "audiobooks".


### PR DESCRIPTION
## The bug, measured on production

Every audiobook predating 2026-07-30 is served over the ABS API with **one chapter spanning the whole file**.

| measurement | value |
|---|---|
| ABS items sampled | 500 |
| `numChapters == numAudioFiles` | **500 / 500** |
| single-file containers > 10,000 s | 213 |
| …of those reporting > 1 chapter | **0** |
| random `.m4b`/`.m4a` probed on disk | 40 |
| …carrying real embedded markers | **19** (16–118 chapters each) |
| `PersistChaptersForBook` warnings, 14 d of prod logs | **0** |
| `ffprobe` on prod | present |

A concrete response before the fix — `Angel in the Whirlwind`, one `.m4b`:

```json
"chapters": [{ "id": 0, "start": 0, "end": 463, "title": "Angel in the Whirlwind …" }]
```

## Root cause

Chapter extraction is **write-path-only**. `SaveChaptersForBook` has exactly one non-test caller — `scanner.PersistChaptersForBook` (`internal/scanner/process_file.go:259`) — reached only from the `saveBook` success branch (`scanner.go:851`, `scanner.go:1035`). The feature landed 2026-07-30, the library predates it, and incremental scans skip unchanged files via the scan cache. No pre-existing book was ever probed and none ever would be. Zero warnings in 14 days: it is not failing, it never runs.

It stayed invisible because the read path has a fallback. With nothing persisted, `mapper.go:243` synthesizes chapters from the track list — one per file. For a multi-file book that looks right. For a single-file book it is the whole book as one block, which reads as "this book has no chapters."

## What this adds

`maintenance.chapters-backfill`:

- **Dry run** unless `{"apply": true}`
- **Refuses to start without `ffprobe`** — a run that could not measure anything must not look like a library with no markers
- `runtime.NumCPU()` worker pool via `registry.RunItems` (CLAUDE.md concurrency mandate)
- `{"bookIds": [...]}` restricts a run to an explicit cohort; `{"limit": N}` caps **writes only**, never the measurement
- Writes **only** the `chapters:` keyspace — no `UpdateBook`, so the write-back-wipe class structurally does not apply. `DeleteChaptersForBook` reverts a book to today's behaviour.

## Two scoping decisions, stated

**Multi-file books are skipped deliberately.** Their persisted form is byte-identical to the mapper's live synthesis, so writing it changes no API response — while creating a staleness hazard the read path cannot detect: `len(stored) > 0` short-circuits the live synthesis, so a stale list would silently win after a book gains or loses a file. There is no invalidation hook for that today.

**Markerless books are re-probed on every run.** `SaveChaptersForBook` deletes its key on an empty slice, so "probed, found none" is byte-identical to "never probed". The only durable marker available is `internal/operations/freshness`, which has **zero non-test callers** and would need a new `ServerDeps` accessor plus server wiring. That is wider than the benefit while this op is manual-trigger only. Filed in `todo.d/` as a hard prerequisite before the op is ever given a `Schedule`.

## Verification

All 7 tests **verified by mutation** — each guard removed in turn, confirming it turns exactly its own test red, then restored:

| mutation | test that went red |
|---|---|
| multi-file guard removed | `MultiFileBook_NeverProbedOrWritten` |
| dry-run gate ignored | `DryRunPersistsNothing` |
| already-persisted skip removed | `AlreadyPersisted_SkipsWithoutProbing` |
| ffprobe refusal downgraded | `NoFFprobe_RefusesToRun` |
| chapter `end` values corrupted | `SingleFileWithMarkers_PersistsVerbatim` |
| `BookIDs` restriction ignored | `BookIDsRestrictsScope` |

`go test ./internal/plugins/maintenance/ -run TestChaptersBackfill` → ok.

> **Note on `make ci`:** `make staticcheck` fails with 5 findings — all pre-existing and reproduced identically on a clean `main` checkout (`dataloss_preserve_invariant_test.go`, `regroup_shattered_ai_test.go`, `userdata_test.go`). None are in this diff.

## Not run yet

The op has never been run against production. `todo.d/` records the sequence: dry run over the 77-book `job` test cohort, apply over it and check against the ffprobe oracle (`Deadly Jobs` must report 231 chapters, `The Icarus Job` 28, `The Colchis Job` 20, and the two markerless files must stay at one), then a whole-library apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t