### PR TITLE
fix(maintenance): chapters-backfill discarded 16k books on a stale path

### DIFF
--- a/changelog.d/20260813_120500_fix_chapters_backfill_path_fallback.md
+++ b/changelog.d/20260813_120500_fix_chapters_backfill_path_fallback.md
@@ -1,0 +1,32 @@
+### Fixed
+
+- **`maintenance.chapters-backfill` discarded ~16,000 recoverable books because its
+  path fallback tested for an EMPTY path instead of a MISSING one.** Resolution fell
+  back to `Book.FilePath` only when the `BookFile` row's path was the empty string. The
+  common real failure is different: a move/organize updates `Book.FilePath` and leaves
+  the `BookFile` row pointing at the old location, so the path is *populated and wrong*.
+  Such a path sailed past the emptiness check and died 300ms later inside `ffprobe`,
+  where it was tallied as a **probe failure** rather than the **resolution failure** it
+  was — pointing at the audio files as the culprit instead of the database.
+
+  Measured on the whole library: `probe-failed=16130`, 33.7% of single-file books. An
+  independent `test -e` sweep over a 400-book random sample agreed (88 of 295 = 29.8%
+  missing), ruling out `ffprobe` concurrency exhaustion. Of those 88, **86 (97.7%) had a
+  `Book.FilePath` that was a regular file on disk** — recoverable, and being thrown away.
+  Only 2 were genuinely gone.
+
+  The fallback now fires when the `BookFile` path does not *resolve*, not only when it is
+  *empty*. The `BookFile` row still wins whenever it resolves — it is the more specific
+  source, and preferring the fallback unconditionally would reroute every book in the
+  library rather than the broken ones. Non-regular files (a multi-file book's
+  `Book.FilePath` is its *folder*) are rejected, since handing `ffprobe` a directory
+  produces a confusing decode error instead of a clean skip.
+
+  Books resolved through the fallback are counted and reported separately as
+  `recovered-via-book-path=N`, never folded into the persisted total: those rows are
+  written from a secondary path source, and if that source is ever wrong there has to be
+  a way to identify the affected books after the fact.
+
+  Checked before shipping: across all 63,870 book rows, 1,264 `Book.FilePath` values are
+  shared by more than one book (4,353 rows) — but **0 of the 88 recoverable rows** were
+  among them, so the fallback cannot currently write one book's chapters onto another.

--- a/internal/plugins/maintenance/chapters_backfill.go
+++ b/internal/plugins/maintenance/chapters_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/chapters_backfill.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 5d3b7e14-9c62-4a8f-b0d7-2e6194af8c35
 // last-edited: 2026-08-13
 
@@ -68,6 +68,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"runtime"
 	"strings"
 	"sync/atomic"
@@ -180,6 +181,18 @@ func (p *Plugin) chaptersBackfillDef() sdk.OperationDef {
 // multiple RunItems workers, so all of them are atomic rather than
 // mutex-guarded — there is no invariant spanning two counters that would need
 // them to move together.
+// chaptersBackfillResolves reports whether path names an existing REGULAR
+// file. Directories are rejected deliberately rather than incidentally: a
+// multi-file book's Book.FilePath is its FOLDER, and handing a directory to
+// ffprobe yields a confusing decode error instead of a clean skip. On the
+// 2026-08-13 sample every recoverable Book.FilePath was a regular file (86
+// regular, 0 directories), so this guard fires on nothing today — it is here so
+// that stays true.
+func chaptersBackfillResolves(path string) bool {
+	st, err := os.Stat(path)
+	return err == nil && st.Mode().IsRegular()
+}
+
 type chaptersBackfillCounters struct {
 	examined       atomic.Int64
 	skipMultiFile  atomic.Int64
@@ -191,6 +204,11 @@ type chaptersBackfillCounters struct {
 	persisted      atomic.Int64
 	persistFailed  atomic.Int64
 	chaptersWorked atomic.Int64
+	// recoveredViaBook counts books probed via Book.FilePath because the
+	// BookFile row's path was populated but did not exist on disk. Reported on
+	// its own line so a run's output distinguishes rows written from the
+	// authoritative path from rows written from the fallback.
+	recoveredViaBook atomic.Int64
 }
 
 func (c *chaptersBackfillCounters) summary(apply bool) string {
@@ -202,10 +220,11 @@ func (c *chaptersBackfillCounters) summary(apply bool) string {
 	}
 	return fmt.Sprintf(
 		"examined=%d %s=%d (%d chapters) | skipped: multi-file=%d already-had=%d no-path=%d | "+
-			"no-markers=%d probe-failed=%d persist-failed=%d",
+			"no-markers=%d probe-failed=%d persist-failed=%d | recovered-via-book-path=%d",
 		c.examined.Load(), verb, n, c.chaptersWorked.Load(),
 		c.skipMultiFile.Load(), c.skipHasStored.Load(), c.skipNoPath.Load(),
 		c.noChapters.Load(), c.probeFailed.Load(), c.persistFailed.Load(),
+		c.recoveredViaBook.Load(),
 	)
 }
 
@@ -279,17 +298,35 @@ func (p *Plugin) runChaptersBackfill(ctx context.Context, raw json.RawMessage, r
 			return nil
 		}
 
+		// Resolve the file to probe. The BookFile row is the more specific
+		// source and wins when it RESOLVES — but "non-empty" is not "resolves".
+		// A move/organize updates Book.FilePath and leaves the BookFile row
+		// pointing at the old location, so a populated-but-stale path sails
+		// past an emptiness check and dies 300ms later inside ffprobe, where it
+		// is counted as a probe failure rather than the resolution failure it
+		// is. Measured on the whole library 2026-08-13: probe-failed=16130,
+		// 33.7% of single-file books. An independent `test -e` sweep over a
+		// 400-book random sample agreed (88/295 = 29.8% missing, ruling out
+		// ffprobe concurrency exhaustion), and of those 88, 86 had a
+		// Book.FilePath that WAS a regular file on disk. Falling back on
+		// non-existence rather than only on emptiness recovers them.
 		path := ""
 		if len(files) == 1 {
 			path = strings.TrimSpace(files[0].FilePath)
 		}
-		if path == "" {
-			b, berr := store.GetBookByID(id)
-			if berr != nil || b == nil {
-				c.skipNoPath.Add(1)
-				return nil
+		if path == "" || !chaptersBackfillResolves(path) {
+			if b, berr := store.GetBookByID(id); berr == nil && b != nil {
+				if alt := strings.TrimSpace(b.FilePath); alt != "" && chaptersBackfillResolves(alt) {
+					if path != "" {
+						// Counted separately and NEVER folded into persisted:
+						// these rows were written from a secondary path source,
+						// and if that source turns out wrong there has to be a
+						// way to find them again after the fact.
+						c.recoveredViaBook.Add(1)
+					}
+					path = alt
+				}
 			}
-			path = strings.TrimSpace(b.FilePath)
 		}
 		if path == "" {
 			c.skipNoPath.Add(1)

--- a/internal/plugins/maintenance/chapters_backfill_test.go
+++ b/internal/plugins/maintenance/chapters_backfill_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/chapters_backfill_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 8a41c0e6-52b7-4d93-9f18-7c3ea05b61d4
 // last-edited: 2026-08-13
 
@@ -9,6 +9,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -500,6 +502,159 @@ func TestChaptersBackfill_ProgressLabelReportsEligibleCount(t *testing.T) {
 				t.Fatalf("final per-item label = %q, want it to contain %q\n"+
 					"a label that lags the work it describes makes a multi-hour "+
 					"run look like it is doing nothing", last, want)
+			}
+		})
+	}
+}
+
+// ── case 10: the fallback must fire on a MISSING path, not only an EMPTY one ──
+//
+// 🔴 THE DEFECT THIS GUARDS. Path resolution originally fell back to
+// Book.FilePath only when the BookFile row's path was the empty string. A
+// move/organize updates Book.FilePath and leaves the BookFile row pointing at
+// the old location, so the common failure is a path that is POPULATED and
+// WRONG — which sailed past the emptiness check and died inside ffprobe, where
+// it was tallied as a probe failure rather than the resolution failure it was.
+//
+// Measured on production 2026-08-13, whole-library dry run: probe-failed=16130,
+// 33.7% of single-file books. An independent `test -e` sweep over a 400-book
+// random sample agreed at 88/295 = 29.8%, ruling out ffprobe concurrency
+// exhaustion as the cause. Of those 88, 86 had a Book.FilePath that WAS a
+// regular file on disk — i.e. ~97% were recoverable and were being discarded.
+//
+// 🔴 THESE CASES USE REAL FILES ON DISK, unlike every other test in this file.
+// That is load-bearing, not incidental: the other cases seed synthetic paths
+// like /lib/Title/track00.m4b that have never existed, so to them EVERY path is
+// missing and a fallback keyed on existence is indistinguishable from one keyed
+// on emptiness. A suite of synthetic paths cannot detect this bug in either
+// direction, which is exactly how it shipped.
+//
+// The assertion is on WHICH PATH THE PROBE RECEIVED, not on whether chapters
+// landed. The stub returns chapters for any input, so "chapters were persisted"
+// is satisfied by the pre-fix code in the both-exist case and would not fail.
+type chbfPathSpy struct {
+	mu     chan struct{}
+	paths  []string
+	result []audioutil.Chapter
+}
+
+func (s *chbfPathSpy) install(t *testing.T) {
+	t.Helper()
+	s.mu = make(chan struct{}, 1)
+	prev := probeChaptersFn
+	probeChaptersFn = func(_ context.Context, _, path string) ([]audioutil.Chapter, error) {
+		s.mu <- struct{}{}
+		s.paths = append(s.paths, path)
+		<-s.mu
+		return s.result, nil
+	}
+	t.Cleanup(func() { probeChaptersFn = prev })
+}
+
+// chbfSeedBookAt creates a single-file book with explicitly chosen paths, so a
+// test can make the BookFile path and the Book path disagree.
+func chbfSeedBookAt(t *testing.T, s *database.PebbleStore, title, bookPath, bookFilePath string) string {
+	t.Helper()
+	bk, err := s.CreateBook(&database.Book{Title: title, FilePath: bookPath})
+	if err != nil {
+		t.Fatalf("CreateBook(%s): %v", title, err)
+	}
+	if err := s.CreateBookFile(&database.BookFile{BookID: bk.ID, FilePath: bookFilePath}); err != nil {
+		t.Fatalf("CreateBookFile(%s): %v", title, err)
+	}
+	return bk.ID
+}
+
+// chbfTouch creates an empty regular file and returns its path.
+func chbfTouch(t *testing.T, dir, name string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", p, err)
+	}
+	return p
+}
+
+func TestChaptersBackfill_FallsBackWhenBookFilePathIsMissingNotOnlyEmpty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore and real files; skipped in -short")
+	}
+
+	tmp := t.TempDir()
+	realBook := chbfTouch(t, tmp, "organized.m4b")
+	realBookFile := chbfTouch(t, tmp, "authoritative.m4b")
+	missing := filepath.Join(tmp, "moved-away.m4b") // deliberately never created
+
+	cases := []struct {
+		name         string
+		bookPath     string
+		bookFilePath string
+		wantProbed   string
+		wantRecover  int // expected recovered-via-book-path count
+		why          string
+	}{{
+		name:         "bookfile path missing, book path resolves",
+		bookPath:     realBook,
+		bookFilePath: missing,
+		wantProbed:   realBook,
+		wantRecover:  1,
+		why:          "the 16,130-book production case: populated but stale",
+	}, {
+		name:         "both resolve",
+		bookPath:     realBook,
+		bookFilePath: realBookFile,
+		wantProbed:   realBookFile,
+		wantRecover:  0,
+		why: "the BookFile row is the more specific source and must WIN when it " +
+			"resolves; silently preferring whichever was checked last would " +
+			"reroute every book in the library, not just the broken ones",
+	}, {
+		name:         "neither resolves",
+		bookPath:     missing,
+		bookFilePath: missing,
+		wantProbed:   missing,
+		wantRecover:  0,
+		why: "with no working alternative the original path is kept and the " +
+			"failure is still counted as a probe failure — the fallback must " +
+			"not invent a resolution it does not have",
+	}, {
+		name:         "book path is a directory",
+		bookPath:     tmp,
+		bookFilePath: missing,
+		wantProbed:   missing,
+		wantRecover:  0,
+		why: "a multi-file book's Book.FilePath is its FOLDER; handing a " +
+			"directory to ffprobe yields a confusing decode error instead of " +
+			"a clean skip, so existence alone is not a sufficient test",
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			chbfStubFFprobe(t)
+			spy := &chbfPathSpy{result: chbfChapters()}
+			spy.install(t)
+
+			s := chbfStore(t)
+			chbfSeedBookAt(t, s, "Relocated Book", tc.bookPath, tc.bookFilePath)
+
+			rep := newCHBFLabelReporter()
+			chbfRunWith(t, s, chaptersBackfillParams{Apply: true}, rep)
+
+			if len(spy.paths) != 1 {
+				t.Fatalf("probed %d paths, want exactly 1: %v", len(spy.paths), spy.paths)
+			}
+			if spy.paths[0] != tc.wantProbed {
+				t.Fatalf("probed %q, want %q\n%s", spy.paths[0], tc.wantProbed, tc.why)
+			}
+
+			// The fallback count must be reported SEPARATELY and never folded
+			// into the persisted total: these rows are written from a secondary
+			// path source, and if that source is ever wrong there has to be a
+			// way to identify the affected books after the fact.
+			summary := rep.labels[len(rep.labels)-1]
+			want := fmt.Sprintf("recovered-via-book-path=%d", tc.wantRecover)
+			if !strings.Contains(summary, want) {
+				t.Fatalf("summary = %q, want it to contain %q", summary, want)
 			}
 		})
 	}


### PR DESCRIPTION
## The defect

`maintenance.chapters-backfill` fell back to `Book.FilePath` only when the `BookFile`
row's path was the **empty string**:

```go
if path == "" {          // ← the bug
    b, _ := store.GetBookByID(id)
    path = strings.TrimSpace(b.FilePath)
}
```

The common real failure is different. A move/organize updates `Book.FilePath` and leaves
the `BookFile` row pointing at the old location, so the path is **populated and wrong**.
That sails past the emptiness check and dies 300ms later inside `ffprobe`, where it is
tallied as a **probe failure** rather than the **resolution failure** it is — pointing at
the audio files as the culprit instead of the database.

## The measurement

| source | result |
|---|---|
| whole-library dry run | `probe-failed=16130` — **33.7%** of single-file books |
| independent `test -e` over a 400-book random sample (295 single-file) | 88 missing / 295 = **29.8%** |
| of those 88, `Book.FilePath` exists on disk | **86 (97.7%)** |
| of those 86, file type | **86 regular, 0 directories** |
| genuinely gone | **2** |

The two independent measurements agreeing is what rules out `ffprobe` concurrency
exhaustion — a plain `test -e` has no subprocess to exhaust.

Projected effect: roughly **16,000 additional books** become eligible, taking a
whole-library run from ~14,948 to ~30,700.

## The fix

The fallback fires when the `BookFile` path does not **resolve**, not only when it is
empty. Three deliberate constraints:

1. **The `BookFile` row still wins whenever it resolves.** It is the more specific
   source; preferring the fallback unconditionally would reroute every book in the
   library rather than the broken ones.
2. **Non-regular files are rejected.** A multi-file book's `Book.FilePath` is its
   *folder*, and handing `ffprobe` a directory yields a confusing decode error instead of
   a clean skip. This fires on nothing today (0 directories in the sample) — the guard is
   there so that stays true.
3. **Recovered books are counted separately** and reported as `recovered-via-book-path=N`,
   never folded into the persisted total. Those rows are written from a secondary path
   source; if that source is ever wrong there has to be a way to find them afterward.

## Collision check, run before shipping

The risk of a secondary path source is writing one book's chapters onto another. Across
all 63,870 book rows, **1,264 `Book.FilePath` values are shared by more than one book**
(4,353 rows involved) — so the hazard is real in general. **0 of the 88 recoverable rows
are among them**, so the fallback cannot currently mis-attribute.

## Verification

Every guard mutation-tested — each turns *its own* subcase red with a message naming the
cause:

| mutation | result |
|---|---|
| fallback reverted to the emptiness test | `bookfile_path_missing,_book_path_resolves` FAIL |
| `IsRegular` guard dropped | `book_path_is_a_directory` FAIL |
| counter increment removed | `bookfile_path_missing,_book_path_resolves` FAIL |

The new test uses **real files on disk**, unlike every other case in this file. That is
load-bearing: the existing cases seed synthetic paths (`/lib/Title/track00.m4b`) that
have never existed, so to them *every* path is missing and a fallback keyed on existence
is indistinguishable from one keyed on emptiness. A suite of synthetic paths cannot
detect this bug in either direction — which is how it shipped.

Package green plain and under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t