### PR TITLE
docs(search): record the production shortfall the index repair measured

### DIFF
--- a/docs/executive-summaries/2026-08-13-the-books-search-could-not-see-executive-summary.md
+++ b/docs/executive-summaries/2026-08-13-the-books-search-could-not-see-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-08-13-the-books-search-could-not-see-executive-summary.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 7d915a69-5d11-4e2a-93fd-bdc1f27e70f1 -->
 <!-- last-edited: 2026-08-13 -->
 
@@ -44,10 +44,16 @@ finished and never went back. A half-built catalogue and a complete one looked i
 to it. Because the pass runs oldest-first, the books that never got cards were always
 the **newest** ones.
 
-We measured it on the live server. Books added in April: 97 out of 100 findable. Books
-added in August: **2 out of 100**. Almost everything added recently was invisible to
-search, and would have stayed invisible indefinitely — nothing in the system was ever
-going to notice.
+We now have the exact figure, because the repair reported it when it ran on the live
+server: **16,738 books had no card — just under a quarter of your library.** Every one
+of them was unfindable by any search on the website, silently, and would have stayed
+that way indefinitely. Nothing in the system was ever going to notice.
+
+*(An earlier estimate here, based on spot-checking about ninety books, said roughly 2 in
+100 of August's additions were findable versus 97 in 100 of April's. That pointed the
+right way but understated the total: 16,738 is far more than one month's worth of
+additions, so the hole was wider than the most recent books alone. The measured number
+above replaces it.)*
 
 There was already a repair mechanism, added earlier this month, and it did not help
 here. It repairs cards that were *dropped* when the system got busy. A book whose card
@@ -79,9 +85,21 @@ investigation is how fixes get harder to trust:
 - **Putting quotes around a phrase does not search for that phrase.** It currently
   appears to work by accident.
 
-One decision is yours: the repair runs on the next restart and will work through roughly
-40,000 books in the background. It can happen on the next natural restart or be
-scheduled deliberately.
+## It has now run
+
+The fix was deployed to the live server on the evening of 2026-08-13. On start-up it
+compared the catalogue against the shelves, found the 16,738 missing cards, and began
+working through the library in the background — without interrupting anything. The
+server stayed available and responsive throughout.
+
+The repair re-checks **every** book rather than only the missing ones. That is
+deliberate and not wasted effort: the count tells you *how many* cards are missing but
+never *which*, and the only way to find out which would be to trust the very catalogue
+that is known to be wrong. Re-checking a book that already has a good card is cheap and
+harmless; guessing wrong is not.
+
+It works oldest book first, which means the newest books — the ones most likely to have
+been missing — are the last to be restored.
 
 ## How we know it is fixed
 

--- a/todo.d/20260813-search-index-repair-prod-findings.md
+++ b/todo.d/20260813-search-index-repair-prod-findings.md
@@ -1,0 +1,39 @@
+### Search-index coverage repair — production findings (2026-08-13)
+
+The repair from #2381 ran on prod at 19:20 EDT. Measured, not estimated:
+
+```
+search index is short of the library; marking books for reconciliation
+    indexed=51086  books=67824  shortfall=16738
+```
+
+**16,738 books (24.7% of the library) were missing from the search index** and
+unfindable by any web search. The drain ran clean — `removed=0 failed=0` on every
+batch, ~5,000 per ~2.5 min.
+
+Follow-ups this surfaced:
+
+- [ ] **The store reports 67,824 live books; the API list endpoint reports 63,870.**
+      A 3,954-book gap. `ListBookIDs` already excludes `MarkedForDeletion`, so these
+      are live rows, and `/api/v1/audiobooks` applies no default filter when
+      `library_state` is empty. Paging the endpoint returns exactly 63,870 distinct
+      ids, so it is internally consistent — it simply never serves those 3,954.
+      **Cause not established.** Worth confirming whether they are genuinely
+      unreachable to clients or an artifact of how the total is derived; if the
+      former, it is a third invisible-books population, larger than the 765 in
+      `20260813-primary-version-census-corrections.md` and unrelated to it.
+- [ ] **The coverage gate compares two slightly different populations.**
+      `reconcileSearchIndexCoverage` tests `len(ListBookIDs()) <= DocCount()`.
+      `ListBookIDs` excludes deletion-marked books; `DocCount` counts whatever Bleve
+      holds, which can include docs for books since deleted. If stale docs ever
+      accumulate, the comparison can read "not short" while real books are missing —
+      the same "one comparison cannot distinguish two states" shape as the bug the
+      gate was written to catch. Deletes do flow through `DeleteIndexedBook` from both
+      the index worker and the reconciler, so this is currently latent, not active.
+      Consider comparing sets rather than counts, or logging both numbers on every
+      boot (the `indexed=`/`books=` pair already does this — keep it).
+- [ ] **Re-measure the per-cohort coverage now that a true figure exists.** The
+      earlier 2%-of-August / 97%-of-April figures were *sampled* (n=51 and n=39
+      decided) and pointed the right direction but understated the total: 16,738 is
+      more than a single month's intake, so the gap spans wider than the August
+      cohort alone. Treat the sampled percentages as superseded.

--- a/todo.d/20260813-search-index-repair-prod-findings.md
+++ b/todo.d/20260813-search-index-repair-prod-findings.md
@@ -32,6 +32,22 @@ Follow-ups this surfaced:
       the index worker and the reconciler, so this is currently latent, not active.
       Consider comparing sets rather than counts, or logging both numbers on every
       boot (the `indexed=`/`books=` pair already does this — keep it).
+- [ ] **The search index has ZERO metrics.** A live `/metrics` scrape returns 50 metric
+      families and **not one** mentions search, bleve, index, or dirty. This is the
+      direct reason a quarter of the library was unfindable for an unknown period with
+      nobody noticing — there was no signal to notice. `audiobook_organizer_books_total`
+      already exists, so **half the comparison is exported already**; adding a
+      `search_index_docs_total` gauge (and a dirty-backlog gauge) would have made this
+      bug a visible divergence on a graph rather than a user report. Note this also
+      re-confirms the earlier finding that `SearchIndexDroppedCount` is not on
+      `/metrics` despite a comment saying it is, and extends it: nothing about the index
+      is exported at all.
+- [ ] **`audiobook_organizer_books_total` reports the PRIMARY count, not the total.**
+      It is fed by `CountPrimaryBooks()` (`server_lifecycle.go:393`) while its help text
+      reads *"Current total number of books in library"*. Live value **40,841** against
+      **67,824** live books in the store — under-reporting the library by ~40%. Either
+      rename/reword it or add a true total alongside; any dashboard built on it is
+      currently wrong about the library size.
 - [ ] **Re-measure the per-cohort coverage now that a true figure exists.** The
       earlier 2%-of-August / 97%-of-April figures were *sampled* (n=51 and n=39
       decided) and pointed the right direction but understated the total: 16,738 is


### PR DESCRIPTION
## What this records

The #2381 search-index coverage repair ran against production at 19:20 EDT on 2026-08-13.
This files the measured result and the three follow-ups it surfaced.

## The number

```
search index is short of the library; marking books for reconciliation
    indexed=51086  books=67824  shortfall=16738
```

**16,738 books — 24.7% of the library — were missing from the search index**, and
unfindable by any web search. Nothing in the system reported it; the old
`buildSearchIndexIfEmpty` gate treated a non-empty index as a complete one.

The drain ran clean: `removed=0 failed=0` on every batch, ~5,000 books per ~2.5 min.

## Follow-ups filed

1. **Store reports 67,824 live books; the list endpoint serves 63,870** — a 3,954-book
   gap. `ListBookIDs` already excludes `MarkedForDeletion` and the endpoint applies no
   default filter, and paging returns exactly 63,870 distinct ids, so it is internally
   consistent. **Cause not established** — filed as an evidenced lead, not a diagnosis.
2. **The coverage gate compares a deletion-filtered count against a raw `DocCount`.**
   Latent today (deletes do flow through `DeleteIndexedBook`), but it is the same
   "one comparison cannot distinguish two states" shape as the bug it was written to catch.
3. **The earlier per-cohort coverage figures are superseded.** They were *sampled*
   (n=51 August, n=39 April), pointed the right direction, but understated the total —
   16,738 is more than a single month's intake.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxigqrwz9WfwN1wx8QhoQW