### PR TITLE
fix(organizer): distinguish the three ways a target is occupied, and record every failure

### DIFF
--- a/changelog.d/20260813_190000_organize_failure_accounting.md
+++ b/changelog.d/20260813_190000_organize_failure_accounting.md
@@ -1,0 +1,42 @@
+### Fixed
+
+#### An occupied organize target now says WHICH kind of occupied, and a whole class of failures reaches the change log
+
+Two defects in how a failed organize reports itself. Neither loses data; both
+make a production log impossible to count.
+
+**`ErrTargetOccupied` collapsed two opposite problems.** When the computed
+target path is already taken, there are two real cases and they take opposite
+remedies: another *book row* owns the path (two rows expand to one name — a
+dedup candidate), or a *file with no book row* sits there (residue of a partial
+organize — delete or quarantine it). Both produced a byte-identical error
+string, so a survey of **19,519** occupied-target lines on production could say
+only that they happened.
+
+They are now distinguished by `ErrTargetOccupiedByBook` and
+`ErrTargetOccupiedByOrphan`, and the by-book message names the occupying book's
+ID so a dedup candidate can actually be built. Both still wrap
+`ErrTargetOccupied`, so existing `errors.Is` callers are unaffected.
+
+A third case, `ErrTargetOccupantUnknown`, exists to keep the other two
+trustworthy. "Orphan" is a *positive* finding — the database was asked and
+answered that nobody owns the path. A lookup that never ran, because no store is
+wired or the query itself failed, also yields a nil occupant. Folding the two
+together would manufacture orphans out of database errors and aim file deletion
+at paths a book may well own. A test drives a failing lookup specifically to
+hold that line.
+
+**A failure branch incremented the counter without recording the change.** When
+`CreateOrganizedVersion` fails, `PerformOrganize` bumped `stats.Failed` and
+jumped straight to the progress label, writing no `organize_failed`
+`OperationChange` — while the other failure branch wrote one. The visible
+consequence is not a missing log line (`CreateOrganizedVersion` logs its own
+error) but that the operation's **summary** and the operation's **change log**
+disagree with nothing saying so: reconciling "the op reports N failed" against
+the change rows silently returns fewer than N, and the gap reads as books that
+were fine. This is one concrete mechanism behind an earlier production survey
+being unable to reproduce its own headline figure of 3,194 failures.
+
+`MockStore.CreateOperationChange` was a hard-coded `return nil` with no hook, so
+no test could observe an operation's change log at all. It now takes a
+`CreateOperationChangeFunc` like its neighbours.

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/mock_store.go
-// version: 1.82.0
+// version: 1.83.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-08-06
+// last-edited: 2026-08-13
 
 package database
 
@@ -167,6 +167,11 @@ type MockStore struct {
 	GetSystemActivityLogsFunc   func(source string, limit int) ([]SystemActivityLog, error)
 	PruneOperationLogsFunc      func(olderThan time.Time) (int, error)
 	PruneOperationChangesFunc   func(olderThan time.Time) (int, error)
+	// CreateOperationChangeFunc lets a test observe the change rows an
+	// operation writes. CreateOperationChange returned a bare nil with no hook,
+	// so a test could assert an operation's SUMMARY but never its CHANGE LOG —
+	// and the two disagreeing, silently, is itself a defect class here.
+	CreateOperationChangeFunc func(change *OperationChange) error
 	PruneSystemActivityLogsFunc func(olderThan time.Time) (int, error)
 
 	// AI jobs
@@ -1964,6 +1969,9 @@ func (m *MockStore) Optimize() error {
 }
 
 func (m *MockStore) CreateOperationChange(change *OperationChange) error {
+	if m.CreateOperationChangeFunc != nil {
+		return m.CreateOperationChangeFunc(change)
+	}
 	return nil
 }
 

--- a/internal/organizer/organize_failure_record_test.go
+++ b/internal/organizer/organize_failure_record_test.go
@@ -1,0 +1,166 @@
+// file: internal/organizer/organize_failure_record_test.go
+// version: 1.0.0
+// guid: 6f13c8b0-4a72-49de-85c1-2b90e7d43a1f
+// last-edited: 2026-08-13
+
+package organizer
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/logger"
+)
+
+// PerformOrganize has two places that increment stats.Failed. Only one of them
+// used to write an organize_failed OperationChange.
+//
+// The consequence is not a missing log line — CreateOrganizedVersion logs its
+// own error. It is that the operation's SUMMARY and the operation's CHANGE LOG
+// disagree, and nothing says so. Reconciling "the op reports N failed" against
+// the organize_failed rows silently returns fewer than N, and the difference
+// reads as books that were fine rather than failures nobody recorded.
+//
+// That matters here specifically: an earlier survey of production organize
+// failures could not reproduce its own headline figure of 3,194, and the
+// leading explanation was that the number came from a stats.Failed which counts
+// more than the log lines do. This is one concrete way those two can drift.
+
+// failureRecorder collects the OperationChange rows a run writes.
+type failureRecorder struct {
+	mu      sync.Mutex
+	changes []database.OperationChange
+}
+
+func (r *failureRecorder) record(c *database.OperationChange) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.changes = append(r.changes, *c)
+	return nil
+}
+
+func (r *failureRecorder) ofType(t string) []database.OperationChange {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []database.OperationChange
+	for _, c := range r.changes {
+		if c.ChangeType == t {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// TestOrganizeFailure_CreateVersionFailureIsRecorded drives a real
+// PerformOrganize whose CreateOrganizedVersion cannot succeed, and asserts the
+// failure reaches the operation's change log rather than only the counter.
+func TestOrganizeFailure_CreateVersionFailureIsRecorded(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDir := filepath.Join(tmpDir, "import")
+	rootDir := filepath.Join(tmpDir, "library")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir import: %v", err)
+	}
+	srcPath := filepath.Join(srcDir, "foundation.m4b")
+	if err := os.WriteFile(srcPath, []byte("audio bytes"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	// PerformOrganize reads RootDir and the naming patterns from the process
+	// config. Restore them so this test cannot leak into its neighbours.
+	prev := config.AppConfig
+	t.Cleanup(func() { config.AppConfig = prev })
+	config.AppConfig.RootDir = rootDir
+	config.AppConfig.FolderNamingPattern = "{author}"
+	config.AppConfig.FileNamingPattern = "{title}"
+	config.AppConfig.OrganizationStrategy = "copy"
+
+	const bookID = "book-createfail"
+	const opID = "op-createfail"
+	createErr := errors.New("pebble: batch commit failed")
+
+	rec := &failureRecorder{}
+	mockDB := &database.MockStore{
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			if id != bookID {
+				return nil, nil
+			}
+			return &database.Book{
+				ID:       bookID,
+				Title:    "Foundation",
+				FilePath: srcPath,
+				Author:   &database.Author{Name: "Asimov"},
+			}, nil
+		},
+		// FilterBooksNeedingOrganization refuses any book outside RootDir that
+		// has no active book_files — it cannot know which files to copy. Without
+		// this the book is filtered out before organize runs and the test
+		// passes vacuously against a run that did nothing.
+		GetBookFilesFunc: func(string) ([]database.BookFile, error) {
+			return []database.BookFile{{BookID: bookID, FilePath: srcPath}}, nil
+		},
+		// The organized-version row cannot be written. This is the branch that
+		// used to bump the counter and jump straight to the progress label.
+		CreateBookFunc: func(*database.Book) (*database.Book, error) {
+			return nil, createErr
+		},
+		CreateOperationChangeFunc: rec.record,
+	}
+
+	svc := NewService(mockDB)
+	// Set by the server package in production; nil here would panic inside
+	// CreateOrganizedVersion before the failure under test could happen.
+	svc.ApplyOrganizedFileMetadata = func(*database.Book, string) {}
+
+	err := svc.PerformOrganize(
+		context.Background(),
+		&Request{OperationID: opID, BookIDs: []string{bookID}},
+		logger.New("test"),
+	)
+	// One book, and it failed, so the run is a total failure and reports one.
+	// The assertion under test is the change record, not this error.
+	if err == nil {
+		t.Log("PerformOrganize returned nil; the outcome contract is covered by organize_outcome_test.go")
+	}
+
+	// Prove the run actually REACHED the book before asserting anything about
+	// what it recorded. The first draft of this test mocked no book_files, so
+	// FilterBooksNeedingOrganization dropped the book, PerformOrganize
+	// processed zero books, and "no organize_failed change was written" was
+	// true for a reason that had nothing to do with the defect. A missing-row
+	// assertion is only evidence if the row had a chance to exist.
+	summaries := rec.ofType("organize_summary")
+	if len(summaries) != 1 {
+		t.Fatalf("expected one organize_summary row, got %d", len(summaries))
+	}
+	if !strings.Contains(summaries[0].NewValue, "failed:1") ||
+		!strings.Contains(summaries[0].NewValue, "total:1") {
+		t.Fatalf("the run did not reach the book — summary was %q, want failed:1 and total:1",
+			summaries[0].NewValue)
+	}
+
+	failures := rec.ofType("organize_failed")
+	if len(failures) != 1 {
+		t.Fatalf("expected exactly 1 organize_failed change for the failed book, got %d (%+v)",
+			len(failures), rec.changes)
+	}
+	if failures[0].BookID != bookID {
+		t.Errorf("organize_failed change names book %q, want %q", failures[0].BookID, bookID)
+	}
+	if failures[0].OperationID != opID {
+		t.Errorf("organize_failed change names operation %q, want %q", failures[0].OperationID, opID)
+	}
+	// The recorded value must carry WHY. A change row that says only "it
+	// failed" leaves the reconciliation possible but the diagnosis impossible,
+	// which is half the point of writing the row at all.
+	if failures[0].NewValue == "" {
+		t.Error("organize_failed change recorded no reason")
+	}
+}

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -1,7 +1,7 @@
 // file: internal/organizer/organizer.go
-// version: 1.20.0
+// version: 1.21.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-08-11
+// last-edited: 2026-08-13
 
 package organizer
 
@@ -34,6 +34,58 @@ import (
 // via GetBookByFilePath, and either create a dedup candidate or ask
 // the user to resolve the collision before retrying.
 var ErrTargetOccupied = errors.New("organize: target path already occupied by a different file")
+
+// The three ways a target can be occupied. Every occupied-target error wraps
+// BOTH ErrTargetOccupied and exactly one of these, so existing
+// errors.Is(err, ErrTargetOccupied) callers keep working unchanged while a new
+// caller can ask which kind it is.
+//
+// Why this needed splitting: the two real cases take OPPOSITE remediation, and
+// until now they produced a byte-identical error string, so a production log
+// could not be counted into "how many need dedup" and "how many need cleanup".
+// A survey of 19,519 occupied-target lines on production could say only that
+// they existed.
+//
+//   - ByBook   — another book row owns the target. Two library rows expand to
+//     the same name. Actionable as a dedup candidate.
+//   - ByOrphan — a file sits at the target and NO book row claims it, e.g. the
+//     residue of a partial organize. Actionable as file cleanup; opening a
+//     dedup candidate for it would be meaningless, there is no second book.
+//
+// The third exists so the other two stay trustworthy:
+//
+//   - Unknown  — the ownership question was never answered, because there is
+//     no store wired or the lookup itself failed. This is NOT an orphan. An
+//     orphan is a positive finding ("the DB was asked and said nobody owns
+//     it"); folding a failed lookup into it would manufacture orphans out of
+//     database errors and send someone deleting files on the strength of a
+//     question that was never asked.
+var (
+	ErrTargetOccupiedByBook   = errors.New("occupant is another book row")
+	ErrTargetOccupiedByOrphan = errors.New("occupant is an untracked file with no book row")
+	ErrTargetOccupantUnknown  = errors.New("occupant not identified: no store wired or lookup failed")
+)
+
+// newTargetOccupiedError builds the occupied-target error, tagging it with
+// which of the three cases applies.
+//
+// occupantKnown means the ownership lookup RAN AND SUCCEEDED — it is not
+// "occupant != nil". The two must stay separate: a successful lookup returning
+// nil is the orphan finding, while a lookup that never ran also has a nil
+// occupant and means nothing at all.
+func newTargetOccupiedError(targetPath string, occupant *database.Book, occupantKnown bool) error {
+	switch {
+	case occupant != nil:
+		return fmt.Errorf("%w: %w (book %s): %s",
+			ErrTargetOccupied, ErrTargetOccupiedByBook, occupant.ID, targetPath)
+	case occupantKnown:
+		return fmt.Errorf("%w: %w: %s",
+			ErrTargetOccupied, ErrTargetOccupiedByOrphan, targetPath)
+	default:
+		return fmt.Errorf("%w: %w: %s",
+			ErrTargetOccupied, ErrTargetOccupantUnknown, targetPath)
+	}
+}
 
 // Organizer handles file organization operations
 type Organizer struct {
@@ -170,9 +222,20 @@ func (o *Organizer) OrganizeBook(book *database.Book) (string, string, error) {
 		// Case 2: ask the DB who owns the target. If it's the current
 		// book, this is a re-organize no-op — don't panic, don't fire
 		// the collision hook, just return the target.
+		//
+		// The lookup's result is kept rather than discarded: the same answer
+		// that distinguishes case 2 also distinguishes case 3 from case 4,
+		// and those two need opposite remediation (see below).
+		var occupant *database.Book
+		occupantKnown := false
 		if o.store != nil && book.ID != "" {
-			if owner, lookupErr := o.store.GetBookByFilePath(targetPath); lookupErr == nil && owner != nil && owner.ID == book.ID {
-				return targetPath, "", nil
+			owner, lookupErr := o.store.GetBookByFilePath(targetPath)
+			if lookupErr == nil {
+				occupantKnown = true
+				occupant = owner
+				if owner != nil && owner.ID == book.ID {
+					return targetPath, "", nil
+				}
 			}
 		}
 		// Case 3/4: collision. Fire the hook so the server can create a
@@ -184,7 +247,7 @@ func (o *Organizer) OrganizeBook(book *database.Book) (string, string, error) {
 		if o.hooks != nil {
 			o.hooks.OnCollision(book.ID, targetPath)
 		}
-		return targetPath, "", fmt.Errorf("%w: %s", ErrTargetOccupied, targetPath)
+		return targetPath, "", newTargetOccupiedError(targetPath, occupant, occupantKnown)
 	}
 
 	// Perform the organization based on strategy

--- a/internal/organizer/service.go
+++ b/internal/organizer/service.go
@@ -1,7 +1,7 @@
 // file: internal/organizer/service.go
-// version: 1.15.0
+// version: 1.16.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
-// last-edited: 2026-08-12
+// last-edited: 2026-08-13
 
 package organizer
 
@@ -986,6 +986,31 @@ func (orgSvc *Service) organizeBooks(ctx context.Context, booksToOrganize []data
 						statsMu.Lock()
 						stats.Failed++
 						statsMu.Unlock()
+
+						// Record the failure against the operation, the same
+						// way the file-operation failure path above does.
+						//
+						// This branch used to increment stats.Failed and jump
+						// straight to the progress label, writing no
+						// OperationChange at all. The consequence is not a
+						// missing log line — CreateOrganizedVersion logs its
+						// own error — it is that the operation's summary and
+						// the operation's change log DISAGREE, with nothing
+						// saying so. Reconciling "the op reports N failed"
+						// against the organize_failed rows silently returns
+						// fewer than N, and the gap looks like clean books
+						// rather than unrecorded failures.
+						if operationID != "" {
+							_ = orgSvc.db.CreateOperationChange(&database.OperationChange{
+								ID:          ulid.Make().String(),
+								OperationID: operationID,
+								BookID:      book.ID,
+								ChangeType:  "organize_failed",
+								FieldName:   "file_path",
+								OldValue:    oldPath,
+								NewValue:    createErr.Error(),
+							})
+						}
 						goto progress
 					}
 

--- a/internal/organizer/target_occupied_classification_test.go
+++ b/internal/organizer/target_occupied_classification_test.go
@@ -1,0 +1,221 @@
+// file: internal/organizer/target_occupied_classification_test.go
+// version: 1.0.0
+// guid: 2d7f4a19-8b06-4c35-91ea-3f70c852bd64
+// last-edited: 2026-08-13
+
+package organizer
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// An occupied target has three possible meanings and they were, until now, one
+// byte-identical error string. A production survey of 19,519 occupied-target
+// log lines could therefore say only that they happened — not how many needed
+// dedup and how many needed file cleanup, which are opposite remedies.
+//
+//	ByBook   — another book row owns the target. Two rows expand to one name.
+//	           Remedy: a dedup candidate.
+//	ByOrphan — a file sits there and NO book row claims it. Remedy: delete or
+//	           quarantine the file. Opening a dedup candidate is meaningless;
+//	           there is no second book.
+//	Unknown  — the ownership question was never answered.
+//
+// The third case is the one that makes the other two worth having. "Orphan" is
+// a POSITIVE finding: the database was asked, and answered that nobody owns the
+// path. A lookup that never ran — no store wired, or the query itself failed —
+// also has a nil occupant. Folding the two together would manufacture orphans
+// out of database errors and point cleanup at files that a book may well own.
+// These tests exist mostly to hold that line.
+
+// occupiedFixture builds two different source files whose metadata expands to
+// the same target, organizes the first, and returns the organizer plus the
+// second book, which is now guaranteed to collide.
+func occupiedFixture(t *testing.T, store database.Store) (*Organizer, *database.Book) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	srcDir := filepath.Join(tmpDir, "source")
+	dstDir := filepath.Join(tmpDir, "output")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+
+	srcA := filepath.Join(srcDir, "a.m4b")
+	srcB := filepath.Join(srcDir, "b.m4b")
+	if err := os.WriteFile(srcA, []byte("content A"), 0644); err != nil {
+		t.Fatalf("write A: %v", err)
+	}
+	if err := os.WriteFile(srcB, []byte("content B - different bytes"), 0644); err != nil {
+		t.Fatalf("write B: %v", err)
+	}
+
+	org := NewOrganizer(&config.Config{
+		RootDir:              dstDir,
+		FolderNamingPattern:  "{author}",
+		FileNamingPattern:    "{title}",
+		OrganizationStrategy: "copy",
+	})
+
+	// Organize A with no store, so the fixture's own setup cannot depend on
+	// the lookup behaviour under test.
+	bookA := &database.Book{
+		ID:       "book-a",
+		Title:    "Foundation",
+		FilePath: srcA,
+		Author:   &database.Author{Name: "Asimov"},
+	}
+	if _, _, err := org.OrganizeBook(bookA); err != nil {
+		t.Fatalf("fixture setup: organizing A must succeed, got %v", err)
+	}
+
+	if store != nil {
+		org.SetStore(store)
+	}
+	return org, &database.Book{
+		ID:       "book-b",
+		Title:    "Foundation",
+		FilePath: srcB,
+		Author:   &database.Author{Name: "Asimov"},
+	}
+}
+
+// assertExactlyOneKind pins that the three sub-sentinels are mutually
+// exclusive. Without this an implementation could tag an error with two of them
+// and satisfy every individual errors.Is assertion while making the counts
+// derived from them sum to more than the number of failures.
+func assertExactlyOneKind(t *testing.T, err error, want error) {
+	t.Helper()
+
+	if !errors.Is(err, ErrTargetOccupied) {
+		t.Errorf("every occupied-target error must still satisfy errors.Is(err, ErrTargetOccupied); got %v", err)
+	}
+
+	kinds := []struct {
+		name string
+		err  error
+	}{
+		{"ByBook", ErrTargetOccupiedByBook},
+		{"ByOrphan", ErrTargetOccupiedByOrphan},
+		{"Unknown", ErrTargetOccupantUnknown},
+	}
+	matched := 0
+	for _, k := range kinds {
+		if errors.Is(err, k.err) {
+			matched++
+			if k.err != want {
+				t.Errorf("error was tagged %s, want %v; full error: %v", k.name, want, err)
+			}
+		}
+	}
+	if matched != 1 {
+		t.Errorf("expected exactly one of ByBook/ByOrphan/Unknown to match, %d did: %v", matched, err)
+	}
+}
+
+// TestTargetOccupied_ByAnotherBook — the dedup-actionable case.
+func TestTargetOccupied_ByAnotherBook(t *testing.T) {
+	occupantID := "book-occupant-01"
+	store := &database.MockStore{
+		GetBookByFilePathFunc: func(path string) (*database.Book, error) {
+			return &database.Book{ID: occupantID, Title: "Foundation", FilePath: path}, nil
+		},
+	}
+
+	org, bookB := occupiedFixture(t, store)
+	_, _, err := org.OrganizeBook(bookB)
+	if err == nil {
+		t.Fatal("expected an occupied-target error, got nil")
+	}
+	assertExactlyOneKind(t, err, ErrTargetOccupiedByBook)
+
+	// The occupant's ID has to reach the message. Knowing "another book owns
+	// it" without knowing WHICH book leaves the dedup candidate unbuildable,
+	// which is the entire point of distinguishing this case.
+	if !strings.Contains(err.Error(), occupantID) {
+		t.Errorf("error must name the occupying book %q so a dedup candidate can be built; got %v",
+			occupantID, err)
+	}
+}
+
+// TestTargetOccupied_ByOrphanFile — the cleanup-actionable case. The lookup
+// runs and succeeds, and reports that no book row owns the path.
+func TestTargetOccupied_ByOrphanFile(t *testing.T) {
+	store := &database.MockStore{
+		GetBookByFilePathFunc: func(string) (*database.Book, error) {
+			return nil, nil
+		},
+	}
+
+	org, bookB := occupiedFixture(t, store)
+	_, _, err := org.OrganizeBook(bookB)
+	if err == nil {
+		t.Fatal("expected an occupied-target error, got nil")
+	}
+	assertExactlyOneKind(t, err, ErrTargetOccupiedByOrphan)
+}
+
+// TestTargetOccupied_FailedLookupIsNotAnOrphan is the load-bearing test.
+//
+// A failed lookup and a successful "nobody owns it" both yield a nil occupant.
+// If the classifier keys off the occupant pointer alone, every database error
+// during an organize run is reported as an orphan file — and orphan is the
+// finding whose remedy is deleting the file.
+func TestTargetOccupied_FailedLookupIsNotAnOrphan(t *testing.T) {
+	store := &database.MockStore{
+		GetBookByFilePathFunc: func(string) (*database.Book, error) {
+			return nil, errors.New("pebble: iterator error")
+		},
+	}
+
+	org, bookB := occupiedFixture(t, store)
+	_, _, err := org.OrganizeBook(bookB)
+	if err == nil {
+		t.Fatal("expected an occupied-target error, got nil")
+	}
+	assertExactlyOneKind(t, err, ErrTargetOccupantUnknown)
+
+	if errors.Is(err, ErrTargetOccupiedByOrphan) {
+		t.Error("a FAILED ownership lookup was reported as an orphan — this sends cleanup at a file that may well be owned")
+	}
+}
+
+// TestTargetOccupied_NoStoreIsUnknown covers the other way the question goes
+// unasked. Every pre-existing collision test in this package constructs the
+// organizer without a store, so this is also the case they all now produce.
+func TestTargetOccupied_NoStoreIsUnknown(t *testing.T) {
+	org, bookB := occupiedFixture(t, nil)
+	_, _, err := org.OrganizeBook(bookB)
+	if err == nil {
+		t.Fatal("expected an occupied-target error, got nil")
+	}
+	assertExactlyOneKind(t, err, ErrTargetOccupantUnknown)
+}
+
+// TestTargetOccupied_SelfOwnedTargetIsStillANoOp guards the case that must NOT
+// become an error. When the DB says this exact book already owns the target,
+// it is a re-organize no-op — the same successful lookup that distinguishes
+// ByBook from ByOrphan is the one that has to keep letting this through.
+func TestTargetOccupied_SelfOwnedTargetIsStillANoOp(t *testing.T) {
+	store := &database.MockStore{
+		GetBookByFilePathFunc: func(path string) (*database.Book, error) {
+			return &database.Book{ID: "book-b", Title: "Foundation", FilePath: path}, nil
+		},
+	}
+
+	org, bookB := occupiedFixture(t, store)
+	target, _, err := org.OrganizeBook(bookB)
+	if err != nil {
+		t.Fatalf("a book that already owns the target must be a no-op, got %v", err)
+	}
+	if target == "" {
+		t.Error("no-op must still report the target path")
+	}
+}


### PR DESCRIPTION
Two defects in how a failed organize reports itself. Neither loses data; both make a production log impossible to count.

## 1. `ErrTargetOccupied` collapsed two opposite problems

When the computed target is already taken there are two real cases, with **opposite** remedies:

| case | what it means | remedy |
|---|---|---|
| **ByBook** | another book row owns the path — two rows expand to one name | open a dedup candidate |
| **ByOrphan** | a file sits there and no book row claims it — residue of a partial organize | delete or quarantine the file |

Both produced a **byte-identical error string**, so the survey of **19,519** occupied-target lines on production could say only that they happened — not how many needed dedup and how many needed cleanup.

Now tagged with `ErrTargetOccupiedByBook` / `ErrTargetOccupiedByOrphan`, and the by-book message **names the occupying book's ID** so the dedup candidate is actually buildable. Both still wrap `ErrTargetOccupied`, so existing `errors.Is` callers are unaffected — asserted directly.

### The third case is the point

`ErrTargetOccupantUnknown` exists to keep the other two trustworthy.

"Orphan" is a **positive finding**: the database was asked and answered that nobody owns the path. A lookup that *never ran* — no store wired, or the query failed — also yields a nil occupant. Folding them together **manufactures orphans out of database errors** and aims file deletion at paths a book may well own.

So the classifier keys off *"the lookup ran and succeeded"*, not off the occupant pointer, and a test drives a failing lookup specifically to hold that line.

## 2. A failure branch incremented the counter without recording the change

When `CreateOrganizedVersion` fails, `PerformOrganize` bumped `stats.Failed` and jumped straight to the progress label, writing no `organize_failed` `OperationChange` — while the other failure branch wrote one.

The visible consequence isn't a missing log line (`CreateOrganizedVersion` logs its own error). It's that the operation's **summary** and its **change log** disagree, with nothing saying so. Reconciling "the op reports N failed" against the change rows silently returns fewer than N, and the gap reads as books that were fine.

That's one concrete mechanism behind an earlier production survey being [unable to reproduce its own headline figure](../blob/main/todo.d/20260812-organize-collision-anatomy.md) of 3,194 failures.

`MockStore.CreateOperationChange` was a hard-coded `return nil` with no hook, so **no test could observe an operation's change log at all**. It now takes a `CreateOperationChangeFunc` like its neighbours. (Hand-written mock, not the mockery-generated one under `mocks/`.)

## Verifying the instrument

Five negative controls, each turning the right test red:

| break | test that caught it |
|---|---|
| classify off the occupant **pointer** alone | `FailedLookupIsNotAnOrphan`, `NoStoreIsUnknown` |
| `occupantKnown` hardcoded `true` | same two |
| drop the occupant ID from the message | `ByAnotherBook` |
| tag an error with two kinds at once | `assertExactlyOneKind` |
| revert the change-record fix | `CreateVersionFailureIsRecorded` |

The last one is worth its detail: the reverted run **still reports `failed:1 total:1`** in its summary and writes **zero** `organize_failed` rows — the two-sources-disagreeing defect shown directly.

That test asserts the summary *first*, because its own first draft mocked no `book_files`, the book was filtered out before organize ran, and "no change row was written" was true for a reason unrelated to the defect. **A missing-row assertion is only evidence if the row had a chance to exist.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp