### PR TITLE
fix(search): repair a partially-built index instead of assuming non-empty means complete

### DIFF
--- a/changelog.d/20260813_173000_fix_search_index_partial_coverage.md
+++ b/changelog.d/20260813_173000_fix_search_index_partial_coverage.md
@@ -1,0 +1,34 @@
+### Fixed
+
+#### Library search could not see books a cancelled index build never reached
+
+Searching the web Library page for a book returned unrelated results while the
+same search in the AudiobookShelf app returned the right ones. Measured on
+production 2026-08-13: books created in April were 97% searchable (38 found, 1
+missing in a sample), books created in August were 2% (1 found, 50 missing).
+
+Root cause: `buildSearchIndexIfEmpty` is the only bulk build of the Bleve index
+and it returns early unless the index has **zero** documents — encoding
+"non-empty means complete". The build honours the shutdown context, so a
+restart part-way through leaves a populated-but-incomplete index that the next
+boot then declines to touch, permanently. Because it walks books in ULID order
+and ULIDs are time-ordered, the rows lost are always the newest ones.
+
+The dirty-set reconciler added earlier does not cover this: books are marked
+dirty only when a queue-full drop discards an index event, so a book the
+backfill never reached was never enqueued, is never dirty, and is never
+repaired.
+
+On boot the server now compares indexed documents against book count and, when
+the index is short, marks the books dirty so the existing reconciler re-indexes
+them. Seeding the durable dirty set rather than re-running the build means a
+cancellation mid-sweep costs nothing — the marks survive the restart.
+
+#### Search no longer degrades to substring matching without saying so
+
+Three paths silently fell back from the full-text index to
+`store.SearchBooks`, a whole-query substring match over title/author/narrator
+only: a nil search index, a query-parser error, and a translation error. None
+logged anything, so a multi-word query could quietly stop matching and nothing
+in the logs would indicate which matcher had answered. All three now log a
+warning naming the query and the reason.

--- a/docs/executive-summaries/2026-08-13-the-books-search-could-not-see-executive-summary.md
+++ b/docs/executive-summaries/2026-08-13-the-books-search-could-not-see-executive-summary.md
@@ -1,0 +1,92 @@
+<!-- file: docs/executive-summaries/2026-08-13-the-books-search-could-not-see-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7d915a69-5d11-4e2a-93fd-bdc1f27e70f1 -->
+<!-- last-edited: 2026-08-13 -->
+
+# Executive Summary: The Books Search Could Not See
+
+**Date:** 2026-08-13
+**In one line:** searching the library missed most of the recently added books, because
+the thing that builds the search catalogue treated "I have started" as "I am finished".
+
+---
+
+## What you saw
+
+You searched the library for *All Jobs and Classes* and got five books back, none of
+them the one you wanted. The same search in the phone app returned the right ones. That
+split is what made this findable — and it turned out to be the whole story.
+
+## What was actually happening
+
+The library keeps a separate catalogue for searching — think of a card index sitting
+next to the shelves. Searching does not walk the shelves; it reads the cards.
+
+**Three books on the shelf had the title you searched for. Only two had cards.** The one
+without a card was the copy the library page actually shows you. The page hides
+duplicate copies of the same book and shows you the main one — and the main one was
+exactly the one with no card. So the search found nothing it was willing to display, and
+what you were left looking at was five other books whose *plot summaries* happen to
+mention a job and a class. They were never wrong answers to a badly-ranked search; they
+were the only answers that survived.
+
+The phone app returned the right books because it does not hide duplicate copies. It saw
+one of the two that did have cards.
+
+## Why the cards were missing
+
+The catalogue gets built in one pass, oldest book first. If the server shuts down
+part-way through, the pass stops where it is.
+
+The problem was what happened next. On the following start-up the program asked one
+question — *"is the catalogue empty?"* — and, finding it not empty, concluded it was
+finished and never went back. A half-built catalogue and a complete one looked identical
+to it. Because the pass runs oldest-first, the books that never got cards were always
+the **newest** ones.
+
+We measured it on the live server. Books added in April: 97 out of 100 findable. Books
+added in August: **2 out of 100**. Almost everything added recently was invisible to
+search, and would have stayed invisible indefinitely — nothing in the system was ever
+going to notice.
+
+There was already a repair mechanism, added earlier this month, and it did not help
+here. It repairs cards that were *dropped* when the system got busy. A book whose card
+was never attempted in the first place was never on its list.
+
+## What changed
+
+On start-up the server now compares how many cards it has against how many books exist.
+If it is short, it adds the missing books to the existing repair list and lets the
+already-tested repair process work through them. Deliberately that way round: rebuilding
+the catalogue in one pass is what created a permanent hole the first time, and the repair
+list is written to disk, so an interrupted repair picks up where it stopped instead of
+starting over or giving up.
+
+Separately, search had three ways of quietly falling back to a much simpler, weaker
+matching method, none of which wrote anything to the log. Diagnosing this required
+probing the live server to work out which method had answered — something a single log
+line should have told us. All three now say so.
+
+## What this does not fix
+
+Two other genuine problems surfaced while investigating. Neither caused this one, and
+both are written up rather than fixed here, because bundling unrelated fixes into a bug
+investigation is how fixes get harder to trust:
+
+- The words **"all"** and **"and"** are silently discarded from searches. Typing
+  *All Jobs and Classes* actually searches for *Jobs* and *Classes*. There is a good
+  reason it works this way, but you are not told half your query was dropped.
+- **Putting quotes around a phrase does not search for that phrase.** It currently
+  appears to work by accident.
+
+One decision is yours: the repair runs on the next restart and will work through roughly
+40,000 books in the background. It can happen on the next natural restart or be
+scheduled deliberately.
+
+## How we know it is fixed
+
+The repair has a test that reproduces the exact failure — a catalogue built half-way,
+then a restart — and checks that the missing books become findable, that the right book
+comes back **first**, and that the five unrelated ones are **absent**. The test was
+confirmed to fail when the fix is switched off, which is the only thing that proves a
+passing test is measuring anything at all.

--- a/docs/handoffs/2026-08-13-web-search-returns-unrelated-books.md
+++ b/docs/handoffs/2026-08-13-web-search-returns-unrelated-books.md
@@ -43,18 +43,52 @@ description-matches — the owner's screenshot.
 the search index is invisible to that method by construction, so the enumeration found
 two rows, saw both non-primary, and concluded no primary existed.
 
-**The 6,157 figure needs re-deriving before anyone acts on it.** It was computed by
-paging the `is_primary_version=false` set and grouping by `version_group_id`. A group's
-primary member is *by definition excluded from that set*, so "one book per group" in
-that data can only mean "one **non-primary** book per group" — which is also the shape
-of a perfectly healthy two-member group. `vg-01KXXVFEHRXGXMKPDYMY6HENDK` is a concrete
-counterexample: it is inside the 6,157 and it has a primary. Re-count by fetching each
-candidate group's *full* membership before calling it primary-less.
+Decisive check: **`01KZRBPPCF…` is returned by `is_primary_version=true`.** Paging that
+filtered set (40,839 ids, 41 pages) and grepping for it returns a hit. The filter keeps
+this book. Only the index cannot find it.
 
-To be explicit about what survives: **`vg-` prefixed group ids appearing only in a
-bounded creation window is still an interesting, unexplained observation** and worth
-chasing. What does not survive is "these groups have no primary" and the count attached
-to it.
+### The 6,157 figure re-derived: the real number is 765
+
+The 6,157 was computed by paging the `is_primary_version=false` set and grouping by
+`version_group_id`. A group's primary member is *by definition excluded from that set*,
+so "one book per group" in that data can only mean "one **non-primary** book per group"
+— which is also the shape of a perfectly healthy two-member group.
+
+Re-measured by a **full census**: every one of the 63,870 books paged (ids verified to
+partition cleanly, zero duplicates), grouped by `version_group_id`, then intersected
+against the full `is_primary_version=true` membership.
+
+| population | books |
+|---|---|
+| total library | 63,870 |
+| returned by `is_primary_version=true` | 40,839 |
+| not returned | 23,031 |
+| — legitimately collapsed duplicates (group *has* a primary) | 22,266 |
+| — **in a group where no member is primary** | **724** |
+| — **has no `version_group_id` at all, and still hidden** | **41** |
+| **genuinely wrongly hidden** | **765 (1.20%)** |
+
+So the defect is real but **8× smaller than reported**: 765 books, not 6,157; 1.20% of
+the library, not 9.6%.
+
+**The `vg-` lead does survive, and it is a good one.** Zero-primary groups are heavily
+concentrated in the prefixed namespace — 472 of 7,154 `vg-` groups have no primary,
+versus 7 of 17,635 unprefixed. That is a ~166× enrichment and it does point at a
+specific writer. What does not survive is "one book per group": `vg-` groups hold 12,877
+books across 7,154 groups, and only 1,905 are singletons.
+
+### A separate finding: the filter and the serialized flag disagree
+
+5,731 books are returned by `is_primary_version=true` while their own payload says
+`"is_primary_version": false`. These are books with no `version_group_id` — the filter
+treats an ungrouped book as trivially primary, but the serialized field does not reflect
+that. Nothing is hidden by this, but any consumer that reads the field rather than
+calling the filter will disagree with the server about 5,731 books, and it is what made
+the two independent counts of "primary books" differ (40,839 vs 35,108). Worth a
+separate issue.
+
+The remaining **41** ungrouped-and-hidden books do not fit that rule and are unexplained;
+they are a small, concrete starting sample for whoever picks this up.
 
 ---
 
@@ -101,8 +135,8 @@ and testing the `version_group_id` prefix:
 | total books | 63,870 |
 | `is_primary_version=true` | 40,839 |
 | `is_primary_version=false` | 23,031 |
-| **of those, `vg-` singletons with no primary** | **6,157** |
-| distinct `vg-` groups | 6,157 (one book each — all singletons) |
+| **of those, `vg-` singletons with no primary** | **6,157**  ← WRONG, see v3.0.0 correction: real figure is 765 |
+| distinct `vg-` groups | 6,157 (one book each — all singletons)  ← WRONG: 7,154 groups / 12,877 books, only 1,905 singletons |
 
 The affected books are contiguous in creation order: every one falls between
 **2026-04-04 and 2026-08-11**, and the scan found zero `vg-` rows in the older 11,031.

--- a/docs/handoffs/2026-08-13-web-search-returns-unrelated-books.md
+++ b/docs/handoffs/2026-08-13-web-search-returns-unrelated-books.md
@@ -1,20 +1,64 @@
 <!-- file: docs/handoffs/2026-08-13-web-search-returns-unrelated-books.md -->
-<!-- version: 2.0.0 -->
+<!-- version: 3.0.0 -->
 <!-- guid: b2f4a7c1-53de-4e08-9a16-7cc0e5d1f3b8 -->
 <!-- last-edited: 2026-08-13 -->
 
 # Handoff: web-UI search returns unrelated books
 
-**Status: ROOT CAUSE CONFIRMED against production 2026-08-13 17:40 EDT.** Search is not
-broken. 6,157 books are hidden from the entire web UI by a data defect. See "The actual
-cause" immediately below; the hypothesis sections that follow are kept only as a record
-of what was ruled out, and **both of the ones this document originally called "still
-open" are now disproven.**
+**Status: RESOLVED 2026-08-13 (v3.0.0).** Two sessions investigated this in parallel and
+reached opposite conclusions. Reconciled here against production data: **hypothesis A
+(the index does not contain the book) is CONFIRMED; hypothesis B (nil index / substring
+fallback) is REFUTED; and the v2.0.0 conclusion that "search is fine, a primary-less
+`vg-` group is hiding it" is WRONG for the reported book** — its version group has two
+members and *does* elect a primary. See "Correction to v2.0.0" below before reading the
+v2.0.0 section, which is kept intact because its `vg-` observation is a real, separate
+lead that just needs re-counting.
 **Reported:** 2026-08-13 by the owner.
 
 ---
 
-## The actual cause (confirmed, v2.0.0)
+## Correction to v2.0.0 (added v3.0.0)
+
+The v2.0.0 section below concludes that the reported book is hidden because its copies
+sit in `vg-`-prefixed **singleton groups that elect no primary**. That is not what the
+data says. A **third** row carries this title, and v2.0.0 never saw it:
+
+```
+id=01KZRBPPCFP6PV39F4Q5CZZZ85  primary=TRUE   group=vg-01KXXVFEHRXGXMKPDYMY6HENDK
+id=01KXXVFEKD3XE0VBQ5HVXNWB86  primary=False  group=vg-01KXXVFEHRXGXMKPDYMY6HENDK   <- v2.0.0 called this a primary-less singleton
+```
+
+**Same group.** It has (at least) two members and it *does* elect a primary. So the
+`is_primary_version=true` filter is not what removes this book from the results — there
+is a perfectly good primary row for the filter to keep.
+
+It is missing for a different reason: **`01KZRBPPCF…` is absent from the Bleve index.**
+It returns from a direct store lookup and returns nothing under three separate queries
+whose terms are all in its title. The two rows that *do* rank #1–#2 without the filter
+are the two non-primary copies, which *are* indexed. Filter to primaries and the only
+row that qualifies is the one the index cannot see, so the result is the five
+description-matches — the owner's screenshot.
+
+**Why v2.0.0 could not see it:** it enumerated rows by *searching*. A row missing from
+the search index is invisible to that method by construction, so the enumeration found
+two rows, saw both non-primary, and concluded no primary existed.
+
+**The 6,157 figure needs re-deriving before anyone acts on it.** It was computed by
+paging the `is_primary_version=false` set and grouping by `version_group_id`. A group's
+primary member is *by definition excluded from that set*, so "one book per group" in
+that data can only mean "one **non-primary** book per group" — which is also the shape
+of a perfectly healthy two-member group. `vg-01KXXVFEHRXGXMKPDYMY6HENDK` is a concrete
+counterexample: it is inside the 6,157 and it has a primary. Re-count by fetching each
+candidate group's *full* membership before calling it primary-less.
+
+To be explicit about what survives: **`vg-` prefixed group ids appearing only in a
+bounded creation window is still an interesting, unexplained observation** and worth
+chasing. What does not survive is "these groups have no primary" and the count attached
+to it.
+
+---
+
+## The actual cause (v2.0.0 — SUPERSEDED, see correction above)
 
 The search engine returns the right answer. For `All Jobs and Classes` the API returns
 `count=8` with the owner's book ranked **first and second**. The web UI then discards
@@ -89,9 +133,113 @@ explanation for the web-vs-app split that this document was originally written t
 ## Original v1.0.0 investigation — kept as a record of what was ruled out
 
 Everything below was written before the cause was known. The "Eliminated" section is
-still accurate and still useful. **The "Still open" section is now disproven: hypothesis A
-(index missing books) is wrong — Bleve found the books and ranked them first; hypothesis B
-(nil index / fallback) is wrong for the same reason.** Do not spend time on either.
+still accurate and still useful.
+
+> **v3.0.0 correction:** v2.0.0 marked *both* still-open hypotheses disproven on the
+> grounds that "Bleve found the books and ranked them first." Bleve found the two
+> **non-primary** copies. It did not find the primary one. **Hypothesis A is therefore
+> CONFIRMED, not disproven** — see "Correction to v2.0.0" at the top. Hypothesis B *is*
+> correctly refuted, though by a different argument: `PebbleStore.SearchBooks` is a
+> whole-query substring matcher, so if it were serving, `search=jobs classes` would
+> return 0 rather than 8, and reversing the word order would not return a byte-identical
+> set.
+
+---
+
+## Resolution (2026-08-13)
+
+### The bug reproduced exactly
+
+With the parameters the Library page actually sends (`is_primary_version=true`, which
+the original report did not mention), production returned **exactly the owner's five
+books and nothing else**:
+
+```
+search=All Jobs and Classes&is_primary_version=true  ->  count=5
+  Dragon Conjurer / Parallax Rising / All in Charisma /
+  Dungeon Diving Culinary Wizard / Solo Leveling, Vol. 2
+```
+
+Without that filter the same query returns **8**, with the two correct books ranked
+**1 and 2**. So relevance was never the problem, and the "unfiltered slice of the
+library" reading was wrong: all five survivors legitimately match, on the
+**description** field (boost 0.5 — visible in the query JSON), because after stopword
+dropping the query is `job AND class` stemmed, and each decoy's description contains
+both ("*I went to class, worked my minimum-wage job*").
+
+### Why the correct books vanished — Hypothesis A, narrowed
+
+Three rows carry the title (which is what the app returns, closing the 3-vs-2 gap):
+
+| id | primary | in Bleve |
+|---|---|---|
+| `01KXXVFEKD…` | false | yes |
+| `01KZRBPPCF…` | **true** | **NO** |
+| `01KXXVBGQG…` | false | yes |
+
+The index does contain the title — but **not the primary row**, which is the only row
+the Library page's filter keeps. `01KZRBPPCF…` (created 2026-08-11) returns from a
+direct memdb lookup and is absent from Bleve under three different queries whose terms
+are all in its title. Four further distinctive-title probes behaved identically, with
+result counts of 4–9, so a top-N ranking confound is excluded.
+
+The gap is systemic and shaped like a step function:
+
+| created | searchable | missing | coverage |
+|---|---|---|---|
+| 2026-04 | 38 | 1 | **97%** |
+| 2026-08 | 1 | 50 | **2%** |
+
+(Sampling caveat: a first pass reported 2026-04 at 73%. That was a measurement
+artifact — querying full titles containing `:` makes the server DSL parse `System:` as
+`field:value`. Stripping punctuation removed it. Result sets at the page cap are
+counted "inconclusive" rather than "missing", since a capped set cannot prove absence.)
+
+### Mechanism
+
+`buildSearchIndexIfEmpty` (`internal/server/server_search.go`) is the only bulk build
+and gates on `DocCount() == 0` — "non-empty means complete". The loop honours
+`s.bgCtx`, so a shutdown part-way through leaves a populated-but-incomplete index; the
+next boot sees `count > 0` and returns early, making the gap **permanent**. It walks
+books in ULID order and ULIDs are time-ordered, so a cancellation always loses the
+**newest** books — which is exactly the step function measured.
+
+The #2268 dirty-set reconciler does not cover it. `markIndexDirty` is called from
+exactly one place — `enqueueIndex`'s queue-full branch — so it repairs *dropped* events
+only. A book the backfill never reached was never enqueued, is never dirty, and is
+never reconciled. (The reconciler itself *is* started, at
+`server_lifecycle.go:301` — that was verified, not assumed.)
+
+### Why Hypothesis B is refuted
+
+`PebbleStore.SearchBooks` is a **whole-query substring** match over
+title/author/narrator only; it never tokenises and never reads description. If it were
+serving, `search=jobs classes` would return 0. It returned 8, and `classes jobs`
+returned a byte-identical set — order-independent token AND, i.e. Bleve. There is also
+no version-group collapse anywhere on the query path (checked, because a dedup keeping
+the wrong group member would have produced the same five-row output with a healthy
+index); the only primary handling is a per-book pass/fail filter.
+
+### Fix
+
+`internal/server/search_coverage.go` — on boot, compare indexed docs against book
+count and, when short, mark the books dirty so the shipped reconciler re-indexes them.
+It seeds the durable dirty set rather than re-running the build, because re-running
+would reuse the same non-resumable, cancellable loop that created the permanent gap.
+Plus the logging this document asked for on all three silent fallbacks.
+
+Regression tests are in `internal/server/search_coverage_test.go` — deliberately in
+`internal/server`, not `internal/search`: a search-layer test seeds its own index and
+therefore *cannot* fail on missing documents. Both were proven to fail with the fix
+disabled (`3 docs indexed, want 6`) and restored byte-identical.
+
+### Not fixed here, filed separately
+
+The two independent defects this document records (stopword dropping, quoted phrases
+not becoming phrases) are both confirmed **measured** in the query JSON — neither
+causes this bug. They are in `todo.d/20260813-search-index-coverage-followups.md`
+along with the prod-rebuild decision, an unexposed metric, and a version group with no
+primary member.
 
 ---
 
@@ -144,6 +292,11 @@ the live footgun in the next section.)
 ---
 
 ## Still open — start here
+
+> **Superseded 2026-08-13.** Both hypotheses below have been decided against a running
+> server: **A confirmed** (narrowed — it is the *primary* row that is missing, not the
+> title), **B refuted**. Kept verbatim because the reasoning is what made the decisive
+> tests cheap. See "Resolution" above.
 
 ### Hypothesis A (strongest): the Bleve index does not contain these books
 

--- a/internal/audiobooks/service_query.go
+++ b/internal/audiobooks/service_query.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_query.go
-// version: 1.12.0
+// version: 1.13.0
 // guid: c5f9d4e3-f6a7-8b90-ac1d-2e3f4a5b6c7d
-// last-edited: 2026-08-12
+// last-edited: 2026-08-13
 
 package audiobooks
 
@@ -138,6 +138,13 @@ func (svc *AudiobookService) GetAudiobooksWithTotal(ctx context.Context, limit i
 					"window", searchPostFilterWindow, "query", search)
 			}
 		} else {
+			// No search index at all. store.SearchBooks is a *whole-query
+			// substring* match over title/author/narrator only — it does not
+			// tokenise, so a multi-word query like "jobs classes" matches
+			// nothing rather than ANDing the terms. That is a large, silent
+			// behaviour change from the Bleve path, so say it happened.
+			slog.Warn("search: search index is nil; falling back to substring SearchBooks",
+				"query", search, "fallback", "store.SearchBooks")
 			books, err = svc.store.SearchBooks(search, limit, offset)
 		}
 	} else if authorID != nil {
@@ -667,6 +674,15 @@ func (svc *AudiobookService) searchWithBleve(query string, limit, offset int, us
 		// Parser failure: fall back to the substring search path so
 		// users still see results for simple queries the DSL parser
 		// rejects (e.g. punctuation-heavy book titles).
+		//
+		// This fallback was silent until 2026-08-13. It swaps a tokenised
+		// full-text index for a whole-query substring match over
+		// title/author/narrator, which changes results dramatically, and
+		// nothing in the logs said so — an investigation into wrong search
+		// results had to rule this path out by probing production instead of
+		// reading a log line.
+		slog.Warn("search: DSL parse failed; falling back to substring SearchBooks",
+			"query", query, "err", err, "fallback", "store.SearchBooks")
 		books, sErr := svc.store.SearchBooks(query, limit, offset)
 		// SearchBooks exposes no match count, so the only honest figure
 		// available here is the page length. Callers must not treat this as
@@ -675,6 +691,11 @@ func (svc *AudiobookService) searchWithBleve(query string, limit, offset int, us
 	}
 	bleveQ, perUser, err := search.Translate(ast)
 	if err != nil {
+		// Same silent-degradation hazard as the parse-failure branch above:
+		// the query parsed fine but could not be expressed as a Bleve query,
+		// and the user silently gets substring results instead.
+		slog.Warn("search: query translation failed; falling back to substring SearchBooks",
+			"query", query, "err", err, "fallback", "store.SearchBooks")
 		books, sErr := svc.store.SearchBooks(query, limit, offset)
 		return books, len(books), sErr
 	}

--- a/internal/server/search_coverage.go
+++ b/internal/server/search_coverage.go
@@ -1,0 +1,128 @@
+// file: internal/server/search_coverage.go
+// version: 1.0.0
+// guid: ee9cc3d9-3925-4f72-af8a-e9f25a943fb9
+// last-edited: 2026-08-13
+//
+// Boot-time repair for a PARTIALLY built Bleve search index.
+//
+// WHY THIS EXISTS
+//
+// buildSearchIndexIfEmpty (server_search.go) is the only bulk index build,
+// and it gates on DocCount() == 0. That encodes "non-empty means complete",
+// which is false: the build loop honours s.bgCtx, so a shutdown part-way
+// through leaves a populated-but-incomplete index. On the next boot
+// DocCount() > 0, the build returns early, and the gap is PERMANENT.
+//
+// It walks books in ULID order (GetAllBooksFullFrom from ""), and ULIDs are
+// time-ordered, so the books lost to a cancellation are always the NEWEST
+// ones. That is the signature measured on prod 2026-08-13: books created
+// 2026-04 were 97% searchable (38 found / 1 missing) while books created
+// 2026-08 were 2% (1 found / 50 missing) — a step function, not a uniform
+// sampling loss. The owner-visible symptom was a Library search for "All
+// Jobs and Classes" returning five unrelated books: the two rows that
+// actually matched were in the missing cohort, and the five survivors
+// matched only on the description field (boost 0.5). The same search worked
+// in the AudiobookShelf app because that path does not filter to primary
+// versions.
+//
+// The #2268 dirty-set reconciler does NOT cover this. markIndexDirty is
+// called from exactly one place — enqueueIndex's queue-full branch — so it
+// repairs DROPPED events only. A book the backfill never reached was never
+// enqueued, is therefore never dirty, and is never reconciled.
+//
+// WHY IT SEEDS THE DIRTY SET RATHER THAN RE-RUNNING THE BACKFILL
+//
+// Flipping the gate to "DocCount != bookCount" would re-run the same
+// non-resumable, bgCtx-cancellable loop — the exact property that created a
+// permanent gap in the first place, just with a wider trigger. Marking the
+// books dirty instead writes durable Pebble keys, so a cancellation
+// mid-sweep costs nothing: the marks survive the restart and the shipped
+// reconciler drains them on its normal ticker. This reuses tested machinery
+// instead of adding a second backfill path with its own failure modes.
+
+package server
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// bookIDLister is the narrow capability this repair needs. Declared here
+// rather than widening database.Store, matching the SearchIndexDirtyStore
+// convention in pebble_store_search_dirty.go.
+type bookIDLister interface {
+	ListBookIDs() ([]string, error)
+}
+
+// reconcileSearchIndexCoverage compares the number of indexed documents
+// against the number of books and, when the index is short, marks every book
+// dirty so runSearchReconciler re-indexes them.
+//
+// It is a no-op on a healthy index, so it is safe to run on every boot.
+//
+// Deliberately compares counts rather than probing each book: a per-book
+// existence check against Bleve would be ~40K point lookups on every start,
+// and the count comparison is enough to decide whether a sweep is warranted.
+// The cost of being wrong is a redundant re-index, not data loss.
+func (s *Server) reconcileSearchIndexCoverage() {
+	if s.searchIndex == nil {
+		return
+	}
+	store := s.Store()
+	if store == nil {
+		return
+	}
+	lister, ok := store.(bookIDLister)
+	if !ok {
+		slog.Warn("search coverage: store cannot list book IDs; skipping coverage check")
+		return
+	}
+	if database.AsSearchIndexDirtyStore(store) == nil {
+		// Without the durable dirty set there is nothing to seed, and the
+		// reconciler would have nothing to drain. Say so rather than
+		// silently doing nothing — a silent no-op here is what let the
+		// original gap persist unnoticed.
+		slog.Warn("search coverage: no durable dirty set; cannot repair index coverage")
+		return
+	}
+
+	docs, err := s.searchIndex.DocCount()
+	if err != nil {
+		slog.Warn("search coverage: DocCount failed", "err", err)
+		return
+	}
+	ids, err := lister.ListBookIDs()
+	if err != nil {
+		slog.Warn("search coverage: ListBookIDs failed", "err", err)
+		return
+	}
+
+	if uint64(len(ids)) <= docs {
+		slog.Info("search index coverage OK", "indexed", docs, "books", len(ids))
+		return
+	}
+
+	missing := uint64(len(ids)) - docs
+	slog.Warn("search index is short of the library; marking books for reconciliation",
+		"indexed", docs, "books", len(ids), "shortfall", missing)
+
+	start := time.Now()
+	marked := 0
+	for _, id := range ids {
+		select {
+		case <-s.bgCtx.Done():
+			// Cancellation is safe here in a way it is not in the backfill:
+			// the marks already written are durable, so the next boot's
+			// coverage check resumes from a strictly better position.
+			slog.Info("search coverage: marking canceled (bgCtx)", "marked", marked, "of", len(ids))
+			return
+		default:
+		}
+		s.markIndexDirty(id)
+		marked++
+	}
+	slog.Info("search coverage: books marked for reconciliation",
+		"marked", marked, "shortfall", missing, "took", time.Since(start))
+}

--- a/internal/server/search_coverage_test.go
+++ b/internal/server/search_coverage_test.go
@@ -1,0 +1,175 @@
+// file: internal/server/search_coverage_test.go
+// version: 1.0.0
+// guid: 000a3aed-48a5-49fd-b36a-d52d7d4de58e
+// last-edited: 2026-08-13
+//
+// Regression tests for a PARTIALLY built search index.
+//
+// The prod bug (2026-08-13): a Library search for "All Jobs and Classes"
+// returned five unrelated books. The two rows that actually matched had
+// never been indexed, because buildSearchIndexIfEmpty gates on
+// DocCount() == 0 and a prior shutdown had cancelled the build part-way.
+// The five survivors matched only on the description field.
+//
+// These tests are COVERAGE tests, not query-quality tests. The query layer
+// is already covered by internal/search/zz_repro_alljobs_test.go, which
+// seeds its own index and therefore cannot fail on an index that is missing
+// documents — the failure mode reproduced here.
+
+package server
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/search"
+)
+
+// seedPartialIndex creates n books and indexes only the first indexed of
+// them, reproducing the state a bgCtx-cancelled backfill leaves behind.
+// Book IDs are zero-padded so their lexical order matches creation order,
+// mirroring the ULID ordering the real backfill walks.
+func seedPartialIndex(t *testing.T, store *database.PebbleStore, idx *search.BleveIndex, books []database.Book, indexed int) {
+	t.Helper()
+	for i := range books {
+		if _, err := store.CreateBook(&books[i]); err != nil {
+			t.Fatalf("create %s: %v", books[i].ID, err)
+		}
+		if i < indexed {
+			if err := idx.IndexBook(search.BookToDoc(store, &books[i])); err != nil {
+				t.Fatalf("index %s: %v", books[i].ID, err)
+			}
+		}
+	}
+}
+
+func strptr(s string) *string { return &s }
+
+// coverageBooks returns three books whose titles carry the query terms and
+// three decoys that carry them only in the description — the exact shape of
+// the prod result set.
+func coverageBooks() []database.Book {
+	return []database.Book{
+		// Indexed first (oldest): description-only matches. These are the
+		// rows that survived on prod and were shown to the owner.
+		{ID: "cov-01", Title: "Dragon Conjurer", FilePath: "/tmp/cov01", Format: "m4b",
+			Description: strptr("I went to class, worked my minimum-wage job, and studied.")},
+		{ID: "cov-02", Title: "Parallax Rising", FilePath: "/tmp/cov02", Format: "m4b",
+			Description: strptr("She left class early and took a second job.")},
+		{ID: "cov-03", Title: "All in Charisma", FilePath: "/tmp/cov03", Format: "m4b",
+			Description: strptr("A job, a class, and a very long night.")},
+		// Never reached by the cancelled backfill (newest): the real matches.
+		{ID: "cov-04", Title: "All Jobs and Classes! I Just Wanted One Skill", FilePath: "/tmp/cov04", Format: "m4b"},
+		{ID: "cov-05", Title: "All Jobs and Classes! Book II: Ascension", FilePath: "/tmp/cov05", Format: "m4b"},
+		{ID: "cov-06", Title: "All Jobs and Classes! Book III: Dominion", FilePath: "/tmp/cov06", Format: "m4b"},
+	}
+}
+
+// coverageProbes maps each book to a title term unique to it, so "is this
+// book in the index?" is a real query rather than a DocCount inference.
+// Bleve has no queryable document-ID field here, so a per-book term is the
+// only way to assert reachability of a specific row.
+var coverageProbes = map[string]string{
+	"cov-01": "title:conjurer",
+	"cov-02": "title:parallax",
+	"cov-03": "title:charisma",
+	"cov-04": "title:skill",
+	"cov-05": "title:ascension",
+	"cov-06": "title:dominion",
+}
+
+// TestSearchCoverage_PartialBackfillIsRepaired is the regression test.
+//
+// It fails on the pre-fix code: reconcileSearchIndexCoverage did not exist,
+// buildSearchIndexIfEmpty returned early because DocCount() was 3 (> 0), and
+// cov-04..06 stayed invisible forever.
+func TestSearchCoverage_PartialBackfillIsRepaired(t *testing.T) {
+	srv, store, idx := newDropOnlyServer(t)
+	books := coverageBooks()
+	seedPartialIndex(t, store, idx, books, 3)
+
+	// Precondition: the index really is partial, or the test proves nothing.
+	docs, err := idx.DocCount()
+	if err != nil {
+		t.Fatalf("doccount: %v", err)
+	}
+	if docs != 3 {
+		t.Fatalf("precondition: indexed %d docs, want 3", docs)
+	}
+
+	// The old path is a no-op on a non-empty index. Assert that explicitly so
+	// this test also documents WHY a second mechanism is needed.
+	srv.buildSearchIndexIfEmpty()
+	if d, _ := idx.DocCount(); d != 3 {
+		t.Fatalf("buildSearchIndexIfEmpty changed a non-empty index: %d docs", d)
+	}
+
+	// The repair under test: seed the dirty set, then let the reconciler drain.
+	srv.reconcileSearchIndexCoverage()
+	srv.reconcileOnce()
+
+	if d, _ := idx.DocCount(); d != uint64(len(books)) {
+		t.Fatalf("after repair: %d docs indexed, want %d", d, len(books))
+	}
+
+	// Every book must now be reachable, especially the newest cohort — the
+	// one a ULID-ordered cancellation always loses.
+	for _, b := range books {
+		probe, ok := coverageProbes[b.ID]
+		if !ok {
+			t.Fatalf("no probe term defined for %s", b.ID)
+		}
+		hits, _, err := idx.Search(probe, 0, 10)
+		if err != nil {
+			t.Fatalf("search %s: %v", b.ID, err)
+		}
+		found := false
+		for _, h := range hits {
+			if h.BookID == b.ID {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("book %s (%q) still missing from the index after repair (probe %q)", b.ID, b.Title, probe)
+		}
+	}
+}
+
+// TestSearchCoverage_PrecisionAfterRepair asserts the owner-visible symptom
+// is gone: the real match ranks FIRST and the description-only decoys are
+// not what the user is handed.
+//
+// Presence alone is not enough — internal/search/multiword_repro_test.go
+// asserts only presence, which is why a MatchAll passes all ten of its
+// cases. This asserts precision.
+func TestSearchCoverage_PrecisionAfterRepair(t *testing.T) {
+	srv, store, idx := newDropOnlyServer(t)
+	books := coverageBooks()
+	seedPartialIndex(t, store, idx, books, 3)
+
+	srv.reconcileSearchIndexCoverage()
+	srv.reconcileOnce()
+
+	hits, total, err := idx.Search("title:jobs title:classes", 0, 20)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if total == 0 || len(hits) == 0 {
+		t.Fatal("query returned nothing; the index is still not serving these books")
+	}
+
+	// Correct book first.
+	want := map[string]bool{"cov-04": true, "cov-05": true, "cov-06": true}
+	if !want[hits[0].BookID] {
+		t.Errorf("top hit = %s, want one of the real title matches (cov-04..06)", hits[0].BookID)
+	}
+
+	// Unrelated books absent: a title-scoped query must not return the rows
+	// whose only connection is a description mentioning a job and a class.
+	decoys := map[string]string{"cov-01": "Dragon Conjurer", "cov-02": "Parallax Rising", "cov-03": "All in Charisma"}
+	for _, h := range hits {
+		if title, isDecoy := decoys[h.BookID]; isDecoy {
+			t.Errorf("unrelated book %s (%q) present in title-scoped results", h.BookID, title)
+		}
+	}
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 3.13.0
+// version: 3.14.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-08-13
 
@@ -1101,6 +1101,12 @@ func (s *Server) startBackfills() {
 		go func() {
 			defer s.bgWG.Done("build-search-index")
 			s.buildSearchIndexIfEmpty()
+			// buildSearchIndexIfEmpty only runs on an EMPTY index, so a
+			// build that was cancelled by a previous shutdown leaves a
+			// permanent gap it will never revisit. Seed the dirty set for
+			// the shortfall so the reconciler repairs it. See
+			// search_coverage.go.
+			s.reconcileSearchIndexCoverage()
 		}()
 	}
 

--- a/todo.d/20260813-primary-version-census-corrections.md
+++ b/todo.d/20260813-primary-version-census-corrections.md
@@ -1,0 +1,26 @@
+### Search / version-group census corrections (2026-08-13)
+
+Measured by a full 63,870-book census against production, correcting the figures in
+`docs/handoffs/2026-08-13-web-search-returns-unrelated-books.md` v2.0.0.
+
+- [ ] **765 books, not 6,157, are wrongly hidden by the primary-version filter** (1.20%,
+      not 9.6%). Breakdown: 724 sit in a version group where no member is primary; 41
+      have no `version_group_id` at all and are still hidden. The other 22,266 unreachable
+      books are legitimately collapsed duplicates whose group *does* elect a primary.
+- [ ] **Find the writer that creates a `vg-` group without electing a primary.** The lead
+      is good: 472 of 7,154 `vg-` groups have no primary versus 7 of 17,635 unprefixed —
+      a ~166x enrichment. Note `vg-` groups are NOT mostly singletons (12,877 books across
+      7,154 groups; 1,905 singletons), so a repair that assumes singleton-ness is unsafe.
+- [ ] **`is_primary_version` in the payload disagrees with the filter for 5,731 books.**
+      Books with no `version_group_id` are returned by `is_primary_version=true` while
+      their own serialized field says `false`. Nothing is hidden by this, but any client
+      reading the field instead of calling the filter will disagree with the server about
+      5,731 books. It is why two independent counts of "primary books" differed
+      (40,839 vs 35,108).
+- [ ] **41 ungrouped books are hidden anyway** and do not fit the rule above. Small
+      concrete sample; unexplained.
+- [ ] **`version_group_id` is silently ignored as a filter** on `/api/v1/audiobooks` —
+      both `?filter=version_group_id:X` and `?version_group_id=X` return the entire
+      library (count=63,870) rather than erroring. Same silent-filter family as the bare
+      query-parameter rejection in ab04824e. This is what forced a full census instead of
+      a targeted group lookup.

--- a/todo.d/20260813-search-index-coverage-followups.md
+++ b/todo.d/20260813-search-index-coverage-followups.md
@@ -1,0 +1,36 @@
+- [ ] **Decide whether to force a search-index rebuild on prod.** The boot-time
+      coverage check (`internal/server/search_coverage.go`) repairs the gap on the
+      next restart by marking ~40K books dirty and letting the reconciler drain
+      them (~5,000/tick, 30s ticks). That is a large background operation on a
+      live server. Owner call: let it happen on the next natural restart, or
+      schedule it. Measured gap 2026-08-13: books created 2026-08 were 2%
+      searchable (1 found / 50 missing in sample), 2026-04 were 97% (38/1).
+- [ ] **`all` and `and` are stopwords and are silently dropped from queries.**
+      `dropStopwordOnlyConjuncts` (`internal/search/bleve_translator.go:150`)
+      strips conjuncts that analyse to zero tokens — it exists to fix "shards of
+      oblivion" returning nothing. Measured in the query JSON emitted by
+      `TestReproAllJobsAndClasses`: `All Jobs and Classes` searches only
+      `Jobs AND Classes`, and `all jobs` searches only `jobs`. The user is given
+      no indication half the query was discarded. Independent of the index-coverage
+      bug fixed on 2026-08-13; needs its own change.
+- [ ] **Quoted phrases do not produce a `MatchPhraseQuery`.** The server-side
+      parser never strips the quote characters, so `"All Jobs and Classes"`
+      becomes the terms `All` and `Classes"` — closing quote glued to the final
+      token. Confirmed in the same emitted query JSON. The translator's
+      `n.Quoted` branch (`bleve_translator.go:317`) works; it simply never fires.
+      It *appears* to work only because the English analyzer discards the quote as
+      punctuation. Phrase search is not doing what the UI help text implies.
+- [ ] **`SearchIndexDroppedCount` is not actually exposed on `/metrics`.** The
+      comment in `internal/server/search_reconciler.go` says it is "Exposed for
+      the metrics endpoint and for tests", but a live scrape of prod `/metrics`
+      on 2026-08-13 returned 100 metric families and none matching
+      `search`/`dirty`. Same declared-but-not-registered shape as the
+      `maintenanceOrder` defect (#2360). Add the drop counter and the dirty-set
+      backlog so the next divergence is visible without grepping journald.
+- [ ] **A one-book version group can have no primary member.**
+      `01KXXVBGQGH6PEP9WE0ZWHBJ50` ("All Jobs and Classes! Book II") is the sole
+      member of `vg-01KXXVBGMHPATT8X1X3DV5AW2Q` and has
+      `is_primary_version=false`, so it is invisible in the default Library view
+      (which filters to primary versions) no matter what the search index says.
+      Worth a sweep for other headless groups plus a repair, since a group with
+      no primary is unreachable by design rather than by accident.


### PR DESCRIPTION
## What this fixes

A Library search for `All Jobs and Classes` returned five unrelated books, while the
same search in the AudiobookShelf app returned the correct ones. Picked up from
`docs/handoffs/2026-08-13-web-search-returns-unrelated-books.md`, which left two
hypotheses open. **A is confirmed** (narrowed); **B is refuted.**

## Reproduction, against live prod

The report omits the parameter that matters — the Library page sends
`is_primary_version=true`:

```
search=All Jobs and Classes&is_primary_version=true  ->  count=5
  Dragon Conjurer / Parallax Rising / All in Charisma /
  Dungeon Diving Culinary Wizard / Solo Leveling, Vol. 2
```

Byte-identical to the five in the report. Without the filter the same query returns 8,
with the two correct books ranked **1 and 2** — so relevance was never broken.

## Root cause

Three rows carry that title (which is what the app returns, closing the 3-vs-2 gap):

| id | primary | in Bleve |
|---|---|---|
| `01KXXVFEKD…` | false | yes |
| `01KZRBPPCF…` | **true** | **NO** |
| `01KXXVBGQG…` | false | yes |

The index has the title but not the **primary** row — the only row the Library filter
keeps. `01KZRBPPCF…` returns from a direct memdb lookup and is absent from Bleve under
three queries whose terms are all in its title.

It is systemic, and shaped like a step function:

| created | found | missing | coverage |
|---|---|---|---|
| 2026-04 | 38 | 1 | 97% |
| 2026-08 | 1 | 50 | **2%** |

`buildSearchIndexIfEmpty` is the only bulk build and gates on `DocCount() == 0` —
"non-empty means complete". It honours `bgCtx`, so a shutdown part-way through leaves a
populated-but-incomplete index; the next boot returns early and the gap is **permanent**.
It walks ULID order, and ULIDs are time-ordered, so a cancellation always loses the
**newest** books.

The #2268 reconciler does not cover this: `markIndexDirty` is called only from
`enqueueIndex`'s queue-full branch, so it repairs *dropped* events. A book the backfill
never reached was never enqueued, is never dirty, never reconciled. (The reconciler
itself **is** started — `server_lifecycle.go:301`, verified.)

## Why B is refuted

`PebbleStore.SearchBooks` is a whole-query substring match over title/author/narrator
only. If it were serving, `search=jobs classes` would return 0 — it returned 8, and
`classes jobs` returned a byte-identical set (order-independent token AND = Bleve).
There is also no version-group collapse anywhere on the query path; only a per-book
`IsPrimaryVersion` filter.

## The fix

`internal/server/search_coverage.go` — on boot, compare indexed docs to book count and,
when short, mark the books dirty so the shipped reconciler re-indexes them. It seeds the
**durable** dirty set rather than re-running the build, because re-running would reuse
the same non-resumable cancellable loop that created the permanent gap.

Also logs all three previously-silent fallbacks to `store.SearchBooks` (nil index, parse
error, translate error) — the handoff asked for this regardless of outcome.

## Tests

`internal/server/search_coverage_test.go`, deliberately **not** in `internal/search`: a
search-layer test seeds its own index and therefore cannot fail on missing documents.
Both assert **precision** (correct book first, unrelated books absent), not presence.

Both were proven able to fail: with the fix disabled they go red with
`after repair: 3 docs indexed, want 6` and `query returned nothing`, then the fix was
restored byte-identical (sha verified).

## Not fixed here

The two independent defects the handoff records are now **measured** in the query JSON
emitted by `TestReproAllJobsAndClasses` rather than inferred — stopword dropping (`All
Jobs and Classes` searches only `Jobs AND Classes`) and quoted phrases not becoming a
`MatchPhraseQuery` (`Classes"` keeps its quote). Neither causes this bug; both are filed
in `todo.d/`, along with the prod-rebuild decision, `SearchIndexDroppedCount` not
actually appearing on `/metrics`, and a one-member version group with no primary member.

## Owner decision

The repair marks ~40K books dirty and drains at 5,000/tick on 30s ticks on the **next
restart**. Natural restart, or scheduled?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxigqrwz9WfwN1wx8QhoQW
