### PR TITLE
fix(operations): report progress labels after the work, not before

### DIFF
--- a/changelog.d/20260813_112000_fix_runitems_progress_label_lag.md
+++ b/changelog.d/20260813_112000_fix_runitems_progress_label_lag.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **Operation progress labels reported state from before their own item ran.**
+  `registry.RunItems` rendered each item's label *before* invoking the work
+  function and reused that same string for the post-completion
+  `UpdateProgress`. Because labels typically close over running tallies and all
+  `Concurrency` workers snapshot their label at dispatch — before any of them
+  finishes — the reported counts lagged by up to one full worker pool. Measured
+  on `maintenance.chapters-backfill`: a 12-book apply run that persisted all 12
+  printed `persist=0` on ten of its twelve lines and never rose above 2. On a
+  whole-library run this reads as hours of total failure. The label is now
+  re-rendered after the work function; `SetCurrentItem` still receives the
+  pre-work label, which correctly names the item being started.
+- **`maintenance.chapters-backfill` progress counted only persisted books**, so
+  a dry run — which never increments that counter — sat at zero for its entire
+  duration and was indistinguishable from a run that found nothing. The first
+  production cohort pass printed `persist=0 markers=0` throughout while
+  identifying 33 eligible books and 1,247 chapters. The label now reports
+  `eligible` (persisted + would-persist), which advances in both modes.

--- a/internal/operations/registry/run_items.go
+++ b/internal/operations/registry/run_items.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/run_items.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a2b3c4d5-e6f7-8901-abcd-ef2345678901
-// last-edited: 2026-07-18
+// last-edited: 2026-08-13
 
 package registry
 
@@ -116,11 +116,19 @@ func RunItems[T any](ctx context.Context, r Reporter, items []T, fn func(ctx con
 			itemCtx, cancel = context.WithTimeout(ctx, opt.PerItemTimeout)
 			defer cancel()
 		}
-		l := lbl(i, progTotal)
-		r.SetCurrentItem(l)
+		r.SetCurrentItem(lbl(i, progTotal))
 		err := fn(itemCtx, item)
 		done := int(completed.Add(1))
-		_ = r.UpdateProgress(opt.ProgressOffset+done, progTotal, l)
+		// Re-render the label AFTER fn rather than reusing the pre-work string.
+		// Labels commonly close over running tallies, and with Concurrency = N
+		// all N workers snapshot their label at dispatch — before any of them
+		// has finished — so a reused string reports state from before its own
+		// item ran. Measured on chapters-backfill: a 12-book apply that wrote
+		// all 12 printed "persist=0" on ten lines and never exceeded 2, which
+		// reads as total failure for the hours a whole-library run takes.
+		// SetCurrentItem above still gets the pre-work label: it names the item
+		// being STARTED, which is what it is for.
+		_ = r.UpdateProgress(opt.ProgressOffset+done, progTotal, lbl(i, progTotal))
 		return err
 	}
 

--- a/internal/plugins/maintenance/chapters_backfill.go
+++ b/internal/plugins/maintenance/chapters_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/chapters_backfill.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 5d3b7e14-9c62-4a8f-b0d7-2e6194af8c35
 // last-edited: 2026-08-13
 
@@ -339,9 +339,13 @@ func (p *Plugin) runChaptersBackfill(ctx context.Context, raw json.RawMessage, r
 		Concurrency:   runtime.NumCPU(),
 		ProgressTotal: len(ids),
 		ErrMode:       registry.ErrModeCollect,
+		// Reports ELIGIBLE (= persisted + wouldPersist), not persisted. A dry
+		// run never increments persisted, so a label reading it sat at zero for
+		// the whole run and was indistinguishable from a run finding nothing —
+		// the opposite of the truth on the first cohort pass, which found 33.
 		Label: func(i, total int) string {
-			return fmt.Sprintf("Books %d/%d (persist=%d markers=%d)",
-				i+1, total, c.persisted.Load(), c.chaptersWorked.Load())
+			return fmt.Sprintf("Books %d/%d (eligible=%d chapters=%d)",
+				i+1, total, c.persisted.Load()+c.wouldPersist.Load(), c.chaptersWorked.Load())
 		},
 	})
 

--- a/internal/plugins/maintenance/chapters_backfill_test.go
+++ b/internal/plugins/maintenance/chapters_backfill_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/chapters_backfill_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 8a41c0e6-52b7-4d93-9f18-7c3ea05b61d4
 // last-edited: 2026-08-13
 
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -416,5 +417,90 @@ func TestChaptersBackfill_BookIDsRestrictsScope(t *testing.T) {
 	}
 	if got, _ := s.GetChaptersForBook(outOfScope); len(got) != 0 {
 		t.Fatalf("out-of-scope book got %d chapters; the BookIDs restriction leaked", len(got))
+	}
+}
+
+// ── case 9: the progress label must report the work actually done ───────────
+//
+// The label is the ONLY feedback a whole-library run gives for hours. The first
+// cohort run printed "persist=0 markers=0" on every line while genuinely
+// persisting 33 books, which reads as total failure to anyone watching. Two
+// separate defects produced that:
+//
+//  1. the label read c.persisted, which is 0 by definition in a dry run, and
+//  2. registry.RunItems computes the label BEFORE invoking the work function
+//     and reuses that pre-work string for the post-completion UpdateProgress,
+//     so every line reports the state from before its own item ran.
+//
+// (2) lives in shared infrastructure used by every op and is filed separately;
+// this op defends against both by reporting the eligible-book count, which is
+// incremented in BOTH modes, and by asserting the LAST label is non-zero.
+type chbfLabelReporter struct {
+	fakeReporter
+	mu     chan struct{}
+	labels []string
+}
+
+func newCHBFLabelReporter() *chbfLabelReporter {
+	return &chbfLabelReporter{mu: make(chan struct{}, 1)}
+}
+
+func (r *chbfLabelReporter) UpdateProgress(_, _ int, label string) error {
+	r.mu <- struct{}{}
+	r.labels = append(r.labels, label)
+	<-r.mu
+	return nil
+}
+
+func chbfRunWith(t *testing.T, s *database.PebbleStore, params chaptersBackfillParams, rep *chbfLabelReporter) {
+	t.Helper()
+	raw, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	p := &Plugin{deps: fakeDeps{store: &chbfDecorator{Store: s}}}
+	if err := p.runChaptersBackfill(context.Background(), raw, rep); err != nil {
+		t.Fatalf("runChaptersBackfill: %v", err)
+	}
+}
+
+func TestChaptersBackfill_ProgressLabelReportsEligibleCount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	for _, apply := range []bool{false, true} {
+		name := "dryRun"
+		if apply {
+			name = "apply"
+		}
+		t.Run(name, func(t *testing.T) {
+			chbfStubFFprobe(t)
+			spy := &chbfProbeSpy{result: chbfChapters()}
+			spy.install(t)
+
+			s := chbfStore(t)
+			const n = 12
+			for i := 0; i < n; i++ {
+				chbfSeedBook(t, s, fmt.Sprintf("Labelled Book %02d", i), 1)
+			}
+
+			rep := newCHBFLabelReporter()
+			chbfRunWith(t, s, chaptersBackfillParams{Apply: apply}, rep)
+
+			if len(rep.labels) < n {
+				t.Fatalf("got %d progress labels for %d books", len(rep.labels), n)
+			}
+			// The LAST per-item label must account for every eligible book.
+			// Asserting merely "non-zero" passes against the pre-fix code,
+			// which reached persist=2 of 12 — the tripwire has to be the
+			// full count or it does not detect the defect it was written for.
+			want := fmt.Sprintf("eligible=%d chapters=%d", n, n*len(chbfChapters()))
+			last := rep.labels[len(rep.labels)-2] // -1 is the final summary line
+			if !strings.Contains(last, want) {
+				t.Fatalf("final per-item label = %q, want it to contain %q\n"+
+					"a label that lags the work it describes makes a multi-hour "+
+					"run look like it is doing nothing", last, want)
+			}
+		})
 	}
 }

--- a/todo.d/2026-08-13-stale-bookfile-paths-and-durations.md
+++ b/todo.d/2026-08-13-stale-bookfile-paths-and-durations.md
@@ -1,0 +1,44 @@
+## Library data integrity — surfaced by the chapters-backfill cohort run
+
+Measured 2026-08-13 against the 77-book `job` test cohort on production. These are
+**pre-existing defects the backfill exposed**, not regressions from it.
+
+- [ ] **`BookFile.FilePath` rows point at files that do not exist — 14 of 58
+      single-file cohort books (24%).** The op probed
+      `.../Timothy Zahn/The Icarus Job/The Icarus Job/The Icarus Job - Timothy Zahn - read by narrator.m4b`;
+      the file actually lives at `.../Unknown Author/The Icarus Job/`. Eight of
+      the fourteen are filed under `Cliff Kurt`, **who is the narrator, not the
+      author** — the real files are under `PZG/`. The signature is a path
+      recomputed from edited metadata without the file ever being moved (or a
+      re-organize that never wrote back the `BookFile` row). Any op that resolves
+      a file by stored path silently degrades on these. Full list:
+      `probe-failed=15` in op `01KZXSZM5K6DA7QP21DPRAR17C`.
+- [ ] **`Book.FilePath` and `BookFile.FilePath` disagree for the same book.** For
+      `The Icarus Job` the book row points into the iTunes tree while the book-file
+      row points at a nonexistent path under the organized tree. Any consumer that
+      picks the "wrong" one gets a different answer. Decide which is authoritative
+      and make the other derive from it.
+- [ ] **Stored `duration` is short of the real container by 119–186s on 7 cohort
+      books.** Confirmed by ffprobe: `Mushoku Tensei … Vol. 03` stores 33582s while
+      both physical copies measure 33767.759s. The chapter timelines written by the
+      backfill are correct; the duration field is stale. Related:
+      `project_duration_filesize_aggregation` (snapshots, not sums).
+- [ ] **Multi-file chapter synthesis produces a timeline that stops short.** One of
+      the two `Genesis` rows (1,189 files) serves 1,189 chapters ending at 32,636s
+      against a 258,256s duration; its twin ends correctly at 258,256s. The mapper's
+      per-file synthesis is picking up wrong or missing per-file durations.
+- [ ] **Duplicate book rows per title under different author folders** (`Deadly Jobs`
+      ×3, `The Icarus Job` ×3, every `Mushoku Tensei` volume ×2 as `PZG` and
+      `Unknown Author`). Worth checking as a *source* for exact-pending dedup
+      regrowing to 5,947 by 2026-08-12 — that note says it needs a source fix
+      rather than another drain. Pointer only; not chased here.
+
+## Follow-up on the op itself
+
+- [ ] `registry.RunItems` label re-render (fixed 2026-08-13) changed shared
+      infrastructure used by every op. Progress labels for other ops now advance
+      one item later than before — verify none of them assumed the old timing.
+- [ ] One unreproduced failure of `internal/plugins/maintenance` was observed on
+      2026-08-13 during mutation testing; 8 subsequent runs (3 under `-race`, plus
+      `internal/operations/registry`) were green and the failure detail was not
+      captured before re-running. If it recurs, capture the output first.


### PR DESCRIPTION
## What

Two compounding defects made operation progress reporting lie about how much work had been done.

**1. Shared infrastructure — `registry.RunItems` (affects every op).**
The label was rendered *before* the work function ran, and that same pre-work string was reused for the post-completion `UpdateProgress`. Labels typically close over running tallies, and with `Concurrency = N` all N workers snapshot their label at dispatch — before any of them finishes — so every line reported state from before its own item ran.

**2. `maintenance.chapters-backfill`'s own label** read the `persisted` counter, which is zero by definition in a dry run.

## Evidence

Both were found by running the op against a 77-book production cohort. Measured on a 12-book apply that persisted all 12:

| label | pre-fix | post-fix |
|---|---|---|
| line 10 of 12 | `persist=0` | `eligible=10` |
| final per-item | `persist=2` | `eligible=12 chapters=72` |

The first production cohort pass printed `persist=0 markers=0` on every line while identifying **33 eligible books and 1,247 chapters**. Over the hours a whole-library run takes, that reads as total failure.

`SetCurrentItem` still receives the pre-work label — it names the item being *started*, which is what it is for.

## Verification

New test `TestChaptersBackfill_ProgressLabelReportsEligibleCount` runs both modes and asserts the final per-item label accounts for every eligible book.

Confirmed as a real tripwire by mutation — reverting each fix independently turns it red:

- revert `run_items.go` → `final per-item label = "Books 9/12 (eligible=11 chapters=66)"`
- revert the op's counter → `final per-item label = "Books 5/12 (eligible=0 chapters=72)"`

An earlier version of this test asserted only "non-zero" and **passed against the bug** (pre-fix apply reached `persist=2`), so the assertion is the full count.

`go build ./...` clean. `internal/plugins/maintenance` + `internal/operations/registry` green, including 3 runs under `-race`.

⚠️ One unreproduced failure of `internal/plugins/maintenance` was seen during mutation testing; 8 subsequent runs were green and the detail was not captured before re-running. Filed in `todo.d/` rather than papered over.

## Also filed

`todo.d/2026-08-13-stale-bookfile-paths-and-durations.md` records the **pre-existing** library defects the cohort run surfaced (not regressions from this PR):

- 14 of 58 single-file `BookFile.FilePath` rows point at nonexistent files — 8 filed under `Cliff Kurt`, who is the *narrator*, not the author
- `Book.FilePath` and `BookFile.FilePath` disagree for the same book
- stored `duration` runs 119–186s short of the real container on 7 books (ffprobe-confirmed)
- multi-file chapter synthesis stops short on one `Genesis` row (ends 32,636s of 258,256s)

## Note on staticcheck

The 5 pre-existing `make ci` staticcheck findings are unchanged and reproduce identically on a clean `main` checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t