### PR TITLE
fix(maintenance): resolve the chapter store through the decorator chain

### DIFF
--- a/changelog.d/20260813_103000_fix_chapters_backfill_wrapped_store.md
+++ b/changelog.d/20260813_103000_fix_chapters_backfill_wrapped_store.md
@@ -1,0 +1,29 @@
+### Fixed
+
+#### Chapter backfill op could not run in production — the store is wrapped
+
+`maintenance.chapters-backfill` shipped hours earlier and refused on its very
+first production run:
+
+```
+cannot run: store is *server.indexedStore, which does not persist chapters
+```
+
+`deps.Store()` returns `Server.store`, which is **replaced** by the
+`*server.indexedStore` decorator at `server_lifecycle.go:290` once the search
+index opens. That decorator embeds `database.Store`, so only methods on *that*
+interface are promoted — and the chapter methods are not on it. The op's bare
+`store.(chapterPersister)` therefore failed against every real server while
+passing every test, because the tests handed it a raw `*PebbleStore` that
+production never uses.
+
+Resolution now goes through `database.AsCapability`, which walks the decorator
+chain. This is the **third** recorded instance of this exact bug: `AsPebbleStore`
+already documents two prod jobs silently degraded for weeks by the same wrapper.
+Those failed silently because they had non-Pebble fallbacks; this one refused
+loudly, which is the only reason it surfaced in a single run.
+
+The test helper now wraps every case in a production-shaped decorator, so the
+undecorated path is no longer reachable from the suite, plus an explicit
+double-wrapped case proving the chain is walked rather than unwrapped once.
+Verified by restoring the bare assertion: all 7 tests go red.

--- a/internal/plugins/maintenance/chapters_backfill.go
+++ b/internal/plugins/maintenance/chapters_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/chapters_backfill.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5d3b7e14-9c62-4a8f-b0d7-2e6194af8c35
 // last-edited: 2026-08-13
 
@@ -121,6 +121,22 @@ var probeChaptersFn = audioutil.ProbeChapters
 // *database.PebbleStore so a future backend that implements the same two
 // methods works unchanged — and so a backend that does NOT gets a clear refusal
 // instead of a nil-pointer panic.
+//
+// 🔴 RESOLVE IT WITH database.AsCapability, NEVER A BARE ASSERTION. deps.Store()
+// returns Server.store, which is REPLACED by the *server.indexedStore decorator
+// at server_lifecycle.go:290 once the search index opens. indexedStore embeds
+// database.Store, so only methods on THAT interface are promoted — and the
+// chapter methods are not on it. A bare `store.(chapterPersister)` therefore
+// fails in production while passing every test that hands the op a raw
+// *PebbleStore.
+//
+// That is not hypothetical here: this op shipped with the bare assertion and its
+// first production run refused with "store is *server.indexedStore, which does
+// not persist chapters". It is also the third recorded instance of this exact
+// bug — see AsPebbleStore's doc comment for the two prod jobs that were silently
+// degraded for weeks by the same decorator. Those degraded SILENTLY because they
+// had non-Pebble fallbacks; this one refused loudly, which is the only reason it
+// was caught in one run.
 type chapterPersister interface {
 	GetChaptersForBook(bookID string) ([]database.Chapter, error)
 	SaveChaptersForBook(bookID string, chapters []database.Chapter) error
@@ -216,9 +232,10 @@ func (p *Plugin) runChaptersBackfill(ctx context.Context, raw json.RawMessage, r
 	if store == nil {
 		return fmt.Errorf("database not initialized")
 	}
-	persister, ok := store.(chapterPersister)
+	persister, ok := database.AsCapability[chapterPersister](store)
 	if !ok {
-		return fmt.Errorf("cannot run: store is %T, which does not persist chapters", store)
+		return fmt.Errorf("cannot run: store is %T, which does not persist chapters "+
+			"(and no store in its decorator chain does)", store)
 	}
 	if !params.Apply {
 		_ = reporter.Log(slog.LevelInfo, "DRY RUN — no chapters will be written")

--- a/internal/plugins/maintenance/chapters_backfill_test.go
+++ b/internal/plugins/maintenance/chapters_backfill_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/chapters_backfill_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8a41c0e6-52b7-4d93-9f18-7c3ea05b61d4
 // last-edited: 2026-08-13
 
@@ -83,14 +83,37 @@ func chbfSeedBook(t *testing.T, s *database.PebbleStore, title string, nFiles in
 	return bk.ID
 }
 
-// chbfRun executes the op against store with the given params.
+// chbfDecorator mirrors *server.indexedStore: it embeds database.Store and opts
+// into the unwrap contract, so ONLY the methods on database.Store are promoted.
+// The chapter methods are not on that interface, which means a bare
+// `store.(chapterPersister)` fails through this wrapper exactly as it does in
+// production.
+//
+// 🔴 EVERY TEST HERE RUNS THROUGH THIS WRAPPER, deliberately. The op originally
+// shipped with a bare assertion and a green suite, because the suite handed it a
+// raw *PebbleStore that production never uses — the decorator is installed at
+// server_lifecycle.go:290. The first real run refused outright. Testing against
+// the undecorated store is what made that possible, so the undecorated path is
+// no longer reachable from these tests.
+type chbfDecorator struct {
+	database.Store
+}
+
+func (d *chbfDecorator) Unwrap() database.Store { return d.Store }
+
+// Compile-time proof the wrapper advertises the unwrap capability, the same
+// guard indexed_store.go carries.
+var _ database.StoreUnwrapper = (*chbfDecorator)(nil)
+
+// chbfRun executes the op against store with the given params, THROUGH the
+// production-shaped decorator.
 func chbfRun(t *testing.T, s *database.PebbleStore, params chaptersBackfillParams) error {
 	t.Helper()
 	raw, err := json.Marshal(params)
 	if err != nil {
 		t.Fatalf("marshal params: %v", err)
 	}
-	p := &Plugin{deps: fakeDeps{store: s}}
+	p := &Plugin{deps: fakeDeps{store: &chbfDecorator{Store: s}}}
 	return p.runChaptersBackfill(context.Background(), raw, &fakeReporter{})
 }
 
@@ -297,6 +320,47 @@ func TestChaptersBackfill_MultiFileBook_NeverProbedOrWritten(t *testing.T) {
 	if n := spy.calls.Load(); n != 1 {
 		t.Fatalf("probe ran %d times; want exactly 1 (the single-file control only) "+
 			"— the multi-file book is paying for an ffprobe it never uses", n)
+	}
+}
+
+// ── case 6b: the decorator chain is walked, not asserted through ────────────
+//
+// 🔴 THE BUG THIS PINS SHIPPED. Production wraps the store in
+// *server.indexedStore (server_lifecycle.go:290), which embeds database.Store and
+// therefore promotes only that interface's methods. The chapter methods are not
+// on it, so the op's original bare `store.(chapterPersister)` failed at runtime
+// with "store is *server.indexedStore, which does not persist chapters" — while
+// every test passed, because the tests handed it a raw *PebbleStore.
+//
+// This test wraps the store TWICE. One layer would pass against an
+// implementation that unwraps exactly once; the chain has to actually be walked.
+func TestChaptersBackfill_ResolvesChapterStoreThroughDecoratorChain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	chbfStubFFprobe(t)
+	spy := &chbfProbeSpy{result: chbfChapters()}
+	spy.install(t)
+
+	s := chbfStore(t)
+	id := chbfSeedBook(t, s, "Behind Two Wrappers", 1)
+
+	doubled := &chbfDecorator{Store: &chbfDecorator{Store: s}}
+	p := &Plugin{deps: fakeDeps{store: doubled}}
+	raw, err := json.Marshal(chaptersBackfillParams{Apply: true})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := p.runChaptersBackfill(context.Background(), raw, &fakeReporter{}); err != nil {
+		t.Fatalf("op refused to run behind a decorator chain: %v", err)
+	}
+
+	got, err := s.GetChaptersForBook(id)
+	if err != nil {
+		t.Fatalf("GetChaptersForBook: %v", err)
+	}
+	if len(got) != 6 {
+		t.Fatalf("persisted %d chapters through the decorator chain, want 6", len(got))
 	}
 }
 


### PR DESCRIPTION
## The op could not run at all

`maintenance.chapters-backfill` merged in #2364 and refused on its **first** production run, 3 minutes after deploy:

```json
{"level":"error","message":"operation finished",
 "error":"cannot run: store is *server.indexedStore, which does not persist chapters",
 "duration_ms":25}
```

## Why

`deps.Store()` returns `Server.store`, which is **replaced** by the `*server.indexedStore` decorator at `server_lifecycle.go:290` once the search index opens. `indexedStore` embeds `database.Store`, so only methods on *that* interface are promoted — and `GetChaptersForBook` / `SaveChaptersForBook` are not on it. The bare `store.(chapterPersister)` assertion fails through the wrapper against every real server, while passing every test, because the tests handed it a raw `*PebbleStore` that production never uses.

Resolution now goes through `database.AsCapability`, which walks the chain.

## This is the third instance of this exact bug

`AsPebbleStore`'s doc comment already records two prod jobs silently degraded for weeks by the same decorator:

- `sweep-pebble-metrics-ttl` logged "store is not a PebbleStore; skipping" and no-opped, so expired metrics snapshots grew unbounded.
- `recompute-book-aggregates` fell back to its interface path, skipping the completion sentinel and redoing a full 40k-book backfill every run.

Both failed **silently** because they had deliberate non-Pebble fallbacks, which made a wrapped Pebble store indistinguishable from an unsupported backend. This op had no fallback and refused outright — the only reason a single run caught it.

## Why the test suite missed it, and what changed

The suite constructed `database.NewPebbleStore(t.TempDir())` and passed it directly. That is not the shape production has.

`chbfDecorator` now mirrors `indexedStore` — embeds `database.Store`, implements `Unwrap()`, carries the same `var _ database.StoreUnwrapper` compile-time guard — and **every** existing case runs through it, so the undecorated path is no longer reachable from the suite. Added `TestChaptersBackfill_ResolvesChapterStoreThroughDecoratorChain`, which wraps **twice**: one layer would pass against an implementation that unwraps exactly once.

## Verification

Restored the bare assertion and confirmed all 7 tests go red, including the 6 that previously passed against it:

```
--- FAIL: TestChaptersBackfill_SingleFileWithMarkers_PersistsVerbatim
--- FAIL: TestChaptersBackfill_DryRunPersistsNothing
--- FAIL: TestChaptersBackfill_AlreadyPersisted_SkipsWithoutProbing
--- FAIL: TestChaptersBackfill_NoMarkers_WritesNothingAndReprobes
--- FAIL: TestChaptersBackfill_MultiFileBook_NeverProbedOrWritten
--- FAIL: TestChaptersBackfill_ResolvesChapterStoreThroughDecoratorChain
--- FAIL: TestChaptersBackfill_BookIDsRestrictsScope
```

Then restored the fix: `go test ./internal/plugins/maintenance/ -run TestChaptersBackfill` → ok.

## Note on the scanner

`scanner.PersistChaptersForBook` uses the same bare `store.(*database.PebbleStore)` pattern, so I checked it: `scanner.SetStore(resolvedStore)` runs at `server.go:468`, **before** the wrapper is installed, so the scanner holds the raw store and is unaffected. The original root-cause analysis in #2364 stands — chapters were never persisted because the scanner path never runs for pre-existing books, not because of this assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t