### PR TITLE
fix(api): reject filter field names passed as bare query parameters

### DIFF
--- a/changelog.d/20260813_161500_fix_bare_filter_field_params.md
+++ b/changelog.d/20260813_161500_fix_bare_filter_field_params.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Asking the library to filter by a field name used directly in the web address
+  — for example `?title=Skills` — silently listed the entire library instead,
+  complete with a matching total, because field filters have to be sent in the
+  `filters` parameter and anything else was ignored. Such a request is now
+  answered with an error explaining the correct form, rather than with every
+  book in the library. The web interface already used the correct form and was
+  unaffected; this misled people querying the API by hand, including one
+  investigation that recorded the wrong root cause because of it.

--- a/internal/server/handlers/audiobooks/bare_filter_param_test.go
+++ b/internal/server/handlers/audiobooks/bare_filter_param_test.go
@@ -1,0 +1,116 @@
+// file: internal/server/handlers/audiobooks/bare_filter_param_test.go
+// version: 1.0.0
+// guid: 5a9e2c68-4b71-4d03-9e85-1c6f0a37b2d9
+// last-edited: 2026-08-13
+
+package audiobookshandler
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// Field filters travel inside the `filters` JSON parameter. Passed bare
+// (?title=Skills) gin ignores the parameter entirely, so the request lists the
+// whole library while looking exactly like a narrowed query — count included.
+//
+// Measured on production 2026-08-13: ?title=Skills answered count=63870 with
+// non-matching rows, while filters=[{"field":"title","value":"Skills"}]
+// answered 25 and value "zzqqxx" answered 0. The 63,870 was read as evidence
+// of a storage-layer filtering bug and written into a handoff as a root cause.
+// It was not one.
+
+// queryCtx builds a gin context carrying only a query string, which is all
+// firstBareFilterFieldParam inspects.
+func queryCtx(t *testing.T, rawQuery string) *gin.Context {
+	t.Helper()
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("GET", "/api/v1/audiobooks?"+rawQuery, nil)
+	return c
+}
+
+func TestFirstBareFilterFieldParam_RejectsFilterFieldsPassedBare(t *testing.T) {
+	// Every name the guard knows must be caught on its own — a set that is
+	// only spot-checked drifts into holes.
+	for field := range filterFieldQueryParams {
+		t.Run(field, func(t *testing.T) {
+			got, bare := firstBareFilterFieldParam(
+				queryCtx(t, url.Values{field: {"anything"}}.Encode()))
+			require.True(t, bare, "bare ?%s= must be rejected", field)
+			require.Equal(t, field, got)
+		})
+	}
+}
+
+func TestFirstBareFilterFieldParam_AllowsRealParameters(t *testing.T) {
+	// The genuine query parameters this endpoint accepts. If the guard fired
+	// on any of these it would break working clients — including the web UI,
+	// which sends the `filters` form plus these.
+	// Derived from the accessors ListAudiobooks actually reads, across every
+	// spelling (c.Query, c.QueryArray, httputil.ParseQuery*), not from one
+	// grep of one form — see the note on filterFieldQueryParams.
+	realParams := []string{
+		"limit", "offset", "sort_by", "sort_order", "filters", "search",
+		"author_id", "series_id", "tag", "tags", "show_quarantined",
+		"is_primary_version", "has_file_errors", "missing_covers",
+		"in_import_path", "no_isbn", "duplicates_flagged",
+		"coverage_percent_min", "coverage_percent_max",
+		// Both a filter field name AND a genuine bare parameter. An earlier
+		// revision of the guard rejected it and broke
+		// TestListBooksWithTagFilter, which asserts
+		// ?tag=…&library_state=organized narrows to one book. This entry is
+		// the regression pin for that.
+		"library_state",
+		"fingerprint_status",
+	}
+	for _, p := range realParams {
+		t.Run(p, func(t *testing.T) {
+			_, bare := firstBareFilterFieldParam(
+				queryCtx(t, url.Values{p: {"1"}}.Encode()))
+			require.False(t, bare,
+				"%q is a real query parameter and must not be rejected", p)
+		})
+	}
+}
+
+// TestFirstBareFilterFieldParam_AuthorIDIsNotAuthor pins the one adjacent pair
+// that would be easy to get wrong: "author" is a filter field, "author_id" is
+// a genuine parameter. A prefix or substring match instead of exact-name
+// lookup would break the library's author drill-down.
+func TestFirstBareFilterFieldParam_AuthorIDIsNotAuthor(t *testing.T) {
+	_, bare := firstBareFilterFieldParam(queryCtx(t, "author_id=42"))
+	require.False(t, bare, "author_id is a real parameter, not the author filter field")
+
+	got, bare := firstBareFilterFieldParam(queryCtx(t, "author=Tolkien"))
+	require.True(t, bare)
+	require.Equal(t, "author", got)
+}
+
+// TestFirstBareFilterFieldParam_Deterministic guards the message: with several
+// bad fields at once, the reported one must not vary between identical
+// requests. Go randomizes map iteration, so an unsorted implementation names a
+// different field on each retry.
+func TestFirstBareFilterFieldParam_Deterministic(t *testing.T) {
+	q := url.Values{"title": {"a"}, "genre": {"b"}, "narrator": {"c"}}.Encode()
+	first, bare := firstBareFilterFieldParam(queryCtx(t, q))
+	require.True(t, bare)
+	for i := 0; i < 25; i++ {
+		got, ok := firstBareFilterFieldParam(queryCtx(t, q))
+		require.True(t, ok)
+		require.Equal(t, first, got, "reported field must be stable across calls")
+	}
+	// Sorted order, so the alphabetically-first offender is named.
+	require.Equal(t, "genre", first)
+}
+
+func TestFirstBareFilterFieldParam_NoParamsIsClean(t *testing.T) {
+	_, bare := firstBareFilterFieldParam(queryCtx(t, ""))
+	require.False(t, bare)
+
+	_, bare = firstBareFilterFieldParam(queryCtx(t, "limit=50&offset=0"))
+	require.False(t, bare)
+}

--- a/internal/server/handlers/audiobooks/handler.go
+++ b/internal/server/handlers/audiobooks/handler.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/audiobooks/handler.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 51fac747-9478-4075-8621-9da4bbdedc37
 // last-edited: 2026-08-13
 
@@ -51,6 +51,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -236,8 +237,83 @@ func ptrStr(p *string) string {
 // has_file_errors fast-path, quick-query (missing_covers / in_import_path /
 // no_isbn / duplicates_flagged) fast-path, then the filtered list pipeline with
 // the list cache (skipped when per-user filters are active).
+// filterFieldQueryParams are names that mean something only INSIDE the
+// `filters` JSON parameter of the library list. Mirrors the field switch in
+// audiobooks.matchesFieldFilters.
+//
+// Omitting a name is harmless — the guard simply does not fire for it, which
+// is today's behavior. INCLUDING a name wrongly is NOT harmless: it rejects a
+// request that used to work. Some names are BOTH a filter field and a genuine
+// bare parameter, and those must stay out.
+//
+// "library_state" is exactly that case and is deliberately absent: it is a
+// real bare parameter, read at ParseQueryString(c, "library_state") below, and
+// TestListBooksWithTagFilter asserts ?tag=…&library_state=organized narrows to
+// one book. An earlier revision of this set included it and broke that test.
+// The near-miss is worth recording: the collision survey that produced this
+// set grepped only c.Query("…") and so could not see the ParseQueryString
+// form. Check every accessor helper, not one spelling, before adding a name.
+//
+// "author" belongs here while "author_id" does not — adjacent names, different
+// things, and only exact-name lookup keeps them apart.
+var filterFieldQueryParams = map[string]struct{}{
+	"title": {}, "author": {}, "narrator": {}, "series": {}, "genre": {},
+	"language": {}, "publisher": {}, "edition": {}, "format": {}, "codec": {},
+	"quality": {}, "description": {},
+	"metadata_review_status": {}, "review": {}, "has_cover": {},
+	"has_written": {}, "needs_writeback": {}, "has_organized": {},
+	"itunes_sync_status": {}, "duration_seconds": {},
+	"read_status": {}, "progress_pct": {}, "last_played": {},
+	"user_rating_overall": {}, "user_rating_story": {},
+	"user_rating_performance": {},
+}
+
+// firstBareFilterFieldParam reports the first filter-field name the request
+// passed as a bare query parameter, if any. Sorted so the message is
+// deterministic when a caller gets several wrong at once — an error that names
+// a different field on each retry is its own small cruelty.
+func firstBareFilterFieldParam(c *gin.Context) (string, bool) {
+	found := make([]string, 0, 2)
+	for name := range c.Request.URL.Query() {
+		if _, ok := filterFieldQueryParams[name]; ok {
+			found = append(found, name)
+		}
+	}
+	if len(found) == 0 {
+		return "", false
+	}
+	sort.Strings(found)
+	return found[0], true
+}
+
 func (h *Handler) ListAudiobooks(c *gin.Context) {
 	store := h.store
+
+	// A field name passed as a bare query parameter (?title=Skills) is not a
+	// filter — field filters travel inside the `filters` JSON parameter. gin
+	// silently ignores unrecognized parameters, so such a request returned the
+	// ENTIRE library while looking exactly like a narrowed query, count and
+	// all.
+	//
+	// Measured on production 2026-08-13: ?title=Skills answered count=63870
+	// with non-matching rows, while
+	// filters=[{"field":"title","value":"Skills"}] correctly answered 25. That
+	// 63,870 was read as evidence of a storage-layer filtering bug and written
+	// into a handoff as a root cause. It was not one. The cost of this silence
+	// was a misdiagnosis, not a user-facing outage — the web UI sends the
+	// `filters` form.
+	//
+	// Same reasoning as the empty-filter-value rejection below: answering a
+	// request that meant to narrow with the whole library is the worst
+	// available response, so say so instead.
+	if field, bare := firstBareFilterFieldParam(c); bare {
+		httputil.RespondWithBadRequest(c,
+			"\""+field+"\" is not a query parameter; it is a filter field. A bare "+
+				"\""+field+"\" is ignored, which would list the entire library rather than "+
+				"narrowing it. Pass it inside the filters parameter instead, e.g. "+
+				"filters=[{\"field\":\""+field+"\",\"value\":\"...\"}].")
+		return
+	}
 
 	// Parse pagination parameters
 	params := httputil.ParsePaginationParams(c)


### PR DESCRIPTION
## The bug

Field filters travel inside the `filters` JSON parameter. Passed bare (`?title=Skills`) gin ignores the parameter entirely, so the request listed the **entire library** while looking exactly like a narrowed query — matching count and all.

Measured on production 2026-08-13:

| request | count | rows |
|---|---|---|
| `?title=Skills` | **63,870** | non-matching |
| `filters=[{"field":"title","value":"Skills"}]` | 25 | correct |
| `filters=[{"field":"title","value":"zzqqxx"}]` | 0 | — |

## What this actually cost

A misdiagnosis, not an outage.

That 63,870 was read as evidence of a storage-layer filtering bug during the memdb-fallback investigation and **written into a handoff document as the root cause**. It was never that. The web UI sends the `filters` form and was never affected — this only ever bit callers querying the API by hand.

Same reasoning as the adjacent empty-filter-value rejection (#2363): answering a request that plainly meant to narrow with the whole library is the worst available response, so say so instead.

## A near-miss worth recording — it's the same class of mistake as the bug

The first revision of the field set included `library_state` and **broke `TestListBooksWithTagFilter`**, which asserts `?tag=…&library_state=organized` narrows to one book.

`library_state` is *both* a filter field and a genuine bare parameter. The collision survey that produced the set grepped only `c.Query("…")` — and therefore could not see the `httputil.ParseQueryString` form that actually reads it. One spelling checked, not every accessor.

The set was rebuilt by enumerating every accessor helper the handler uses. `library_state` and `fingerprint_status` are now pinned in the allow-list test so the regression cannot return.

**Asymmetry that makes this safe:** omitting a name is harmless — the guard just doesn't fire, which is today's behavior. Including one wrongly is *not* harmless: it rejects a request that used to work. So the set deliberately errs toward incomplete.

## Verification

- Full `./internal/server/...` green, **exit 0, 15 packages** — this is what caught the `library_state` regression in the first place.
- Guard tests: **5 top-level, 47 subtests**, counted explicitly rather than trusting exit 0 — a table test that silently iterates nothing also reports success.
- Negative control: stubbing the guard to return `false` fails 30 subtests.
- Determinism test: Go randomizes map iteration, so an unsorted implementation would name a different field on each retry; the reported field is asserted stable across 25 calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp