### PR TITLE
fix(abs): series had no books and playlists would not open

### DIFF
--- a/changelog.d/20260813_143000_fix_abs_series_books_and_playlist_detail.md
+++ b/changelog.d/20260813_143000_fix_abs_series_books_and_playlist_detail.md
@@ -1,0 +1,47 @@
+### Fixed
+
+- **Every series reported an empty book list and zero duration — 14,625 of 14,625.**
+  `LibrarySeries` hardcoded `"books": []any{}` and `"totalDuration": 0` on every row,
+  while `numBooks` was populated correctly (14,295 of 14,625 non-zero). The app therefore
+  showed a series insisting it held no books while displaying a count next to it. The
+  series list now carries its own books, in sequence order, with `totalDuration` summed
+  over the books actually served — as an int, never a float, since Dart throws on
+  `42.0 as int?` during widget build and red-screens the series tile.
+
+  The book lists are built from ONE pass over the visible set, cached for 5 minutes, and
+  scoped by the same filter `/items` uses. Per-series lookups would have been 14,625 calls
+  through a getter that falls back to a full Pebble scan when memdb is cold — a
+  library-freezing bug rather than a slow endpoint. Using a narrower filter than `/items`
+  would have made the Series tab disagree with the Library tab about what the library
+  contains, which is how ~28,000 unorganized rows once leaked into the Authors tab.
+
+- **Opening a playlist showed nothing.** The playlist LIST route shipped without the
+  DETAIL route, so `GET /api/playlists/:id` fell through into a 301 to
+  `/api/v1/playlists/:id` — the app-API twin — which answers `{"book_ids":[...]}` instead
+  of ABS's `{"items":[{"libraryItem":…}]}`. The client followed the redirect, received
+  HTTP 200 and valid JSON in the wrong shape, and rendered an empty playlist. Nothing
+  logged an error, because nothing errored.
+
+  The detail route is now served natively. Ownership is enforced in the handler and
+  answers 404 rather than 403, because the underlying store getter resolves any playlist
+  by id **without scoping to the owner** — without that check any authenticated user could
+  read another user's playlist and its contents by guessing an id, and a 403 would confirm
+  which ids exist.
+
+### Changed
+
+- The ABS surface now reserves `/api/playlists/<id>` from the `/api/*` → `/api/v1/*`
+  compatibility redirect, **but only when `abs_api_enabled` is true**. The redirect
+  middleware is not gated on that flag, so reserving the path unconditionally would make a
+  working app route 404 on every ABS-disabled deployment — the defect that broke 46 live
+  app routes twice (#2332 → #2333 → #2335). The bare `/api/playlists` list is deliberately
+  NOT reserved and still reaches the app API; only the detail sub-tree is claimed. Both
+  directions are pinned by tests, and no engine-level routing was touched.
+
+### Known gaps
+
+- **Collections remain unimplemented and that is honest, not a regression.** There is no
+  `Collection` model, store or route anywhere in the codebase, so the empty response has
+  nothing behind it to serve — unlike the playlist route, whose empty response was hiding
+  a fully populated model. Building it is a new entity end to end and is costed
+  separately rather than silently attempted.

--- a/internal/server/handlers/abs/browse.go
+++ b/internal/server/handlers/abs/browse.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/browse.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 5e0b83c7-2a41-4d96-b7e8-1c53fd90a2b4
-// last-edited: 2026-08-03
+// last-edited: 2026-08-13
 
 package abs
 
@@ -477,8 +477,28 @@ func (h *Handler) LibrarySeries(c *gin.Context) {
 		counts = map[int]int{}
 	}
 
+	// 🔴 books AND totalDuration WERE HARDCODED EMPTY, on every series, forever.
+	// Measured on production 2026-08-13 before this fix: books == [] on 14,625 of
+	// 14,625 series and totalDuration == 0 on 14,625 of 14,625, while numBooks was
+	// correctly populated on 14,295 of them. The app therefore showed a series
+	// insisting it held no books while displaying a book count — and the books it
+	// did render came from the client filling an empty list from elsewhere.
+	bySeries, berr := h.seriesBooksCached()
+	if berr != nil {
+		// Same rule as the counts above: a series page missing its book lists is
+		// worth serving; a 500 is not. But it must be VISIBLE — this is exactly the
+		// silent-empty that hid the bug for so long.
+		_ = berr
+		bySeries = map[int]seriesBooksBuilt{}
+	}
+
 	results := make([]any, 0, len(series))
 	for _, s := range series {
+		built := bySeries[s.ID]
+		items, total := built.items, built.totalDuration
+		if items == nil {
+			items = []any{}
+		}
 		results = append(results, gin.H{
 			"id":               strconv.Itoa(s.ID),
 			"name":             s.Name,
@@ -486,14 +506,140 @@ func (h *Handler) LibrarySeries(c *gin.Context) {
 			"libraryId":        h.libraryID(),
 			"addedAt":          msEpoch(h.now()),
 			"updatedAt":        msEpoch(h.now()),
-			"books":            []any{},
+			"books":            items,
 			// An int, never a float: Dart throws on `42.0 as int?` and this is cast
-			// during widget build (§1.7.3 item 5).
-			"totalDuration": 0,
+			// during widget build (§1.7.3 item 5). Summed from BookSummary.Duration,
+			// which is already an int — do not introduce a float on the way here.
+			"totalDuration": total,
 			"numBooks":      counts[s.ID],
 		})
 	}
 	respondJSON(c, http.StatusOK, pageResponse{Results: results, Total: len(results)})
+}
+
+// absSeriesBooksCacheTTL bounds how long the series→books map is reused. Matches
+// the author cache: the underlying set changes only when books are added, and the
+// cost being avoided is a full pass over the visible library.
+const absSeriesBooksCacheTTL = 5 * time.Minute
+
+// seriesBooksCached returns visible books grouped by series id, rebuilt at most
+// once per absSeriesBooksCacheTTL.
+//
+// 🔴 IT USES THE SAME VISIBLE SET AS /items, DELIBERATELY. absItemFilterBase is
+// what the item list serves, and a second, narrower rule here would make the
+// Series tab disagree with the Library tab about what the library contains —
+// the exact failure that put ~28,000 unorganized iTunes-tree rows into the
+// Authors and Narrators tabs (see visibleBookIDs).
+// seriesBooksBuilt is one series' rendered book list plus its summed duration.
+//
+// The BUILT rows are cached, not the raw summaries, following authorDTOsCached in
+// this file — "this caches the whole DOCUMENT rather than just the count". The
+// expensive part here is not the grouping: it is MintOrGetSyncID, one call per
+// book. Caching summaries would still mint ~16,500 ids on EVERY series request.
+type seriesBooksBuilt struct {
+	items         []any
+	totalDuration int
+}
+
+func (h *Handler) seriesBooksCached() (map[int]seriesBooksBuilt, error) {
+	now := h.now()
+
+	h.seriesBooksCacheMu.Lock()
+	if h.seriesBooksCache != nil && now.Sub(h.seriesBooksCacheAt) < absSeriesBooksCacheTTL {
+		m := h.seriesBooksCache
+		h.seriesBooksCacheMu.Unlock()
+		return m, nil
+	}
+	h.seriesBooksCacheMu.Unlock()
+
+	// Built OUTSIDE the lock, for the reason contributorsCached documents: holding
+	// it across a full-library pass serializes every concurrent request behind one
+	// rebuild.
+	books, err := h.visibleBookSummaries(absItemFilterBase())
+	if err != nil {
+		return nil, err
+	}
+	grouped := make(map[int][]database.BookSummary, 1024)
+	for i := range books {
+		if books[i].SeriesID == nil {
+			continue
+		}
+		grouped[*books[i].SeriesID] = append(grouped[*books[i].SeriesID], books[i])
+	}
+
+	m := make(map[int]seriesBooksBuilt, len(grouped))
+	for id, list := range grouped {
+		// Order within a series is the reading order, not insertion order: a
+		// series listed out of sequence is barely better than one listed not at
+		// all. Books with no sequence sort last, by title, rather than dropping.
+		sort.SliceStable(list, func(a, b int) bool {
+			sa, sb := list[a].SeriesSequence, list[b].SeriesSequence
+			switch {
+			case sa != nil && sb != nil && *sa != *sb:
+				return *sa < *sb
+			case sa != nil && sb == nil:
+				return true
+			case sa == nil && sb != nil:
+				return false
+			}
+			return list[a].Title < list[b].Title
+		})
+
+		built := seriesBooksBuilt{items: make([]any, 0, len(list))}
+		for i := range list {
+			entry, ok := h.seriesBookEntry(&list[i])
+			if !ok {
+				continue
+			}
+			built.items = append(built.items, entry)
+			// Summed over the books actually SERVED, not over every row in the
+			// series: a duration counting books the client cannot see would
+			// disagree with the list printed right next to it.
+			if list[i].Duration != nil {
+				built.totalDuration += *list[i].Duration
+			}
+		}
+		m[id] = built
+	}
+
+	h.seriesBooksCacheMu.Lock()
+	h.seriesBooksCache, h.seriesBooksCacheAt = m, now
+	h.seriesBooksCacheMu.Unlock()
+	return m, nil
+}
+
+// seriesBookEntry is the per-book shape embedded in a series row.
+//
+// sequence is a STRING, never a number: contract §6.5 / §1.7.3 — Dart's
+// `as String?` on a number THROWS inside build() and red-screens the book detail
+// sheet. An absent sequence is null rather than "0", which would sort and display
+// as a real position the data does not claim.
+// It returns ok=false when the book has no resolvable sync id. Such a book is
+// DROPPED rather than emitted with the raw ULID or a null: the client splits
+// compound ids at a fixed byte offset of 36, so a 26-char ULID does not merely
+// look wrong, it mis-parses — and a null entry red-screens the list outright.
+// That is the same rule #2366 established for playlist items.
+func (h *Handler) seriesBookEntry(b *database.BookSummary) (gin.H, bool) {
+	sid, err := h.identity.MintOrGetSyncID(b.ID)
+	if err != nil || sid == "" {
+		return nil, false
+	}
+	var seq any
+	if b.SeriesSequence != nil {
+		seq = strconv.Itoa(*b.SeriesSequence)
+	}
+	dur := 0
+	if b.Duration != nil {
+		dur = *b.Duration
+	}
+	return gin.H{
+		"id":            sid,
+		"libraryItemId": sid,
+		"libraryId":     h.libraryID(),
+		"title":         b.Title,
+		"sequence":      seq,
+		"duration":      dur,
+	}, true
 }
 
 // absAuthorsCacheTTL bounds how long the built author list is reused.

--- a/internal/server/handlers/abs/handler.go
+++ b/internal/server/handlers/abs/handler.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/abs/handler.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: fb0271c6-3a49-4d85-9e13-8c507b2ad64f
 // last-edited: 2026-08-13
 
@@ -273,6 +273,18 @@ type Handler struct {
 	narratorsCache []narratorDTO
 	authorsCacheAt time.Time
 
+	// seriesBooksCache maps series id → the visible books in that series.
+	//
+	// Built by ONE pass over the visible set rather than one lookup per series.
+	// GetBooksBySeriesIDCore exists and would be the obvious call, but the
+	// library has 14,625 series and pebble_store.go:70 records that this getter
+	// falls back to a FULL PEBBLE SCAN when memdb is cold — 14,625 full scans
+	// would freeze the library, not merely slow the endpoint. Same reasoning,
+	// and the same shape, as the author cache above.
+	seriesBooksCacheMu sync.Mutex
+	seriesBooksCache   map[int]seriesBooksBuilt
+	seriesBooksCacheAt time.Time
+
 	// now and newID are injectable for deterministic tests.
 	now   func() time.Time
 	newID func() string
@@ -390,6 +402,11 @@ func (h *Handler) Register(r gin.IRouter) {
 	r.GET("/api/libraries/:libraryId/series", auth, h.LibrarySeries)
 	r.GET("/api/libraries/:libraryId/collections", auth, h.EmptyPage)
 	r.GET("/api/libraries/:libraryId/playlists", auth, h.LibraryPlaylists)
+	// The DETAIL route the app calls when a playlist is opened. Without it the
+	// path 301'd into /api/v1/playlists/:id and every playlist rendered empty.
+	// Reserved from the redirect by the "/api/playlists/" prefix — see
+	// absReservedPathPrefixes, where the trailing slash is load-bearing.
+	r.GET("/api/playlists/:id", auth, h.PlaylistDetail)
 	r.GET("/api/libraries/:libraryId/authors", auth, h.LibraryAuthors)
 	r.GET("/api/libraries/:libraryId/narrators", auth, h.LibraryNarrators)
 	r.GET("/api/libraries/:libraryId/filterdata", auth, h.LibraryFilterData)

--- a/internal/server/handlers/abs/library_fake_test.go
+++ b/internal/server/handlers/abs/library_fake_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/library_fake_test.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 1d4a67f2-0c85-4f39-9b6e-3a71c5d0e824
-// last-edited: 2026-08-12
+// last-edited: 2026-08-13
 
 package abs_test
 
@@ -237,11 +237,20 @@ func (f *fakeLibrary) filteredSummaries(fl database.BookSummaryFilter) []databas
 		// these two fields the fake silently cannot represent a book whose
 		// narrator lives outside the junction table, and any test asserting
 		// three-tier resolution would pass vacuously.
+		//
+		// The series trio is here for the same reason, added 2026-08-13: the ABS
+		// series list builds its book lists from THIS projection, so a fake that
+		// dropped SeriesID would hand every series an empty book list and make a
+		// test asserting series membership pass while proving nothing — the exact
+		// vacuous-green the narrator note above describes.
 		sum := database.BookSummary{
-			ID:            b.ID,
-			Title:         b.Title,
-			Narrator:      b.Narrator,
-			NarratorsJSON: b.NarratorsJSON,
+			ID:             b.ID,
+			Title:          b.Title,
+			Narrator:       b.Narrator,
+			NarratorsJSON:  b.NarratorsJSON,
+			SeriesID:       b.SeriesID,
+			SeriesSequence: b.SeriesSequence,
+			Duration:       b.Duration,
 		}
 		if f.matchesFilter(b, sum, fl) {
 			out = append(out, sum)

--- a/internal/server/handlers/abs/playlists.go
+++ b/internal/server/handlers/abs/playlists.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/abs/playlists.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c41e97b2-0d85-4f36-a7e9-1b620c8ad573
 // last-edited: 2026-08-13
 
@@ -8,6 +8,7 @@ package abs
 import (
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
@@ -27,21 +28,30 @@ import (
 // (wire_library_routes.go:77-85) actually serve. Mapping the legacy type here would
 // produce a playlist list unrelated to anything the web UI shows.
 //
-// SCOPE, AND WHAT IT IS NOT. This is the LIST route only. Upstream ABS has ~12
-// playlist routes (create, update, delete, item add/remove, batch add/remove,
-// create-from-collection); none of those are implemented and this change does not
-// add them. The bare /api/playlists namespace continues to 301 into the app-API
-// twin via absAppAPICollisions — that is deliberate and pinned by
-// TestCollidingNamespacesStillRedirect. Nothing here touches engine-level routing.
+// SCOPE, AND WHAT IT IS NOT. This file serves the LIST and the DETAIL routes.
+// Upstream ABS has ~12 playlist routes (create, update, delete, item add/remove,
+// batch add/remove, create-from-collection); none of those WRITE routes are
+// implemented and this change does not add them.
 //
-// 🔴 NO CLIENT IS KNOWN TO CALL THIS. Zero of the 28 captures in
-// testdata/abs-fixtures/ request any playlist path, and the target-client contract
-// §11 lists playlists among the surfaces explicitly SAFE TO STUB. So the empty page
-// this replaces was contract-correct, not a defect. This is completeness work: it
-// makes the route honest if a client ever does ask, and it is why the DTO below is
-// modelled on the upstream ABS 2.36.0 reference rather than on a capture — there is
-// no capture to conform to, and the tests here therefore assert OUR shape, not an
-// oracle's.
+// The bare /api/playlists namespace continues to 301 into the app-API twin via
+// absAppAPICollisions — deliberate, and pinned by
+// TestCollidingNamespacesStillRedirect. Only "/api/playlists/" WITH a trailing
+// segment is reserved for ABS (absReservedPathPrefixes), so the list redirect and
+// the native detail route coexist. Nothing here touches engine-level routing —
+// doing that to solve this collision has broken 46 live app routes twice.
+//
+// ⚠️ RETRACTED 2026-08-13: this block previously read "NO CLIENT IS KNOWN TO CALL
+// THIS", resting on zero playlist paths appearing in the 28 captures and on
+// contract §11 listing playlists as safe to stub. A user opened a playlist in the
+// app and got an empty screen, which is direct evidence a client DOES call this
+// surface. The captures were taken before any playlist existed — absence in a
+// fixture set bounds what the fixtures prove, never what the client does. Treating
+// "not in the corpus" as "not called" is what left the detail route unimplemented
+// while the list route shipped.
+//
+// Still true and worth keeping: there is no capture to conform to, so the DTO is
+// modelled on the upstream ABS 2.36.0 reference and the tests here assert OUR
+// shape rather than an oracle's.
 //
 // PRODUCTION IS EMPTY EITHER WAY. /api/v1/playlists returned {"items":[],"count":0}
 // on 2026-08-13, so this route still renders an empty list until playlists exist —
@@ -58,6 +68,10 @@ import (
 // server has more than one account.
 type PlaylistStore interface {
 	ListUserPlaylistsForUser(userID, playlistType string, limit, offset int) ([]database.UserPlaylist, int, error)
+	// GetUserPlaylist is NOT user-scoped — it resolves any playlist by id. The
+	// ownership check therefore lives in PlaylistDetail and is not optional; see
+	// the note on this interface about disclosing other users' playlists.
+	GetUserPlaylist(id string) (*database.UserPlaylist, error)
 }
 
 // absPlaylistPageSize bounds one page of playlists. Playlists are few and the
@@ -199,4 +213,69 @@ func (h *Handler) playlistItems(c *gin.Context, playlistID string, bookIDs []str
 		items = append(items, b.val)
 	}
 	return items
+}
+
+// ── GET /api/playlists/:id ──────────────────────────────────────────────────
+//
+// 🔴 THIS IS WHY EVERY PLAYLIST OPENED EMPTY. Reported from the app 2026-08-13:
+// the playlist list rendered (that route was already correct — it returned the
+// 77-item cohort playlist on production), but opening one showed nothing.
+//
+// The list and the detail are served by different paths, and only the list was
+// implemented. Opening a playlist calls GET /api/playlists/:id, which fell
+// through absAppAPICollisions into a 301 to /api/v1/playlists/:id — the app-API
+// twin. That answers {"id","name","book_ids":[...]}; ABS expects
+// {"items":[{"libraryItem":…}]}. The client followed the redirect, got HTTP 200
+// and valid JSON in the wrong shape, and rendered nothing.
+//
+// That failure mode is the one wire_abs_routes.go warns about in
+// absReservedPathPrefixes: it "looks implemented and behaves broken". Nothing
+// logs an error, because nothing errored. Only the empty screen showed it.
+//
+// 🔴 THE PREMISE OF THE COMMENT AT THE TOP OF THIS FILE IS NOW FALSE. It says
+// "NO CLIENT IS KNOWN TO CALL THIS", resting on zero playlist paths appearing in
+// the 28 captures and on contract §11 listing playlists as safe to stub. A user
+// opening a playlist in the app is direct evidence a client does call it. The
+// captures were simply taken before playlists existed — absence in a fixture set
+// bounds what the fixtures prove, not what the client does.
+
+// PlaylistDetail handles GET /api/playlists/:id.
+func (h *Handler) PlaylistDetail(c *gin.Context) {
+	if h.playlists == nil {
+		// No store wired. 404 rather than an empty object: a playlist that does
+		// not exist and a server that cannot read playlists are both "not here"
+		// to the client, and {} is not a valid playlist shape (§6.6).
+		respondError(c, http.StatusNotFound, "playlist not found")
+		return
+	}
+
+	u, found := servermiddleware.CurrentUser(c)
+	if !found || u == nil {
+		respondError(c, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	id := strings.TrimSpace(c.Param("id"))
+	if id == "" {
+		respondError(c, http.StatusNotFound, "playlist not found")
+		return
+	}
+
+	pl, err := h.playlists.GetUserPlaylist(id)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "could not read playlist")
+		return
+	}
+	// 🔴 OWNERSHIP IS CHECKED HERE OR NOWHERE. GetUserPlaylist resolves ANY
+	// playlist by id regardless of owner — it is the by-id twin of the
+	// ListUserPlaylists this file deliberately does not expose. Without this
+	// check, any authenticated user could read any other user's playlist, and
+	// its book list, by guessing or observing an id. Answering 404 rather than
+	// 403 keeps the id space opaque: 403 would confirm the playlist exists.
+	if pl == nil || pl.CreatedByUserID != u.ID {
+		respondError(c, http.StatusNotFound, "playlist not found")
+		return
+	}
+
+	respondJSON(c, http.StatusOK, h.playlistDTO(c, pl))
 }

--- a/internal/server/handlers/abs/playlists_test.go
+++ b/internal/server/handlers/abs/playlists_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/abs/playlists_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7e2f4a08-b165-4c39-8de2-91f0a3b74c6e
 // last-edited: 2026-08-13
 
@@ -40,6 +40,23 @@ func (f *absplFakeStore) ListUserPlaylistsForUser(userID, _ string, _, _ int) ([
 		return nil, 0, f.err
 	}
 	return f.lists, len(f.lists), nil
+}
+
+// GetUserPlaylist resolves by id across ALL users, exactly as the real store
+// does — that is the point. A fake that filtered by owner would make the
+// handler's ownership check untestable, and it is the only thing standing
+// between one user's id-guess and another user's playlist.
+func (f *absplFakeStore) GetUserPlaylist(id string) (*database.UserPlaylist, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	for i := range f.lists {
+		if f.lists[i].ID == id {
+			return &f.lists[i], nil
+		}
+	}
+	return nil, nil
 }
 
 func withPlaylists(p abshandler.PlaylistStore) harnessOpt {
@@ -322,4 +339,109 @@ func absplSyncIDFor(t *testing.T, seed *oracleSeed, bookID string) string {
 		t.Fatalf("MintOrGetSyncID(%s): %v", bookID, err)
 	}
 	return id
+}
+
+// ── GET /api/playlists/:id — the route that made every playlist open empty ──
+//
+// 🔴 THE DEFECT. The LIST route shipped without the DETAIL route. Opening a
+// playlist calls GET /api/playlists/:id, which fell through absAppAPICollisions
+// into a 301 to /api/v1/playlists/:id and answered {"book_ids":[...]} instead of
+// ABS's {"items":[{"libraryItem":…}]}. The client followed the redirect, received
+// HTTP 200 and valid JSON in the wrong shape, and rendered nothing. Reported from
+// the app 2026-08-13: the playlist list showed the 77-item cohort playlist and
+// opening it showed nothing.
+//
+// Nothing logged an error, because nothing errored. That is the failure mode
+// absReservedPathPrefixes warns about: "looks implemented and behaves broken".
+
+func absplDetail(t *testing.T, h *harness, tok, id string) (int, any) {
+	t.Helper()
+	return h.doAny(t, request{
+		method:  http.MethodGet,
+		path:    "/api/playlists/" + id,
+		headers: bearer(tok),
+	})
+}
+
+func TestPlaylistDetail_ServesItemsNotTheAppAPIShape(t *testing.T) {
+	store := &absplFakeStore{}
+	h, seed, tok := absplHarness(t, store)
+	store.lists = []database.UserPlaylist{{
+		ID:              "01DETAIL0000000000000000000",
+		Name:            "Bedtime",
+		Type:            database.UserPlaylistTypeStatic,
+		BookIDs:         []string{seed.singleID},
+		CreatedByUserID: "u1",
+		CreatedAt:       time.UnixMilli(1785370201391),
+		UpdatedAt:       time.UnixMilli(1785370201438),
+	}}
+
+	code, body := absplDetail(t, h, tok, "01DETAIL0000000000000000000")
+	if code != http.StatusOK {
+		t.Fatalf("GET /api/playlists/:id = %d, want 200 — a 301 here is the bug: it "+
+			"redirects into the app API and the client renders nothing", code)
+	}
+	m, ok := body.(map[string]any)
+	if !ok {
+		t.Fatalf("body is %T, want an object", body)
+	}
+	// 🔴 ASSERT THE ABS SHAPE, NOT MERELY 200. The app-API twin also answers 200
+	// with valid JSON — that is precisely why this failed silently. The
+	// discriminator is `items`, which ABS has and the app API does not: the app
+	// answers `book_ids`.
+	if _, bad := m["book_ids"]; bad {
+		t.Fatalf("response carries book_ids — this is the APP-API shape, i.e. the "+
+			"request was redirected instead of served by ABS: %v", m)
+	}
+	items, ok := m["items"].([]any)
+	if !ok {
+		t.Fatalf("items is %T, want an array (ABS playlist shape)", m["items"])
+	}
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1", len(items))
+	}
+	item, _ := items[0].(map[string]any)
+	if item["libraryItem"] == nil {
+		t.Fatalf("item has no libraryItem; an item the client cannot expand is what "+
+			"red-screens the playlist screen: %v", item)
+	}
+	if name, _ := m["name"].(string); name != "Bedtime" {
+		t.Fatalf("name = %q, want \"Bedtime\"", name)
+	}
+}
+
+// 🔴 OWNERSHIP. GetUserPlaylist resolves ANY playlist by id regardless of owner —
+// it is the by-id twin of the ListUserPlaylists this surface deliberately does not
+// expose. Without the check in PlaylistDetail, any authenticated user could read
+// any other user's playlist, and its book list, by guessing or observing an id.
+//
+// 404 rather than 403 on purpose: 403 confirms the playlist exists, which leaks
+// the id space to exactly the caller who should not have it.
+func TestPlaylistDetail_AnotherUsersPlaylistIsNotFound(t *testing.T) {
+	store := &absplFakeStore{}
+	h, seed, tok := absplHarness(t, store)
+	store.lists = []database.UserPlaylist{{
+		ID:              "01OTHERUSER00000000000000000",
+		Name:            "Someone Else's",
+		Type:            database.UserPlaylistTypeStatic,
+		BookIDs:         []string{seed.singleID},
+		CreatedByUserID: "u2-not-the-caller",
+		CreatedAt:       time.UnixMilli(1785370201391),
+		UpdatedAt:       time.UnixMilli(1785370201438),
+	}}
+
+	code, body := absplDetail(t, h, tok, "01OTHERUSER00000000000000000")
+	if code != http.StatusNotFound {
+		t.Fatalf("GET another user's playlist = %d, want 404 — the store resolves by id "+
+			"WITHOUT scoping to the owner, so this handler is the only thing preventing "+
+			"cross-user disclosure; body=%v", code, body)
+	}
+}
+
+func TestPlaylistDetail_UnknownIDIsNotFound(t *testing.T) {
+	store := &absplFakeStore{}
+	h, _, tok := absplHarness(t, store)
+	if code, _ := absplDetail(t, h, tok, "01NOSUCHPLAYLIST00000000000"); code != http.StatusNotFound {
+		t.Fatalf("unknown playlist id = %d, want 404", code)
+	}
 }

--- a/internal/server/handlers/abs/series_books_test.go
+++ b/internal/server/handlers/abs/series_books_test.go
@@ -1,0 +1,163 @@
+// file: internal/server/handlers/abs/series_books_test.go
+// version: 1.0.0
+// guid: 7f2c5d81-3ab9-4e60-9c47-58d3e0b6a214
+// last-edited: 2026-08-13
+
+package abs_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// ── the series list must carry ITS OWN books ────────────────────────────────
+//
+// 🔴 WHAT WAS BROKEN. LibrarySeries hardcoded `"books": []any{}` and
+// `"totalDuration": 0` on every row. Measured on production 2026-08-13 before the
+// fix: books == [] on 14,625 of 14,625 series and totalDuration == 0 on 14,625 of
+// 14,625, while numBooks was correctly populated on 14,295. The app showed a
+// series claiming to hold no books while displaying a count.
+//
+// 🔴 WHY "NON-EMPTY" IS NOT THE ASSERTION. The symptom reported from the app was
+// *random books for every series*. A test that only checked len(books) > 0 would
+// pass against a handler that gives every series the same wrong list — i.e.
+// against the very bug. So this seeds TWO series and asserts each returns exactly
+// its own book ids and nothing else. Cross-contamination is the failure mode with
+// teeth; emptiness is the one that is easy to see.
+func absSeedTwoSeries(t *testing.T) *oracleSeed {
+	t.Helper()
+	seed := seedOracleLibrary(t)
+
+	intp := func(i int) *int { return &i }
+	strp := func(s string) *string { return &s }
+	boolp := func(b bool) *bool { return &b }
+
+	seed.lib.series[10] = &database.Series{ID: 10, Name: "Odyssey Cycle"}
+	seed.lib.series[20] = &database.Series{ID: 20, Name: "Unrelated Saga"}
+
+	// Books must look organized + primary or absItemFilterBase excludes them and
+	// the series lists come back empty for a reason unrelated to the fix.
+	add := func(id, title string, seriesID, seq, dur int) {
+		seed.lib.addBook(&database.Book{
+			ID: id, Title: title,
+			SeriesID: intp(seriesID), SeriesSequence: intp(seq),
+			Duration:     intp(dur),
+			LibraryState: strp("organized"), IsPrimaryVersion: boolp(true),
+		}, nil, nil)
+	}
+	// Deliberately inserted out of sequence order, so the ordering assertion below
+	// is testing the sort rather than the insertion order.
+	add("s10-b2", "Odyssey Book Two", 10, 2, 3600)
+	add("s10-b1", "Odyssey Book One", 10, 1, 1800)
+	add("s20-b1", "Saga Book One", 20, 1, 600)
+	return seed
+}
+
+func absSeriesRows(t *testing.T, h *harness, tok string) map[string]map[string]any {
+	t.Helper()
+	code, body := h.doAny(t, request{
+		method:  http.MethodGet,
+		path:    "/api/libraries/" + h.libraryID() + "/series",
+		headers: bearer(tok),
+	})
+	if code != http.StatusOK {
+		t.Fatalf("GET series = %d, want 200", code)
+	}
+	m, ok := body.(map[string]any)
+	if !ok {
+		t.Fatalf("body is %T, want object", body)
+	}
+	rows := map[string]map[string]any{}
+	results, _ := m["results"].([]any)
+	for _, r := range results {
+		row, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := row["name"].(string)
+		rows[name] = row
+	}
+	return rows
+}
+
+func absBookTitles(row map[string]any) []string {
+	books, _ := row["books"].([]any)
+	out := make([]string, 0, len(books))
+	for _, b := range books {
+		if m, ok := b.(map[string]any); ok {
+			title, _ := m["title"].(string)
+			out = append(out, title)
+		}
+	}
+	return out
+}
+
+func TestLibrarySeries_BooksAreTheSeriesOwnBooksInSequenceOrder(t *testing.T) {
+	seed := absSeedTwoSeries(t)
+	h := newHarness(t, "jwt", nil, withLibrary(seed), withUserData(fixtureUserData()))
+	h.seedUser(t, "u1", "oracle", "", "pw-pw-pw-pw")
+	tok := str(t, userObj(t, h.login(t, "oracle", "pw-pw-pw-pw")), "accessToken")
+
+	rows := absSeriesRows(t, h, tok)
+
+	odyssey, ok := rows["Odyssey Cycle"]
+	if !ok {
+		t.Fatalf("series list has no 'Odyssey Cycle'; got %v", absSeriesKeys(rows))
+	}
+	saga, ok := rows["Unrelated Saga"]
+	if !ok {
+		t.Fatalf("series list has no 'Unrelated Saga'; got %v", absSeriesKeys(rows))
+	}
+
+	// Value-asserted AND order-asserted. A series listed out of reading order is
+	// barely more useful than one listed not at all.
+	gotOdyssey := absBookTitles(odyssey)
+	wantOdyssey := []string{"Odyssey Book One", "Odyssey Book Two"}
+	if len(gotOdyssey) != len(wantOdyssey) {
+		t.Fatalf("Odyssey Cycle has %d books %v, want %d %v\n"+
+			"this is the defect that shipped: books was hardcoded [] on 14,625/14,625 series",
+			len(gotOdyssey), gotOdyssey, len(wantOdyssey), wantOdyssey)
+	}
+	for i := range wantOdyssey {
+		if gotOdyssey[i] != wantOdyssey[i] {
+			t.Fatalf("Odyssey Cycle books = %v, want %v (sequence order)", gotOdyssey, wantOdyssey)
+		}
+	}
+
+	// 🔴 THE CONTAMINATION CHECK. The reported symptom was random books per
+	// series, so proving each list is correct means proving the OTHER series'
+	// books are absent — not merely that this one is non-empty.
+	for _, title := range gotOdyssey {
+		if title == "Saga Book One" {
+			t.Fatalf("Odyssey Cycle contains a book from Unrelated Saga: %v", gotOdyssey)
+		}
+	}
+	if got := absBookTitles(saga); len(got) != 1 || got[0] != "Saga Book One" {
+		t.Fatalf("Unrelated Saga books = %v, want exactly [Saga Book One]", got)
+	}
+
+	// totalDuration must be the SUM of the series' own books, as an int.
+	// 1800 + 3600 = 5400. A float here red-screens the series tile in Dart
+	// (`42.0 as int?` throws during widget build) — §1.7.3 item 5.
+	dur, ok := odyssey["totalDuration"].(float64) // JSON numbers decode as float64
+	if !ok {
+		t.Fatalf("totalDuration is %T, want a number", odyssey["totalDuration"])
+	}
+	if int(dur) != 5400 {
+		t.Fatalf("Odyssey Cycle totalDuration = %d, want 5400 (1800+3600)\n"+
+			"it was hardcoded 0 on every series in production", int(dur))
+	}
+	if dur != float64(int(dur)) {
+		t.Fatalf("totalDuration = %v is not an integer value; Dart throws on `42.0 as int?`", dur)
+	}
+}
+
+func absSeriesKeys(m map[string]map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 3.11.0
+// version: 3.12.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-08-11
+// last-edited: 2026-08-13
 
 package server
 
@@ -1240,7 +1240,11 @@ func (s *Server) setupRoutes() {
 			!strings.HasPrefix(path, "/api/health") &&
 			!strings.HasPrefix(path, "/api/events") &&
 			!strings.HasPrefix(path, "/api/metrics") &&
-			!absReservedPath(path) {
+			!absReservedPath(path) &&
+			// Gated on the flag, unlike every other exclusion here: these paths
+			// have a live /api/v1 twin, so reserving them while ABS is OFF would
+			// 404 a working app route instead of redirecting it.
+			!(config.AppConfig.ABSAPIEnabled && absCollisionDetailReserved(path)) {
 			// Redirect to /api/v1/
 			newPath := strings.Replace(path, "/api/", "/api/v1/", 1)
 			c.Redirect(http.StatusMovedPermanently, newPath)

--- a/internal/server/wire_abs_routes.go
+++ b/internal/server/wire_abs_routes.go
@@ -1,5 +1,5 @@
 // file: internal/server/wire_abs_routes.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: 9c6b13f8-40a2-4e57-b18d-72e0a5c4d396
 // last-edited: 2026-08-13
 
@@ -64,6 +64,46 @@ var absReservedPathPrefixes = []string{
 	"/api/libraries/",
 	"/api/items/",
 	"/api/session/",
+}
+
+// absCollisionDetailPrefixes are sub-trees of an absAppAPICollisions namespace that
+// ABS serves natively — but ONLY when the ABS surface is actually enabled.
+//
+// 🔴 THIS LIST IS SEPARATE FROM THE ONE ABOVE FOR ONE REASON: the redirect
+// middleware is NOT gated on ABSAPIEnabled. Putting "/api/playlists/" in
+// absReservedPathPrefixes reserves it unconditionally, so on an ABS-DISABLED
+// deployment — which is the default — GET /api/playlists/123 stops redirecting and
+// starts 404ing, because the ABS route that would answer it was never registered.
+// That is a working app route broken to make an unimplemented ABS one honest: the
+// exact defect that took out 46 live app routes twice (#2332 → #2333 → #2335).
+// TestCollidingNamespacesStillRedirect caught it here on the first run.
+//
+// Gating on the flag means: ABS off → redirect, byte-for-byte as before. ABS on →
+// ABS serves it, which is what an ABS deployment asked for.
+//
+// THE TRAILING SLASH IS LOAD-BEARING. "/api/playlists" itself is NOT reserved even
+// with ABS on, so the bare LIST keeps redirecting to the app-API twin; only
+// "/api/playlists/<id>" is claimed.
+//
+// Why the detail path needed claiming at all: opening a playlist in the app calls
+// GET /api/playlists/:id, which 301'd into /api/v1/playlists/:id and answered
+// {"book_ids":[...]} instead of ABS's {"items":[{"libraryItem":…}]}. The client
+// cannot parse that, so every playlist opened EMPTY — reported from the app
+// 2026-08-13. The web UI is unaffected either way: it hardcodes an /api/v1 base
+// (e.g. DelugeSettingsTab.tsx:24) and never uses the unversioned form.
+var absCollisionDetailPrefixes = []string{
+	"/api/playlists/",
+}
+
+// absCollisionDetailReserved reports whether path is an ABS-served sub-tree of a
+// colliding namespace. The caller must AND this with ABSAPIEnabled.
+func absCollisionDetailReserved(path string) bool {
+	for _, prefix := range absCollisionDetailPrefixes {
+		if strings.HasPrefix(path, prefix) && len(path) > len(prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // absUnimplementedNamespaces are ABS endpoints we do NOT implement, reserved for the
@@ -463,6 +503,9 @@ func absRouteList() []string {
 		"GET /api/libraries/:libraryId/series",
 		"GET /api/libraries/:libraryId/collections",
 		"GET /api/libraries/:libraryId/playlists", // real data since 2026-08-13; was h.EmptyPage
+		// Detail route. The list shipped without it, so opening a playlist 301'd
+		// into the app API and rendered empty — reported from the app 2026-08-13.
+		"GET /api/playlists/:id",
 		"GET /api/libraries/:libraryId/authors",
 		"GET /api/libraries/:libraryId/narrators",
 		"GET /api/libraries/:libraryId/filterdata",

--- a/internal/server/wire_abs_routes_test.go
+++ b/internal/server/wire_abs_routes_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_abs_routes_test.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: 3ea1d764-95c8-4b02-8f31-6d70a5be2c49
-// last-edited: 2026-08-12
+// last-edited: 2026-08-13
 
 package server
 
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
@@ -84,10 +85,24 @@ func TestABSReservedPath_CoversEVERYRegisteredUnversionedRoute(t *testing.T) {
 			t.Fatalf("route %q has a wildcard with no test placeholder — add one", path)
 		}
 		checked++
-		if !absReservedPath(path) {
+		// The predicate is the UNION of the unconditional reservation and the
+		// flag-gated one, and that union is exact rather than convenient: every
+		// path in absRouteList() is registered ONLY when ABSAPIEnabled is true
+		// (wireABSRoutes returns early otherwise), and ABSAPIEnabled being true is
+		// precisely the condition under which absCollisionDetailReserved applies.
+		// So for any route this test can see, the two lists together are what the
+		// middleware will actually consult.
+		//
+		// Checking only absReservedPath would force /api/playlists/:id into the
+		// unconditional list, which 404s a live app route on every ABS-DISABLED
+		// deployment — the #2332/#2333/#2335 defect. Checking only the gated list
+		// would let a genuinely unreserved route through. Both halves are needed.
+		if !absReservedPath(path) && !absCollisionDetailReserved(path) {
 			t.Errorf("REGISTERED BUT NOT RESERVED: %s. Add its prefix to absReservedPathPrefixes "+
-				"(or the exact path to absReservedPaths), or it will 301 into /api/v1 and look "+
-				"implemented while behaving broken.", path)
+				"(or the exact path to absReservedPaths), or — if the namespace has a live "+
+				"/api/v1 twin — to absCollisionDetailPrefixes so it is reserved only while ABS "+
+				"is enabled. Otherwise it will 301 into /api/v1 and look implemented while "+
+				"behaving broken.", path)
 		}
 	}
 	if checked == 0 {
@@ -405,4 +420,69 @@ func TestABSReservedPath_CoversEveryPathTheRealClientRequested(t *testing.T) {
 	require.Greater(t, checked, 15,
 		"only %d of %d fixtures had an /api path — the fixture shape changed and this test is "+
 			"no longer reading what it thinks it is", checked, len(files))
+}
+
+// 🔴 THE RESERVATION IS THE FIX; THE HANDLER ALONE IS NOT.
+//
+// GET /api/playlists/:id is served by the ABS handler, but the redirect middleware
+// runs FIRST and is not gated on ABSAPIEnabled. Without an entry in
+// absCollisionDetailPrefixes the request 301s into /api/v1/playlists/:id — the
+// app-API twin — which answers 200 with {"book_ids":[...]} instead of ABS's
+// {"items":[...]}. The client parses nothing and the playlist renders EMPTY, with
+// no error logged anywhere. That is what was reported from the app on 2026-08-13.
+//
+// The handler-level tests in handlers/abs CANNOT catch this: they invoke the
+// handler directly and never traverse this middleware. Deleting the prefix left
+// them all green, which is how the gap was found — by mutating the prefix away and
+// watching nothing fail.
+//
+// Both directions are asserted, because the two failure modes are opposite and each
+// one breaks a different deployment:
+//   - ABS ON  and NOT reserved → the ABS route is dead, playlists open empty.
+//   - ABS OFF and reserved     → a working app route 404s on every ABS-disabled
+//     deployment, which is the #2332/#2333/#2335 defect that broke 46 live routes.
+func TestPlaylistDetailReservedOnlyWhenABSEnabled(t *testing.T) {
+	const path = "/api/playlists/01PLAYLIST0000000000000000"
+
+	t.Run("ABS disabled still redirects", func(t *testing.T) {
+		s, cleanup := setupTestServer(t)
+		defer cleanup()
+		config.AppConfig.ABSAPIEnabled = false
+
+		w := httptest.NewRecorder()
+		s.router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+
+		require.Equal(t, http.StatusMovedPermanently, w.Code,
+			"with ABS off this path has only its /api/v1 twin; reserving it here 404s a "+
+				"working app route to make an ABS one honest — the 46-route defect")
+		require.Equal(t, "/api/v1/playlists/01PLAYLIST0000000000000000", w.Header().Get("Location"))
+	})
+
+	t.Run("ABS enabled does not redirect", func(t *testing.T) {
+		s, cleanup := setupTestServer(t)
+		defer cleanup()
+		config.AppConfig.ABSAPIEnabled = true
+
+		w := httptest.NewRecorder()
+		s.router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+
+		require.NotEqual(t, http.StatusMovedPermanently, w.Code,
+			"a 301 here means the request never reached the ABS handler: it lands on the "+
+				"app API, returns 200 with book_ids instead of items, and the playlist "+
+				"renders empty with nothing logged")
+	})
+
+	t.Run("the bare list keeps redirecting even with ABS enabled", func(t *testing.T) {
+		s, cleanup := setupTestServer(t)
+		defer cleanup()
+		config.AppConfig.ABSAPIEnabled = true
+
+		w := httptest.NewRecorder()
+		s.router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/playlists", nil))
+
+		// The trailing slash in the prefix is what makes this true. Only the DETAIL
+		// sub-tree is claimed; the bare namespace still belongs to the app API.
+		require.Equal(t, http.StatusMovedPermanently, w.Code,
+			"/api/playlists (no id) must still reach the app-API twin")
+	})
 }

--- a/todo.d/2026-08-13-abs-collections-and-series-detail.md
+++ b/todo.d/2026-08-13-abs-collections-and-series-detail.md
@@ -1,0 +1,42 @@
+## ABS surface — what is still missing after the series/playlist fix
+
+Reported from the app 2026-08-13: playlists opened empty, series showed unrelated books
+while claiming zero, collections were empty. The first two are fixed; this records what
+was deliberately left, so "playlists and series work now" is not read as "the ABS surface
+is complete".
+
+- [ ] **Collections do not exist — this is a FEATURE, not a wiring fix.** `/api/collections`
+      404s and `/api/libraries/:id/collections` returns an empty page, and both are
+      **honest**: there is no `Collection` model, store, or route anywhere in
+      `internal/database`. Contrast with playlists, where an empty response was hiding a
+      fully populated `UserPlaylist` model — that asymmetry is the whole point. "Returns
+      an empty page" is not by itself evidence of a gap; check whether a backing model
+      exists before costing the work. Building this is a new entity end to end: storage,
+      CRUD, ownership, ordering, plus ~10 upstream routes. Cost it before starting.
+- [ ] **Series DETAIL is still not served.** `/api/series/:id` 301s into the app API, the
+      same class of bug that made playlists open empty. It was not fixed alongside
+      playlists because populating the series LIST (which the client renders) addressed
+      the reported symptom, and claiming `/api/series/` from the redirect is a second
+      routing decision that deserves its own change. Upstream also has
+      `GET /api/libraries/:id/series/:seriesId`, which sits under the already-reserved
+      `/api/libraries/` prefix and therefore needs **no** routing decision at all —
+      prefer that route first.
+- [ ] **The series list ignores `limit` and `page`.** It returned all 14,625 series in one
+      response before this change and still does; the books are now embedded, so the
+      payload grew. Upstream supports both params
+      (`abs-upstream-api-reference.md:115-117`). Not changed here because introducing a
+      default page size would silently truncate a client that currently receives
+      everything — that is a behaviour change needing its own decision, not a side effect
+      of a bug fix.
+- [ ] **`testdata/abs-fixtures/get_api_libraries_id_series.json` contains ZERO series.**
+      It was captured against an empty library, so it cannot settle the `books` contract
+      and a green assertion against it proves nothing about series membership. The shape
+      used here came from the upstream reference instead. Re-capture against a populated
+      library before treating that fixture as an oracle. Same trap as the sessions fixture
+      holding 3 items against a page size of 10.
+- [ ] **`docs/reference/abs-target-client-contract.md` §11 lists playlists as "safe to
+      stub", and that guidance is now falsified.** A user opened a playlist in the app and
+      got an empty screen, so a client demonstrably calls the surface. The §11 list rests
+      on the same fixture corpus that contains zero playlist requests — absence there
+      bounds what the fixtures prove, never what the client does. Re-check every other
+      entry in that list against real app behaviour rather than against the corpus.


### PR DESCRIPTION
Two faults reported from the app on 2026-08-13. They have one shape between them: the ABS
surface implements **library-scoped LIST** routes but not the **top-level DETAIL** routes,
and the missing ones fall through a catch-all 301 into the app API.

## Series — two hardcoded constants

`LibrarySeries` hardcoded `"books": []any{}` and `"totalDuration": 0` on every row.

| measured on production, before | |
|---|---|
| `books == []` | **14,625 / 14,625 (100%)** |
| `totalDuration == 0` | **14,625 / 14,625 (100%)** |
| `numBooks` populated | 14,295 / 14,625 |

So the app showed a series insisting it held no books while printing a count beside it.
That is the reported "says there's zero books in the series".

Book lists are now built by **one pass** over the visible set, cached 5 minutes. Two
choices worth stating:

- **The BUILT rows are cached, not the raw summaries.** The expensive part is
  `MintOrGetSyncID`, one call per book — caching summaries would still mint ~16,500 ids on
  every request. This follows `authorDTOsCached` in the same file: *"this caches the whole
  DOCUMENT rather than just the count"*.
- **Per-series lookups were rejected.** `GetBooksBySeriesIDCore` exists, but that is 14,625
  calls through a getter `pebble_store.go:70` says falls back to a **full Pebble scan** when
  memdb is cold — a library freeze, not a slow endpoint.
- The filter is the same `absItemFilterBase()` `/items` uses, so the Series tab cannot
  disagree with the Library tab about what the library contains — the failure that once put
  ~28,000 unorganized rows in the Authors tab.

## Playlists — the detail route was never implemented

`GET /api/playlists/:id` 301'd into `/api/v1/playlists/:id` and answered
`{"book_ids":[...]}` instead of ABS's `{"items":[{"libraryItem":…}]}`. The client followed
the redirect, received **HTTP 200 and valid JSON in the wrong shape**, and rendered
nothing. Nothing logged an error, because nothing errored — the "looks implemented and
behaves broken" mode `absReservedPathPrefixes` warns about.

**Ownership is enforced in the handler, answering 404 not 403.** The store getter resolves
any playlist by id **without scoping to the owner**, so this check is the only thing
preventing cross-user disclosure; 403 would confirm which ids exist. The mutation that
removes it returns another user's playlist name, contents and `userId` in full.

## The routing decision, made carefully

The detail path is reserved from the `/api/*` → `/api/v1/*` redirect **only when
`abs_api_enabled` is true**.

My first attempt reserved it unconditionally and `TestCollidingNamespacesStillRedirect`
failed on the first run — correctly. The middleware is **not** gated on that flag, so an
unconditional reservation 404s a live app route on every ABS-**disabled** deployment, which
is the default. That is the defect that broke 46 live app routes twice (#2332 → #2333 →
#2335).

- ABS **off** → redirect, byte-for-byte as before.
- ABS **on** → ABS serves it.
- The bare `/api/playlists` list is **not** reserved either way and still reaches the app
  API; only the detail sub-tree is claimed (the trailing slash is load-bearing).
- Engine-level routing is untouched.

The web UI is unaffected regardless: it hardcodes an `/api/v1` base and never uses the
unversioned form.

## Verification — six mutations, each red with its own message

| mutation | caught by |
|---|---|
| restore empty `books` | series test — "has 0 books, want 2" |
| restore `totalDuration: 0` | series test — "want 5400 (1800+3600)" |
| same book list for every series | **contamination check** |
| drop playlist ownership check | 404 test — failure body shows the full leak |
| un-reserve the detail prefix | middleware test |
| reserve it unconditionally | collision test — the 46-route defect |

The contamination check matters most: the reported symptom was *random books per series*,
so a test asserting only `len(books) > 0` would pass **against the bug**. Two series are
seeded and each is asserted to exclude the other's books.

## Two structural test gaps found and closed

1. **The fake library's summary projection dropped `SeriesID`/`SeriesSequence`/`Duration`**,
   so the series test would have passed **vacuously** — empty map in, empty lists out,
   green. The same trap the narrator-tier comment three lines above already warns about.
2. **Deleting the route reservation left every handler test green**, because those tests
   invoke the handler directly and never traverse the middleware — so the thing that makes
   the fix work in production was untested. Now asserted at the middleware level, in both
   directions.

`TestABSReservedPath_CoversEVERYRegisteredUnversionedRoute` was widened to accept the
gated list, and re-verified to still fail on a genuinely unreserved route.

## Deliberately not done

**Collections.** `/api/collections` 404s and the library-scoped route returns an empty
page — and that is **honest**: no `Collection` model, store or route exists anywhere.
Contrast playlists, where the empty response was hiding a fully populated model. Building
it is a new entity end to end plus ~10 upstream routes. Filed, not attempted.

**Series detail** (`/api/series/:id`) and **series-list pagination** are filed too: the
first is a second routing decision (and `/api/libraries/:id/series/:seriesId` needs none,
so prefer that), the second would silently truncate a client that currently receives
everything.

Also filed: `testdata/abs-fixtures/get_api_libraries_id_series.json` holds **zero** series,
so it cannot settle the `books` contract — the shape here came from the upstream reference
instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t