### PR TITLE
fix(database): apply every filter in the memdb-unavailable fallback

### DIFF
--- a/changelog.d/20260813_093000_fix_memdb_fallback_filter.md
+++ b/changelog.d/20260813_093000_fix_memdb_fallback_filter.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- Filtered library queries no longer return almost the entire library when the
+  in-memory index is unavailable. During the ~2 minute startup warmup (and
+  permanently when the in-memory index is disabled or has been abandoned after a
+  write-buffer overflow), searching or filtering the library fell back to a path
+  that applied only two of its eight filters — so a title search returned every
+  book, with a matching total to go with it. The fallback now applies every
+  filter, and the total is computed by the same code that selects the rows, so
+  the two cannot disagree. As a side effect the fallback no longer loads the
+  whole library into memory before filtering; it only builds the rows that match.

--- a/internal/audiobooks/service_filtering.go
+++ b/internal/audiobooks/service_filtering.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/service_filtering.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: b4e8c3d2-e5f6-7a80-9b0c-1d2e3f4a5b6c
 // last-edited: 2026-08-13
 
@@ -587,9 +587,6 @@ func bookSummariesToBooks(summaries []database.BookSummary) []database.Book {
 // re-slicing an already-paginated page by the original offset is what made
 // "page 2" (any offset>0) return zero rows.
 func (svc *AudiobookService) summariesPushdown(limit, offset int, isPrimary *bool, sortBy string, sortAscending, excludeQuarantined bool) (summaries []database.BookSummary, didPushdown bool, err error) {
-	type filteredSummaryStore interface {
-		GetAllBookSummariesFiltered(limit, offset int, f database.BookSummaryFilter) ([]database.BookSummary, error)
-	}
 	filter := database.BookSummaryFilter{
 		IsPrimaryVersion:   isPrimary,
 		SortBy:             sortBy,
@@ -610,6 +607,45 @@ func (svc *AudiobookService) summariesPushdown(limit, offset int, isPrimary *boo
 	return s, false, e
 }
 
+// filteredSummaryStore is the fast-path contract for pushing a
+// BookSummaryFilter down into the store.
+//
+// The marker method is the point. This interface used to be declared inline
+// as GetAllBookSummariesFiltered alone, and the callers below read a
+// successful type assertion as proof the filter had been applied — then
+// skipped their own post-filter pass on the strength of it. But a type
+// assertion answers "does this type have the method?", never "did the method
+// honor the filter?". PebbleStore satisfied it while its memdb-unavailable
+// fallback applied only 2 of 8 predicates, so a filtered library query issued
+// during the ~2 minute startup warmup returned very nearly the whole library
+// and the post-filter pass that would have caught it was skipped by design.
+//
+// Requiring a second, purpose-built method makes the default fail-safe: a
+// store that has not deliberately declared full conformance simply does not
+// satisfy this interface, so didPushdown is false and the caller post-filters
+// in memory — slower, but correct. Partial conformance now requires an
+// explicit false claim rather than arriving by omission.
+//
+// See PebbleStore.HonorsEveryBookSummaryFilter for what implementing it
+// commits to.
+type filteredSummaryStore interface {
+	GetAllBookSummariesFiltered(limit, offset int, f database.BookSummaryFilter) ([]database.BookSummary, error)
+	HonorsEveryBookSummaryFilter()
+}
+
+// countingFilteredStore is the count-side half of filteredSummaryStore, and
+// carries the same conformance requirement for the same reason.
+//
+// The count path is the less forgiving of the two: countSummariesPushdownFiltered
+// returns this store's number directly with no post-filter correction
+// available, so a partial implementer here produces a wrong pagination total
+// with nothing downstream to catch it. That is how a filtered query came back
+// reporting a total of 63,870.
+type countingFilteredStore interface {
+	CountBookSummariesFiltered(f database.BookSummaryFilter) (int, error)
+	HonorsEveryBookSummaryFilter()
+}
+
 // summariesPushdownFiltered runs the full pushdown — every filter the
 // memdb walker can apply in-loop is on the BookSummaryFilter. Returns at
 // most `limit` summaries (after `offset` matches are skipped). Walker
@@ -621,9 +657,6 @@ func (svc *AudiobookService) summariesPushdown(limit, offset int, isPrimary *boo
 // non-memdb test path). This boolean is the contract that lets the
 // caller skip the post-filter pass safely in production.
 func (svc *AudiobookService) summariesPushdownFiltered(limit, offset int, filter database.BookSummaryFilter) (summaries []database.BookSummary, didPushdown bool, err error) {
-	type filteredSummaryStore interface {
-		GetAllBookSummariesFiltered(limit, offset int, f database.BookSummaryFilter) ([]database.BookSummary, error)
-	}
 	if fs, ok := svc.store.(filteredSummaryStore); ok {
 		s, e := fs.GetAllBookSummariesFiltered(limit, offset, filter)
 		return s, true, e
@@ -648,9 +681,6 @@ func (svc *AudiobookService) summariesPushdownFiltered(limit, offset int, filter
 // itself fell back to unfiltered summaries (mock/non-memdb path), we
 // re-apply the filter here so the count is still correct.
 func (svc *AudiobookService) countSummariesPushdownFiltered(filter database.BookSummaryFilter) (int, error) {
-	type countingFilteredStore interface {
-		CountBookSummariesFiltered(f database.BookSummaryFilter) (int, error)
-	}
 	if cs, ok := svc.store.(countingFilteredStore); ok {
 		return cs.CountBookSummariesFiltered(filter)
 	}

--- a/internal/audiobooks/service_filtering_conformance_test.go
+++ b/internal/audiobooks/service_filtering_conformance_test.go
@@ -1,0 +1,92 @@
+// file: internal/audiobooks/service_filtering_conformance_test.go
+// version: 1.0.0
+// guid: 6d2a9f14-7c85-4b30-a1e9-3f8c5b26d047
+// last-edited: 2026-08-13
+
+package audiobooks
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/stretchr/testify/require"
+)
+
+// This file pins the distinction that the library-list pushdown got wrong:
+// "can you filter?" is not "did you filter?".
+//
+// summariesPushdownFiltered reports didPushdown=true when the store satisfies
+// filteredSummaryStore, and its callers in service_query.go skip their own
+// post-filter pass on the strength of that report. When conformance was
+// inferred from the presence of GetAllBookSummariesFiltered alone, a store
+// that applied a subset of the filter satisfied the assertion exactly as well
+// as one that applied all of it — and the skipped post-filter pass was the
+// only thing that would have caught the difference. That is how a filtered
+// library query returned ~63,870 rows during the startup warmup.
+//
+// The marker method makes the fast path opt-in, so the failure mode of an
+// unaware implementer is "slow but correct" rather than "fast and wrong".
+
+// partialFilterStore has the filter methods but never declares conformance —
+// the shape of a store that applies some predicates and not others. It must
+// NOT satisfy either pushdown interface.
+type partialFilterStore struct{}
+
+func (partialFilterStore) GetAllBookSummariesFiltered(limit, offset int, f database.BookSummaryFilter) ([]database.BookSummary, error) {
+	return nil, nil
+}
+
+func (partialFilterStore) CountBookSummariesFiltered(f database.BookSummaryFilter) (int, error) {
+	return 0, nil
+}
+
+// conformingFilterStore is partialFilterStore plus the explicit declaration.
+// It is the positive control: the marker is what flips satisfaction, so a
+// test that only checked the negative case would also pass if the interfaces
+// were unsatisfiable by anything at all.
+type conformingFilterStore struct{ partialFilterStore }
+
+func (conformingFilterStore) HonorsEveryBookSummaryFilter() {}
+
+func TestFilteredSummaryStore_MethodAloneIsNotConformance(t *testing.T) {
+	var partial any = partialFilterStore{}
+
+	_, ok := partial.(filteredSummaryStore)
+	require.False(t, ok,
+		"a store exposing GetAllBookSummariesFiltered without declaring "+
+			"HonorsEveryBookSummaryFilter must NOT satisfy filteredSummaryStore; "+
+			"the caller skips its post-filter pass whenever this assertion succeeds")
+
+	_, ok = partial.(countingFilteredStore)
+	require.False(t, ok,
+		"a store exposing CountBookSummariesFiltered without declaring "+
+			"HonorsEveryBookSummaryFilter must NOT satisfy countingFilteredStore; "+
+			"its number is returned as the pagination total with no correction available")
+}
+
+func TestFilteredSummaryStore_MarkerGrantsConformance(t *testing.T) {
+	var conforming any = conformingFilterStore{}
+
+	_, ok := conforming.(filteredSummaryStore)
+	require.True(t, ok,
+		"declaring HonorsEveryBookSummaryFilter must satisfy filteredSummaryStore")
+
+	_, ok = conforming.(countingFilteredStore)
+	require.True(t, ok,
+		"declaring HonorsEveryBookSummaryFilter must satisfy countingFilteredStore")
+}
+
+// TestPebbleStoreDeclaresFilterConformance guards the production path. If
+// PebbleStore ever loses the marker, every library query silently drops to
+// the fetch-everything-and-post-filter path — correct, but a full-corpus
+// fetch per request. That regression is invisible in output and shows up only
+// as latency, so assert it directly.
+func TestPebbleStoreDeclaresFilterConformance(t *testing.T) {
+	var store any = &database.PebbleStore{}
+
+	_, ok := store.(filteredSummaryStore)
+	require.True(t, ok, "PebbleStore must satisfy filteredSummaryStore")
+
+	_, ok = store.(countingFilteredStore)
+	require.True(t, ok, "PebbleStore must satisfy countingFilteredStore")
+}

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.123.0
+// version: 1.124.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-08-11
+// last-edited: 2026-08-13
 
 package database
 
@@ -684,11 +684,19 @@ func (p *PebbleStore) CountBookSummariesFiltered(f BookSummaryFilter) (int, erro
 	if p.UseMemDB && p.mem() != nil {
 		return p.mem().CountBookSummaries(f)
 	}
-	summaries, err := p.GetAllBookSummariesFiltered(0, 0, f)
+	// Count without projecting: walkFilteredBooksPebble applies the same
+	// predicate set the row path uses, so the count and the rows can never
+	// disagree — the failure mode that reported count=63870 alongside a page
+	// of non-matching rows.
+	n := 0
+	err := p.walkFilteredBooksPebble(f, func(*Book) bool {
+		n++
+		return true
+	})
 	if err != nil {
 		return 0, err
 	}
-	return len(summaries), nil
+	return n, nil
 }
 
 // GetAllBookSummariesFiltered is the filtered variant used by the library
@@ -700,39 +708,171 @@ func (p *PebbleStore) GetAllBookSummariesFiltered(limit, offset int, f BookSumma
 	if p.UseMemDB && p.mem() != nil {
 		return p.mem().GetBookSummaries(limit, offset, f)
 	}
-	// Pebble fallback: filter manually after a full scan. Matches the
-	// historical service behavior so we never regress correctness when
-	// memdb is unavailable.
-	summaries, err := p.getAllBookSummariesFull(0, 0)
+	if offset < 0 {
+		offset = 0
+	}
+	// Pebble fallback. This path must honor EVERY predicate on f, not a
+	// convenient subset: memdb is not merely a warmup-window optimization
+	// that a slower-but-correct fallback covers for. UseMemDB=false is
+	// permanent for the process, and memSync marks the warmup ABANDONED on
+	// pending-write-buffer overflow, which parks reads here for the rest of
+	// the process lifetime (see memdb_sync.go). Its comment there —
+	// "reads then stay on Pebble — slower, but they cannot lie" — is the
+	// invariant this function has to make true.
+	//
+	// The previous implementation applied only IsPrimaryVersion and
+	// ExcludeQuarantined and silently dropped Predicate (which carries every
+	// service-layer field filter: title, author, narrator, ...),
+	// LibraryState, ReviewStatus, RestrictToIDs and MarkedForDeletion. A
+	// filtered library query issued while memdb was unavailable therefore
+	// returned very nearly the whole library, with the matching count to
+	// go with it.
+	//
+	// It also fetched all ~68K summaries before filtering. Filtering during
+	// the walk means only matched rows are ever projected.
+	out := make([]BookSummary, 0, summaryPageCap(limit))
+	skipped := 0
+	err := p.walkFilteredBooksPebble(f, func(b *Book) bool {
+		// Offset is consumed against the POST-filter set so a page of N
+		// holds N matches, matching memdb's pagination semantics.
+		if skipped < offset {
+			skipped++
+			return true
+		}
+		out = append(out, bookToSummary(b))
+		return limit <= 0 || len(out) < limit
+	})
 	if err != nil {
 		return nil, err
 	}
-	filtered := summaries[:0]
-	excludeDeleted := f.MarkedForDeletion == nil
-	for _, s := range summaries {
-		if excludeDeleted {
-			if s.IsPrimaryVersion != nil && false { /* IsPrimaryVersion on BookSummary, MarkedForDeletion is not — handle conservatively below */
-			}
+	return out, nil
+}
+
+// summaryPageCap bounds the pre-allocation for a summary page so an
+// unbounded (limit<=0) whole-library query does not reserve a
+// million-element slice up front.
+func summaryPageCap(limit int) int {
+	if limit <= 0 || limit > 4096 {
+		return 4096
+	}
+	return limit
+}
+
+// walkFilteredBooksPebble iterates the Pebble book keyspace and invokes visit
+// once per book satisfying every predicate on f, in key (ID) order. visit
+// returns false to stop the walk early.
+//
+// This is the single filtering implementation behind both the row path
+// (GetAllBookSummariesFiltered) and the count path
+// (CountBookSummariesFiltered) when memdb is unavailable, so the two cannot
+// drift into disagreeing about what matches.
+//
+// Predicate ordering mirrors MemStore.GetBookSummaries: cheap pointer and
+// string comparisons first, the caller-supplied Predicate last, since it is
+// the only one that can run arbitrary work.
+//
+// Deliberate divergence from memdb, in the safe direction: memdb stores
+// books stripped of Description/VersionNotes/BookSig* (stripBookForMemdb),
+// so a Predicate reading those fields sees nil there but real values here.
+// Predicates must not depend on stripped fields; this path being the more
+// capable of the two means such a predicate fails visibly on the production
+// memdb path rather than only in the fallback.
+//
+// Sorting is NOT applied here — the walk is Pebble key order regardless of
+// f.SortBy, unchanged from the previous fallback. Callers needing an ordered
+// page sort in application memory. See TODO: the fallback silently ignores
+// f.SortBy the same way it used to silently ignore the filters.
+func (p *PebbleStore) walkFilteredBooksPebble(f BookSummaryFilter, visit func(*Book) bool) error {
+	// A non-nil but empty RestrictToIDs means "no book is eligible" — return
+	// before opening an iterator, mirroring memdb's short-circuit.
+	if f.RestrictToIDs != nil && len(f.RestrictToIDs) == 0 {
+		return nil
+	}
+
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book:0"),
+		UpperBound: []byte("book:;"),
+	})
+	if err != nil {
+		return err
+	}
+	defer iter.Close()
+
+	// excludeDeleted: by default marked-for-deletion rows are dropped. An
+	// explicit f.MarkedForDeletion inverts this into an equality test, so
+	// MarkedForDeletion=true returns ONLY deleted rows. The old fallback
+	// reached the corpus through GetAllBooksCore, which drops deleted rows
+	// unconditionally before any filter runs — so that filter could only
+	// ever return the empty set.
+	excludeDeleted := true
+	requireDeleted := false
+	if f.MarkedForDeletion != nil {
+		excludeDeleted = false
+		requireDeleted = *f.MarkedForDeletion
+	}
+
+	for iter.First(); iter.Valid(); iter.Next() {
+		// Skip path index keys (book:series and book:author indexes removed in Task 3.4)
+		if strings.Contains(string(iter.Key()), ":path:") {
+			continue
 		}
+
+		var book Book
+		if err := json.Unmarshal(iter.Value(), &book); err != nil {
+			return err
+		}
+
 		if f.IsPrimaryVersion != nil {
-			eff := s.IsPrimaryVersion == nil || *s.IsPrimaryVersion
+			// A nil IsPrimaryVersion on the row counts as primary, matching
+			// memdb and the historical service behavior.
+			eff := book.IsPrimaryVersion == nil || *book.IsPrimaryVersion
 			if eff != *f.IsPrimaryVersion {
 				continue
 			}
 		}
-		if f.ExcludeQuarantined && s.QuarantinedAt != nil {
+		isDeleted := book.MarkedForDeletion != nil && *book.MarkedForDeletion
+		if excludeDeleted {
+			if isDeleted {
+				continue
+			}
+		} else if isDeleted != requireDeleted {
 			continue
 		}
-		filtered = append(filtered, s)
+		if f.ExcludeQuarantined && book.QuarantinedAt != nil {
+			continue
+		}
+		if f.LibraryState != "" {
+			ls := ""
+			if book.LibraryState != nil {
+				ls = *book.LibraryState
+			}
+			if ls != f.LibraryState {
+				continue
+			}
+		}
+		if f.ReviewStatus != "" {
+			rs := ""
+			if book.MetadataReviewStatus != nil {
+				rs = *book.MetadataReviewStatus
+			}
+			if !strings.EqualFold(rs, f.ReviewStatus) {
+				continue
+			}
+		}
+		if f.RestrictToIDs != nil {
+			if _, ok := f.RestrictToIDs[book.ID]; !ok {
+				continue
+			}
+		}
+		if f.Predicate != nil && !f.Predicate(&book) {
+			continue
+		}
+
+		if !visit(&book) {
+			return nil
+		}
 	}
-	if offset >= len(filtered) {
-		return nil, nil
-	}
-	end := len(filtered)
-	if limit > 0 && offset+limit < end {
-		end = offset + limit
-	}
-	return filtered[offset:end], nil
+	return nil
 }
 
 // getAllBookSummariesFull is the Pebble-backed implementation.
@@ -753,40 +893,55 @@ func (p *PebbleStore) getAllBookSummariesFull(limit, offset int) ([]BookSummary,
 		return nil, nil
 	}
 	summaries := make([]BookSummary, 0, len(books))
-	for _, b := range books {
+	for i := range books {
+		b := &books[i]
 		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
 			continue
 		}
-		summaries = append(summaries, BookSummary{
-			ID:                   b.ID,
-			Title:                b.Title,
-			AuthorID:             b.AuthorID,
-			SeriesID:             b.SeriesID,
-			SeriesSequence:       b.SeriesSequence,
-			FilePath:             b.FilePath,
-			Format:               b.Format,
-			Duration:             b.Duration,
-			OriginalFilename:     b.OriginalFilename,
-			FileSize:             b.FileSize,
-			FileHash:             b.FileHash,
-			OriginalFileHash:     b.OriginalFileHash,
-			OrganizedFileHash:    b.OrganizedFileHash,
-			LibraryState:         b.LibraryState,
-			QuarantinedAt:        b.QuarantinedAt,
-			QuarantineReason:     b.QuarantineReason,
-			CoverURL:             b.CoverURL,
-			Narrator:             b.Narrator,
-			NarratorsJSON:        b.NarratorsJSON,
-			TranscribedTitle:     b.TranscribedTitle,
-			CreatedAt:            b.CreatedAt,
-			UpdatedAt:            b.UpdatedAt,
-			MetadataUpdatedAt:    b.MetadataUpdatedAt,
-			IsPrimaryVersion:     b.IsPrimaryVersion,
-			VersionGroupID:       b.VersionGroupID,
-			MetadataReviewStatus: b.MetadataReviewStatus,
-		})
+		full := b.ToBook()
+		summaries = append(summaries, bookToSummary(&full))
 	}
 	return summaries, nil
+}
+
+// bookToSummary projects a Book into the lightweight BookSummary the library
+// list view consumes.
+//
+// This is the single projection used by every Pebble-side summary path
+// (getAllBookSummariesFull and the filtered walk). It is field-for-field
+// identical to the projection MemStore.GetBookSummaries builds, which is the
+// point: three hand-maintained copies of the same field list is how a
+// summary field comes to be populated on one backend and silently empty on
+// another.
+func bookToSummary(b *Book) BookSummary {
+	return BookSummary{
+		ID:                   b.ID,
+		Title:                b.Title,
+		AuthorID:             b.AuthorID,
+		SeriesID:             b.SeriesID,
+		SeriesSequence:       b.SeriesSequence,
+		FilePath:             b.FilePath,
+		Format:               b.Format,
+		Duration:             b.Duration,
+		OriginalFilename:     b.OriginalFilename,
+		FileSize:             b.FileSize,
+		FileHash:             b.FileHash,
+		OriginalFileHash:     b.OriginalFileHash,
+		OrganizedFileHash:    b.OrganizedFileHash,
+		LibraryState:         b.LibraryState,
+		QuarantinedAt:        b.QuarantinedAt,
+		QuarantineReason:     b.QuarantineReason,
+		CoverURL:             b.CoverURL,
+		Narrator:             b.Narrator,
+		NarratorsJSON:        b.NarratorsJSON,
+		TranscribedTitle:     b.TranscribedTitle,
+		CreatedAt:            b.CreatedAt,
+		UpdatedAt:            b.UpdatedAt,
+		MetadataUpdatedAt:    b.MetadataUpdatedAt,
+		IsPrimaryVersion:     b.IsPrimaryVersion,
+		VersionGroupID:       b.VersionGroupID,
+		MetadataReviewStatus: b.MetadataReviewStatus,
+	}
 }
 
 func (p *PebbleStore) GetBookByID(id string) (*Book, error) {

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -748,6 +748,39 @@ func (p *PebbleStore) GetAllBookSummariesFiltered(limit, offset int, f BookSumma
 	return out, nil
 }
 
+// HonorsEveryBookSummaryFilter is a marker declaring that this store applies
+// EVERY predicate on BookSummaryFilter — on both the memdb path and the
+// Pebble fallback — and that its returned page is already paginated against
+// the post-filter set.
+//
+// It exists because the caller cannot otherwise tell the difference. The
+// service layer skips its own post-filter pass when the store reports a
+// pushdown, and it decided that from a plain type assertion on
+// GetAllBookSummariesFiltered — which answers "does this type have the
+// method?", never "did the method honor the filter?". A store that applied a
+// subset satisfied that assertion just as well as one that applied
+// everything, and the skipped post-filter pass was the only thing that would
+// have caught it.
+//
+// Do not add this method to a store that filters partially. Omitting it is
+// safe: the caller falls back to fetching unfiltered and post-filtering
+// in-memory — slower, but correct. Adding it falsely is not detectable at
+// runtime.
+//
+// CAVEAT: a type that EMBEDS *PebbleStore inherits this marker whether or not
+// it means to. A wrapper that embeds the store and overrides
+// GetAllBookSummariesFiltered with a narrower implementation therefore
+// declares full conformance by accident — the same by-omission failure the
+// marker exists to prevent, arriving through the other door. Such a wrapper
+// must either delegate to the embedded store (as pushdownSpyStore does) or
+// stop embedding it.
+//
+// The declaration is backed by
+// TestGetAllBookSummariesFiltered_PebbleFallbackHonorsEveryPredicate, which
+// asserts both backends against an oracle built from the fixtures. A new
+// implementer adding this marker is expected to earn it the same way.
+func (p *PebbleStore) HonorsEveryBookSummaryFilter() {}
+
 // summaryPageCap bounds the pre-allocation for a summary page so an
 // unbounded (limit<=0) whole-library query does not reserve a
 // million-element slice up front.

--- a/internal/database/pebble_summaries_fallback_filter_test.go
+++ b/internal/database/pebble_summaries_fallback_filter_test.go
@@ -1,0 +1,299 @@
+// file: internal/database/pebble_summaries_fallback_filter_test.go
+// version: 1.0.0
+// guid: 4f7c1d92-8b3e-4a56-9d07-2e6b5a1c8f43
+// last-edited: 2026-08-13
+
+package database
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// This file pins the contract that GetAllBookSummariesFiltered's Pebble
+// fallback must honor EVERY predicate on the BookSummaryFilter, not just the
+// two it currently implements.
+//
+// Why it matters: memdb is not merely a startup-warmup optimization that a
+// slow-but-correct fallback covers for. Two states leave reads on Pebble
+// indefinitely:
+//
+//  1. UseMemDB=false — configuration, permanent for the process.
+//  2. memPendingAbandoned — memdb_sync.go marks warmup abandoned when the
+//     pending-write buffer overflows, and refuses to publish for the rest of
+//     the process lifetime. Its own comment states the intent this file
+//     tests: "Reads then stay on Pebble — slower, but they cannot lie."
+//
+// They can lie today. On production 2026-08-13 08:50:29, during the 115,971 ms
+// warmup, GET /api/v1/audiobooks?title=Skills returned count=63870 with
+// non-matching rows; the same query post-warmup returned the correct 25. The
+// fallback honors only IsPrimaryVersion and ExcludeQuarantined and silently
+// discards Predicate (which carries every field-filter: title, author,
+// narrator, ...), LibraryState, ReviewStatus, RestrictToIDs, and
+// MarkedForDeletion.
+//
+// The oracle below is computed from the seed fixtures directly rather than by
+// comparing the two backends against each other, so a defect present in BOTH
+// paths still fails the test. The memdb path is included as a control: it is
+// expected to pass at HEAD, which is what makes a Pebble-path failure
+// attributable to the fallback rather than to a bad expectation.
+
+// fallbackFixture is a self-describing seed row. The test persists it via
+// CreateBook and evaluates the expected filter result against these same
+// fields, so the expectation never depends on the code under test.
+type fallbackFixture struct {
+	id           string // assigned by CreateBook
+	title        string
+	libraryState string
+	reviewStatus string
+	primary      bool
+	quarantined  bool
+	deleted      bool
+}
+
+// seedFallbackBooks creates a small deterministic corpus spanning every
+// filterable dimension the BookSummaryFilter carries.
+func seedFallbackBooks(t *testing.T, p *PebbleStore) []fallbackFixture {
+	t.Helper()
+
+	// Titles are chosen so that a substring predicate for "Skills" matches a
+	// strict, known subset — mirroring the production ?title=Skills query.
+	fixtures := []fallbackFixture{
+		{title: "Skills of the Trade", libraryState: "organized", reviewStatus: "matched", primary: true},
+		{title: "Advanced Skills", libraryState: "imported", reviewStatus: "no_match", primary: true},
+		{title: "Skills", libraryState: "organized", reviewStatus: "matched", primary: false},
+		{title: "The Hobbit", libraryState: "organized", reviewStatus: "matched", primary: true},
+		{title: "Dune", libraryState: "imported", reviewStatus: "no_match", primary: true},
+		{title: "Neuromancer", libraryState: "suspicious", reviewStatus: "matched", primary: true},
+		{title: "Skills Quarantined", libraryState: "organized", reviewStatus: "matched", primary: true, quarantined: true},
+		{title: "Skills Deleted", libraryState: "organized", reviewStatus: "matched", primary: true, deleted: true},
+	}
+
+	for i := range fixtures {
+		f := &fixtures[i]
+		ls := f.libraryState
+		rs := f.reviewStatus
+		primary := f.primary
+		b := &Book{
+			Title:                f.title,
+			FilePath:             fmt.Sprintf("/tmp/fallbackfilter_%02d.m4b", i),
+			LibraryState:         &ls,
+			MetadataReviewStatus: &rs,
+			IsPrimaryVersion:     &primary,
+		}
+		if f.quarantined {
+			now := time.Now().UTC()
+			b.QuarantinedAt = &now
+		}
+		if f.deleted {
+			del := true
+			b.MarkedForDeletion = &del
+		}
+		created, err := p.CreateBook(b)
+		require.NoError(t, err)
+		require.NotNil(t, created)
+		f.id = created.ID
+	}
+	return fixtures
+}
+
+// titlePredicate builds the same shape the service layer pushes down for a
+// ?title= field-filter: a case-insensitive substring match evaluated against
+// the full *Book.
+func titlePredicate(substr string) func(*Book) bool {
+	return func(b *Book) bool {
+		return strings.Contains(strings.ToLower(b.Title), strings.ToLower(substr))
+	}
+}
+
+// idsOf collects and sorts the IDs from a summary slice for set comparison.
+func idsOf(summaries []BookSummary) []string {
+	out := make([]string, 0, len(summaries))
+	for _, s := range summaries {
+		out = append(out, s.ID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// expectIDs collects the IDs of fixtures satisfying keep, sorted.
+func expectIDs(fixtures []fallbackFixture, keep func(fallbackFixture) bool) []string {
+	out := make([]string, 0, len(fixtures))
+	for _, f := range fixtures {
+		if keep(f) {
+			out = append(out, f.id)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestGetAllBookSummariesFiltered_PebbleFallbackHonorsEveryPredicate runs one
+// filter matrix through BOTH the memdb-delegation path (UseMemDB=true, the
+// production default) and the Pebble scan-fallback path (UseMemDB=false),
+// asserting each against an oracle derived from the seed fixtures.
+func TestGetAllBookSummariesFiltered_PebbleFallbackHonorsEveryPredicate(t *testing.T) {
+	p := setupTestPebbleStore(t)
+	p.WaitForWarmup()
+
+	fixtures := seedFallbackBooks(t, p)
+
+	cases := []struct {
+		name   string
+		filter BookSummaryFilter
+		// want is evaluated against the fixtures to build the expected ID set.
+		want func(fallbackFixture) bool
+	}{
+		{
+			// The production symptom: ?title=Skills returned the whole
+			// library. Deleted rows are excluded by default; quarantined rows
+			// are NOT excluded unless ExcludeQuarantined is set.
+			name:   "TitlePredicate",
+			filter: BookSummaryFilter{Predicate: titlePredicate("Skills")},
+			want: func(f fallbackFixture) bool {
+				return strings.Contains(f.title, "Skills") && !f.deleted
+			},
+		},
+		{
+			// A predicate matching nothing must return nothing. The prod log
+			// showed zzqqxx→0 only AFTER warmup published; during warmup this
+			// is the case that returns the entire corpus.
+			name:   "PredicateMatchesNothing",
+			filter: BookSummaryFilter{Predicate: titlePredicate("zzqqxx")},
+			want:   func(fallbackFixture) bool { return false },
+		},
+		{
+			name:   "LibraryState",
+			filter: BookSummaryFilter{LibraryState: "imported"},
+			want: func(f fallbackFixture) bool {
+				return f.libraryState == "imported" && !f.deleted
+			},
+		},
+		{
+			name:   "ReviewStatus",
+			filter: BookSummaryFilter{ReviewStatus: "no_match"},
+			want: func(f fallbackFixture) bool {
+				return f.reviewStatus == "no_match" && !f.deleted
+			},
+		},
+		{
+			// Predicate AND LibraryState must both apply — a fallback that
+			// honors one and drops the other still over-returns.
+			name: "PredicateAndLibraryState",
+			filter: BookSummaryFilter{
+				Predicate:    titlePredicate("Skills"),
+				LibraryState: "organized",
+			},
+			want: func(f fallbackFixture) bool {
+				return strings.Contains(f.title, "Skills") &&
+					f.libraryState == "organized" && !f.deleted
+			},
+		},
+		{
+			// MarkedForDeletion=true is the inverse of the default: it must
+			// return ONLY deleted rows. getAllBookSummariesFull drops every
+			// deleted row unconditionally before the filter is consulted, so
+			// the fallback returns the empty set for this filter today.
+			name:   "MarkedForDeletionTrue",
+			filter: BookSummaryFilter{MarkedForDeletion: boolPtr(true)},
+			want:   func(f fallbackFixture) bool { return f.deleted },
+		},
+		{
+			// CONTROL: IsPrimaryVersion is one of the two predicates the
+			// fallback already implements. It must stay green on both paths —
+			// if this reddens, the fix over-reached.
+			name:   "IsPrimaryVersionControl",
+			filter: BookSummaryFilter{IsPrimaryVersion: boolPtr(false)},
+			want: func(f fallbackFixture) bool {
+				return !f.primary && !f.deleted
+			},
+		},
+		{
+			// CONTROL: ExcludeQuarantined is the other already-implemented
+			// predicate.
+			name:   "ExcludeQuarantinedControl",
+			filter: BookSummaryFilter{ExcludeQuarantined: true},
+			want: func(f fallbackFixture) bool {
+				return !f.quarantined && !f.deleted
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		for _, useMemDB := range []bool{true, false} {
+			backend := "MemDBPath"
+			if !useMemDB {
+				backend = "PebbleFallbackPath"
+			}
+			t.Run(tc.name+"/"+backend, func(t *testing.T) {
+				p.UseMemDB = useMemDB
+				want := expectIDs(fixtures, tc.want)
+
+				got, err := p.GetAllBookSummariesFiltered(0, 0, tc.filter)
+				require.NoError(t, err)
+				require.Equal(t, want, idsOf(got),
+					"%s returned the wrong row set for filter %s", backend, tc.name)
+
+				// The count path has the identical fallback and is what made
+				// the production response report count=63870. Assert it
+				// separately — it delegates today, but a fix that repairs
+				// only the row path would leave the count lying.
+				n, err := p.CountBookSummariesFiltered(tc.filter)
+				require.NoError(t, err)
+				require.Equal(t, len(want), n,
+					"%s returned the wrong count for filter %s", backend, tc.name)
+			})
+		}
+	}
+}
+
+// TestGetAllBookSummariesFiltered_FallbackPaginatesPostFilter pins that
+// offset/limit are applied to the POST-filter set on the Pebble fallback, the
+// same as memdb does. A fallback that filters correctly but paginates the
+// pre-filter set would return short or empty pages — the failure mode a
+// previous pagination bug in this same area already produced once.
+func TestGetAllBookSummariesFiltered_FallbackPaginatesPostFilter(t *testing.T) {
+	p := setupTestPebbleStore(t)
+	p.WaitForWarmup()
+
+	fixtures := seedFallbackBooks(t, p)
+	filter := BookSummaryFilter{Predicate: titlePredicate("Skills")}
+	want := expectIDs(fixtures, func(f fallbackFixture) bool {
+		return strings.Contains(f.title, "Skills") && !f.deleted
+	})
+	require.Len(t, want, 4, "fixture guard: expected 4 non-deleted Skills books")
+
+	for _, useMemDB := range []bool{true, false} {
+		backend := "MemDBPath"
+		if !useMemDB {
+			backend = "PebbleFallbackPath"
+		}
+		t.Run(backend, func(t *testing.T) {
+			p.UseMemDB = useMemDB
+
+			// Walk the whole matched set one page at a time and assert the
+			// pages PARTITION it — every matched ID appears exactly once
+			// across pages, and nothing unmatched appears at all. Asserting
+			// per-page length alone would pass even if paging over the
+			// pre-filter set silently dropped rows.
+			const pageSize = 2
+			seen := make([]string, 0, len(want))
+			for offset := 0; offset < len(want); offset += pageSize {
+				page, err := p.GetAllBookSummariesFiltered(pageSize, offset, filter)
+				require.NoError(t, err)
+				require.NotEmpty(t, page,
+					"%s: page at offset %d was empty but %d matches remain",
+					backend, offset, len(want)-offset)
+				seen = append(seen, idsOf(page)...)
+			}
+			sort.Strings(seen)
+			require.Equal(t, want, seen,
+				"%s: paged results must partition the matched set exactly", backend)
+		})
+	}
+}


### PR DESCRIPTION
## The bug

Observed on production 2026-08-13 08:50:29, during the 115,971 ms startup warmup:

```
GET /api/v1/audiobooks?title=Skills  ->  count=63870, with non-matching rows
```

The same query at 08:54:43, post-warmup, returned the correct 25.

Two cooperating defects, both instances of *a mechanism reporting success while meaning nothing*:

**1. `PebbleStore.GetAllBookSummariesFiltered`'s fallback filtered almost nothing.** Its comment claimed it would "filter manually after a full scan … so we never regress correctness when memdb is unavailable." It applied only `IsPrimaryVersion` and `ExcludeQuarantined`, silently discarding `Predicate` (which carries every service-layer field filter — title, author, narrator, …), `LibraryState`, `ReviewStatus`, `RestrictToIDs` and `MarkedForDeletion`. The last was a literal dead branch:

```go
if s.IsPrimaryVersion != nil && false { /* ... handle conservatively below */ }
```

which handled nothing below. `CountBookSummariesFiltered` shared the fallback, which is why the *count* was 63,870 and not just the rows.

**2. `summariesPushdownFiltered` reported the filter as applied regardless.** It returned `didPushdown=true` for any store with a method of the right name, and `service_query.go` skips its post-filter pass on that basis — the one pass positioned to catch defect 1.

## Two failure directions, not one

- Most filters **over-returned**, leaking the corpus.
- `MarkedForDeletion=true` **under-returned to exactly zero**, because the fallback reached the corpus through `GetAllBooksCore`, which drops deleted rows unconditionally *before* any filter runs.

## Why this is not just a warmup-window bug

`UseMemDB=false` is permanent for the process, and `memSync` marks the warmup **abandoned** on pending-write-buffer overflow and refuses to publish for the rest of the process lifetime. Its comment there is the invariant this PR makes true:

> reads then stay on Pebble — slower, but they cannot lie.

That is also what settled the fix direction. Fail-closed (erroring when a filter cannot be honored) would take the library page down for the entire life of a process that had merely overflowed its warmup buffer, and would contradict an invariant the codebase already committed to in writing. Filtering properly in the fallback makes that invariant true instead.

## The fix

Filtering now happens during a single Pebble walk shared by the row path and the count path, so a page and its total cannot disagree. Only matching rows are projected, replacing a materialize-all-then-filter pass over ~68K summaries — the correctness fix and a memory reduction are the same edit. The `Book -> BookSummary` projection is consolidated into one function, replacing three hand-maintained copies.

For defect 2, conformance becomes an explicit opt-in marker method. A store that has not deliberately declared it no longer satisfies the interface, so `didPushdown` is false and the caller post-filters — slower, but correct. **Partial conformance now requires an explicit false claim rather than arriving by omission.** The count side gets the same requirement and needs it more: its number becomes the pagination total with no correction available downstream.

## Cost, stated plainly

With memdb unavailable, every filtered query walks the full Pebble keyspace. That is strictly less work than the path it replaces (which materialized all ~68K summaries first), but it is still O(corpus) per query. The predicate loop is in-memory field comparison; the cost is the JSON unmarshal that the previous code also paid, so no worker pool is warranted here.

## Not addressed

The fallback still ignores `f.SortBy` and walks in Pebble key order — unchanged from before, and called out in the code rather than left silent. It is the same *claims-more-than-it-does* shape and deserves its own change.

## Verification

- New tests assert against an **oracle computed from the seed fixtures**, not by comparing the two backends — so a defect present in both still fails.
- Watched red first: 7 failures, **all** on `PebbleFallbackPath`, **zero** on `MemDBPath`. The sharpest, `PredicateMatchesNothing`, returned the entire non-deleted corpus instead of 0 — the `count=63870` shape.
- Both already-implemented predicates are asserted as **controls** and stay green on both paths, catching over-reach.
- Pagination is asserted to **partition** the matched set, not by per-page length — a fixture too small to page would otherwise leave both clamps dead code.
- Negative control on the marker: removing it from `filteredSummaryStore` fails the conformance test with the intended message while the count-side assertion stays green, confirming the assertions are independent.
- `internal/database` run to completion **3×** (exit 0 each; it is the wait-bound package that stalls in CI, so n=1 would not be a measurement). `internal/audiobooks` 2× green. `go build ./...` and `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp