### PR TITLE
perf(database): split warmup's discarded bytes by field group

### DIFF
--- a/changelog.d/20260813_181000_warmup_discard_by_field.md
+++ b/changelog.d/20260813_181000_warmup_discard_by_field.md
@@ -1,0 +1,38 @@
+### Changed
+
+#### Warmup byte accounting now says WHICH field the discarded bytes belong to
+
+The aggregate shipped earlier the same day established the size of the problem:
+on production, **1,853 MB of the 2,436 MB** read in the `book_files` warmup
+phase — **76%** — is decoded and then thrown away by `stripBookFileForMemdb`.
+That phase is 113,778 ms of a 134,572 ms warmup.
+
+It does not say which field, and the candidates are not interchangeable.
+`AcoustIDFingerprint` is a `[]byte` inline in the row; moving it to a sidecar
+key means rewriting ~13 read sites and retiring the write-back preserve-guards
+in `pebble_store_bookfiles.go` that exist *because* a bare memdb round-trip once
+wiped fingerprints in production — the two writes would have to become one
+atomic batch. `IntroTranscription` and the diagnostic strings are `*string`
+fields with far fewer readers and no such guard. Recommending the expensive,
+data-loss-sensitive option on the strength of an aggregate that might be
+dominated by the cheap one would repeat exactly the error the aggregate caught:
+the call graph implied ~99% and the measurement said 76%.
+
+So the warmup log gains `discarded_field_mb`, splitting the total across six
+field groups, and the `books` phase — 729 MB across 67,824 rows, the
+second-largest and previously unmeasured — is now accounted too.
+
+One finding fell out of writing the tests. **`AcoustIDSeg0..6` cannot be seeded
+through `CreateBookFile` at all**: the write path deliberately omits them from
+the stored row and keeps them only in the `book_file_acoustid:` secondary index
+(already pinned by `TestCreateBookFile_StoredValueLacksSegs`). A row written by
+current code contributes exactly zero to that group. So a nonzero
+`acoustid_seg0_6` in production is **not** ongoing cost that a schema change
+would remove — it measures how much un-migrated legacy data is still in the
+keyspace, and the remedy is a backfill, not a redesign. That is recorded as its
+own test, seeding a legacy row as raw JSON because the supported API refuses to
+produce one.
+
+`BookSigV1` and `BookSigV1Mask` are charged their plain length, not
+`EncodedLen`: they are already base64 *strings* in the struct, so encoding them
+again would overstate the books phase against `book_files` by 4/3.

--- a/internal/database/memdb_store.go
+++ b/internal/database/memdb_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/memdb_store.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000003
 // last-edited: 2026-08-13
 
@@ -42,6 +42,46 @@ type MemStore struct {
 	// LastWarmupBytes for why the pair is worth carrying.
 	lastWarmBytes     map[string]int64
 	lastWarmDiscarded map[string]int64
+	// lastWarmDiscardedByField breaks lastWarmDiscarded down by which group of
+	// fields the bytes belonged to, keyed by the DiscardField* constants.
+	lastWarmDiscardedByField map[string]int64
+}
+
+// Keys for the per-field discarded-byte breakdown. These are field GROUPS, not
+// individual struct fields: the unit of the decision they inform is "should
+// this group move out of the row", and a group either moves together or not at
+// all. AcoustIDSeg0..6 in particular are seven fields with one lifecycle.
+//
+// They are deliberately not the JSON tag names. A JSON tag is a wire-format
+// detail that can change without the grouping changing, and these strings end
+// up in production logs that get compared across releases.
+const (
+	DiscardFieldAcoustIDFingerprint    = "acoustid_fingerprint"
+	DiscardFieldAcoustIDSegments       = "acoustid_seg0_6"
+	DiscardFieldIntroTranscription     = "intro_transcription"
+	DiscardFieldFingerprintDiagnostics = "fingerprint_diagnostics"
+	DiscardFieldDescription            = "description_and_notes"
+	DiscardFieldBookSignature          = "book_sig_v1_and_mask"
+)
+
+// LastWarmupDiscardedByField returns the discarded-byte totals split by field
+// group, keyed by the DiscardField* constants.
+//
+// LastWarmupBytes answers "is a fix worth doing" (production 2026-08-13: 76% of
+// the book_files phase). This answers "which fix", and the candidates are not
+// equivalent in risk: moving AcoustIDFingerprint out of the row retires the
+// write-back preserve-guards that exist because a bare memdb round-trip once
+// wiped fingerprints in production, while moving IntroTranscription does not.
+// Choosing the expensive option off an aggregate that might be dominated by the
+// cheap one would repeat the error the aggregate just caught.
+func (m *MemStore) LastWarmupDiscardedByField() map[string]int64 {
+	m.warmCountsMu.RLock()
+	defer m.warmCountsMu.RUnlock()
+	out := make(map[string]int64, len(m.lastWarmDiscardedByField))
+	for k, v := range m.lastWarmDiscardedByField {
+		out[k] = v
+	}
+	return out
 }
 
 // WarmupPhaseKeyCommit is the lastWarmDurations key holding the txn.Commit

--- a/internal/database/memdb_warmup.go
+++ b/internal/database/memdb_warmup.go
@@ -1,5 +1,5 @@
 // file: internal/database/memdb_warmup.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000004
 // last-edited: 2026-08-13
 
@@ -44,6 +44,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	durations := map[string]time.Duration{}
 	bytesScanned := map[string]int64{}
 	bytesDiscarded := map[string]int64{}
+	byField := map[string]int64{}
 
 	// warm runs one prefix scan and records how long it took.
 	//
@@ -80,22 +81,64 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	// would understate the waste by 4/3. String fields are charged their plain
 	// length, which slightly understates them (JSON escaping adds bytes) — a
 	// direction that can only make the finding more conservative, never less.
-	discardedEncodedLen := func(bf *BookFile) int64 {
-		n := int64(base64.StdEncoding.EncodedLen(len(bf.AcoustIDFingerprint)))
-		n += int64(len(bf.AcoustIDSeg0) + len(bf.AcoustIDSeg1) + len(bf.AcoustIDSeg2) +
-			len(bf.AcoustIDSeg3) + len(bf.AcoustIDSeg4) + len(bf.AcoustIDSeg5) +
-			len(bf.AcoustIDSeg6))
-		for _, s := range []*string{
-			bf.IntroTranscription,
-			bf.FingerprintDiagnosticJSON,
-			bf.FingerprintFailureReason,
-			bf.FingerprintFailureDetail,
-		} {
+	// strLen charges a *string its encoded length, treating nil as absent.
+	strLen := func(ss ...*string) int64 {
+		var n int64
+		for _, s := range ss {
 			if s != nil {
 				n += int64(len(*s))
 			}
 		}
 		return n
+	}
+
+	// discardBookFile charges each group of discarded BookFile fields
+	// separately, and returns the row's total.
+	//
+	// The per-group split is the point. The aggregate measured on production
+	// 2026-08-13 — 1,853 MB discarded of 2,436 MB read in the book_files phase,
+	// 76% — establishes that the fix is to stop storing SOMETHING in the row,
+	// but not which thing, and the candidates are not interchangeable:
+	//
+	//   - AcoustIDFingerprint is a []byte. Moving it to a sidecar key means
+	//     rewriting ~13 read sites and, more seriously, retiring the
+	//     write-back preserve-guards in pebble_store_bookfiles.go that exist
+	//     because a bare memdb round-trip once wiped fingerprints in
+	//     production. The two writes would have to become one atomic batch.
+	//   - IntroTranscription and the diagnostic strings are *string fields
+	//     with far fewer readers and no such guard.
+	//
+	// Picking the expensive, data-loss-sensitive option on the strength of an
+	// aggregate that might be dominated by the cheap one is exactly the error
+	// the aggregate itself just caught: the call graph implied ~99% and the
+	// measurement said 76%.
+	discardBookFile := func(bf *BookFile) int64 {
+		fp := int64(base64.StdEncoding.EncodedLen(len(bf.AcoustIDFingerprint)))
+		segs := int64(len(bf.AcoustIDSeg0) + len(bf.AcoustIDSeg1) + len(bf.AcoustIDSeg2) +
+			len(bf.AcoustIDSeg3) + len(bf.AcoustIDSeg4) + len(bf.AcoustIDSeg5) +
+			len(bf.AcoustIDSeg6))
+		transcript := strLen(bf.IntroTranscription)
+		diagnostics := strLen(bf.FingerprintDiagnosticJSON, bf.FingerprintFailureReason,
+			bf.FingerprintFailureDetail)
+
+		byField[DiscardFieldAcoustIDFingerprint] += fp
+		byField[DiscardFieldAcoustIDSegments] += segs
+		byField[DiscardFieldIntroTranscription] += transcript
+		byField[DiscardFieldFingerprintDiagnostics] += diagnostics
+		return fp + segs + transcript + diagnostics
+	}
+
+	// discardBook does the same for the books phase, the second-largest at
+	// 729 MB across 67,824 rows on production. BookSigV1 and BookSigV1Mask are
+	// already base64 *strings* in the struct, so their stored length is their
+	// length — no EncodedLen, which would over-charge them by 4/3.
+	discardBook := func(b *Book) int64 {
+		description := strLen(b.Description, b.VersionNotes)
+		signature := strLen(b.BookSigV1, b.BookSigV1Mask)
+
+		byField[DiscardFieldDescription] += description
+		byField[DiscardFieldBookSignature] += signature
+		return description + signature
 	}
 
 	// safeInsert tries to insert an object, logging+counting failures rather
@@ -131,6 +174,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 		if err := json.Unmarshal(val, &b); err != nil {
 			return false, nil
 		}
+		bytesDiscarded[memTableBooks] += discardBook(&b)
 		return safeInsert(memTableBooks, stripBookForMemdb(&b), key)
 	}); err != nil {
 		return fmt.Errorf("warmup books: %w", err)
@@ -187,7 +231,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 		if err := json.Unmarshal(val, &bf); err != nil {
 			return false, nil
 		}
-		bytesDiscarded[memTableBookFiles] += discardedEncodedLen(&bf)
+		bytesDiscarded[memTableBookFiles] += discardBookFile(&bf)
 		return safeInsert(memTableBookFiles, stripBookFileForMemdb(&bf), key)
 	}); err != nil {
 		return fmt.Errorf("warmup book_files: %w", err)
@@ -325,6 +369,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	m.lastWarmDurations = maps.Clone(durations)
 	m.lastWarmBytes = maps.Clone(bytesScanned)
 	m.lastWarmDiscarded = maps.Clone(bytesDiscarded)
+	m.lastWarmDiscardedByField = maps.Clone(byField)
 	m.warmCountsMu.Unlock()
 
 	slog.Info("memdb warmup complete",
@@ -353,6 +398,10 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 		// see MemStore.LastWarmupBytes.
 		"phase_mb", bytesMegabytes(bytesScanned),
 		"discarded_mb", bytesMegabytes(bytesDiscarded),
+		// Which FIELD GROUP the discarded bytes belong to. The per-phase total
+		// says a fix is worth doing; this says which fix, and the candidates
+		// differ by an order of magnitude in risk — see discardBookFile.
+		"discarded_field_mb", bytesMegabytes(byField),
 	)
 	if len(skips) > 0 {
 		slog.Warn("memdb warmup: rows skipped by table",

--- a/internal/database/memdb_warmup_discard_field_test.go
+++ b/internal/database/memdb_warmup_discard_field_test.go
@@ -1,0 +1,259 @@
+// file: internal/database/memdb_warmup_discard_field_test.go
+// version: 1.0.0
+// guid: c4e08b52-71a9-4d36-9f2b-6a30df518e7c
+// last-edited: 2026-08-13
+
+package database
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The aggregate shipped first said 76% of the book_files phase is read only to
+// be discarded (production 2026-08-13: 1,853 MB of 2,436 MB). It does not say
+// WHICH field, and the candidates are not interchangeable:
+//
+//   - AcoustIDFingerprint sits behind write-back preserve-guards that exist
+//     because a bare memdb round-trip once wiped fingerprints in production.
+//     Moving it out of the row retires those guards and needs an atomic batch.
+//   - IntroTranscription and the diagnostic strings have neither.
+//
+// So the per-field split has to be trustworthy in a specific way: each group's
+// bytes must land under ITS OWN key. A version that charged everything to the
+// fingerprint would produce a confident, wrong recommendation to do the
+// expensive and dangerous thing. These tests seed one group at a time so
+// cross-attribution cannot hide.
+
+func discardStrPtr(s string) *string { return &s }
+
+// seedOneBookFile writes a single book_file row, letting the caller populate
+// exactly one discarded field group.
+func seedOneBookFile(t *testing.T, store *PebbleStore, tag string, mutate func(*BookFile)) {
+	t.Helper()
+	hash := "discardfield-" + tag
+	book, err := store.CreateBook(&Book{
+		Title:    "Discard Field " + tag,
+		FilePath: "/tmp/discardfield_" + tag + ".m4b",
+		FileHash: &hash,
+	})
+	require.NoError(t, err)
+
+	fh := "discardfield-file-" + tag
+	bf := &BookFile{
+		BookID:   book.ID,
+		FilePath: "/tmp/discardfield_" + tag + ".mp3",
+		FileHash: fh,
+		Format:   "mp3",
+	}
+	if mutate != nil {
+		mutate(bf)
+	}
+	require.NoError(t, store.CreateBookFile(bf))
+}
+
+// TestDiscardByField_ChargesEachGroupToItsOwnKey is the load-bearing case. Each
+// subtest populates exactly ONE group, so any cross-attribution shows up as a
+// nonzero total under a key that should be untouched.
+func TestDiscardByField_ChargesEachGroupToItsOwnKey(t *testing.T) {
+	const blob = 8192
+
+	cases := []struct {
+		name     string
+		key      string
+		mutate   func(*BookFile)
+		wantSize int64
+	}{
+		{
+			name: "fingerprint",
+			key:  DiscardFieldAcoustIDFingerprint,
+			mutate: func(bf *BookFile) {
+				bf.AcoustIDFingerprint = warmBytesFingerprint(blob)
+			},
+			// A []byte is base64 in the stored row, so the charge is the
+			// ENCODED length. Charging the decoded length here would understate
+			// the fingerprint's share by 4/3 — and understating precisely the
+			// field whose removal is expensive is the way to reach the wrong
+			// recommendation while looking rigorous.
+			wantSize: int64(base64.StdEncoding.EncodedLen(blob)),
+		},
+		// AcoustIDSeg0..6 is deliberately absent from this table — it cannot be
+		// seeded through CreateBookFile at all. See
+		// TestDiscardByField_SegmentsAreChargedOnlyFromLegacyRows.
+		{
+			name: "intro transcription",
+			key:  DiscardFieldIntroTranscription,
+			mutate: func(bf *BookFile) {
+				bf.IntroTranscription = discardStrPtr(strings.Repeat("t", blob))
+			},
+			wantSize: blob,
+		},
+		{
+			name: "fingerprint diagnostics",
+			key:  DiscardFieldFingerprintDiagnostics,
+			mutate: func(bf *BookFile) {
+				bf.FingerprintDiagnosticJSON = discardStrPtr(strings.Repeat("d", blob))
+			},
+			wantSize: blob,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := setupTestPebbleStore(t)
+			store.WaitForWarmup()
+			seedOneBookFile(t, store, tc.name, tc.mutate)
+
+			mem := warmBytesFresh(t, store)
+			byField := mem.LastWarmupDiscardedByField()
+
+			require.GreaterOrEqual(t, byField[tc.key], tc.wantSize,
+				"%q must be charged at least the %d bytes seeded into it", tc.key, tc.wantSize)
+
+			// Every OTHER book_file group must stay at zero. This is the
+			// assertion that catches an implementation which sums correctly in
+			// total but attributes to the wrong key.
+			for _, other := range []string{
+				DiscardFieldAcoustIDFingerprint,
+				DiscardFieldAcoustIDSegments,
+				DiscardFieldIntroTranscription,
+				DiscardFieldFingerprintDiagnostics,
+			} {
+				if other == tc.key {
+					continue
+				}
+				require.Zero(t, byField[other],
+					"seeded only %q, but %q was charged %d bytes", tc.key, other, byField[other])
+			}
+		})
+	}
+}
+
+// TestDiscardByField_SegmentsAreChargedOnlyFromLegacyRows records a fact that
+// changes how the production number must be read.
+//
+// AcoustIDSeg0..6 CANNOT be seeded through CreateBookFile: the write path
+// deliberately omits them from the stored row and keeps them only in the
+// book_file_acoustid: secondary index — pinned by
+// TestCreateBookFile_StoredValueLacksSegs. A row written by the current code
+// therefore contributes exactly zero to this group.
+//
+// So a nonzero acoustid_seg0_6 in a production discarded_field_mb is NOT a
+// measure of ongoing cost that a schema change would remove. It is a measure of
+// how much un-migrated legacy data is still sitting in the keyspace, and the
+// remedy is a backfill, not a redesign. Reading it as the former would aim an
+// expensive fix at bytes that new writes already stopped producing.
+//
+// The row here is written as raw JSON precisely because the supported API
+// refuses to produce one.
+func TestDiscardByField_SegmentsAreChargedOnlyFromLegacyRows(t *testing.T) {
+	const segLen = 4096
+
+	store := setupTestPebbleStore(t)
+	store.WaitForWarmup()
+
+	hash := "discardfield-legacy"
+	book, err := store.CreateBook(&Book{
+		Title:    "Discard Field Legacy",
+		FilePath: "/tmp/discardfield_legacy.m4b",
+		FileHash: &hash,
+	})
+	require.NoError(t, err)
+
+	// Control: the supported write path really does drop the segs, so the
+	// legacy charge below cannot be coming from this row.
+	seedOneBookFile(t, store, "legacy-control", func(bf *BookFile) {
+		bf.AcoustIDSeg0 = strings.Repeat("a", segLen)
+	})
+	mem := warmBytesFresh(t, store)
+	require.Zero(t, mem.LastWarmupDiscardedByField()[DiscardFieldAcoustIDSegments],
+		"CreateBookFile omits segs from the stored row, so nothing should be charged yet")
+
+	// Now a legacy-format row, written straight to Pebble.
+	legacy := fmt.Sprintf(
+		`{"id":"01LEGACYSEG","book_id":%q,"file_path":"/tmp/legacy_seg.mp3","acoustid_seg0":%q}`,
+		book.ID, strings.Repeat("a", segLen))
+	require.NoError(t,
+		store.db.Set([]byte("book_file:"+book.ID+":01LEGACYSEG"), []byte(legacy), nil))
+
+	mem = warmBytesFresh(t, store)
+	byField := mem.LastWarmupDiscardedByField()
+	require.GreaterOrEqual(t, byField[DiscardFieldAcoustIDSegments], int64(segLen),
+		"a legacy row carrying acoustid_seg0 must be charged to the segments group")
+}
+
+// TestDiscardByField_CoversTheBooksPhaseToo pins that the books phase — 729 MB
+// across 67,824 rows on production, the second largest — is accounted at all.
+// It was unmeasured in the first version, which meant a fifth of the discarded
+// bytes in the library had no owner.
+func TestDiscardByField_CoversTheBooksPhaseToo(t *testing.T) {
+	const blob = 4096
+
+	store := setupTestPebbleStore(t)
+	store.WaitForWarmup()
+
+	hash := "discardfield-book"
+	sig := strings.Repeat("S", blob)
+	desc := strings.Repeat("D", blob)
+	_, err := store.CreateBook(&Book{
+		Title:       "Discard Field Book",
+		FilePath:    "/tmp/discardfield_book.m4b",
+		FileHash:    &hash,
+		Description: &desc,
+		// BookSigV1 is ALREADY a base64 string in the struct, not a []byte.
+		// Running EncodedLen over it would over-charge it by 4/3 and inflate
+		// the books phase against book_files.
+		BookSigV1: &sig,
+	})
+	require.NoError(t, err)
+
+	mem := warmBytesFresh(t, store)
+	byField := mem.LastWarmupDiscardedByField()
+
+	require.GreaterOrEqual(t, byField[DiscardFieldDescription], int64(blob),
+		"the books phase must charge Description/VersionNotes")
+	require.GreaterOrEqual(t, byField[DiscardFieldBookSignature], int64(blob),
+		"the books phase must charge BookSigV1/BookSigV1Mask")
+	require.Less(t, byField[DiscardFieldBookSignature], int64(blob*4/3),
+		"BookSigV1 is already base64; charging it EncodedLen over-states it by 4/3")
+}
+
+// TestDiscardByField_SumsToThePerPhaseTotal is the consistency check between
+// the two views. If they disagree, one of them is wrong and neither can be
+// trusted to pick a fix — which is the only thing these numbers exist for.
+func TestDiscardByField_SumsToThePerPhaseTotal(t *testing.T) {
+	store := setupTestPebbleStore(t)
+	store.WaitForWarmup()
+
+	for i := 0; i < 4; i++ {
+		tag := fmt.Sprintf("sum%02d", i)
+		seedOneBookFile(t, store, tag, func(bf *BookFile) {
+			bf.AcoustIDFingerprint = warmBytesFingerprint(2048)
+			bf.AcoustIDSeg0 = strings.Repeat("a", 128)
+			bf.IntroTranscription = discardStrPtr(strings.Repeat("t", 512))
+		})
+	}
+
+	mem := warmBytesFresh(t, store)
+	_, discarded := mem.LastWarmupBytes()
+	byField := mem.LastWarmupDiscardedByField()
+
+	var fieldSum int64
+	for _, v := range byField {
+		fieldSum += v
+	}
+
+	var phaseSum int64
+	for _, v := range discarded {
+		phaseSum += v
+	}
+
+	require.Equal(t, phaseSum, fieldSum,
+		"per-field totals (%d) and per-phase totals (%d) describe the same bytes and must agree",
+		fieldSum, phaseSum)
+	require.Greater(t, fieldSum, int64(0), "the fixture seeds discarded bytes, so the sum cannot be zero")
+}


### PR DESCRIPTION
## Why

The aggregate from #2380, measured on production this afternoon:

    duration_ms=134572
    phase_ms     = book_files:113778  books:13763 ...
    phase_mb     = book_files:2436    books:729   ...
    discarded_mb = book_files:1853

**76% of the `book_files` phase is read only to be discarded.** That establishes a fix is worth doing. It does not say *which* fix, and the candidates are not interchangeable:

| candidate | cost to move out of the row |
|---|---|
| `AcoustIDFingerprint` (`[]byte`) | ~13 read sites, **plus** retiring the write-back preserve-guards in `pebble_store_bookfiles.go` that exist *because* a bare memdb round-trip once wiped fingerprints in production. The two writes must become one atomic batch. |
| `IntroTranscription`, diagnostics (`*string`) | few readers, no guard |

Recommending the expensive, data-loss-sensitive option off an aggregate that might be dominated by the cheap one would repeat the exact error the aggregate caught — the call graph implied ~99%, the measurement said 76%.

## What

`discarded_field_mb` splits the total across six field groups. The `books` phase — **729 MB across 67,824 rows**, second-largest and previously unmeasured — is now accounted too.

`BookSigV1`/`BookSigV1Mask` are charged their plain length, **not** `EncodedLen`: they're already base64 *strings* in the struct, so encoding them again would overstate the books phase against `book_files` by 4/3.

## A finding that changes how to read the number

**`AcoustIDSeg0..6` cannot be seeded through `CreateBookFile` at all.** The write path deliberately omits them from the stored row, keeping them only in the `book_file_acoustid:` secondary index — already pinned by `TestCreateBookFile_StoredValueLacksSegs`. A row written by current code contributes **exactly zero** to that group.

So a nonzero `acoustid_seg0_6` in production is **not** ongoing cost a schema change would remove. It measures how much un-migrated legacy data is still in the keyspace, and the remedy is a backfill, not a redesign. Reading it the other way would aim an expensive fix at bytes new writes already stopped producing.

That's now its own test, seeding a legacy row as raw JSON because the supported API refuses to produce one.

## Verifying the instrument

Four negative controls, each turning the right test red:

| break | test that caught it |
|---|---|
| cross-attribute transcript → fingerprint | `ChargesEachGroupToItsOwnKey/intro_transcription` |
| `EncodedLen` over `BookSigV1` (already b64) | `CoversTheBooksPhaseToo` |
| books phase stops populating `byField` | `CoversTheBooksPhaseToo` |
| charge fingerprint `DecodedLen` not `EncodedLen` | `ChargesEachGroupToItsOwnKey/fingerprint` |

A fifth attempt — deleting the `base64` call outright — exited non-zero **without running anything**, because the import went unused. Exit status alone would have scored that as a passing control. Re-run as `DecodedLen` so the binary compiles and the assertion actually executes.

`SumsToThePerPhaseTotal` cross-checks the two views against each other: if per-field and per-phase disagree, neither can be trusted to pick a fix, which is the only thing these numbers exist for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp