### PR TITLE
perf(database): attribute memdb warmup time per phase instead of one total

### DIFF
--- a/changelog.d/20260813_113000_perf_warmup_phase_timing.md
+++ b/changelog.d/20260813_113000_perf_warmup_phase_timing.md
@@ -1,0 +1,9 @@
+### Changed
+
+- Startup now reports how long each stage of building the in-memory index took,
+  instead of one combined number. The index takes about two minutes to build on
+  a production-sized library, during which the library is slow and — until the
+  fix earlier today — could return wrong results; the combined number said it
+  was slow but not which stage to blame. The time spent committing the index is
+  reported separately, because that would point at a different fix than the
+  scans would.

--- a/internal/database/memdb_store.go
+++ b/internal/database/memdb_store.go
@@ -8,6 +8,7 @@ package database
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/go-memdb"
 )
@@ -29,7 +30,17 @@ type MemStore struct {
 	warmCountsMu    sync.RWMutex
 	lastWarmCounts  map[string]int
 	lastWarmScanned map[string]int
+	// lastWarmDurations records how long each per-table prefix scan took in
+	// the most recent WarmFromPebble, plus a "commit" entry for txn.Commit.
+	// Retained rather than only logged so the split is assertable in a test
+	// and readable from a running process, not just recoverable by grepping
+	// startup logs after the fact.
+	lastWarmDurations map[string]time.Duration
 }
+
+// WarmupPhaseKeyCommit is the lastWarmDurations key holding the txn.Commit
+// cost. It is not a table, so it cannot collide with one.
+const WarmupPhaseKeyCommit = "commit"
 
 // LastWarmupCounts returns the per-table row counts from the most recent
 // WarmFromPebble, and the per-table count of Pebble keys scanned to produce
@@ -48,6 +59,25 @@ func (m *MemStore) LastWarmupCounts() (rows, scanned map[string]int) {
 		scanned[k] = v
 	}
 	return rows, scanned
+}
+
+// LastWarmupDurations returns how long each phase of the most recent
+// WarmFromPebble took, keyed by table name, plus WarmupPhaseKeyCommit for the
+// transaction commit.
+//
+// The sum of these is less than the warmup's reported total; the remainder is
+// setup and teardown either side. A commit entry that dominates would mean the
+// ten scans are not where the time goes, and that the fix is to stop holding
+// one write transaction across all of them rather than to make the scans
+// faster.
+func (m *MemStore) LastWarmupDurations() map[string]time.Duration {
+	m.warmCountsMu.RLock()
+	defer m.warmCountsMu.RUnlock()
+	out := make(map[string]time.Duration, len(m.lastWarmDurations))
+	for k, v := range m.lastWarmDurations {
+		out[k] = v
+	}
+	return out
 }
 
 // NewMemStore allocates an empty MemStore with the full schema applied.

--- a/internal/database/memdb_warmup.go
+++ b/internal/database/memdb_warmup.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_warmup.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000004
-// last-edited: 2026-08-11
+// last-edited: 2026-08-13
 
 package database
 
@@ -40,6 +40,28 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	counts := map[string]int{}
 	scanned := map[string]int{}
 	skips := map[string]int{}
+	durations := map[string]time.Duration{}
+
+	// warm runs one prefix scan and records how long it took.
+	//
+	// Per-phase timing is the whole point. Warmup published a single total —
+	// 115,971 ms on production 2026-08-13 — which establishes that the library
+	// is wrong-or-unusable for about two minutes after every restart, but says
+	// nothing about which of the ten scans to attack. The ten are not
+	// comparable: "book:" scans ~7.5 keys per admitted row and inserts into a
+	// heavily indexed table, while "blocked:hash:" is a handful of rows into a
+	// table with one index. Optimizing without knowing the split would be
+	// guessing, and this codebase has already paid for one extrapolated
+	// data-structure cost estimate that was off by several times.
+	//
+	// Cost of the measurement itself: two time.Now() calls per prefix, twenty
+	// for the whole warmup.
+	warm := func(prefix, table string, fn func(key string, val []byte) (bool, error)) (int, int, error) {
+		phaseStart := time.Now()
+		rows, keys, err := warmIter(ctx, p.db, prefix, fn)
+		durations[table] = time.Since(phaseStart)
+		return rows, keys, err
+	}
 
 	// safeInsert tries to insert an object, logging+counting failures rather
 	// than aborting the warmup. Returns whether the row actually landed in
@@ -66,7 +88,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	// Strip heavy fields (Description, BookSigV1, etc.) before insertion
 	// — see memdb_strip.go. Cuts radix-tree footprint from ~10GB to ~2GB
 	// on the production library.
-	if n, keys, err := warmIter(ctx, p.db, "book:", func(key string, val []byte) (bool, error) {
+	if n, keys, err := warm("book:", memTableBooks, func(key string, val []byte) (bool, error) {
 		if strings.Count(key, ":") != 1 {
 			return false, nil
 		}
@@ -83,7 +105,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	}
 
 	// Authors: author:<id> (skip author:name:* index)
-	if n, keys, err := warmIter(ctx, p.db, "author:", func(key string, val []byte) (bool, error) {
+	if n, keys, err := warm("author:", memTableAuthors, func(key string, val []byte) (bool, error) {
 		if strings.Contains(key, ":name:") {
 			return false, nil
 		}
@@ -103,7 +125,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	}
 
 	// Series: series:<id>
-	if n, keys, err := warmIter(ctx, p.db, "series:", func(key string, val []byte) (bool, error) {
+	if n, keys, err := warm("series:", memTableSeries, func(key string, val []byte) (bool, error) {
 		if strings.Count(key, ":") != 1 {
 			return false, nil
 		}
@@ -122,7 +144,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	// BookFiles: book_file:<bookID>:<fileID>
 	// Strip AcoustIDSeg1..6 and fingerprint-diagnostic fields before
 	// insertion — see memdb_strip.go. Cuts ~70MB heap across 308K rows.
-	if n, keys, err := warmIter(ctx, p.db, "book_file:", func(key string, val []byte) (bool, error) {
+	if n, keys, err := warm("book_file:", memTableBookFiles, func(key string, val []byte) (bool, error) {
 		if strings.Count(key, ":") != 2 {
 			return false, nil
 		}
@@ -142,7 +164,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	// One key yields many rows, so track the row count directly rather than
 	// letting warmIter infer it from the per-key admitted flag.
 	bookAuthorRows := 0
-	if _, keys, err := warmIter(ctx, p.db, "book_authors:", func(key string, val []byte) (bool, error) {
+	if _, keys, err := warm("book_authors:", memTableBookAuthors, func(key string, val []byte) (bool, error) {
 		var list []BookAuthor
 		if err := json.Unmarshal(val, &list); err != nil {
 			return false, nil
@@ -163,7 +185,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 
 	// BookNarrators: book_narrators:<bookID> contains []BookNarrator; flatten.
 	bookNarratorRows := 0
-	if _, keys, err := warmIter(ctx, p.db, "book_narrators:", func(key string, val []byte) (bool, error) {
+	if _, keys, err := warm("book_narrators:", memTableBookNarrators, func(key string, val []byte) (bool, error) {
 		var list []BookNarrator
 		if err := json.Unmarshal(val, &list); err != nil {
 			return false, nil
@@ -183,7 +205,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	}
 
 	// Narrators: narrator:<id>
-	if n, keys, err := warmIter(ctx, p.db, "narrator:", func(key string, val []byte) (bool, error) {
+	if n, keys, err := warm("narrator:", memTableNarrators, func(key string, val []byte) (bool, error) {
 		var nrt Narrator
 		if err := json.Unmarshal(val, &nrt); err != nil {
 			return false, nil
@@ -197,7 +219,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	}
 
 	// ImportPaths: import_path:<id> (skip import_path:path:* index)
-	if n, keys, err := warmIter(ctx, p.db, "import_path:", func(key string, val []byte) (bool, error) {
+	if n, keys, err := warm("import_path:", memTableImportPaths, func(key string, val []byte) (bool, error) {
 		if strings.Contains(key, ":path:") {
 			return false, nil
 		}
@@ -214,7 +236,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	}
 
 	// AuthorAliases: author_alias:<id>
-	if n, keys, err := warmIter(ctx, p.db, "author_alias:", func(key string, val []byte) (bool, error) {
+	if n, keys, err := warm("author_alias:", memTableAuthorAliases, func(key string, val []byte) (bool, error) {
 		var aa AuthorAlias
 		if err := json.Unmarshal(val, &aa); err != nil {
 			return false, nil
@@ -228,7 +250,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	}
 
 	// BlockedHashes: blocked:hash:<hash>
-	if n, keys, err := warmIter(ctx, p.db, "blocked:hash:", func(key string, val []byte) (bool, error) {
+	if n, keys, err := warm("blocked:hash:", memTableBlockedHashes, func(key string, val []byte) (bool, error) {
 		var bh DoNotImport
 		if err := json.Unmarshal(val, &bh); err != nil {
 			return false, nil
@@ -248,11 +270,23 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	// prefix scan + JSON unmarshal). The scanner uses a single
 	// GetAllWorks at scan start, which is the only meaningful caller.
 
+	// Time the commit separately rather than folding it into the phase total.
+	// A single write txn is held open across all ten scans, so if go-memdb
+	// defers real work to commit, that cost would otherwise be invisible —
+	// attributed to nothing and sitting in the gap between the phase sum and
+	// duration_ms. Whether the fix is "parallelize the scans" or "don't hold
+	// one txn across all of them" turns on this number.
+	commitStart := time.Now()
 	txn.Commit()
+	commitDur := time.Since(commitStart)
+	commitMS := commitDur.Milliseconds()
+
+	durations[WarmupPhaseKeyCommit] = commitDur
 
 	m.warmCountsMu.Lock()
 	m.lastWarmCounts = maps.Clone(counts)
 	m.lastWarmScanned = maps.Clone(scanned)
+	m.lastWarmDurations = maps.Clone(durations)
 	m.warmCountsMu.Unlock()
 
 	slog.Info("memdb warmup complete",
@@ -268,6 +302,12 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 		"author_aliases", counts[memTableAuthorAliases],
 		"blocked_hashes", counts[memTableBlockedHashes],
 		"skipped_total", sumInts(skips),
+		// Per-phase milliseconds, keyed by table. The sum is less than
+		// duration_ms: the gap is txn.Commit plus the setup either side, and
+		// a large gap is itself the finding — it would mean the commit, not
+		// the scans, is what holds the library down for two minutes.
+		"phase_ms", durationsMillis(durations),
+		"commit_ms", commitMS,
 	)
 	if len(skips) > 0 {
 		slog.Warn("memdb warmup: rows skipped by table",
@@ -281,6 +321,17 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	}
 
 	return nil
+}
+
+// durationsMillis renders per-phase durations as whole milliseconds keyed by
+// table, so the warmup log carries a breakdown a reader can act on instead of
+// a single total that only says "slow".
+func durationsMillis(d map[string]time.Duration) map[string]int64 {
+	out := make(map[string]int64, len(d))
+	for table, dur := range d {
+		out[table] = dur.Milliseconds()
+	}
+	return out
 }
 
 func sumInts(m map[string]int) int {

--- a/internal/database/memdb_warmup_timing_test.go
+++ b/internal/database/memdb_warmup_timing_test.go
@@ -1,0 +1,110 @@
+// file: internal/database/memdb_warmup_timing_test.go
+// version: 1.0.0
+// guid: 8c4d1e73-5f26-4a90-b8e1-7d0a3c5f2b64
+// last-edited: 2026-08-13
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Warmup published a single duration — 115,971 ms on production 2026-08-13 —
+// which says the library is wrong-or-unusable for about two minutes after
+// every restart but not which of the ten prefix scans is responsible. These
+// tests pin the per-phase breakdown so the number cannot quietly go back to
+// being a single opaque total.
+//
+// The assertions are deliberately about COVERAGE and STRUCTURE, not about
+// wall-clock thresholds: a timing test that asserts "books took less than N ms"
+// is a flake generator on shared CI, and would tell us nothing about
+// production hardware anyway. What matters is that every phase is attributed
+// and nothing is silently missing from the accounting.
+
+func TestWarmupDurations_EveryWarmedTableIsAttributed(t *testing.T) {
+	store := setupTestPebbleStore(t)
+	store.WaitForWarmup()
+
+	// Seed a little of everything the warmup scans so no phase is trivially
+	// empty. Books carry the indexes that matter most.
+	for i := 0; i < 5; i++ {
+		hash := fmt.Sprintf("timinghash%03d", i)
+		_, err := store.CreateBook(&Book{
+			Title:    fmt.Sprintf("Timing Book %03d", i),
+			FilePath: fmt.Sprintf("/tmp/warmtiming_%03d.m4b", i),
+			FileHash: &hash,
+		})
+		require.NoError(t, err)
+	}
+
+	mem, err := NewMemStore()
+	require.NoError(t, err)
+	require.NoError(t, mem.WarmFromPebble(context.Background(), store))
+
+	durations := mem.LastWarmupDurations()
+	require.NotEmpty(t, durations, "warmup must record per-phase durations")
+
+	// Every table the warmup reports a row count for must also have a
+	// duration. A phase that scans but is never timed is exactly the blind
+	// spot this change exists to remove.
+	rows, _ := mem.LastWarmupCounts()
+	for table := range rows {
+		_, ok := durations[table]
+		require.True(t, ok,
+			"table %q has a warmup row count but no recorded duration", table)
+	}
+
+	// The commit is timed separately and on purpose: a single write txn is
+	// held open across all ten scans, so if go-memdb defers work to commit
+	// that cost would otherwise be attributed to nothing at all.
+	_, ok := durations[WarmupPhaseKeyCommit]
+	require.True(t, ok, "txn.Commit must be timed separately from the scans")
+
+	// Durations are wall-clock measurements, so they may legitimately round
+	// to zero on a tiny fixture. They must never be negative — that would
+	// mean a phase key was written from the wrong clock reading.
+	for phase, d := range durations {
+		require.GreaterOrEqual(t, d.Nanoseconds(), int64(0),
+			"phase %q recorded a negative duration", phase)
+	}
+}
+
+// TestWarmupDurations_AreNotCarriedAcrossWarms guards the accessor against
+// returning stale numbers. LastWarmupDurations describes "the most recent
+// WarmFromPebble"; if a second warm reused the first warm's map the reported
+// split would describe a run that already ended.
+func TestWarmupDurations_AreNotCarriedAcrossWarms(t *testing.T) {
+	store := setupTestPebbleStore(t)
+	store.WaitForWarmup()
+
+	hash := "timingrewarm001"
+	_, err := store.CreateBook(&Book{
+		Title:    "Rewarm Book",
+		FilePath: "/tmp/warmtiming_rewarm.m4b",
+		FileHash: &hash,
+	})
+	require.NoError(t, err)
+
+	mem, err := NewMemStore()
+	require.NoError(t, err)
+	require.NoError(t, mem.WarmFromPebble(context.Background(), store))
+	first := mem.LastWarmupDurations()
+	require.NotEmpty(t, first)
+
+	// Mutating the returned map must not reach into the store — the accessor
+	// hands out a copy, so a caller that scribbles on it cannot corrupt the
+	// next reader's view.
+	for k := range first {
+		first[k] = -1
+	}
+
+	second := mem.LastWarmupDurations()
+	for phase, d := range second {
+		require.GreaterOrEqual(t, d.Nanoseconds(), int64(0),
+			"phase %q leaked a mutation from a previously returned map", phase)
+	}
+}


### PR DESCRIPTION
## Why

Warmup published a single duration — **115,971 ms** on production 2026-08-13. That establishes the library is wrong-or-unusable for about two minutes after every restart, but not *which* of the ten prefix scans to attack.

The ten are not comparable. `book:` scans ~7.5 Pebble keys per admitted row and inserts into the most heavily indexed table; `blocked:hash:` is a handful of rows into a table with one index.

## This is measurement only — deliberately no optimization

The obvious move is to fan the scans out across a worker pool, per the repo's concurrency rule. **That is not obviously available here.** A single go-memdb write txn is held open across all ten scans, and go-memdb write txns are exclusive — so `txn.Insert` cannot be parallelized against it.

Whether the win is in the **JSON unmarshal** (parallelizable via producer/consumer) or in **radix-tree index insertion** (not, while one txn is held) decides which fix is even possible. That is exactly what was unmeasured. Shipping a worker pool first would have been guessing, and this codebase has already paid once for an extrapolated data-structure cost estimate that turned out to be off by several times.

## `txn.Commit` is timed separately, on purpose

go-memdb may defer real work to commit. A commit that dominates would mean the answer is *"stop holding one txn across all ten scans"* rather than *"make the scans faster"* — a different change entirely. Folded into the phase total it would have been invisible; held as an unattributed gap it would have been attributed to nothing.

## Retained, not just logged

Durations live on the `MemStore` next to the existing warm counts and are exposed via `LastWarmupDurations()`. That makes the split assertable in a test and readable from a running process, rather than only recoverable by grepping startup logs after the fact.

## What the tests assert — and what they deliberately don't

Coverage and structure, **not wall-clock thresholds**:

- every table with a warmup row count must also have a recorded duration;
- `txn.Commit` must be timed separately;
- no duration may be negative (that would mean a phase was written from the wrong clock reading);
- the accessor hands out a copy, so a caller mutating the returned map cannot corrupt the next reader.

A `books took under N ms` assertion would be a CI flake generator on shared runners and would say nothing about production hardware. Coverage is the property that actually protects the change.

## Verification

- Negative control: reverting one call site to the untimed helper fails with `table "series" has a warmup row count but no recorded duration`. Restored and re-verified at 10/10 timed call sites.
- Full `internal/database` package green, exit 0. `go build ./...` and `go vet` clean.

## Next step (not in this PR)

Read `phase_ms` and `commit_ms` off a production restart, then pick the fix that the split actually supports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp