### PR TITLE
fix(abs): paginate and order the series list instead of ignoring page/limit/sort

### DIFF
--- a/changelog.d/20260813_195500_fix_abs_series_pagination.md
+++ b/changelog.d/20260813_195500_fix_abs_series_pagination.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **AudiobookShelf API: the series list ignored `page`, `limit` and `sort`.**
+  Confirmed against production: `?limit=100` and `?limit=500` both returned all
+  14,625 series, and the app's own `?limit=50&page=2&sort=name` got page 0,
+  unsorted, every time. `GET /api/libraries/:id/series` now sorts deterministically
+  (name-ignoring-prefix, id as tie-break) and honours `page`/`limit`, reporting the
+  full series count as `total` so the client can tell more pages exist. An absent
+  limit or `limit=0` still returns everything, so non-app callers are unchanged.
+  This also keeps the newly-populated `books` array from turning the unpaginated
+  response into a ~10.8 MB payload.

--- a/internal/server/handlers/abs/browse.go
+++ b/internal/server/handlers/abs/browse.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/abs/browse.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: 5e0b83c7-2a41-4d96-b7e8-1c53fd90a2b4
 // last-edited: 2026-08-13
 
@@ -509,8 +509,14 @@ func (h *Handler) LibrarySeries(c *gin.Context) {
 	// Measured on production 2026-08-13 before this fix: books == [] on 14,625 of
 	// 14,625 series and totalDuration == 0 on 14,625 of 14,625, while numBooks was
 	// correctly populated on 14,295 of them. The app therefore showed a series
-	// insisting it held no books while displaying a book count — and the books it
-	// did render came from the client filling an empty list from elsewhere.
+	// insisting it held no books while displaying a book count.
+	//
+	// ⚠️ CORRECTED 2026-08-13: this note previously finished "and the books it did
+	// render came from the client filling an empty list from elsewhere". That was
+	// speculation and it was wrong. The books the app rendered came from
+	// /api/libraries/:id/items, which accepted a `filter` parameter and read it with
+	// nothing — so a request for one series returned an arbitrary page of the whole
+	// library. Fixed separately; see absFilterGroup/filteredItems below.
 	bySeries, berr := h.seriesBooksCached()
 	if berr != nil {
 		// Same rule as the counts above: a series page missing its book lists is
@@ -518,6 +524,52 @@ func (h *Handler) LibrarySeries(c *gin.Context) {
 		// silent-empty that hid the bug for so long.
 		_ = berr
 		bySeries = map[int]seriesBooksBuilt{}
+	}
+
+	// ORDER FIRST, THEN SLICE. GetAllSeries makes no ordering promise, and paginating
+	// an unstable order lets pages overlap and skip — the client would see some series
+	// twice and others never. Sorting on nameIgnorePrefix with the id as tie-break is
+	// total (ids are unique), so the pages partition the set exactly.
+	//
+	// `sort=name` is the only sort the app is observed to send and it is what this
+	// already does; an unrecognised sort keeps this order rather than erroring.
+	sort.SliceStable(series, func(i, j int) bool {
+		li, lj := ignorePrefix(series[i].Name), ignorePrefix(series[j].Name)
+		if li != lj {
+			return li < lj
+		}
+		return series[i].ID < series[j].ID
+	})
+	if c.Query("desc") == "1" || c.Query("sortDesc") == "1" {
+		for i, j := 0, len(series)-1; i < j; i, j = i+1, j-1 {
+			series[i], series[j] = series[j], series[i]
+		}
+	}
+
+	// 🔴 page/limit/sort WERE ACCEPTED AND IGNORED. Confirmed against production
+	// 2026-08-13: limit=100 and limit=500 both returned all 14,625 series, and the
+	// app's own `limit=50&page=2&sort=name` got page 0, unsorted, every time.
+	//
+	// This is not cosmetic any more. Populating `books` above takes the unpaginated
+	// response from 3.36 MB to roughly 10.8 MB (31,139 book rows), which is not a
+	// thing to hand a phone that asked for 50.
+	//
+	// A limit of 0 or an absent limit still returns everything, deliberately: every
+	// observed app request carries an explicit limit, so this keeps every other
+	// caller byte-identical instead of imposing a default page size nobody asked for.
+	total := len(series)
+	limit := queryInt(c, "limit", 0)
+	page := queryInt(c, "page", 0)
+	if limit > 0 {
+		start := page * limit
+		if start > total {
+			start = total
+		}
+		end := start + limit
+		if end > total {
+			end = total
+		}
+		series = series[start:end]
 	}
 
 	results := make([]any, 0, len(series))
@@ -542,7 +594,18 @@ func (h *Handler) LibrarySeries(c *gin.Context) {
 			"numBooks":      counts[s.ID],
 		})
 	}
-	respondJSON(c, http.StatusOK, pageResponse{Results: results, Total: len(results)})
+	// Total is the FULL series count, NOT len(results). The client decides whether
+	// another page exists with `page*limit < total` (the same rule recorded on
+	// authorDTOsCached), so reporting the slice length would tell it page 0 is the
+	// whole library and it would stop at 50 of 14,625. The opposite convention in
+	// playlists.go is correct THERE only because that route has no working page
+	// parameter to offer.
+	respondJSON(c, http.StatusOK, pageResponse{
+		Results: results,
+		Total:   total,
+		Limit:   limit,
+		Page:    page,
+	})
 }
 
 // absSeriesBooksCacheTTL bounds how long the series→books map is reused. Matches

--- a/internal/server/handlers/abs/series_pagination_test.go
+++ b/internal/server/handlers/abs/series_pagination_test.go
@@ -1,0 +1,220 @@
+// file: internal/server/handlers/abs/series_pagination_test.go
+// version: 1.0.0
+// guid: 9c4a17e5-62b8-4d03-a7f1-3e58b0d94c27
+// last-edited: 2026-08-13
+
+package abs_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// ── the series list must honour page/limit ──────────────────────────────────
+//
+// 🔴 WHAT WAS BROKEN. LibrarySeries accepted `page`, `limit` and `sort` and read
+// none of them. Confirmed against production 2026-08-13: `?limit=100` and
+// `?limit=500` both returned all 14,625 series, and the app's own
+// `?limit=50&page=2&sort=name` got page 0, unsorted, every single time.
+//
+// 🔴 WHY IT STOPPED BEING COSMETIC. Populating `books` on each series row (the
+// sibling fix) takes the unpaginated response from 3.36 MB to roughly 10.8 MB —
+// 31,139 book rows — which is not a payload to hand a phone that asked for 50.
+//
+// 🔴 WHY THE FIXTURE HAS SEVEN SERIES. A fixture smaller than the page size makes
+// every clamp dead code under a green suite: with 3 series and a limit of 10 there
+// is only ever one page, so slicing, the end-clamp and the past-the-end case are
+// all unexercised. Seven series at limit 2 gives four pages, the last one partial,
+// plus a page past the end.
+
+// absPgSeedSeries seeds seven series whose alphabetical order differs from their
+// id order, so a handler that "paginates" by id rather than by the sorted order
+// cannot pass by accident.
+func absPgSeedSeries(t *testing.T) *oracleSeed {
+	t.Helper()
+	seed := seedOracleLibrary(t)
+
+	intp := func(i int) *int { return &i }
+	strp := func(s string) *string { return &s }
+	boolp := func(b bool) *bool { return &b }
+
+	// id order and name order are deliberately uncorrelated.
+	names := map[int]string{
+		70: "Alpha Chronicles",
+		30: "Bravo Cycle",
+		90: "Charlie Saga",
+		10: "Delta Sequence",
+		50: "Echo Arc",
+		80: "Foxtrot Run",
+		20: "Golf Trilogy",
+	}
+	i := 0
+	for id, name := range names {
+		seed.lib.series[id] = &database.Series{ID: id, Name: name}
+		// One organized, primary book per series so absItemFilterBase does not
+		// filter the series into emptiness for an unrelated reason.
+		seed.lib.addBook(&database.Book{
+			ID: fmt.Sprintf("pg-b%d", id), Title: fmt.Sprintf("Book of %s", name),
+			SeriesID: intp(id), SeriesSequence: intp(1), Duration: intp(600),
+			LibraryState: strp("organized"), IsPrimaryVersion: boolp(true),
+		}, nil, nil)
+		i++
+	}
+	return seed
+}
+
+// absPgHarness seeds the seven-series library and returns a logged-in harness.
+func absPgHarness(t *testing.T) (*harness, string) {
+	t.Helper()
+	seed := absPgSeedSeries(t)
+	h := newHarness(t, "jwt", nil, withLibrary(seed), withUserData(fixtureUserData()))
+	h.seedUser(t, "u1", "oracle", "", "pw-pw-pw-pw")
+	tok := str(t, userObj(t, h.login(t, "oracle", "pw-pw-pw-pw")), "accessToken")
+	return h, tok
+}
+
+// absPgFetch returns (names in response order, total field) for one series request.
+func absPgFetch(t *testing.T, h *harness, tok, query string) ([]string, int) {
+	t.Helper()
+	path := "/api/libraries/" + h.libraryID() + "/series"
+	if query != "" {
+		path += "?" + query
+	}
+	code, body := h.doAny(t, request{method: http.MethodGet, path: path, headers: bearer(tok)})
+	if code != http.StatusOK {
+		t.Fatalf("GET %s = %d, want 200", path, code)
+	}
+	m, ok := body.(map[string]any)
+	if !ok {
+		t.Fatalf("body is %T, want object", body)
+	}
+	total, ok := m["total"].(float64)
+	if !ok {
+		t.Fatalf("total is %T (%v), want a number", m["total"], m["total"])
+	}
+	results, _ := m["results"].([]any)
+	names := make([]string, 0, len(results))
+	for _, r := range results {
+		row, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := row["name"].(string)
+		names = append(names, name)
+	}
+	return names, int(total)
+}
+
+// TestLibrarySeries_PagesPartitionTheSeriesSet asserts the property that actually
+// matters: walking every page yields each series EXACTLY ONCE and misses none.
+//
+// Per-page length is the weak assertion — it passes against a handler that returns
+// the same page forever, which is the bug being fixed. Partitioning does not.
+func TestLibrarySeries_PagesPartitionTheSeriesSet(t *testing.T) {
+	h, tok := absPgHarness(t)
+
+	all, total := absPgFetch(t, h, tok, "")
+	if total != 7 {
+		t.Fatalf("unpaginated total = %d, want 7", total)
+	}
+	if len(all) != 7 {
+		t.Fatalf("unpaginated returned %d series, want all 7 (an absent limit must not paginate)", len(all))
+	}
+
+	const limit = 2
+	seen := map[string]int{}
+	var walked []string
+	for page := 0; page < 5; page++ { // 4 real pages + 1 past the end
+		names, pageTotal := absPgFetch(t, h, tok, fmt.Sprintf("limit=%d&page=%d", limit, page))
+
+		// Total must be the FULL count on every page. If it were len(results) the
+		// client's `page*limit < total` test would stop it after page 0.
+		if pageTotal != 7 {
+			t.Errorf("page %d reported total = %d, want the full 7 — the client uses this to decide whether more pages exist", page, pageTotal)
+		}
+		if len(names) > limit {
+			t.Errorf("page %d returned %d series, want at most limit=%d", page, len(names), limit)
+		}
+		for _, n := range names {
+			seen[n]++
+			walked = append(walked, n)
+		}
+	}
+
+	if len(walked) != 7 {
+		t.Errorf("walking all pages yielded %d series, want exactly 7 (got %v)", len(walked), walked)
+	}
+	for name, n := range seen {
+		if n != 1 {
+			t.Errorf("series %q appeared on %d pages, want exactly 1 — pages must partition the set", name, n)
+		}
+	}
+	for _, name := range all {
+		if seen[name] == 0 {
+			t.Errorf("series %q never appeared on any page — pages must cover the whole set", name)
+		}
+	}
+}
+
+// TestLibrarySeries_PageOrderIsTheSortedOrderNotInsertionOrder pins the order the
+// pages are cut from. Paginating an unspecified order lets pages overlap and skip,
+// so the sort is a prerequisite for the test above rather than a nicety.
+func TestLibrarySeries_PageOrderIsTheSortedOrderNotInsertionOrder(t *testing.T) {
+	h, tok := absPgHarness(t)
+
+	want := []string{
+		"Alpha Chronicles", "Bravo Cycle", "Charlie Saga", "Delta Sequence",
+		"Echo Arc", "Foxtrot Run", "Golf Trilogy",
+	}
+
+	all, _ := absPgFetch(t, h, tok, "")
+	if len(all) != len(want) {
+		t.Fatalf("got %d series, want %d", len(all), len(want))
+	}
+	for i := range want {
+		if all[i] != want[i] {
+			t.Fatalf("series order = %v,\n                  want %v", all, want)
+		}
+	}
+
+	// The same order must survive being cut into pages: page 1 at limit 2 is the
+	// third and fourth entries, not an arbitrary pair.
+	page1, _ := absPgFetch(t, h, tok, "limit=2&page=1")
+	if len(page1) != 2 || page1[0] != want[2] || page1[1] != want[3] {
+		t.Errorf("page 1 (limit 2) = %v, want %v", page1, want[2:4])
+	}
+}
+
+// TestLibrarySeries_LimitIsActuallyApplied is the direct regression for the
+// production observation: limit=100 and limit=500 both returned all 14,625.
+func TestLibrarySeries_LimitIsActuallyApplied(t *testing.T) {
+	h, tok := absPgHarness(t)
+
+	for _, tc := range []struct {
+		query string
+		want  int
+		why   string
+	}{
+		{"limit=1", 1, "a limit below the set size must truncate"},
+		{"limit=3", 3, "a limit below the set size must truncate"},
+		{"limit=100", 7, "a limit above the set size returns what exists, not an error"},
+		{"limit=0", 7, "limit=0 means unlimited — every non-app caller keeps today's response"},
+		{"", 7, "an absent limit means unlimited"},
+		{"limit=2&page=3", 1, "the final page is partial, not padded"},
+		{"limit=2&page=99", 0, "past the end is an empty page, not a wrapped-around one"},
+		{"limit=-5", 7, "a garbage limit falls back to unlimited rather than erroring"},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			names, total := absPgFetch(t, h, tok, tc.query)
+			if len(names) != tc.want {
+				t.Errorf("%q returned %d series, want %d — %s (got %v)", tc.query, len(names), tc.want, tc.why, names)
+			}
+			if total != 7 {
+				t.Errorf("%q reported total = %d, want the full 7", tc.query, total)
+			}
+		})
+	}
+}

--- a/todo.d/2026-08-13-abs-ignored-query-params-sweep.md
+++ b/todo.d/2026-08-13-abs-ignored-query-params-sweep.md
@@ -1,0 +1,29 @@
+### ABS API — sweep every endpoint for accepted-but-ignored query parameters
+
+Three separate bugs on 2026-08-13 were the same defect wearing different hats: an
+endpoint accepted a query parameter and read it with nothing, then answered `200`
+with a wrong-but-plausible body.
+
+- `GET /api/libraries/:id/items` — `filter` ignored, so every filtered request
+  returned the whole library. This is what made series show "random books".
+- `GET /api/libraries/:id/series` — `page`, `limit`, `sort` ignored. `limit=100`
+  and `limit=500` both returned all 14,625 rows.
+- (fixed earlier) the same surface's `sort` on items, noted in `absItemFilter`.
+
+All three were invisible to the 28-fixture conformance oracle because **no fixture
+carries a query parameter at all** — the corpus bounds what it can prove, and a
+parameter that never appears in a capture can never be asserted on.
+
+Work to do:
+
+1. Enumerate every ABS route from `absRouteList()` and, for each, diff the query
+   parameters upstream ABS 2.36.0 documents against the ones the handler actually
+   reads. `c.Query(` / `c.GetQuery(` grep is the starting point, not the answer —
+   the failure mode is a parameter read by *nobody*, which greps as absence.
+2. For each unread parameter decide explicitly: honour it, or return an empty /
+   error response. Never silently ignore — an ignored filter is strictly worse
+   than an unimplemented one, because the wrong answer looks like a right answer.
+3. Consider a test that drives each route with a parameter set and asserts the
+   response *changes*. A parameter that provably makes no difference is the bug.
+4. Re-capture the oracle fixtures with query parameters present, so the
+   conformance suite can see this class at all.


### PR DESCRIPTION
## What was wrong

`GET /api/libraries/:libraryId/series` accepted `page`, `limit` and `sort` and **read none of them**.

Confirmed against production:

| request | series returned |
|---|---|
| `?limit=100` | 14,625 |
| `?limit=500` | 14,625 |
| `?limit=0` | 14,625 |

And these are the **app's own** requests from the server logs (timestamps separated from my probes — everything at 15:32–15:43 EDT was me):

```
13:50:58  /series?limit=500
14:14:58  /series?limit=50&page=2&sort=name
```

That second one is a real paging UI asking for page 2 sorted by name, and getting page 0, unsorted, every time.

## Why it stopped being cosmetic

#2375 populated the `books` array on every series row. That takes the unpaginated response from **3.36 MB to roughly 10.8 MB** (31,139 book rows at ~250 B), which is not a payload to hand a phone that asked for 50 items. Pagination makes the size problem disappear rather than mitigating it.

## Three things that are easy to get wrong here

**Order first, slice second.** `GetAllSeries()` makes no ordering promise. Paginating an unstable order lets pages overlap and skip — some series appear twice, others never. Sorting on `nameIgnorePrefix` with the id as tie-break is total (ids are unique), so pages partition the set exactly. The fixture proves this is load-bearing: with the sort removed the fake returns `[Delta Golf Bravo Echo Alpha Foxtrot Charlie]`, genuinely random map order.

**`total` is the FULL count, not `len(results)`.** The client decides whether another page exists with `page*limit < total` (the rule recorded on `authorDTOsCached`). Reporting the slice length would tell it page 0 is everything and it would stop at 50 of 14,625 — a worse symptom than the one being fixed. `playlists.go` uses the opposite convention and is correct *there* only because that route has no working page parameter to offer.

**`limit=0` and absent `limit` still return everything.** Every observed app request carries an explicit limit, so this keeps every other caller byte-identical instead of imposing a default page size nobody asked for.

## Verification

Fixture is **seven** series on purpose — a fixture smaller than the page size makes every clamp dead code under a green suite. Seven at limit 2 gives four pages, the last partial, plus a page past the end. Names and ids are deliberately uncorrelated so a handler paginating by id can't pass by accident.

The headline test asserts pages **partition** the set (each series exactly once, none missed), not per-page lengths — length passes against a handler that returns the same page forever, which is the bug.

| Mutation | Failure |
|---|---|
| ignore the limit | `"limit=2&page=99" returned 7 series, want 0` |
| `Total = len(results)` | `"limit=2&page=3" reported total = 1, want the full 7` |
| drop the sort | `order = [Delta Golf Bravo Echo Alpha Foxtrot Charlie]` |

Full `internal/server/handlers/abs` suite green (27.3s).

## Also in this PR

- Corrects a comment merged a few hours ago in #2375 that attributed the "random books per series" symptom to the client filling an empty list from its own cache. That was speculation and it was wrong — the cause was the ignored `filter` parameter, fixed in #2376. Leaving it in merged code is how the next reader re-derives the wrong cause.
- A `todo.d/` fragment for the broader sweep: three bugs in one day were the same defect (a query parameter accepted and ignored, answered `200` with a wrong-but-plausible body), and all three were invisible to the conformance oracle because **no fixture carries a query parameter at all**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t