### PR TITLE
docs(search): correct the handoff — search is fine, 6,157 books are hidden

### DIFF
--- a/docs/handoffs/2026-08-13-web-search-returns-unrelated-books.md
+++ b/docs/handoffs/2026-08-13-web-search-returns-unrelated-books.md
@@ -1,15 +1,97 @@
 <!-- file: docs/handoffs/2026-08-13-web-search-returns-unrelated-books.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 2.0.0 -->
 <!-- guid: b2f4a7c1-53de-4e08-9a16-7cc0e5d1f3b8 -->
 <!-- last-edited: 2026-08-13 -->
 
 # Handoff: web-UI search returns unrelated books
 
-**Status:** root cause NOT yet established. Four candidate mechanisms; two eliminated by
-test, two still open and both cheaply decidable against production.
+**Status: ROOT CAUSE CONFIRMED against production 2026-08-13 17:40 EDT.** Search is not
+broken. 6,157 books are hidden from the entire web UI by a data defect. See "The actual
+cause" immediately below; the hypothesis sections that follow are kept only as a record
+of what was ruled out, and **both of the ones this document originally called "still
+open" are now disproven.**
 **Reported:** 2026-08-13 by the owner.
-**Do not start by re-reading the translator.** It has been tested and it is correct — see
-"Eliminated" below. Starting there will burn an hour reproducing a passing result.
+
+---
+
+## The actual cause (confirmed, v2.0.0)
+
+The search engine returns the right answer. For `All Jobs and Classes` the API returns
+`count=8` with the owner's book ranked **first and second**. The web UI then discards
+both, because the Library page filters to primary versions by default and **neither copy
+is flagged as one.**
+
+Adding the UI's own filter to the API call reproduces the owner's screenshot exactly —
+the same five books, no target:
+
+```
+?search=All%20Jobs%20and%20Classes                       -> count=8, target ranked #1 and #2
+?search=All%20Jobs%20and%20Classes&is_primary_version=true -> count=5, target GONE
+```
+
+The five survivors are legitimate low-boost matches on `description` and other non-title
+fields. They are not noise from a broken query; they are what is left after the real
+match is filtered out.
+
+### Why the books are invisible
+
+```
+id=01KXXVFEKD3XE0VBQ5HVXNWB86  primary=False  group=vg-01KXXVFEHRXGXMKPDYMY6HENDK
+id=01KXXVBGQGH6PEP9WE0ZWHBJ50  primary=False  group=vg-01KXXVBGMHPATT8X1X3DV5AW2Q
+id=01KNDCC3F1BASPVH21TVV8J78R  primary=True   group=01KNDCC3F1BASPVH21TX0N8KZH   (Dragon Conjurer)
+```
+
+Healthy books sit in unprefixed version groups where exactly one member is primary
+(verified on a two-member group: *Dungeon Diving Culinary Wizard* 1 and 2 share one group
+and elect one primary). The broken books sit in **`vg-`-prefixed groups, one book per
+group, with no primary elected at all**. A singleton group whose only member is not
+primary can never satisfy `is_primary_version=true`.
+
+### Blast radius: 6,157 books, 9.6% of the library
+
+Counted exhaustively by paging the full non-primary set (23,031 books, 24 pages of 1,000)
+and testing the `version_group_id` prefix:
+
+| | |
+|---|---|
+| total books | 63,870 |
+| `is_primary_version=true` | 40,839 |
+| `is_primary_version=false` | 23,031 |
+| **of those, `vg-` singletons with no primary** | **6,157** |
+| distinct `vg-` groups | 6,157 (one book each — all singletons) |
+
+The affected books are contiguous in creation order: every one falls between
+**2026-04-04 and 2026-08-11**, and the scan found zero `vg-` rows in the older 11,031.
+That bounds this to one code path introduced or active in that window — find what mints a
+`vg-`-prefixed group id and you have the writer.
+
+**This is not a search bug. These 6,157 books are invisible everywhere the web UI applies
+its default primary-version filter** — library browsing, counts, and any filtered view —
+not only in search. The ABS mobile app does not apply that filter, which is the whole
+explanation for the web-vs-app split that this document was originally written to chase.
+
+### What to do next
+
+1. Find the writer that mints `vg-`-prefixed `version_group_id` values and does not elect
+   a primary. That is the defect; everything else here is a symptom.
+2. Decide the repair for existing data: a singleton group's only member should almost
+   certainly be its primary. A backfill that elects the sole member of any
+   single-member group is the obvious candidate — **but confirm the group really is a
+   singleton before flipping the flag**, or a real duplicate pair gets two primaries.
+3. Add an invariant test: no version group may have zero primaries. This class of defect
+   is exactly what an invariant suite catches and no unit test will.
+4. Only then revisit search. The two genuine search defects recorded further down
+   (stopword dropping, quoted phrases) are real and still worth fixing, but neither is
+   the reported bug.
+
+---
+
+## Original v1.0.0 investigation — kept as a record of what was ruled out
+
+Everything below was written before the cause was known. The "Eliminated" section is
+still accurate and still useful. **The "Still open" section is now disproven: hypothesis A
+(index missing books) is wrong — Bleve found the books and ranked them first; hypothesis B
+(nil index / fallback) is wrong for the same reason.** Do not spend time on either.
 
 ---
 
@@ -110,6 +192,11 @@ temporarily log which branch serves a request.
 Both are genuine, both are currently invisible, neither is proven to be *this* bug.
 
 ### `all` and `and` are English stopwords and are silently dropped
+
+**Confirmed live 2026-08-13:** `?search=all%20jobs` returns `count=283`, topped by *The
+Icarus Job* and *Side Jobs* — because the server actually searched `jobs` alone. This is a
+real, separate, user-visible defect and it is why the owner's `all jobs` attempt looked
+just as broken as the others, for an entirely different reason than the main bug.
 
 `dropStopwordOnlyConjuncts` (`internal/search/bleve_translator.go:150`) strips conjuncts
 that analyse to zero tokens. This exists for a good reason — it fixed "shards of

--- a/todo.d/2026-08-13-vg-singleton-groups-with-no-primary.md
+++ b/todo.d/2026-08-13-vg-singleton-groups-with-no-primary.md
@@ -1,0 +1,44 @@
+### 6,157 books are invisible in the web UI — `vg-` singleton groups elect no primary
+
+Confirmed against production 2026-08-13. Reported as "search is broken"; search is fine.
+
+Books whose `version_group_id` carries a **`vg-` prefix** sit one-per-group with
+`is_primary_version=false` and **no primary elected anywhere in the group**. The web
+Library page filters to primary versions by default, so a singleton group with no
+primary can never satisfy it and the book cannot be seen — in search, in browsing, or
+in any count. The AudiobookShelf app applies no such filter, which is why the same book
+is visible there and was reported as a search discrepancy.
+
+| | |
+|---|---|
+| total books | 63,870 |
+| `is_primary_version=true` | 40,839 |
+| `is_primary_version=false` | 23,031 |
+| **`vg-` singletons with no primary** | **6,157 (9.6% of the library)** |
+
+Counted exhaustively — all 24 pages of the non-primary set, not sampled. Every affected
+book was created between **2026-04-04 and 2026-08-11**; zero `vg-` rows appear in the
+older 11,031 non-primary books, which bounds the writer to that window.
+
+Healthy groups use an unprefixed id and elect exactly one primary (verified on a real
+two-member group). The `vg-` prefix is the tell — find what mints it.
+
+Work:
+
+1. Find the writer that mints a `vg-`-prefixed `version_group_id` without electing a
+   primary. That is the defect. Everything else is cleanup.
+2. Backfill the existing 6,157. The sole member of a single-member group should be its
+   primary — but **verify the group is genuinely a singleton before flipping the flag**,
+   or a real duplicate pair ends up with two primaries and the dedup UI inherits a new
+   class of bug.
+3. Add a data invariant: **no version group may have zero primaries.** This is the shape
+   of defect an invariant suite catches and no unit test will — see the existing
+   data-loss invariant suite (#1930–#1942) for the pattern.
+4. Check whether anything else keys off the `vg-` prefix before renaming or normalising
+   it.
+
+Related but independent, found in the same investigation and recorded in
+`docs/handoffs/2026-08-13-web-search-returns-unrelated-books.md`: search silently drops
+English stopwords (`all jobs` searches only `jobs`, returning 283 results), and quoted
+phrases never become a `MatchPhraseQuery` because the parser leaves the quote characters
+attached to the terms.


### PR DESCRIPTION
Corrects `docs/handoffs/2026-08-13-web-search-returns-unrelated-books.md` (merged in #2379) now that the cause is confirmed against production. **Both hypotheses that document left open are disproven**, so it would have sent the next reader down two dead ends.

## Search is not broken

The engine ranks the owner's book **first and second** for the reported query. The web UI then throws it away. Adding the Library page's own default filter to the API call reproduces the reported screenshot exactly — same five books, no target:

```
?search=All%20Jobs%20and%20Classes                         -> count=8, target ranked #1 and #2
?search=All%20Jobs%20and%20Classes&is_primary_version=true -> count=5, target GONE
```

The five survivors are legitimate low-boost matches on `description` and other non-title fields — what is left after the real match is filtered out.

## Why the books are hidden

```
id=01KXXVFEKD3XE0VBQ5HVXNWB86  primary=False  group=vg-01KXXVFEHRXGXMKPDYMY6HENDK
id=01KXXVBGQGH6PEP9WE0ZWHBJ50  primary=False  group=vg-01KXXVBGMHPATT8X1X3DV5AW2Q
id=01KNDCC3F1BASPVH21TVV8J78R  primary=True   group=01KNDCC3F1BASPVH21TX0N8KZH   (Dragon Conjurer)
```

Healthy books sit in unprefixed groups electing exactly one primary (verified on a real two-member group). These sit in **`vg-`-prefixed groups, one book per group, electing no primary at all.** A singleton group whose only member is not primary can never satisfy `is_primary_version=true`.

## Blast radius — 6,157 books, 9.6% of the library

Counted exhaustively across all 24 pages of the non-primary set, not sampled:

| | |
|---|---|
| total books | 63,870 |
| `is_primary_version=true` | 40,839 |
| `is_primary_version=false` | 23,031 |
| **`vg-` singletons with no primary** | **6,157** |

Every affected book was created between **2026-04-04 and 2026-08-11**; zero `vg-` rows in the older 11,031. That bounds the writer to one window.

**Wider than search:** these books are invisible anywhere the web UI applies its default primary-version filter — browsing and counts included. The ABS app applies no such filter, which is the entire explanation for the web-vs-app split.

## Also in this PR

A `todo.d` fragment so the fix is tracked rather than merely described: find the writer minting `vg-` ids without electing a primary, backfill the 6,157 (**verifying singleton-ness before flipping any flag**, or a real duplicate pair gets two primaries), and add a *no group may have zero primaries* invariant.

One genuine search defect is also confirmed live and recorded as separate: `?search=all%20jobs` returns `count=283` topped by *The Icarus Job*, because `all` is an English stopword and the server searched `jobs` alone.

Docs + fragment only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t