### PR TITLE
fix(server): narrow the ABS playlist reservation to the one route ABS serves

### DIFF
--- a/changelog.d/20260813_203000_fix_abs_playlist_reservation_too_wide.md
+++ b/changelog.d/20260813_203000_fix_abs_playlist_reservation_too_wide.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **The ABS playlist-detail reservation was wider than what ABS actually serves,
+  and it 404'd six working app routes.** Claiming the playlist detail route for the
+  AudiobookShelf API reserved the whole `/api/playlists/` subtree, while ABS answers
+  exactly one route in it (`GET /api/playlists/:id`). On an ABS-enabled deployment
+  the unversioned forms of `PUT`/`DELETE /api/playlists/:id`,
+  `POST /api/playlists/:id/books`, `DELETE /api/playlists/:id/books/:bookID`,
+  `POST /api/playlists/:id/reorder` and `POST /api/playlists/:id/materialize`
+  stopped redirecting to their `/api/v1` twins and started returning 404. The
+  reservation now matches on method plus exactly one path segment, so anything
+  deeper or with a different verb keeps its redirect.

--- a/docs/executive-summaries/2026-08-13-the-endpoints-that-answered-anyway-executive-summary.md
+++ b/docs/executive-summaries/2026-08-13-the-endpoints-that-answered-anyway-executive-summary.md
@@ -1,0 +1,108 @@
+<!-- file: docs/executive-summaries/2026-08-13-the-endpoints-that-answered-anyway-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8d0a1513-e21f-4853-8db2-c536773c0bb8 -->
+<!-- last-edited: 2026-08-13 -->
+
+# Executive Summary: The Endpoints That Answered Anyway
+
+**Date:** 2026-08-13
+**Changes:** PRs #2375, #2376, #2377, #2378
+**Written for:** anyone who uses the audiobook organiser, not the people who build it
+
+---
+
+## In one paragraph
+
+Opening a series in the audiobook app showed a pile of books that had nothing to do with
+that series, while the series itself insisted it contained zero books. Opening a playlist
+showed nothing at all. None of this was a display glitch — the app was asking the right
+questions and the organiser was answering the wrong ones, confidently. When the app asked
+"which books are in this series?", the organiser ignored the "which series" part of the
+question and handed back an arbitrary slice of the entire 34,280-book library. When the
+app asked for a playlist, the organiser quietly forwarded the request to a different
+system that speaks a different language, and the app got back something it could not
+read. Three separate faults, one shape: a request that was accepted, understood by
+nobody, and answered with a straight face.
+
+---
+
+## What you would have noticed
+
+Series pages full of strangers. You tap a series you know has four books in it, and you
+get "Space Carrier Avalon" and a dozen other unrelated titles, with a count underneath
+reading **0 books**. Tap a different series and you get a *different* random assortment —
+which is what made it look like the app was broken rather than the library. Playlists
+opened empty every time, including playlists you had just created and could see on the
+web interface. Long series lists were slow to load, because the organiser was sending the
+complete list of all 14,625 series on every single request, no matter how few the app
+asked for.
+
+---
+
+## What was actually wrong
+
+**The series filter was read by nothing.** The app requests a filtered list of books —
+"only the ones in series 14792". The organiser's code accepted that filter, stored it
+nowhere, consulted it never, and returned page one of everything. This is worse than an
+error, because an error would have shown the app that something was wrong. Instead the
+app received a perfectly valid list of perfectly real books and displayed them. The
+"0 books" count came from a different, correct calculation — so the two halves of the
+screen were disagreeing, and only one of them was lying.
+
+**Playlists were never actually built for the app.** The address the app uses to open a
+playlist had no implementation behind it. Requests to it were being redirected to the
+organiser's own internal interface, which returned the playlist in a format the app has
+no idea how to read. From the app's point of view the playlist was empty.
+
+**Series lists ignored "give me 50."** Page and page-size instructions were discarded, so
+every request for a page returned all 14,625 series, unsorted and always from the
+beginning. Fixing the series-contents bug above would have made each of those responses
+roughly ten megabytes — so this had to be fixed first, before the other fix could ship
+safely.
+
+**And one we caused ourselves, same day.** The playlist fix reserved a slightly wider
+area than it needed. That broke six working operations — editing a playlist, deleting it,
+adding and removing books, reordering it, rebuilding it — which began returning "not
+found" on a live server. Caught within the hour by re-testing the routes rather than
+trusting the fix, and repaired in the same day's work.
+
+---
+
+## How we know it is fixed
+
+Each fault was verified against the live server before and after, not just in tests:
+
+| What the app asks for | Before | After |
+|---|---|---|
+| Books in one specific series | 34,280 results, first one unrelated | **2 results, both correct** |
+| A series' book list and running time | empty, `0` — on all 14,625 series | **populated, correct total** |
+| 3 series, please | all 14,625 (3.4 MB) | **3 results, 2 KB, count still accurate** |
+| Open a playlist | redirected, unreadable | **opens, 77 items** |
+| The six playlist operations | broken by our own fix | **working again** |
+
+Every fix also carries a test that was proven capable of failing — each safeguard was
+deliberately broken to confirm it noticed, then restored. One of those checks turned out
+to be silently useless and was strengthened before it shipped.
+
+---
+
+## Why it went unnoticed for so long
+
+The organiser has an automated conformance suite that compares its answers against 28
+recorded examples of what the real AudiobookShelf server sends. All three faults sailed
+through it, because **not one of those 28 recorded examples contains a search, filter, or
+page instruction.** The suite could only ever check the plain, unfiltered version of each
+question. A request that carries an instruction nobody reads is invisible to a test
+corpus in which no request carries an instruction at all. Re-recording those examples
+with real-world instructions attached is now on the work list.
+
+---
+
+## Still outstanding
+
+- **Author and series detail pages** in the app are not implemented yet and currently
+  return "not found". The app degrades quietly rather than showing an error, so these
+  pages simply render blank. Documented with the routing analysis needed to add them
+  safely.
+- **Collections** are empty in the app because the organiser has no concept of a
+  collection at all — this is an unbuilt feature, not a fault.

--- a/docs/handoffs/2026-08-13-web-search-returns-unrelated-books.md
+++ b/docs/handoffs/2026-08-13-web-search-returns-unrelated-books.md
@@ -1,0 +1,196 @@
+<!-- file: docs/handoffs/2026-08-13-web-search-returns-unrelated-books.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b2f4a7c1-53de-4e08-9a16-7cc0e5d1f3b8 -->
+<!-- last-edited: 2026-08-13 -->
+
+# Handoff: web-UI search returns unrelated books
+
+**Status:** root cause NOT yet established. Four candidate mechanisms; two eliminated by
+test, two still open and both cheaply decidable against production.
+**Reported:** 2026-08-13 by the owner.
+**Do not start by re-reading the translator.** It has been tested and it is correct — see
+"Eliminated" below. Starting there will burn an hour reproducing a passing result.
+
+---
+
+## The report
+
+Searching the web Library page for `All Jobs and Classes` returns five books that have
+nothing to do with the query: *All in Charisma*, *Dragon Conjurer*, *Dungeon Diving
+Culinary Wizard*, *Parallax Rising*, *Solo Leveling Vol. 2*. The owner also tried
+`all jobs`, `all jobs and`, and the quoted `"All Jobs and Classes"` — all bad.
+
+**The same search in the AudiobookShelf mobile app returns the correct 3 books.** So the
+data exists, and at least one index knows about it. This split is the single most
+valuable clue in the report and any hypothesis must explain it.
+
+The result set looks like *an unfiltered slice of the library*, not a bad-relevance
+ranking. That is the signature of a search term that never reached the query — not of a
+query that matched poorly.
+
+---
+
+## Eliminated — do not re-investigate
+
+### 1. The Bleve translator is correct
+
+A precision test was written against the real index (`ParseQuery` → `Translate` →
+`SearchNative`) with the owner's exact title seeded alongside the exact four decoy books
+from the screenshot. **All five query forms returned `total=1`, correct top hit.**
+
+The test file was deliberately left in the tree at
+`internal/search/zz_repro_alljobs_test.go` (throwaway naming; delete it or promote it).
+Run it:
+
+```
+go test ./internal/search/ -run TestReproAllJobsAndClasses -count=1 -v
+```
+
+The emitted query JSON is in the test log and is worth reading — it shows exactly what
+the server builds.
+
+### 2. The client-side parser does not blank the term
+
+`web/src/utils/searchParser.ts` `parseSearch()` was traced by hand for all four inputs.
+None of them contain a `:`, so `tryMatchFieldValue` returns null for every token and
+every word falls through to `freeTextParts`. `freeText` comes back as the **full original
+string** in all four cases. The parameter is sent.
+
+(This was the leading hypothesis and it is wrong. It is still worth knowing because of
+the live footgun in the next section.)
+
+---
+
+## Still open — start here
+
+### Hypothesis A (strongest): the Bleve index does not contain these books
+
+This is the only candidate that cleanly explains why the ABS app finds them and the web
+does not — **they are different search paths**. The web Library page goes through Bleve;
+confirm what the ABS surface actually uses before assuming it shares the index.
+
+Supporting prior: the search index has a documented history of silently dropping updates
+(56,537 drops in 7 days, dirty-set + reconciler shipped in #2268). A book indexed before
+that fix, and never re-indexed, would be invisible to Bleve and visible everywhere else.
+
+Also observed in the shutdown log at 16:42 on 2026-08-13:
+
+```
+level=WARN msg="chromem hydrate finished with error" err="context canceled"
+                                                    books=20656 authors=5521
+```
+
+That is the **chromem** vector store, not Bleve — do not conflate them — but it shows
+hydration being cancelled at 20,656 of 67,824 books, and it is worth checking whether the
+Bleve hydrate has the same cancel-on-shutdown behaviour and the same partial coverage.
+
+**How to decide it, cheaply:** query prod for a book you know exists by a single
+distinctive term (`jobs`) and compare the count against a direct DB/memdb lookup. If
+Bleve returns nothing and memdb returns the three books, this is confirmed and the fix is
+an index rebuild plus a coverage check, not a code change.
+
+### Hypothesis B: the search index is nil in prod and the fallback is the thing misbehaving
+
+`internal/audiobooks/service_query.go:105` branches on `svc.searchIndex != nil`. When
+nil, it falls through to `svc.store.SearchBooks(search, limit, offset)` — a completely
+different matcher whose multi-word behaviour has not been characterised here.
+
+`searchWithBleve` **also** silently falls back to the same `store.SearchBooks` on a
+parser error (line 666) or a translate error (line 677), with no log line on either path.
+If the fallback is what is running, nothing in the logs would say so. That is worth
+fixing regardless of this bug: **add a log line to both fallback branches.**
+
+**How to decide it:** check whether the index initialised at boot, and instrument or
+temporarily log which branch serves a request.
+
+---
+
+## Two real defects found on the way — independent of the main bug
+
+Both are genuine, both are currently invisible, neither is proven to be *this* bug.
+
+### `all` and `and` are English stopwords and are silently dropped
+
+`dropStopwordOnlyConjuncts` (`internal/search/bleve_translator.go:150`) strips conjuncts
+that analyse to zero tokens. This exists for a good reason — it fixed "shards of
+oblivion" returning nothing on 2026-08-11 — but it means:
+
+| user types | server actually searches |
+|---|---|
+| `all jobs` | `jobs` |
+| `all jobs and` | `jobs` |
+| `All Jobs and Classes` | `Jobs AND Classes` |
+
+Verified in the query JSON emitted by the repro test. For a library where *All* is a
+common title word this materially widens results, and the user is given no indication
+that half their query was discarded.
+
+### Quoted phrases are not phrases
+
+`"All Jobs and Classes"` does **not** become a `MatchPhraseQuery`. The server-side parser
+never strips the quote characters, so the terms become `"All` and `Classes"` — the
+closing quote stays glued to the final token. The translator's `n.Quoted` branch
+(`bleve_translator.go:317`) exists and works; it simply never fires for this input.
+
+It currently *appears* to work because the English analyzer strips the quote as
+punctuation, so `Classes"` still matches `classes`. That accident is also why
+`TestMultiWordFreeTextFindsTheBook`'s `{"quoted phrase", "\"Ascend Online\""}` case
+passes. Phrase search is not doing what the UI's help text implies.
+
+---
+
+## Why the existing test suite cannot see any of this
+
+`internal/search/multiword_repro_test.go` asserts only that the wanted book is
+**somewhere in the hits**:
+
+```go
+if total == 0 { t.Fatalf(...) }
+// then: is tc.want anywhere in hits?
+```
+
+It never asserts that unrelated books are absent, and never checks the top hit. **A
+`MatchAll` returning the entire library would pass every one of its ten cases.** It was
+written for a "finds nothing" bug and it is correctly shaped for that bug — but it is
+structurally blind to the "finds everything" bug reported today.
+
+Whatever the fix turns out to be, the regression test must assert **precision** (unrelated
+books absent, correct book first), not presence. The repro test left in the tree is
+already written that way; reuse its shape.
+
+---
+
+## Architectural note for whoever picks this up
+
+There are **two independent query parsers** that must agree and are not tested against
+each other:
+
+- `web/src/utils/searchParser.ts` — client-side, 255 lines, field:value + negation
+- `internal/search/query_parser.go` + `bleve_translator.go` — server-side DSL
+
+The client parses the box, extracts `fieldFilters`, and forwards only `freeText`. The
+server then parses that free text **again** with different rules (stopwords, quoting,
+whitespace-as-AND). Any divergence between them is invisible from either side alone.
+
+The delivery line worth staring at is `web/src/hooks/useLibraryQuery.ts:258`:
+
+```ts
+search: searchText || undefined,
+```
+
+An empty `freeText` — from any future parser change — silently becomes "no search
+parameter", and the server answers with the unfiltered library rather than an error. That
+is the same accepted-but-ignored-parameter family as the three ABS bugs fixed earlier
+today (see `todo.d/2026-08-13-abs-ignored-query-params-sweep.md`); the endpoint cannot
+distinguish "no search" from "search that vanished". Consider making the empty case
+explicit rather than falsy-coalesced.
+
+---
+
+## Environment note
+
+Production was mid-deploy (`systemctl` reported `deactivating`, `:8484` not listening)
+when this investigation ran, so **no live probes were possible** and none of the
+production-side claims above have been checked against a running server. Every
+production statement in this document is drawn from the shutdown log or from prior
+records, and is labelled as hypothesis where it is one. Re-probe once the deploy settles.

--- a/internal/search/zz_repro_alljobs_test.go
+++ b/internal/search/zz_repro_alljobs_test.go
@@ -1,0 +1,71 @@
+// file: internal/search/zz_repro_alljobs_test.go
+// version: 1.0.0
+// guid: 4a1c7e93-0d62-4b58-9f31-6ad2c8b7e015
+// last-edited: 2026-08-13
+
+package search
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Throwaway repro for the 2026-08-13 report: searching "All Jobs and Classes"
+// in the web UI returns unrelated books ("All in Charisma", "Dragon Conjurer").
+// Asserts PRECISION, not just presence — the existing
+// TestMultiWordFreeTextFindsTheBook only checks the wanted book is somewhere in
+// the hits, which a MatchAll would satisfy.
+func TestReproAllJobsAndClasses(t *testing.T) {
+	idx := openTestIndex(t)
+
+	docs := []BookDocument{
+		{BookID: "target", Title: "All Jobs and Classes! I Just Wanted One Skill, But I Got Them All", Author: "Comedian0 L"},
+		{BookID: "charisma", Title: "All in Charisma", Author: "Kyle West"},
+		{BookID: "dragon", Title: "Dragon Conjurer", Author: "Eric Vall"},
+		{BookID: "parallax", Title: "Parallax Rising", Author: "Christopher Hopper"},
+		{BookID: "solo", Title: "Solo Leveling, Vol. 2", Author: "Chugong"},
+	}
+	for _, d := range docs {
+		if err := idx.IndexBook(d); err != nil {
+			t.Fatalf("index %s: %v", d.BookID, err)
+		}
+	}
+
+	for _, q := range []string{
+		"All Jobs and Classes",
+		"all jobs",
+		"all jobs and",
+		`"All Jobs and Classes"`,
+		"All Jobs",
+	} {
+		t.Run(q, func(t *testing.T) {
+			ast, err := ParseQuery(q)
+			if err != nil {
+				t.Logf("PARSE ERROR (falls back to substring SearchBooks): %v", err)
+				return
+			}
+			bq, _, err := Translate(ast)
+			if err != nil {
+				t.Logf("TRANSLATE ERROR: %v", err)
+				return
+			}
+			if bq == nil {
+				t.Errorf("Translate returned NIL query -> caller turns this into MatchAll -> whole library")
+				return
+			}
+			j, _ := json.Marshal(bq)
+			hits, total, err := idx.SearchNative(bq, 0, 10)
+			if err != nil {
+				t.Fatalf("search: %v", err)
+			}
+			t.Logf("query=%s", j)
+			t.Logf("total=%d hits=%v", total, hitIDs(hits))
+			if total > 1 {
+				t.Errorf("IMPRECISE: %d hits for %q; only \"target\" should match. got=%v", total, q, hitIDs(hits))
+			}
+			if len(hits) == 0 || hits[0].BookID != "target" {
+				t.Errorf("WRONG TOP HIT for %q: got %v, want target first", q, hitIDs(hits))
+			}
+		})
+	}
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 3.12.0
+// version: 3.13.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-08-13
 
@@ -1244,7 +1244,7 @@ func (s *Server) setupRoutes() {
 			// Gated on the flag, unlike every other exclusion here: these paths
 			// have a live /api/v1 twin, so reserving them while ABS is OFF would
 			// 404 a working app route instead of redirecting it.
-			!(config.AppConfig.ABSAPIEnabled && absCollisionDetailReserved(path)) {
+			!(config.AppConfig.ABSAPIEnabled && absCollisionDetailReserved(c.Request.Method, path)) {
 			// Redirect to /api/v1/
 			newPath := strings.Replace(path, "/api/", "/api/v1/", 1)
 			c.Redirect(http.StatusMovedPermanently, newPath)

--- a/internal/server/wire_abs_routes.go
+++ b/internal/server/wire_abs_routes.go
@@ -1,5 +1,5 @@
 // file: internal/server/wire_abs_routes.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: 9c6b13f8-40a2-4e57-b18d-72e0a5c4d396
 // last-edited: 2026-08-13
 
@@ -8,6 +8,7 @@ package server
 import (
 	"context"
 	"log/slog"
+	"net/http"
 	"os"
 	"strings"
 
@@ -66,7 +67,7 @@ var absReservedPathPrefixes = []string{
 	"/api/session/",
 }
 
-// absCollisionDetailPrefixes are sub-trees of an absAppAPICollisions namespace that
+// absCollisionDetailRoutes are routes inside an absAppAPICollisions namespace that
 // ABS serves natively — but ONLY when the ABS surface is actually enabled.
 //
 // 🔴 THIS LIST IS SEPARATE FROM THE ONE ABOVE FOR ONE REASON: the redirect
@@ -91,17 +92,49 @@ var absReservedPathPrefixes = []string{
 // cannot parse that, so every playlist opened EMPTY — reported from the app
 // 2026-08-13. The web UI is unaffected either way: it hardcodes an /api/v1 base
 // (e.g. DelugeSettingsTab.tsx:24) and never uses the unversioned form.
-var absCollisionDetailPrefixes = []string{
-	"/api/playlists/",
+// 🔴 THIS IS A ROUTE LIST, NOT A PREFIX LIST, AND THE DIFFERENCE WAS A LIVE BUG.
+//
+// It was written as a prefix subtree match — HasPrefix(path, "/api/playlists/") —
+// which reserved the WHOLE subtree for ABS while ABS answers exactly one route in
+// it, GET /api/playlists/:id. Measured against production 2026-08-13 immediately
+// after that shipped, six working app routes had started 404ing instead of
+// redirecting:
+//
+//	PUT    /api/playlists/:id              DELETE /api/playlists/:id
+//	POST   /api/playlists/:id/books        DELETE /api/playlists/:id/books/:bookID
+//	POST   /api/playlists/:id/reorder      POST   /api/playlists/:id/materialize
+//
+// That is the same defect as #2332 → #2333 → #2335 (46 app routes 404'd), recurring
+// one level down, inside the very change whose comment warns about it. Reserving a
+// namespace for ABS must be as narrow as what ABS actually serves: a reservation
+// wider than the implementation converts working routes into 404s silently, because
+// a 404 on a redirect is indistinguishable from a route that never existed.
+//
+// So the match is on METHOD plus EXACTLY ONE remaining segment. A deeper path or a
+// different verb belongs to the app API and keeps redirecting.
+type absCollisionDetailRoute struct {
+	Method string
+	Prefix string
 }
 
-// absCollisionDetailReserved reports whether path is an ABS-served sub-tree of a
-// colliding namespace. The caller must AND this with ABSAPIEnabled.
-func absCollisionDetailReserved(path string) bool {
-	for _, prefix := range absCollisionDetailPrefixes {
-		if strings.HasPrefix(path, prefix) && len(path) > len(prefix) {
-			return true
+var absCollisionDetailRoutes = []absCollisionDetailRoute{
+	{Method: http.MethodGet, Prefix: "/api/playlists/"},
+}
+
+// absCollisionDetailReserved reports whether (method, path) is a route ABS serves
+// natively inside a colliding namespace. The caller must AND this with ABSAPIEnabled.
+func absCollisionDetailReserved(method, path string) bool {
+	for _, r := range absCollisionDetailRoutes {
+		if method != r.Method || !strings.HasPrefix(path, r.Prefix) {
+			continue
 		}
+		// Exactly one segment: "/api/playlists/abc" yes, "/api/playlists/abc/books"
+		// no — the latter is an app route and must keep its redirect.
+		rest := path[len(r.Prefix):]
+		if rest == "" || strings.Contains(rest, "/") {
+			continue
+		}
+		return true
 	}
 	return false
 }

--- a/internal/server/wire_abs_routes_test.go
+++ b/internal/server/wire_abs_routes_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/wire_abs_routes_test.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: 3ea1d764-95c8-4b02-8f31-6d70a5be2c49
 // last-edited: 2026-08-13
 
@@ -72,6 +72,7 @@ func TestABSReservedPath_CoversEVERYRegisteredUnversionedRoute(t *testing.T) {
 		if len(parts) != 2 {
 			t.Fatalf("malformed absRouteList entry %q", entry)
 		}
+		method := parts[0]
 		path := parts[1]
 		// Only unversioned /api/ paths pass through the redirect middleware. Root paths
 		// (/login, /ping, /status, /logout, /auth/refresh) and /public/* never do.
@@ -97,10 +98,10 @@ func TestABSReservedPath_CoversEVERYRegisteredUnversionedRoute(t *testing.T) {
 		// unconditional list, which 404s a live app route on every ABS-DISABLED
 		// deployment — the #2332/#2333/#2335 defect. Checking only the gated list
 		// would let a genuinely unreserved route through. Both halves are needed.
-		if !absReservedPath(path) && !absCollisionDetailReserved(path) {
+		if !absReservedPath(path) && !absCollisionDetailReserved(method, path) {
 			t.Errorf("REGISTERED BUT NOT RESERVED: %s. Add its prefix to absReservedPathPrefixes "+
 				"(or the exact path to absReservedPaths), or — if the namespace has a live "+
-				"/api/v1 twin — to absCollisionDetailPrefixes so it is reserved only while ABS "+
+				"/api/v1 twin — to absCollisionDetailRoutes so it is reserved only while ABS "+
 				"is enabled. Otherwise it will 301 into /api/v1 and look implemented while "+
 				"behaving broken.", path)
 		}
@@ -485,4 +486,115 @@ func TestPlaylistDetailReservedOnlyWhenABSEnabled(t *testing.T) {
 		require.Equal(t, http.StatusMovedPermanently, w.Code,
 			"/api/playlists (no id) must still reach the app-API twin")
 	})
+}
+
+// 🔴 A RESERVATION WIDER THAN THE IMPLEMENTATION 404s WORKING ROUTES.
+//
+// The reservation above was first written as a prefix subtree match:
+//
+//	strings.HasPrefix(path, "/api/playlists/") && len(path) > len(prefix)
+//
+// ABS serves exactly ONE route in that subtree, GET /api/playlists/:id. The app API
+// serves six more. Measured against production the same day it shipped, all six had
+// gone from 301 to 404 — reachable only by the unversioned form, but silently dead:
+//
+//	PUT    /api/playlists/:id              DELETE /api/playlists/:id
+//	POST   /api/playlists/:id/books        DELETE /api/playlists/:id/books/:bookID
+//	POST   /api/playlists/:id/reorder      POST   /api/playlists/:id/materialize
+//
+// This is the #2332/#2333/#2335 defect (46 app routes 404'd) recurring one level
+// down, inside the change whose own comment warns about it — which is why the check
+// is a test and not a comment. The failure is invisible from the ABS side: every ABS
+// route still works, and a 404 from an over-wide reservation is indistinguishable
+// from a route that was never registered.
+//
+// The table is derived from wire_library_routes.go:77-85, so a new app playlist
+// sub-route added there without widening the ABS handler will fail here.
+func TestPlaylistReservationDoesNotSwallowAppSubRoutes(t *testing.T) {
+	const id = "01PLAYLIST0000000000000000"
+
+	// Every app-API playlist route that lives under the reserved prefix. ABS serves
+	// none of these, so all must keep redirecting even with ABS ON.
+	appRoutes := []struct{ method, path string }{
+		{http.MethodPut, "/api/playlists/" + id},
+		{http.MethodDelete, "/api/playlists/" + id},
+		{http.MethodPost, "/api/playlists/" + id + "/books"},
+		{http.MethodDelete, "/api/playlists/" + id + "/books/01BOOK00000000000000000000"},
+		{http.MethodPost, "/api/playlists/" + id + "/reorder"},
+		{http.MethodPost, "/api/playlists/" + id + "/materialize"},
+	}
+
+	for _, tc := range appRoutes {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			s, cleanup := setupTestServer(t)
+			defer cleanup()
+			config.AppConfig.ABSAPIEnabled = true
+
+			w := httptest.NewRecorder()
+			s.router.ServeHTTP(w, httptest.NewRequest(tc.method, tc.path, nil))
+
+			require.Equal(t, http.StatusMovedPermanently, w.Code,
+				"%s %s is an APP route with no ABS implementation. Reserving it for ABS "+
+					"turns a working call into a 404 that looks like it never existed.",
+				tc.method, tc.path)
+			require.Equal(t,
+				strings.Replace(tc.path, "/api/", "/api/v1/", 1),
+				w.Header().Get("Location"))
+		})
+	}
+
+	// The one route ABS DOES serve must still be claimed — otherwise this test could
+	// be satisfied by reserving nothing at all, which reintroduces the empty-playlist
+	// bug the reservation exists to fix.
+	t.Run("GET is still reserved for ABS", func(t *testing.T) {
+		s, cleanup := setupTestServer(t)
+		defer cleanup()
+		config.AppConfig.ABSAPIEnabled = true
+
+		w := httptest.NewRecorder()
+		s.router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/playlists/"+id, nil))
+
+		require.NotEqual(t, http.StatusMovedPermanently, w.Code,
+			"narrowing the reservation must not un-reserve the route ABS actually serves")
+	})
+}
+
+// absCollisionDetailReserved has TWO independent narrowing rules and the
+// route-level test above only exercises one of them.
+//
+// Every app playlist sub-route uses a non-GET verb, so the method check alone
+// rescues all six — mutating the one-segment rule away leaves that test green.
+// That makes the segment rule dead code under a green suite unless it is asserted
+// directly, which is what this does. It matters the moment anyone adds a GET
+// sub-route (an /items or /cover under a playlist would be the obvious one).
+func TestAbsCollisionDetailReserved_BothNarrowingRules(t *testing.T) {
+	const id = "01PLAYLIST0000000000000000"
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+		want   bool
+		why    string
+	}{
+		{"the route ABS serves", http.MethodGet, "/api/playlists/" + id, true,
+			"this is the whole point of the reservation"},
+		{"a GET one level deeper", http.MethodGet, "/api/playlists/" + id + "/items", false,
+			"the SEGMENT rule: a deeper GET is an app route, and only this case proves that rule is alive"},
+		{"a GET two levels deeper", http.MethodGet, "/api/playlists/" + id + "/items/3", false,
+			"same rule, deeper"},
+		{"a non-GET on the same path", http.MethodPut, "/api/playlists/" + id, false,
+			"the METHOD rule: ABS serves no PUT here"},
+		{"the bare namespace", http.MethodGet, "/api/playlists", false,
+			"the trailing slash keeps the LIST on the app API"},
+		{"the namespace with a slash but no id", http.MethodGet, "/api/playlists/", false,
+			"an empty segment is not an id"},
+		{"an unrelated namespace", http.MethodGet, "/api/authors/147924", false,
+			"nothing outside the table is ever reserved"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := absCollisionDetailReserved(tc.method, tc.path)
+			require.Equal(t, tc.want, got, "%s %s — %s", tc.method, tc.path, tc.why)
+		})
+	}
 }

--- a/todo.d/2026-08-13-abs-author-and-series-detail-routes.md
+++ b/todo.d/2026-08-13-abs-author-and-series-detail-routes.md
@@ -1,0 +1,46 @@
+### ABS author and series detail routes are unimplemented and redirect into a 404
+
+Found by enumerating the paths the app ACTUALLY requested in the server log, rather
+than by reading our own route table — the table can say which routes exist, never
+which absent routes are being asked for.
+
+```
+  6 /api/v1/authors/:num      <- the redirect target
+  3 /api/authors/:num         <- what the app asked for
+  1 /api/series
+```
+
+The 1:2 ratio is the redirect signature (each request logs the 301 and the target).
+Probed against production:
+
+| route | result |
+|---|---|
+| `GET /api/authors/:id` | 301 → `/api/v1/authors/:id` → **404 "endpoint not found"** |
+| `GET /api/series/:id` | 301 → `/api/v1/series/:id` → **404** |
+| `GET /api/series` | 301 → `/api/v1/series` → app-API shape (`{"data":{"items":[…]}}`) |
+
+There is no `GET /authors/:id` in `wire_entities_routes.go` at all — only
+`/authors/:id/books`, `/authors/:id/aliases`, `DELETE /authors/:id` and friends. So
+the ABS author page asks for an author and gets a 404, which the ABS contract tells
+clients to treat as "unsupported, degrade gracefully" — it renders empty, silently.
+Same failure the playlist detail route had.
+
+**This is NOT a quick prefix reservation.** The app API has live routes at
+`GET /series/:id/books`, `PATCH /series/:id`, `PUT /series/:id/name`,
+`POST /series/:id/split`, `DELETE /series/:id`, and the author namespace is denser
+still. Reserving `/api/series/` or `/api/authors/` wholesale is exactly the defect
+that took out 46 live app routes twice (#2332 → #2335) and again, more narrowly, in
+the playlist reservation. Use `absCollisionDetailRoutes`, which matches on method
+plus exactly one segment.
+
+Work:
+
+1. `GET /api/authors/:id` — ABS author DTO with its `libraryItems`. The id is ours
+   (it comes from our own `/libraries/:id/authors` list), so no id-mapping problem.
+2. `GET /api/series/:id` — ditto; the per-series book build already exists and is
+   cached (`seriesBooksCached`).
+3. Decide what bare `GET /api/series` should do. It currently redirects to an
+   app-API shape an ABS client cannot parse — the "looks implemented, behaves
+   broken" case. Either serve it or reserve it as an honest 404.
+4. Each addition needs a `TestPlaylistReservationDoesNotSwallowAppSubRoutes`-style
+   companion listing that namespace's app routes, or the next widening repeats this.


### PR DESCRIPTION
## Problem

#2375 implemented `GET /api/playlists/:id` for the AudiobookShelf API and reserved it from the `/api/*` → `/api/v1/*` redirect. The reservation was a **prefix match on the whole subtree**, but ABS answers exactly one route in it. On an ABS-enabled deployment, six working app routes stopped redirecting and started returning 404:

| route | before this PR |
|---|---|
| `PUT /api/playlists/:id` | 404 |
| `DELETE /api/playlists/:id` | 404 |
| `POST /api/playlists/:id/books` | 404 |
| `DELETE /api/playlists/:id/books/:bookID` | 404 |
| `POST /api/playlists/:id/reorder` | 404 |
| `POST /api/playlists/:id/materialize` | 404 |

Verified live with a no-follow probe, using `/api/authors/*` as a control that still returned 301.

## Fix

`absCollisionDetailPrefixes` → `absCollisionDetailRoutes`, matching on **method AND exactly one path segment**. `GET /api/playlists/abc` is reserved; `GET /api/playlists/abc/books` and every non-GET verb keep their redirect.

This is also the mechanism the author and series namespaces will need — both have dense app-API neighbours, and a wholesale prefix reservation there is the exact defect that 404'd 46 live routes in #2332 → #2335.

## Tests — mutation-verified, and one was worthless until it wasn't

Two new tests, each proven to fail on its own mutation:

- `TestPlaylistReservationDoesNotSwallowAppSubRoutes` — the six routes above, asserting 301 + correct `Location`.
- `TestAbsCollisionDetailReserved_BothNarrowingRules` — 7 direct cases including GET one and two levels deeper.

The second exists because the first is **not sufficient**. Reverting to the wide subtree match came back green: all six broken routes use non-GET verbs, so the method check alone rescues them and the one-segment rule was never exercised — dead code under a green suite. With the added cases:

- drop the method check → `--- FAIL: .../PUT_/api/playlists/...`, `.../DELETE_...`
- drop the one-segment rule → `--- FAIL: .../a_GET_one_level_deeper`, `.../a_GET_two_levels_deeper`
- empty `absCollisionDetailRoutes` → the coverage guard names the unreserved path

Full `internal/server/...` suite: exit 0, 0 failures.

## Also in this PR

- **Executive summary** for the whole 2026-08-13 ABS arc (#2375, #2376, #2377, this) — required by `docs/process/executive-summaries.md` in the same PR as the CHANGELOG/TODO edit.
- **`todo.d` fragment** filing the unimplemented `GET /api/authors/:id` and `GET /api/series/:id`, with the routing analysis that makes them safe to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t