### PR TITLE
perf(database): measure how many bytes warmup reads and how many it discards

### DIFF
--- a/changelog.d/20260813_170000_warmup_byte_accounting.md
+++ b/changelog.d/20260813_170000_warmup_byte_accounting.md
@@ -1,0 +1,42 @@
+### Changed
+
+#### Startup warmup now reports how many bytes it read, and how many it threw away
+
+The memdb warmup log gained two fields, `phase_mb` and `discarded_mb`, alongside
+the per-phase timings added earlier the same day.
+
+Timing alone had taken the investigation as far as it could go. It established
+that `book_files` is 89,357 ms of a 108,768 ms warmup — 82% — and that
+`txn.Commit` is 13 ms, killing the theory that a single write transaction held
+across all ten prefix scans was the cost. A production CPU profile then showed
+61% of the phase inside `pebble.(*Iterator).Next`, nearly all of it in
+`loadDataBlock`: Pebble is pulling a fresh sstable data block off disk for
+almost every row, which is what happens when a data block holds only one or two
+rows because the rows are enormous.
+
+That points at `BookFile.AcoustIDFingerprint` — a `[]byte` stored inline in the
+`book_file:` row, roughly 230 KB of raw chromaprint per two-hour file, which
+`encoding/json` renders as ~307 KB of base64. `stripBookFileForMemdb` nils it
+out the instant it has been decoded, so every one of those bytes is read,
+decompressed, JSON-parsed and base64-decoded in order to be discarded.
+
+Two very different fixes follow from that, and they are not compatible:
+
+- if the blob really is most of the bytes, remove it from the row, which shrinks
+  the work and pays out in five places at once (pread, cgo block decompression,
+  block allocation, JSON, base64);
+- if it is not, parallelize the scan, which divides the work without shrinking
+  it.
+
+The first is a large, data-loss-sensitive schema change. Rather than infer the
+premise from a call graph, the warmup now measures it: `warmIter` sums the
+length of every Pebble value it visits, and the `book_file:` callback charges
+the base64-encoded length of the fields the projection is about to discard.
+Cost is one integer add per key.
+
+Two details are load-bearing and are pinned by tests. Discarded bytes are
+counted in *encoded* length, because the scanned total counts raw JSON value
+bytes — charging a decoded length against an encoded total would understate the
+ratio by 4/3 and produce a number that looks precise and is wrong. And nonzero
+megabyte totals round *up*, so a phase that read half a megabyte never prints as
+`0` and becomes indistinguishable from a phase that read nothing.

--- a/internal/database/memdb_store.go
+++ b/internal/database/memdb_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_store.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000003
-// last-edited: 2026-08-11
+// last-edited: 2026-08-13
 
 package database
 
@@ -36,6 +36,12 @@ type MemStore struct {
 	// and readable from a running process, not just recoverable by grepping
 	// startup logs after the fact.
 	lastWarmDurations map[string]time.Duration
+	// lastWarmBytes records how many bytes of Pebble VALUES each prefix scan
+	// read, and lastWarmDiscarded how many of those bytes belonged to fields
+	// the memdb projection throws away immediately after decoding them. See
+	// LastWarmupBytes for why the pair is worth carrying.
+	lastWarmBytes     map[string]int64
+	lastWarmDiscarded map[string]int64
 }
 
 // WarmupPhaseKeyCommit is the lastWarmDurations key holding the txn.Commit
@@ -78,6 +84,45 @@ func (m *MemStore) LastWarmupDurations() map[string]time.Duration {
 		out[k] = v
 	}
 	return out
+}
+
+// LastWarmupBytes returns, per table, how many bytes of Pebble values the most
+// recent WarmFromPebble read (`scanned`) and how many of those bytes were spent
+// decoding fields that the memdb projection then discards (`discarded`).
+//
+// Why this pair and not just a duration: the per-phase timings shipped earlier
+// established that book_files is 82% of a ~109 s warmup, and a CPU profile
+// showed 61% of the phase inside pebble.Iterator.Next — almost all of it in
+// loadDataBlock, meaning Pebble pulls a fresh sstable data block off disk for
+// nearly every row. That is the signature of rows so large a block holds one or
+// two of them, and BookFile.AcoustIDFingerprint is a []byte held INLINE in the
+// row (~230 KB raw, ~307 KB once encoding/json base64-encodes it) that
+// stripBookFileForMemdb nils out the instant it has been decoded.
+//
+// If that blob really is most of the bytes, the fix is to stop storing it in
+// the row — which pays out in five places at once (pread, cgo block
+// decompression, block alloc, JSON, base64) — and NOT to parallelize the scan,
+// which divides the work without shrinking it. That is a large, data-loss-
+// sensitive schema change, so the premise gets measured rather than inferred
+// from a call graph. This repo has already shipped one extrapolated
+// data-structure cost estimate that was off by several times.
+//
+// `discarded` is accounted in ENCODED bytes (base64 length for []byte fields),
+// because `scanned` counts raw JSON value bytes; comparing a decoded length
+// against an encoded total would understate the ratio by 4/3 and produce a
+// number that looks precise and is wrong.
+func (m *MemStore) LastWarmupBytes() (scanned, discarded map[string]int64) {
+	m.warmCountsMu.RLock()
+	defer m.warmCountsMu.RUnlock()
+	scanned = make(map[string]int64, len(m.lastWarmBytes))
+	for k, v := range m.lastWarmBytes {
+		scanned[k] = v
+	}
+	discarded = make(map[string]int64, len(m.lastWarmDiscarded))
+	for k, v := range m.lastWarmDiscarded {
+		discarded[k] = v
+	}
+	return scanned, discarded
 }
 
 // NewMemStore allocates an empty MemStore with the full schema applied.

--- a/internal/database/memdb_warmup.go
+++ b/internal/database/memdb_warmup.go
@@ -1,5 +1,5 @@
 // file: internal/database/memdb_warmup.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000004
 // last-edited: 2026-08-13
 
@@ -7,6 +7,7 @@ package database
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -41,6 +42,8 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	scanned := map[string]int{}
 	skips := map[string]int{}
 	durations := map[string]time.Duration{}
+	bytesScanned := map[string]int64{}
+	bytesDiscarded := map[string]int64{}
 
 	// warm runs one prefix scan and records how long it took.
 	//
@@ -56,11 +59,43 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	//
 	// Cost of the measurement itself: two time.Now() calls per prefix, twenty
 	// for the whole warmup.
+	//
+	// warm also records how many bytes of Pebble values the phase read. Timing
+	// alone says which phase is slow; bytes say WHY, and the two answers point
+	// at different fixes. See MemStore.LastWarmupBytes.
 	warm := func(prefix, table string, fn func(key string, val []byte) (bool, error)) (int, int, error) {
 		phaseStart := time.Now()
-		rows, keys, err := warmIter(ctx, p.db, prefix, fn)
+		rows, keys, nbytes, err := warmIter(ctx, p.db, prefix, fn)
 		durations[table] = time.Since(phaseStart)
+		bytesScanned[table] = nbytes
 		return rows, keys, err
+	}
+
+	// discardedEncodedLen reports how many bytes of a row's JSON encoding were
+	// occupied by fields the memdb projection is about to throw away.
+	//
+	// Counted in ENCODED length, to be comparable with bytesScanned (raw JSON
+	// value bytes). encoding/json renders a []byte as base64, so a 230 KB
+	// fingerprint costs ~307 KB in the stored row; charging the decoded length
+	// would understate the waste by 4/3. String fields are charged their plain
+	// length, which slightly understates them (JSON escaping adds bytes) — a
+	// direction that can only make the finding more conservative, never less.
+	discardedEncodedLen := func(bf *BookFile) int64 {
+		n := int64(base64.StdEncoding.EncodedLen(len(bf.AcoustIDFingerprint)))
+		n += int64(len(bf.AcoustIDSeg0) + len(bf.AcoustIDSeg1) + len(bf.AcoustIDSeg2) +
+			len(bf.AcoustIDSeg3) + len(bf.AcoustIDSeg4) + len(bf.AcoustIDSeg5) +
+			len(bf.AcoustIDSeg6))
+		for _, s := range []*string{
+			bf.IntroTranscription,
+			bf.FingerprintDiagnosticJSON,
+			bf.FingerprintFailureReason,
+			bf.FingerprintFailureDetail,
+		} {
+			if s != nil {
+				n += int64(len(*s))
+			}
+		}
+		return n
 	}
 
 	// safeInsert tries to insert an object, logging+counting failures rather
@@ -152,6 +187,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 		if err := json.Unmarshal(val, &bf); err != nil {
 			return false, nil
 		}
+		bytesDiscarded[memTableBookFiles] += discardedEncodedLen(&bf)
 		return safeInsert(memTableBookFiles, stripBookFileForMemdb(&bf), key)
 	}); err != nil {
 		return fmt.Errorf("warmup book_files: %w", err)
@@ -287,6 +323,8 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	m.lastWarmCounts = maps.Clone(counts)
 	m.lastWarmScanned = maps.Clone(scanned)
 	m.lastWarmDurations = maps.Clone(durations)
+	m.lastWarmBytes = maps.Clone(bytesScanned)
+	m.lastWarmDiscarded = maps.Clone(bytesDiscarded)
 	m.warmCountsMu.Unlock()
 
 	slog.Info("memdb warmup complete",
@@ -308,6 +346,13 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 		// the scans, is what holds the library down for two minutes.
 		"phase_ms", durationsMillis(durations),
 		"commit_ms", commitMS,
+		// Bytes of Pebble values read per phase, and how many of those bytes
+		// belonged to fields the memdb projection discards immediately after
+		// decoding them. A discarded share near the total means the fix is to
+		// stop storing those fields in the row, not to make the scan faster —
+		// see MemStore.LastWarmupBytes.
+		"phase_mb", bytesMegabytes(bytesScanned),
+		"discarded_mb", bytesMegabytes(bytesDiscarded),
 	)
 	if len(skips) > 0 {
 		slog.Warn("memdb warmup: rows skipped by table",
@@ -330,6 +375,27 @@ func durationsMillis(d map[string]time.Duration) map[string]int64 {
 	out := make(map[string]int64, len(d))
 	for table, dur := range d {
 		out[table] = dur.Milliseconds()
+	}
+	return out
+}
+
+// bytesMegabytes renders per-phase byte totals as megabytes for the warmup log.
+//
+// Nonzero totals round UP, never down. Plain integer division would print 0 for
+// any phase under a megabyte, making "read nothing" and "read a little"
+// indistinguishable — and a zero that can mean two things is how a measurement
+// stops being evidence. With ten phases the ceiling costs at most 10 MB of
+// overstatement against a total measured in gigabytes.
+func bytesMegabytes(b map[string]int64) map[string]int64 {
+	const mb = 1 << 20
+	out := make(map[string]int64, len(b))
+	for table, n := range b {
+		switch {
+		case n == 0:
+			out[table] = 0
+		default:
+			out[table] = (n + mb - 1) / mb
+		}
 	}
 	return out
 }
@@ -453,12 +519,17 @@ func emitMemdbSizeTelemetry(ctx context.Context, m *MemStore, counts map[string]
 // measured against that inflated denominator and appeared to be returning
 // 13.3% of the library; a P0 "silent data loss" investigation followed. The
 // iterators were correct the whole time. Never conflate the two counts again.
-func warmIter(ctx context.Context, db *pebble.DB, prefix string, fn func(key string, val []byte) (bool, error)) (rows int, scanned int, err error) {
+// The third return, `bytes`, is the summed length of the Pebble VALUES visited
+// (not the keys). It is what makes "which phase is slow" answerable as "and
+// why": a phase reading 40 GB and a phase reading 400 MB in the same wall time
+// have nothing in common and take opposite fixes. Cost is one integer add per
+// key.
+func warmIter(ctx context.Context, db *pebble.DB, prefix string, fn func(key string, val []byte) (bool, error)) (rows int, scanned int, bytes int64, err error) {
 	// Bail before creating an iterator if the warmup was canceled (Close). This
 	// keeps cancellation prompt and avoids calling NewIter on a DB that is about
 	// to be closed.
 	if err := ctx.Err(); err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	upper := append([]byte(nil), []byte(prefix)...)
 	// Replace trailing ':' with ';' so the upper bound sorts immediately past
@@ -473,18 +544,20 @@ func warmIter(ctx context.Context, db *pebble.DB, prefix string, fn func(key str
 		UpperBound: upper,
 	})
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	defer iter.Close()
 
 	for iter.First(); iter.Valid(); iter.Next() {
 		if ctx.Err() != nil {
-			return rows, scanned, ctx.Err()
+			return rows, scanned, bytes, ctx.Err()
 		}
 		scanned++
-		admitted, err := fn(string(iter.Key()), iter.Value())
+		val := iter.Value()
+		bytes += int64(len(val))
+		admitted, err := fn(string(iter.Key()), val)
 		if err != nil {
-			return rows, scanned, err
+			return rows, scanned, bytes, err
 		}
 		if admitted {
 			rows++
@@ -493,7 +566,7 @@ func warmIter(ctx context.Context, db *pebble.DB, prefix string, fn func(key str
 	// An iterator that stops short must say so rather than returning a partial
 	// set that reads as complete.
 	if err := iter.Error(); err != nil {
-		return rows, scanned, fmt.Errorf("warmup scan of %q failed after %d keys: %w", prefix, scanned, err)
+		return rows, scanned, bytes, fmt.Errorf("warmup scan of %q failed after %d keys: %w", prefix, scanned, err)
 	}
-	return rows, scanned, nil
+	return rows, scanned, bytes, nil
 }

--- a/internal/database/memdb_warmup_bytes_test.go
+++ b/internal/database/memdb_warmup_bytes_test.go
@@ -1,0 +1,231 @@
+// file: internal/database/memdb_warmup_bytes_test.go
+// version: 1.0.0
+// guid: 3b91d70e-52c4-4f18-a6d3-9e7f04c1b8a5
+// last-edited: 2026-08-13
+
+package database
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Per-phase TIMING (shipped earlier) says book_files is 82% of a ~109 s
+// production warmup. It does not say why, and the two candidate explanations
+// take opposite fixes:
+//
+//	"the scan is serial"  → parallelize it (divides the work)
+//	"the rows are huge"   → stop storing the blob in the row (shrinks the work)
+//
+// Byte accounting separates them. BookFile.AcoustIDFingerprint is a []byte held
+// inline in the Pebble row — ~230 KB raw, ~307 KB once encoding/json
+// base64-encodes it — and stripBookFileForMemdb nils it the instant it has been
+// decoded. These tests pin that the warmup reports how many bytes it read and
+// how many of those it threw away, so the choice between the two fixes rests on
+// a measurement rather than on reading a call graph.
+
+// warmBytesFingerprint returns a deterministic blob standing in for a real
+// chromaprint stream. Size matters: the point of the fixture is a row whose
+// bytes are almost entirely the discarded field, which is the production shape.
+func warmBytesFingerprint(n int) []byte {
+	fp := make([]byte, n)
+	for i := range fp {
+		fp[i] = byte(i % 251)
+	}
+	return fp
+}
+
+// seedWarmBytesBook creates one book and n book_files under it, optionally
+// giving each file a fingerprint blob.
+func seedWarmBytesBook(t *testing.T, store *PebbleStore, tag string, n int, fp []byte) {
+	t.Helper()
+	hash := "warmbytes-" + tag
+	book, err := store.CreateBook(&Book{
+		Title:    "Warm Bytes " + tag,
+		FilePath: "/tmp/warmbytes_" + tag + ".m4b",
+		FileHash: &hash,
+	})
+	require.NoError(t, err)
+
+	for i := 0; i < n; i++ {
+		fh := fmt.Sprintf("warmbytes-%s-%03d", tag, i)
+		bf := &BookFile{
+			BookID:   book.ID,
+			FilePath: fmt.Sprintf("/tmp/warmbytes_%s_%03d.mp3", tag, i),
+			FileHash: fh,
+			Format:   "mp3",
+		}
+		if len(fp) > 0 {
+			bf.AcoustIDFingerprint = fp
+		}
+		require.NoError(t, store.CreateBookFile(bf))
+	}
+}
+
+func warmBytesFresh(t *testing.T, store *PebbleStore) *MemStore {
+	t.Helper()
+	mem, err := NewMemStore()
+	require.NoError(t, err)
+	require.NoError(t, mem.WarmFromPebble(context.Background(), store))
+	return mem
+}
+
+// TestWarmupBytes_AttributesTheDiscardedBlob is the load-bearing case: a
+// fixture whose book_file rows are almost entirely fingerprint must report a
+// discarded share that reflects that.
+//
+// "Nonzero" would not be enough. An implementation that counted only the small
+// scalar fields, or that charged the DECODED fingerprint length against an
+// ENCODED byte total, would report a nonzero number that is wrong by 4/3 or
+// worse — and a wrong ratio here would send the fix at the wrong target.
+func TestWarmupBytes_AttributesTheDiscardedBlob(t *testing.T) {
+	const (
+		files  = 12
+		fpSize = 64 * 1024
+	)
+	store := setupTestPebbleStore(t)
+	store.WaitForWarmup()
+
+	fp := warmBytesFingerprint(fpSize)
+	seedWarmBytesBook(t, store, "fat", files, fp)
+
+	mem := warmBytesFresh(t, store)
+	scanned, discarded := mem.LastWarmupBytes()
+
+	// The fingerprint is base64 in the stored row, so that is the length the
+	// accounting must charge — this is the assertion that catches an
+	// encoded/decoded mixup, which is the easy way to get a plausible wrong
+	// number here.
+	perRow := int64(base64.StdEncoding.EncodedLen(fpSize))
+	wantDiscarded := perRow * files
+
+	require.GreaterOrEqual(t, discarded[memTableBookFiles], wantDiscarded,
+		"discarded bytes must charge the base64 length of the fingerprint (%d/row × %d rows)",
+		perRow, files)
+
+	// Discarded bytes are a subset of bytes read; they cannot exceed them.
+	require.LessOrEqual(t, discarded[memTableBookFiles], scanned[memTableBookFiles],
+		"discarded bytes exceed the bytes actually read — the two are measured against different things")
+
+	// The whole point: on this fixture the blob IS the row. If the ratio came
+	// back low, the premise behind removing the field from the row would be
+	// wrong, and the test should say so rather than pass on a nonzero number.
+	ratio := float64(discarded[memTableBookFiles]) / float64(scanned[memTableBookFiles])
+	require.Greater(t, ratio, 0.9,
+		"fixture rows are ~99%% fingerprint but only %.1f%% of scanned bytes were attributed to discarded fields",
+		ratio*100)
+}
+
+// TestWarmupBytes_NoFingerprintMeansNothingDiscarded is the control. Without
+// it, an implementation that simply returned the scanned total as the discarded
+// total would pass every assertion above.
+func TestWarmupBytes_NoFingerprintMeansNothingDiscarded(t *testing.T) {
+	store := setupTestPebbleStore(t)
+	store.WaitForWarmup()
+
+	seedWarmBytesBook(t, store, "lean", 12, nil)
+
+	mem := warmBytesFresh(t, store)
+	scanned, discarded := mem.LastWarmupBytes()
+
+	require.Greater(t, scanned[memTableBookFiles], int64(0),
+		"rows were written, so the scan must report reading bytes")
+
+	// Rows with no fingerprint, no segments and no transcript have nothing the
+	// projection discards. A nonzero number here means the accounting is
+	// charging fields it should not.
+	require.Zero(t, discarded[memTableBookFiles],
+		"nothing in these rows is discarded, but %d bytes were charged as discarded",
+		discarded[memTableBookFiles])
+}
+
+// TestWarmupBytes_EveryWarmedTableIsAttributed mirrors the timing test's
+// coverage assertion: a phase that scans but reports no byte total is the same
+// blind spot in a different column.
+func TestWarmupBytes_EveryWarmedTableIsAttributed(t *testing.T) {
+	store := setupTestPebbleStore(t)
+	store.WaitForWarmup()
+
+	seedWarmBytesBook(t, store, "cover", 3, warmBytesFingerprint(2048))
+
+	mem := warmBytesFresh(t, store)
+	scanned, _ := mem.LastWarmupBytes()
+	require.NotEmpty(t, scanned, "warmup must record per-phase byte totals")
+
+	rows, _ := mem.LastWarmupCounts()
+	for table, n := range rows {
+		got, ok := scanned[table]
+		require.True(t, ok,
+			"table %q has a warmup row count but no recorded byte total", table)
+		if n > 0 {
+			require.Greater(t, got, int64(0),
+				"table %q admitted %d rows but reports reading 0 bytes", table, n)
+		}
+	}
+}
+
+// TestWarmupBytes_AccessorHandsOutACopy guards against a caller scribbling on
+// the returned maps and corrupting the next reader's view — the same contract
+// LastWarmupDurations has.
+func TestWarmupBytes_AccessorHandsOutACopy(t *testing.T) {
+	store := setupTestPebbleStore(t)
+	store.WaitForWarmup()
+
+	seedWarmBytesBook(t, store, "copy", 2, warmBytesFingerprint(1024))
+
+	mem := warmBytesFresh(t, store)
+	scanned, discarded := mem.LastWarmupBytes()
+	require.NotEmpty(t, scanned)
+
+	for k := range scanned {
+		scanned[k] = -1
+	}
+	for k := range discarded {
+		discarded[k] = -1
+	}
+
+	scanned2, discarded2 := mem.LastWarmupBytes()
+	for table, v := range scanned2 {
+		require.GreaterOrEqual(t, v, int64(0),
+			"table %q leaked a mutation from a previously returned scanned map", table)
+	}
+	for table, v := range discarded2 {
+		require.GreaterOrEqual(t, v, int64(0),
+			"table %q leaked a mutation from a previously returned discarded map", table)
+	}
+}
+
+// TestBytesMegabytes_NonzeroNeverRendersAsZero pins the rounding contract of
+// the log rendering. Plain integer division prints 0 for anything under a
+// megabyte, which makes "read nothing" and "read a little" the same value in
+// the log — and a zero that can mean two things is not a measurement.
+func TestBytesMegabytes_NonzeroNeverRendersAsZero(t *testing.T) {
+	const mb = 1 << 20
+	cases := map[string]struct {
+		in   int64
+		want int64
+	}{
+		"exactly zero":      {0, 0},
+		"one byte":          {1, 1},
+		"just under 1 MB":   {mb - 1, 1},
+		"exactly 1 MB":      {mb, 1},
+		"just over 1 MB":    {mb + 1, 2},
+		"a few gigabytes":   {3 * 1024 * mb, 3 * 1024},
+		"forty gigabytes":   {40 * 1024 * mb, 40 * 1024},
+		"exactly 2 MB flat": {2 * mb, 2},
+	}
+
+	in := make(map[string]int64, len(cases))
+	want := make(map[string]int64, len(cases))
+	for name, c := range cases {
+		in[name] = c.in
+		want[name] = c.want
+	}
+
+	got := bytesMegabytes(in)
+	require.Equal(t, want, got)
+}


### PR DESCRIPTION
## Why

Per-phase warmup timing (shipped earlier today) took this as far as it can go:

- `book_files` is **89,357 ms of a 108,768 ms** production warmup — **82%**
- `commit_ms=13`, which **killed** the theory that one write txn held across all ten prefix scans was the cost

A production CPU profile then put **61% of the phase inside `pebble.(*Iterator).Next`**, nearly all of it in `loadDataBlock` — Pebble pulling a fresh sstable data block off disk for almost every row. That is what happens when a data block holds one or two rows because the rows are enormous.

`BookFile.AcoustIDFingerprint` is a `[]byte` stored **inline in the `book_file:` row** (~230 KB raw per 2-hour file, ~307 KB once `encoding/json` base64-encodes it), and `stripBookFileForMemdb` nils it the instant it has been decoded.

## The decision this unblocks

Two fixes follow, and they are incompatible:

| if | fix | effect |
|---|---|---|
| the blob is most of the bytes | take it out of the row | **shrinks** the work — pays out in pread, cgo decompression, block alloc, JSON *and* base64 |
| it is not | parallelize the scan | **divides** the work |

The first is a large, data-loss-sensitive schema change. This repo has already shipped one extrapolated data-structure cost estimate that was off by several times, so the premise gets **measured**, not inferred from a call graph.

## What this does

`warmIter` sums the length of every Pebble value it visits; the `book_file:` callback charges the base64-encoded length of the fields the projection discards. One integer add per key. The warmup log gains `phase_mb` and `discarded_mb`; `MemStore.LastWarmupBytes` exposes both.

Two details are load-bearing and pinned by tests:

- **discarded bytes are counted in ENCODED length.** The scanned total counts raw JSON value bytes — charging a decoded length against an encoded total understates the ratio by 4/3 and yields a number that looks precise and is wrong.
- **nonzero megabyte totals round UP.** Plain integer division prints `0` for a phase under a megabyte, making "read nothing" and "read a little" the same value.

## Verifying the instrument

Five tests. Four independent breaks, each turning the right one red:

| break | test that caught it |
|---|---|
| drop the discarded accounting | `AttributesTheDiscardedBlob` |
| charge decoded length, not base64 | `AttributesTheDiscardedBlob` |
| `bytesMegabytes` uses plain division | `NonzeroNeverRendersAsZero` |
| `warmIter` stops counting value bytes | 3 of the 5 |

`TestWarmupBytes_NoFingerprintMeansNothingDiscarded` is a deliberate control: without it, an implementation that simply returned the scanned total as the discarded total would pass every other assertion.

## Next

Merge → `make deploy-debug` → restart → read `discarded_mb` against `phase_mb` for `book_files`. That ratio picks the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp