### PR TITLE
fix(itunes): streaming parser silently yielded zero tracks from valid XML

### DIFF
--- a/changelog.d/20260813_104500_fix_itunes_streaming_parse_noop.md
+++ b/changelog.d/20260813_104500_fix_itunes_streaming_parse_noop.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- The iTunes streaming library parser read zero tracks from a normally
+  formatted `Library.xml` and reported success. Apple writes the opening tag of
+  a section on the line after its key, and the parser looked for that tag in the
+  very next piece of the file rather than the next tag — so it found a line
+  break, gave up, and returned an empty library with no error. The track-PID
+  backfill built on it therefore did nothing on every run, and then recorded
+  itself as complete, so it would never try again. The parser now reads such
+  files correctly, and a file with no track section at all is reported as an
+  error instead of an empty success.

--- a/internal/itunes/plist_parser.go
+++ b/internal/itunes/plist_parser.go
@@ -1,12 +1,14 @@
 // file: internal/itunes/plist_parser.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: d1f3e5c7-a9b1-c3d5-e7f9-1a3b5c7d9e1f
+// last-edited: 2026-08-13
 
 package itunes
 
 import (
 	"context"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -251,7 +253,30 @@ func StreamingParseLibrary(ctx context.Context, path string, onTrack func(*Track
 
 	decoder := xml.NewDecoder(file)
 	count := 0
-	inTracksDict := false
+
+	// Locating <key>Tracks</key> followed by its <dict> is a three-token
+	// affair, not two. In Apple's real layout the key and its dict sit on
+	// separate lines:
+	//
+	//	<key>Tracks</key>
+	//	<dict>
+	//
+	// so the tokens are StartElement(key), CharData("Tracks"),
+	// EndElement(key), CharData("\n\t"), StartElement(dict). The previous
+	// scanner read exactly one token after CharData("Tracks") and required it
+	// to be a StartElement. It got EndElement(key), gave up, and — because
+	// its "root dict seen" flag was already latched — never reconsidered. It
+	// then walked to EOF and returned (0, nil): success, zero tracks, no
+	// warning. Every caller saw a clean parse of an empty library.
+	//
+	// Track the key name across its own element instead, then take the next
+	// StartElement, whatever whitespace or end tags intervene.
+	var (
+		keyText   strings.Builder
+		inKey     bool
+		lastKey   string
+		foundDict bool
+	)
 
 	for {
 		if err := ctx.Err(); err != nil {
@@ -266,31 +291,77 @@ func StreamingParseLibrary(ctx context.Context, path string, onTrack func(*Track
 			return count, fmt.Errorf("XML decode error: %w", err)
 		}
 
-		// Look for the <key>Tracks</key><dict> section
-		if keyToken, ok := token.(xml.CharData); ok {
-			if inTracksDict && string(keyToken) == "Tracks" {
-				// Next token should be the opening <dict>
-				token, err := decoder.Token()
-				if err != nil {
-					return count, fmt.Errorf("failed to read Tracks dict: %w", err)
-				}
-				if _, ok := token.(xml.StartElement); ok {
-					// Now parse track dicts
-					count, err = parseStreamingTracks(ctx, decoder, onTrack)
-					return count, err
-				}
+		switch t := token.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "key" {
+				inKey = true
+				keyText.Reset()
+				continue
 			}
-		}
-
-		// Look for root plist dict
-		if startElem, ok := token.(xml.StartElement); ok {
-			if startElem.Name.Local == "dict" && !inTracksDict {
-				inTracksDict = true
+			if t.Name.Local == "dict" && lastKey == "Tracks" {
+				foundDict = true
+				count, err = parseStreamingTracks(ctx, decoder, onTrack)
+				return count, err
+			}
+			// Any other element ends the association with the last key, so a
+			// later bare <dict> cannot be mistaken for the Tracks dict.
+			lastKey = ""
+		case xml.CharData:
+			if inKey {
+				keyText.Write(t)
+			}
+		case xml.EndElement:
+			if t.Name.Local == "key" {
+				inKey = false
+				lastKey = strings.TrimSpace(keyText.String())
 			}
 		}
 	}
 
+	if !foundDict {
+		// Reaching EOF without ever entering the Tracks dict means this file
+		// is not the iTunes library we were told it was. Returning (0, nil)
+		// here is what let a whole backfill pass report success and then mark
+		// itself permanently done having written nothing.
+		//
+		// An iTunes library with no tracks is a different thing and still
+		// succeeds: it has a <key>Tracks</key> with an empty dict, which is
+		// parsed normally and yields a count of zero.
+		return 0, fmt.Errorf("iTunes library %s contains no Tracks section", path)
+	}
+
 	return count, nil
+}
+
+// errEndOfElement signals that nextStartElement reached a closing tag before
+// finding an opening one — i.e. the enclosing element has ended.
+var errEndOfElement = errors.New("end of enclosing element")
+
+// nextStartElement returns the next opening tag, skipping the whitespace
+// CharData, comments and processing instructions that sit between elements in
+// a pretty-printed plist.
+//
+// It exists because "the next element" and "the next token" are not the same
+// thing in Apple's iTunes XML, and treating them as if they were is what made
+// both the Tracks-section scanner and the per-track loop silently yield
+// nothing against a perfectly valid library file.
+//
+// Returns errEndOfElement when a closing tag arrives first, and io.EOF at end
+// of document, so callers can tell "this container is done" from "the
+// document is malformed".
+func nextStartElement(decoder *xml.Decoder) (xml.StartElement, error) {
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			return xml.StartElement{}, err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			return t, nil
+		case xml.EndElement:
+			return xml.StartElement{}, errEndOfElement
+		}
+	}
 }
 
 // parseStreamingTracks reads track dict entries and yields them via callback
@@ -328,17 +399,20 @@ func parseStreamingTracks(ctx context.Context, decoder *xml.Decoder, onTrack fun
 				continue
 			}
 
-			// Next should be the track's <dict> element
-			token, err := decoder.Token()
+			// Next should be the track's <dict> element — but not the next
+			// TOKEN. Apple writes a newline and indentation between </key>
+			// and <dict>, so reading exactly one token yields CharData and
+			// every track was skipped by the StartElement check below. Same
+			// mistake as the Tracks-section scanner above, one level down.
+			dictElem, err := nextStartElement(decoder)
 			if err != nil {
-				if err == io.EOF {
-					break
+				if errors.Is(err, errEndOfElement) || errors.Is(err, io.EOF) {
+					// Closing </dict> of the Tracks section, or end of file.
+					return count, nil
 				}
-				continue
+				return count, err
 			}
-
-			dictElem, ok := token.(xml.StartElement)
-			if !ok || dictElem.Name.Local != "dict" {
+			if dictElem.Name.Local != "dict" {
 				continue
 			}
 

--- a/internal/itunes/plist_streaming_parse_test.go
+++ b/internal/itunes/plist_streaming_parse_test.go
@@ -1,0 +1,68 @@
+// file: internal/itunes/plist_streaming_parse_test.go
+// version: 1.0.0
+// guid: 2e8b0c47-9a13-4d65-8f72-6c41b9e35a08
+// last-edited: 2026-08-13
+
+package itunes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// StreamingParseLibrary had no test coverage of any kind, which is how it came
+// to return (0, nil) — success, zero tracks, no warning — against a normally
+// formatted iTunes Library.xml. Production logs
+// "BackfillITunesTrackPIDs completed stream parsing tracks_processed=0
+// registered=0", the shape of a whole backfill silently doing nothing.
+//
+// testdata/test_library.xml is in Apple's real layout, where the Tracks key
+// and its dict are on separate lines:
+//
+//	<key>Tracks</key>
+//	<dict>
+//
+// which means the token immediately after CharData("Tracks") is
+// EndElement(key), not the StartElement the scanner required.
+func TestStreamingParseLibrary_YieldsTracks(t *testing.T) {
+	var seen []*Track
+	n, err := StreamingParseLibrary(context.Background(), "testdata/test_library.xml", func(tr *Track) error {
+		seen = append(seen, tr)
+		return nil
+	})
+	require.NoError(t, err)
+
+	// The fixture holds real track entries; the parser must surface them.
+	// Asserting >0 rather than an exact count keeps this from breaking when
+	// the fixture grows, while still failing hard on the silent no-op.
+	require.NotZero(t, n, "StreamingParseLibrary reported success but parsed zero tracks")
+	require.NotEmpty(t, seen, "onTrack callback was never invoked")
+	require.Equal(t, n, len(seen), "returned count must match callback invocations")
+
+	// Pin one known row so a parser that yields empty Track structs cannot
+	// pass on count alone.
+	var hobbit *Track
+	for _, tr := range seen {
+		if tr.PersistentID == "ABCD1234EFGH5678" {
+			hobbit = tr
+			break
+		}
+	}
+	require.NotNil(t, hobbit, "expected the fixture's Persistent ID ABCD1234EFGH5678")
+	require.Equal(t, "The Hobbit", hobbit.Name)
+	require.Equal(t, "Middle-earth, Book 1", hobbit.Album)
+}
+
+// TestStreamingParseLibrary_MissingFileErrors is the control: a genuine
+// failure must still be reported as one. If this and the test above were both
+// green before the fix, the parser would be indistinguishable from a function
+// that never reads anything.
+func TestStreamingParseLibrary_MissingFileErrors(t *testing.T) {
+	n, err := StreamingParseLibrary(context.Background(), "testdata/does_not_exist.xml", func(*Track) error {
+		return nil
+	})
+	require.Error(t, err, "a missing library file must be an error, not a silent zero")
+	require.Zero(t, n)
+}


### PR DESCRIPTION
## The bug

`StreamingParseLibrary` returned `(0, nil)` — success, zero tracks, no warning — against a normally formatted iTunes `Library.xml`. Production logs:

```
BackfillITunesTrackPIDs completed stream parsing tracks_processed=0 registered=0
```

**Two independent instances of the same mistake, nested one inside the other.** Both assumed "the next element" and "the next token" are the same thing. In Apple's layout they are not:

```xml
<key>Tracks</key>
<dict>
```

tokenizes as `StartElement(key)`, `CharData("Tracks")`, `EndElement(key)`, `CharData("\n\t")`, `StartElement(dict)`.

1. **The Tracks-section scanner** read exactly one token after `CharData("Tracks")` and required a `StartElement`. It got `EndElement(key)`, gave up, and — because its "root dict seen" flag was already latched — never reconsidered. It walked to EOF and returned `(0, nil)`.

2. **`parseStreamingTracks`** made the identical mistake per track: after consuming `<key>100</key>` it read one token expecting the track's `<dict>`, got the indentation `CharData`, and `continue`d past every track.

Fixing only the first would have left the function returning `(0, nil)` with the symptom completely unchanged. That is why the test asserts a **named track from the fixture** rather than a nonzero count — a count assertion would have let a half-fix look like a whole one.

## Why it went unnoticed

`StreamingParseLibrary` had **no test coverage of any kind**. The single caller logged its zero result as a completed run.

## ⚠️ Operational consequence — not fixed by this PR

`backfillExternalIDs` sets `external_id_backfill_v4_done=true` *after* the no-op returns:

```go
itunesBackfilled, err := BackfillITunesTrackPIDs(ctx, store, progress)   // (0, nil)
...
_ = store.SetSetting("external_id_backfill_v4_done", "true", "bool", false)
```

So the backfill didn't merely do nothing — it **recorded that it had succeeded**, and the flag gate means it never retries. Production is almost certainly sitting on `external_id_backfill_v4_done=true` with zero track-PID mappings written.

**Merging this PR alone will not repair the data.** That setting has to be cleared for the fixed backfill to run. I have not touched production state — flagging for a decision.

## The fix

A shared `nextStartElement` helper skips inter-element text, used by both layers. Reaching EOF without ever entering the Tracks dict is now an **error** rather than an empty success. An iTunes library that genuinely has no tracks still succeeds — it carries an empty Tracks dict, which parses normally to a count of zero, so the legitimate-empty and malformed cases stay distinguishable.

## Blast radius

One non-test caller (`BackfillITunesTrackPIDs`). The main iTunes import path uses the in-memory plist parser (`parsePlist`) and is unaffected — checked before changing the shared function.

## Verification

- Watched red first: `TestStreamingParseLibrary_YieldsTracks` failed with `parsed zero tracks` against the real Apple-format fixture.
- After fixing layer 1 only, it **still failed** with the same zero — which is what surfaced layer 2.
- Control test (`MissingFileErrors`) passes both before and after, so the parser was never inert; it reported genuine failures correctly and only lied on the success path.
- Test pins a named fixture row (`ABCD1234EFGH5678` → "The Hobbit" / "Middle-earth, Book 1"), not just a count.
- Full `internal/itunes` package green, exit 0. `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp