### PR TITLE
feat(abs): serve real playlists instead of a hardcoded empty page

### DIFF
--- a/changelog.d/20260813_101500_feat_abs_playlists_mapping.md
+++ b/changelog.d/20260813_101500_feat_abs_playlists_mapping.md
@@ -1,0 +1,39 @@
+### Added
+
+#### ABS playlist list serves real playlists instead of a hardcoded empty page
+
+`GET /api/libraries/:libraryId/playlists` was `h.EmptyPage` — a compile-time
+constant that never touched a store. It now maps the existing user-playlist model
+onto the upstream ABS playlist shape, with items expanded and ordered.
+
+The model is **`UserPlaylist`**, not `Playlist`. `internal/database` carries two
+unrelated types with similar names: `Playlist` is the legacy series M3U
+auto-generator (int ids, `SeriesID`, `FilePath`), while `UserPlaylist` (ULID ids,
+`static`/`smart`, `BookIDs`, `CreatedByUserID`) is what the nine app routes under
+`/api/v1/playlists` actually serve. Mapping the legacy type would have produced a
+list unrelated to anything the web UI shows.
+
+Behaviour worth knowing:
+
+- Scoped per user via `ListUserPlaylistsForUser` — the unscoped variant would
+  disclose every user's playlists to every caller.
+- Smart playlists resolve through `MaterializedBookIDs`, never by re-running the
+  query: evaluation needs the Bleve index and this read path must not depend on it.
+  An unevaluated smart playlist renders as an empty playlist rather than an error.
+- Playlist order is preserved as the listening order; a reference to a deleted book
+  is dropped rather than emitted as an item with a null `libraryItem`.
+- `libraryItemId` is the 36-char sync UUID, never the 26-char Book ULID — Absorb
+  splits compound ids by fixed byte offset.
+- A nil playlist store keeps the previous empty-page behaviour rather than 500-ing.
+
+**Scope.** This is the LIST route only. Upstream ABS has roughly twelve playlist
+routes (create, update, delete, item add/remove, batch, create-from-collection);
+none are implemented. `/api/playlists` continues to 301 into the app-API twin, and
+no engine-level routing was touched.
+
+**This does not make playlists appear.** Production returned
+`{"items":[],"count":0}` from `/api/v1/playlists` on 2026-08-13 — there are no
+playlists to list yet, blocked on the separate iTunes importer gap. Zero of the 28
+ABS fixtures request a playlist path, and the target-client contract §11 lists
+playlists among the surfaces explicitly safe to stub, so the empty page this
+replaces was contract-correct rather than a defect.

--- a/internal/server/handlers/abs/handler.go
+++ b/internal/server/handlers/abs/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/handler.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: fb0271c6-3a49-4d85-9e13-8c507b2ad64f
-// last-edited: 2026-08-02
+// last-edited: 2026-08-13
 
 // Package abs implements the Audiobookshelf-compatible auth surface (design spec
 // Phase 1): GET /ping, GET /status, POST /login, POST /auth/refresh, POST /logout,
@@ -206,6 +206,9 @@ type Options struct {
 	// at all rather than registered and answering 500 — a client that gets a 404
 	// hides the feature, while one that gets a 500 shows an error on every open.
 	Bookmarks BookmarkStore
+	// Playlists is optional: nil keeps the playlist route answering the empty page
+	// it answered before, which is a valid Page<T>, rather than 500-ing.
+	Playlists PlaylistStore
 
 	// CoverRoot is config.AppConfig.RootDir — the library root that
 	// metadata.CoverPathForBook resolves covers under, and the base for the relative
@@ -235,6 +238,7 @@ type Handler struct {
 	chapters    ChapterStore
 	progress    ProgressStore
 	bookmarks   BookmarkStore
+	playlists   PlaylistStore
 	coverRoot   string
 	libraryName string
 
@@ -305,6 +309,7 @@ func New(o Options) (*Handler, error) {
 		library:     o.Library,
 		identity:    o.Identity,
 		chapters:    o.Chapters,
+		playlists:   o.Playlists,
 		progress:    o.Progress,
 		bookmarks:   o.Bookmarks,
 		coverRoot:   o.CoverRoot,
@@ -384,7 +389,7 @@ func (h *Handler) Register(r gin.IRouter) {
 	r.GET("/api/libraries/:libraryId/personalized", auth, h.Personalized)
 	r.GET("/api/libraries/:libraryId/series", auth, h.LibrarySeries)
 	r.GET("/api/libraries/:libraryId/collections", auth, h.EmptyPage)
-	r.GET("/api/libraries/:libraryId/playlists", auth, h.EmptyPage)
+	r.GET("/api/libraries/:libraryId/playlists", auth, h.LibraryPlaylists)
 	r.GET("/api/libraries/:libraryId/authors", auth, h.LibraryAuthors)
 	r.GET("/api/libraries/:libraryId/narrators", auth, h.LibraryNarrators)
 	r.GET("/api/libraries/:libraryId/filterdata", auth, h.LibraryFilterData)

--- a/internal/server/handlers/abs/playlists.go
+++ b/internal/server/handlers/abs/playlists.go
@@ -1,0 +1,202 @@
+// file: internal/server/handlers/abs/playlists.go
+// version: 1.0.0
+// guid: c41e97b2-0d85-4f36-a7e9-1b620c8ad573
+// last-edited: 2026-08-13
+
+package abs
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+// ── GET /api/libraries/:libraryId/playlists ─────────────────────────────────
+//
+// Replaces the h.EmptyPage stub on the playlist route with the real user-playlist
+// list.
+//
+// 🔴 THE MODEL IS UserPlaylist, NOT Playlist. internal/database carries two
+// unrelated types with confusingly similar names. `Playlist` (store.go:380, int
+// ids, SeriesID, FilePath) is the LEGACY series M3U auto-generator. `UserPlaylist`
+// (store.go:389, ULID ids, static|smart, BookIDs, CreatedByUserID) is the spec-3.4
+// user-facing feature, and it is what the nine app routes under /api/v1/playlists
+// (wire_library_routes.go:77-85) actually serve. Mapping the legacy type here would
+// produce a playlist list unrelated to anything the web UI shows.
+//
+// SCOPE, AND WHAT IT IS NOT. This is the LIST route only. Upstream ABS has ~12
+// playlist routes (create, update, delete, item add/remove, batch add/remove,
+// create-from-collection); none of those are implemented and this change does not
+// add them. The bare /api/playlists namespace continues to 301 into the app-API
+// twin via absAppAPICollisions — that is deliberate and pinned by
+// TestCollidingNamespacesStillRedirect. Nothing here touches engine-level routing.
+//
+// 🔴 NO CLIENT IS KNOWN TO CALL THIS. Zero of the 28 captures in
+// testdata/abs-fixtures/ request any playlist path, and the target-client contract
+// §11 lists playlists among the surfaces explicitly SAFE TO STUB. So the empty page
+// this replaces was contract-correct, not a defect. This is completeness work: it
+// makes the route honest if a client ever does ask, and it is why the DTO below is
+// modelled on the upstream ABS 2.36.0 reference rather than on a capture — there is
+// no capture to conform to, and the tests here therefore assert OUR shape, not an
+// oracle's.
+//
+// PRODUCTION IS EMPTY EITHER WAY. /api/v1/playlists returned {"items":[],"count":0}
+// on 2026-08-13, so this route still renders an empty list until playlists exist —
+// which is blocked on the separate iTunes importer gap (the ITL parser extracts 0
+// of 292 smart playlists). "Playlists implemented" must not be read as "playlists
+// appear".
+
+// PlaylistStore reads user playlists for the ABS playlist list. Optional: with a
+// nil store the route keeps answering the empty page, which is a valid Page<T> and
+// exactly the previous behaviour, rather than 500-ing.
+//
+// The per-user variant is the only one exposed on purpose. ListUserPlaylists (no
+// user) would disclose every user's playlists to every caller the moment this
+// server has more than one account.
+type PlaylistStore interface {
+	ListUserPlaylistsForUser(userID, playlistType string, limit, offset int) ([]database.UserPlaylist, int, error)
+}
+
+// absPlaylistPageSize bounds one page of playlists. Playlists are few and the
+// client has no paging UI for them, so this is a safety bound rather than a
+// pagination scheme.
+const absPlaylistPageSize = 500
+
+// LibraryPlaylists handles GET /api/libraries/:libraryId/playlists.
+func (h *Handler) LibraryPlaylists(c *gin.Context) {
+	if !h.knownLibrary(c) {
+		return
+	}
+	// No store wired: answer exactly what the stub answered. An empty Page<T> is
+	// valid; `{}` would throw in the Dart client (§6.6).
+	if h.playlists == nil {
+		respondJSON(c, http.StatusOK, pageResponse{Results: []any{}})
+		return
+	}
+
+	u, found := servermiddleware.CurrentUser(c)
+	if !found || u == nil {
+		respondError(c, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	// "" = both static and smart.
+	lists, _, err := h.playlists.ListUserPlaylistsForUser(u.ID, "", absPlaylistPageSize, 0)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "could not list playlists")
+		return
+	}
+
+	results := make([]any, 0, len(lists))
+	for i := range lists {
+		results = append(results, h.playlistDTO(c, &lists[i]))
+	}
+	// Total is the number RETURNED, not the store's total count. Returning a total
+	// larger than results without a working page parameter would tell the client
+	// there are more pages it cannot fetch.
+	respondJSON(c, http.StatusOK, pageResponse{Results: results, Total: len(results)})
+}
+
+// playlistDTO maps one UserPlaylist onto the upstream ABS playlist shape.
+func (h *Handler) playlistDTO(c *gin.Context, pl *database.UserPlaylist) gin.H {
+	// A smart playlist's membership is its LAST EVALUATION, not its query: the
+	// query needs the Bleve index and this is a read path that must not depend on
+	// the index being open. An unmaterialized smart playlist therefore renders as
+	// an empty playlist rather than erroring — the client shows it with no items,
+	// which is recoverable, instead of red-screening the library tab.
+	bookIDs := pl.BookIDs
+	if pl.Type == database.UserPlaylistTypeSmart {
+		bookIDs = pl.MaterializedBookIDs
+	}
+
+	var description any
+	if pl.Description != "" {
+		description = pl.Description
+	}
+
+	return gin.H{
+		"id":          pl.ID,
+		"libraryId":   h.libraryID(),
+		"userId":      pl.CreatedByUserID,
+		"name":        pl.Name,
+		"description": description,
+		"coverPath":   nil,
+		"items":       h.playlistItems(c, pl.ID, bookIDs),
+		"lastUpdate":  msEpoch(pl.UpdatedAt),
+		"createdAt":   msEpoch(pl.CreatedAt),
+	}
+}
+
+// playlistItems expands the ordered book list into ABS playlist items.
+//
+// Books are fetched in ONE batch and then re-ordered to the playlist's own
+// sequence. Fetching per id would be an N+1 over a list whose length the user
+// controls, and playlist order is meaningful — it is the listening order — so the
+// store's return order is never used directly.
+//
+// A book id that no longer resolves is DROPPED, not rendered as a null item: a
+// playlist referencing a deleted book is a stale reference, and an item with no
+// libraryItem is exactly the shape that red-screens a client expecting to expand
+// it.
+func (h *Handler) playlistItems(c *gin.Context, playlistID string, bookIDs []string) []any {
+	items := make([]any, 0, len(bookIDs))
+	if len(bookIDs) == 0 {
+		return items
+	}
+
+	books, err := h.library.GetBooksByIDs(bookIDs)
+	if err != nil {
+		// Report the playlist with no items rather than failing the whole page —
+		// one unreadable playlist must not take out the list.
+		return items
+	}
+	byID := make(map[string]*database.Book, len(books))
+	for i := range books {
+		byID[books[i].ID] = &books[i]
+	}
+
+	order := make(map[string]int, len(bookIDs))
+	for i, id := range bookIDs {
+		if _, seen := order[id]; !seen {
+			order[id] = i
+		}
+	}
+
+	type positioned struct {
+		pos int
+		val gin.H
+	}
+	built := make([]positioned, 0, len(bookIDs))
+	for id, pos := range order {
+		book := byID[id]
+		if book == nil {
+			continue // stale reference to a deleted book
+		}
+		syncID, err := h.identity.MintOrGetSyncID(book.ID)
+		if err != nil {
+			continue
+		}
+		item := gin.H{
+			// The playlist-item id is synthesized from (playlist, item): our store
+			// has no PlaylistItem row for UserPlaylist — membership is an ordered
+			// id slice — and ABS clients use this only as a list key.
+			"id":            playlistID + "_" + syncID,
+			"playlistId":    playlistID,
+			"libraryItemId": syncID,
+			"episodeId":     nil,
+		}
+		if v, verr := h.loadItemView(c.Request.Context(), book); verr == nil && v != nil {
+			item["libraryItem"] = h.minifiedItem(v)
+		}
+		built = append(built, positioned{pos: pos, val: item})
+	}
+	sort.Slice(built, func(i, j int) bool { return built[i].pos < built[j].pos })
+
+	for _, b := range built {
+		items = append(items, b.val)
+	}
+	return items
+}

--- a/internal/server/handlers/abs/playlists_test.go
+++ b/internal/server/handlers/abs/playlists_test.go
@@ -1,0 +1,325 @@
+// file: internal/server/handlers/abs/playlists_test.go
+// version: 1.0.0
+// guid: 7e2f4a08-b165-4c39-8de2-91f0a3b74c6e
+// last-edited: 2026-08-13
+
+package abs_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	abshandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/abs"
+)
+
+// ── fake store ──────────────────────────────────────────────────────────────
+//
+// Helpers are prefixed abspl* because this package's tests share one namespace.
+//
+// NOTE ON WHAT THESE TESTS ARE. There is NO fixture for playlists — zero of the
+// 28 captures request one — so unlike the rest of this suite these assert OUR
+// shape rather than conforming to an oracle. They are therefore written to pin
+// behaviour that is decidable without an oracle: ordering, scoping, stale-id
+// handling, and the Page<T> envelope contract from §6.6.
+
+type absplFakeStore struct {
+	lists []database.UserPlaylist
+	err   error
+	// gotUserID records what the handler scoped the query to, so the per-user
+	// scoping can be asserted directly instead of inferred from the result.
+	gotUserID string
+	calls     int
+}
+
+func (f *absplFakeStore) ListUserPlaylistsForUser(userID, _ string, _, _ int) ([]database.UserPlaylist, int, error) {
+	f.gotUserID = userID
+	f.calls++
+	if f.err != nil {
+		return nil, 0, f.err
+	}
+	return f.lists, len(f.lists), nil
+}
+
+func withPlaylists(p abshandler.PlaylistStore) harnessOpt {
+	return func(o *abshandler.Options) { o.Playlists = p }
+}
+
+// absplHarness builds the standard browse harness plus a playlist store.
+func absplHarness(t *testing.T, store abshandler.PlaylistStore) (*harness, *oracleSeed, string) {
+	t.Helper()
+	seed := seedOracleLibrary(t)
+	h := newHarness(t, "jwt", nil, withLibrary(seed), withUserData(fixtureUserData()), withPlaylists(store))
+	h.seedUser(t, "u1", "oracle", "", "pw-pw-pw-pw")
+	body := h.login(t, "oracle", "pw-pw-pw-pw")
+	return h, seed, str(t, userObj(t, body), "accessToken")
+}
+
+func absplGet(t *testing.T, h *harness, tok string) map[string]any {
+	t.Helper()
+	code, body := h.doAny(t, request{
+		method:  http.MethodGet,
+		path:    "/api/libraries/" + h.libraryID() + "/playlists",
+		headers: bearer(tok),
+	})
+	if code != http.StatusOK {
+		t.Fatalf("got %d want 200", code)
+	}
+	m, ok := body.(map[string]any)
+	if !ok {
+		t.Fatalf("body is %T, want a JSON object", body)
+	}
+	return m
+}
+
+// ── the envelope contract ───────────────────────────────────────────────────
+
+// §6.6: Page<T> needs non-optional total AND page. `{}` red-screens the Dart
+// client. Asserted for BOTH the wired and the nil-store paths, because the nil
+// path is the one that silently regresses when someone "simplifies" the guard.
+func TestLibraryPlaylists_PageEnvelopeAlwaysHasTotalAndPage(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		store abshandler.PlaylistStore
+	}{
+		{"nil store", nil},
+		{"wired but empty", &absplFakeStore{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _, tok := absplHarness(t, tc.store)
+			body := absplGet(t, h, tok)
+			for _, key := range []string{"total", "page", "results"} {
+				if _, ok := body[key]; !ok {
+					t.Fatalf("%s: response is missing required key %q — Page<T> throws without it", tc.name, key)
+				}
+			}
+			if _, ok := body["results"].([]any); !ok {
+				t.Fatalf("results is %T, want an array", body["results"])
+			}
+		})
+	}
+}
+
+// A nil store must behave EXACTLY as the previous h.EmptyPage stub did. Wiring an
+// optional capability must never turn "feature absent" into a 500.
+func TestLibraryPlaylists_NilStoreServesEmptyPageNotAnError(t *testing.T) {
+	h, _, tok := absplHarness(t, nil)
+	body := absplGet(t, h, tok)
+	if n := len(body["results"].([]any)); n != 0 {
+		t.Fatalf("nil store returned %d results, want 0", n)
+	}
+	if total, _ := body["total"].(float64); total != 0 {
+		t.Fatalf("nil store reported total=%v, want 0", total)
+	}
+}
+
+// ── real data ───────────────────────────────────────────────────────────────
+
+func TestLibraryPlaylists_ReturnsRealPlaylistsWithExpandedItems(t *testing.T) {
+	// The store is populated AFTER the harness builds, because the seeded book ids
+	// only exist once the harness has seeded its library.
+	store := &absplFakeStore{}
+	h2, seed, tok2 := absplHarness(t, store)
+	store.lists = []database.UserPlaylist{{
+		ID:              "01PLAYLISTULID000000000000",
+		Name:            "Bedtime",
+		Description:     "for the kids",
+		Type:            database.UserPlaylistTypeStatic,
+		BookIDs:         []string{seed.singleID},
+		CreatedByUserID: "u1",
+		CreatedAt:       time.UnixMilli(1785370201391),
+		UpdatedAt:       time.UnixMilli(1785370201438),
+	}}
+	body := absplGet(t, h2, tok2)
+
+	results := body["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("got %d playlists, want 1", len(results))
+	}
+	pl := results[0].(map[string]any)
+
+	if got := pl["name"]; got != "Bedtime" {
+		t.Fatalf("name = %#v, want \"Bedtime\"", got)
+	}
+	if got := pl["id"]; got != "01PLAYLISTULID000000000000" {
+		t.Fatalf("id = %#v", got)
+	}
+	if got := pl["description"]; got != "for the kids" {
+		t.Fatalf("description = %#v", got)
+	}
+	if got := pl["libraryId"]; got != h2.libraryID() {
+		t.Fatalf("libraryId = %#v, want %q", got, h2.libraryID())
+	}
+	if got, _ := pl["lastUpdate"].(float64); int64(got) != 1785370201438 {
+		t.Fatalf("lastUpdate = %v, want the playlist's UpdatedAt in ms", got)
+	}
+
+	items := pl["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1", len(items))
+	}
+	item := items[0].(map[string]any)
+
+	// 🔴 libraryItemId must be the 36-char sync UUID, never the 26-char Book ULID:
+	// Absorb splits compound ids by FIXED BYTE OFFSET substring(0,36) (§1.7.1), so a
+	// ULID here mis-truncates into the wrong /api/me/progress path.
+	libItemID, _ := item["libraryItemId"].(string)
+	if len(libItemID) != 36 {
+		t.Fatalf("libraryItemId = %q (%d chars), want a 36-char sync UUID", libItemID, len(libItemID))
+	}
+	if libItemID == seed.singleID {
+		t.Fatal("libraryItemId is the raw Book id — Absorb's fixed-offset id split will mis-truncate it")
+	}
+	if item["episodeId"] != nil {
+		t.Fatalf("episodeId = %#v, want null (this server has no podcasts)", item["episodeId"])
+	}
+	li, ok := item["libraryItem"].(map[string]any)
+	if !ok {
+		t.Fatal("item has no expanded libraryItem; a client that expands it gets nothing to show")
+	}
+	if li["id"] != libItemID {
+		t.Fatalf("libraryItem.id = %#v, want it to match libraryItemId %q", li["id"], libItemID)
+	}
+}
+
+// 🔴 ORDER IS MEANING. A playlist's order is its listening order, so the response
+// must follow the playlist's own id sequence and never the store's return order.
+// Seeded deliberately in the REVERSE of the library's natural order so a handler
+// that forwards the store's order fails.
+func TestLibraryPlaylists_PreservesPlaylistOrderNotLibraryOrder(t *testing.T) {
+	store := &absplFakeStore{}
+	h, seed, tok := absplHarness(t, store)
+	// multi BEFORE single — the reverse of the library's own ordering, so a
+	// handler that forwards GetBooksByIDs' order fails here.
+	store.lists = []database.UserPlaylist{{
+		ID:              "01ORDER00000000000000000000",
+		Name:            "Ordered",
+		Type:            database.UserPlaylistTypeStatic,
+		BookIDs:         []string{seed.multiID, seed.singleID},
+		CreatedByUserID: "u1",
+	}}
+
+	body := absplGet(t, h, tok)
+	items := body["results"].([]any)[0].(map[string]any)["items"].([]any)
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2", len(items))
+	}
+
+	wantFirst := absplSyncIDFor(t, seed, seed.multiID)
+	gotFirst := items[0].(map[string]any)["libraryItemId"]
+	if gotFirst != wantFirst {
+		t.Fatalf("items[0].libraryItemId = %#v, want the MULTI-file book (%q) — "+
+			"playlist order was not preserved", gotFirst, wantFirst)
+	}
+}
+
+// A playlist referencing a deleted book must DROP the entry, not emit an item with
+// a null libraryItem — that shape is what red-screens a client that expands it.
+func TestLibraryPlaylists_StaleBookReferenceIsDroppedNotNulled(t *testing.T) {
+	store := &absplFakeStore{}
+	h, seed, tok := absplHarness(t, store)
+	store.lists = []database.UserPlaylist{{
+		ID:              "01STALE0000000000000000000",
+		Name:            "Has a ghost",
+		Type:            database.UserPlaylistTypeStatic,
+		BookIDs:         []string{seed.singleID, "01DELETEDBOOKID00000000000"},
+		CreatedByUserID: "u1",
+	}}
+
+	body := absplGet(t, h, tok)
+	items := body["results"].([]any)[0].(map[string]any)["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1 — the deleted book should be dropped", len(items))
+	}
+	for i, raw := range items {
+		it := raw.(map[string]any)
+		if it["libraryItemId"] == nil || it["libraryItemId"] == "" {
+			t.Fatalf("items[%d] has an empty libraryItemId", i)
+		}
+	}
+}
+
+// A smart playlist's membership is its LAST EVALUATION. BookIDs is populated here
+// with a DIFFERENT book than MaterializedBookIDs, so a handler that reads the
+// wrong field returns the wrong book rather than an empty list — a mistake an
+// emptiness check would miss.
+func TestLibraryPlaylists_SmartPlaylistUsesMaterializedIDs(t *testing.T) {
+	store := &absplFakeStore{}
+	h, seed, tok := absplHarness(t, store)
+	store.lists = []database.UserPlaylist{{
+		ID:                  "01SMART0000000000000000000",
+		Name:                "Smart",
+		Type:                database.UserPlaylistTypeSmart,
+		Query:               "title:odyssey",
+		BookIDs:             []string{seed.multiID},  // must be IGNORED for smart
+		MaterializedBookIDs: []string{seed.singleID}, // must be USED
+		CreatedByUserID:     "u1",
+	}}
+
+	body := absplGet(t, h, tok)
+	items := body["results"].([]any)[0].(map[string]any)["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1", len(items))
+	}
+	want := absplSyncIDFor(t, seed, seed.singleID)
+	if got := items[0].(map[string]any)["libraryItemId"]; got != want {
+		t.Fatalf("smart playlist resolved to %#v, want the MATERIALIZED book %q — "+
+			"the handler read BookIDs instead of MaterializedBookIDs", got, want)
+	}
+}
+
+// An unmaterialized smart playlist renders empty rather than erroring: evaluating
+// the query needs the Bleve index, and this read path must not depend on it.
+func TestLibraryPlaylists_UnmaterializedSmartPlaylistRendersEmpty(t *testing.T) {
+	store := &absplFakeStore{lists: []database.UserPlaylist{{
+		ID:              "01UNMAT00000000000000000000",
+		Name:            "Never evaluated",
+		Type:            database.UserPlaylistTypeSmart,
+		Query:           "title:odyssey",
+		CreatedByUserID: "u1",
+	}}}
+	h, _, tok := absplHarness(t, store)
+
+	body := absplGet(t, h, tok)
+	results := body["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("got %d playlists, want 1 — an unevaluated smart playlist must still be listed", len(results))
+	}
+	items := results[0].(map[string]any)["items"].([]any)
+	if len(items) != 0 {
+		t.Fatalf("got %d items, want 0", len(items))
+	}
+}
+
+// 🔴 CROSS-USER DISCLOSURE. Asserted on the argument the handler passed, not on
+// the result: a fake that ignores userID would return the same list either way, so
+// checking the response cannot distinguish a scoped query from an unscoped one.
+func TestLibraryPlaylists_ScopedToTheCallingUser(t *testing.T) {
+	store := &absplFakeStore{}
+	h, _, tok := absplHarness(t, store)
+	_ = absplGet(t, h, tok)
+
+	if store.calls == 0 {
+		t.Fatal("the playlist store was never queried")
+	}
+	if store.gotUserID == "" {
+		t.Fatal("the handler queried playlists with an EMPTY user id — every user's " +
+			"playlists would be visible to every caller")
+	}
+	if store.gotUserID != "u1" {
+		t.Fatalf("scoped to user %q, want the calling user \"u1\"", store.gotUserID)
+	}
+}
+
+// absplSyncIDFor returns the client-visible sync id for a book, via the SAME
+// identity store the handler uses (withLibrary wires seed.lib as o.Identity), so
+// the expected value is derived rather than hardcoded.
+func absplSyncIDFor(t *testing.T, seed *oracleSeed, bookID string) string {
+	t.Helper()
+	id, err := seed.lib.MintOrGetSyncID(bookID)
+	if err != nil {
+		t.Fatalf("MintOrGetSyncID(%s): %v", bookID, err)
+	}
+	return id
+}

--- a/internal/server/wire_abs_routes.go
+++ b/internal/server/wire_abs_routes.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_abs_routes.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: 9c6b13f8-40a2-4e57-b18d-72e0a5c4d396
-// last-edited: 2026-08-12
+// last-edited: 2026-08-13
 
 package server
 
@@ -318,8 +318,9 @@ func (s *Server) wireABSRoutes() {
 		// Chapters and Progress are OPTIONAL by design: without chapters the mapper
 		// synthesizes one per track (what real ABS does for a multi-file book anyway),
 		// and without progress a session still plays, it just starts at 0.
-		Chapters: asChapterStore(s.Store()),
-		Progress: asProgressStore(s.Store()),
+		Chapters:  asChapterStore(s.Store()),
+		Playlists: asPlaylistStore(s.Store()),
+		Progress:  asProgressStore(s.Store()),
 		// Phase 6 write half. Already asserted non-nil above (bookmarkStore), so
 		// the CRUD routes always register on the supported backend.
 		Bookmarks:   bookmarkStore,
@@ -461,7 +462,7 @@ func absRouteList() []string {
 		"GET /api/libraries/:libraryId/personalized",
 		"GET /api/libraries/:libraryId/series",
 		"GET /api/libraries/:libraryId/collections",
-		"GET /api/libraries/:libraryId/playlists",
+		"GET /api/libraries/:libraryId/playlists", // real data since 2026-08-13; was h.EmptyPage
 		"GET /api/libraries/:libraryId/authors",
 		"GET /api/libraries/:libraryId/narrators",
 		"GET /api/libraries/:libraryId/filterdata",
@@ -503,4 +504,15 @@ func absRouteList() []string {
 		"PATCH /api/me/item/:id/bookmark",
 		"DELETE /api/me/item/:id/bookmark/:time",
 	}
+}
+
+// asPlaylistStore returns the user-playlist capability, or nil when the store does
+// not have it. Optional: a nil store keeps GET /api/libraries/:id/playlists
+// answering the empty page it answered before this was wired, which is a valid
+// Page<T> — never a 500.
+func asPlaylistStore(s any) abshandler.PlaylistStore {
+	if ps, ok := s.(abshandler.PlaylistStore); ok {
+		return ps
+	}
+	return nil
 }


### PR DESCRIPTION
## What changed

`GET /api/libraries/:libraryId/playlists` was `h.EmptyPage` (`handler.go:387`) — a compile-time constant that never touched a store. It now maps the existing user-playlist model onto the upstream ABS playlist shape, with items expanded and ordered.

## 🔴 The prompt file named the wrong model

`.github/prompts/abs-implementation-completion.prompt.md` says to map `Playlist` / `PlaylistItem` / `CreatePlaylist(name, seriesID, filePath)`. **That is the legacy series M3U auto-generator** (`store.go:380`, int ids). The nine live app routes at `/api/v1/playlists` (`wire_library_routes.go:77-85`) serve **`UserPlaylist`** (`store.go:389`) — ULID ids, `static`/`smart`, `BookIDs`, per-user `CreatedByUserID`, `MaterializedBookIDs`. Mapping the named type would have produced a playlist list unrelated to anything the web UI shows.

## Behaviour decisions

| decision | why |
|---|---|
| `ListUserPlaylistsForUser`, never `ListUserPlaylists` | the unscoped variant discloses every user's playlists to every caller |
| smart playlists resolve via `MaterializedBookIDs` | evaluating the query needs the Bleve index; this read path must not depend on it. An unevaluated smart playlist renders empty rather than erroring |
| playlist order preserved, not store order | a playlist's order **is** its listening order |
| stale book reference dropped, not nulled | an item with a null `libraryItem` is the shape that red-screens a client that expands it |
| `libraryItemId` is the 36-char sync UUID | Absorb splits compound ids by fixed byte offset `substring(0,36)`; a 26-char ULID mis-truncates into the wrong progress path |
| nil store keeps the empty page | wiring an optional capability must never turn "feature absent" into a 500 |

## Scope — and what this is not

**List route only.** Upstream has ~12 playlist routes (create, update, delete, item add/remove, batch, create-from-collection). None are implemented here. `/api/playlists` continues to 301 into the app-API twin via `absAppAPICollisions`; `TestCollidingNamespacesStillRedirect` and `TestUnimplementedNamespacesHaveNoAppAPITwin` both still pass. No engine-level routing was touched — that has broken 46 live routes twice.

**This does not make playlists appear.** Production returned `{"items":[],"count":0}` from `/api/v1/playlists` on 2026-08-13. The list stays empty until playlists exist, which is blocked on the separate iTunes importer gap (ITL parser extracts 0 of 292 smart playlists).

**No client is known to ask.** Zero of the 28 captures in `testdata/abs-fixtures/` request any playlist path, and the target-client contract §11 lists playlists among the surfaces **explicitly safe to stub**. The empty page this replaces was contract-correct, not a defect — this is completeness work, and it is why the tests assert *our* shape rather than conforming to an oracle. There is no oracle to conform to.

## Verification

8 tests, all **verified by mutation** — each guard broken in turn, confirming it turns its own test red, then restored:

| mutation | test that went red |
|---|---|
| sort order reversed | `PreservesPlaylistOrderNotLibraryOrder` |
| smart playlist reads `BookIDs` | `SmartPlaylistUsesMaterializedIDs` |
| stale book emitted anyway | `StaleBookReferenceIsDroppedNotNulled` |
| user scoping dropped | `ScopedToTheCallingUser` |
| `libraryItemId` uses the raw book id | `ReturnsRealPlaylistsWithExpandedItems` (+2 others) |

- `go test ./internal/server/handlers/abs/` → ok (whole package, 26s)
- `go test ./internal/server/ -run "TestCollidingNamespaces|TestUnimplementedNamespaces"` → ok

The `SmartPlaylistUsesMaterializedIDs` fixture deliberately puts a **different** book in `BookIDs` than in `MaterializedBookIDs`, so reading the wrong field returns the wrong book rather than an empty list — a mistake an emptiness check would miss.

> **Note on `make ci`:** `make staticcheck` fails with 5 findings, all pre-existing and reproduced identically on a clean `main` checkout. None are in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t