### PR TITLE
perf(database): move the book signature out of the book row into a sidecar

### DIFF
--- a/changelog.d/20260813_195000_perf_booksig_sidecar.md
+++ b/changelog.d/20260813_195000_perf_booksig_sidecar.md
@@ -1,0 +1,29 @@
+### Changed
+
+- **Startup no longer reads 580 MB of book signature it throws away.** The five
+  `BookSig*` fields now live under their own `book_sig:<id>` key instead of
+  inline in the `book:<id>` row. Measured on production 2026-08-13: the `books`
+  warmup phase read 729 MB, of which 580 MB (80%) was a signature that the
+  in-memory projection nils out the instant it finishes decoding. The warmup
+  scan is bounded `["book:", "book;")` and `_` sorts above `;`, so the sidecar
+  falls outside the range and those bytes stop being read at all.
+
+  Every signature consumer sees exactly what it saw before — dedup's signature
+  scan and AcoustID-conflict veto, the dataset builder, the op-dependency field
+  predicate, the AcoustID backfill, and the book-signature recovery audit all
+  reach their books through `GetBookByID` or `GetAllBooksFullFrom`, and both
+  hydrate the sidecar. Books already on disk are untouched: when no sidecar key
+  exists the read falls back to the inline value, so the 67,824 existing
+  signatures keep working with nothing migrated.
+
+  This also closes a data-loss shape rather than only a performance one.
+  Previously the sole thing preventing a memdb-projection round-trip from wiping
+  every signature was a hand-maintained preserve-guard in `UpdateBook` — a guard
+  that exists because that wipe already happened once, and whose own comment asks
+  the next author to keep it in sync. A book that arrives carrying no signature
+  now writes no sidecar key and deletes nothing, so not-wiping is the default
+  behaviour instead of something someone has to remember.
+
+  Note this reduces what startup READS, not what the database stores: the
+  copy-on-write `book_ver:` snapshots deliberately keep the full inline
+  signature, because the recovery audit recovers from them.

--- a/internal/database/memdb_strip.go
+++ b/internal/database/memdb_strip.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_strip.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-stripbook0001
-// last-edited: 2026-08-11
+// last-edited: 2026-08-13
 
 package database
 
@@ -26,6 +26,15 @@ package database
 // Predicates that filter by these fields (e.g. `field:description`)
 // silently miss against stripped books. The predicate paths that need
 // them (rare) should be routed through Pebble's GetBookByID instead.
+//
+// The five BookSig* fields are still cleared here even though CreateBook and
+// UpdateBook no longer write them into the row at all (they live under
+// book_sig:<id> — see pebble_store_booksig.go). Rows written before that
+// change still carry them inline and will until the migration op runs, so the
+// strip is what keeps those legacy rows out of the radix tree. Once every row
+// is migrated these five become no-ops; leave them, because the cost is a nil
+// assignment and removing them would silently re-admit ~22 KB per book if any
+// un-migrated row survives.
 func stripBookForMemdb(src *Book) *Book {
 	if src == nil {
 		return nil

--- a/internal/database/memdb_warmup_discard_field_test.go
+++ b/internal/database/memdb_warmup_discard_field_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/memdb_warmup_discard_field_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c4e08b52-71a9-4d36-9f2b-6a30df518e7c
 // last-edited: 2026-08-13
 
@@ -190,6 +190,18 @@ func TestDiscardByField_SegmentsAreChargedOnlyFromLegacyRows(t *testing.T) {
 // across 67,824 rows on production, the second largest — is accounted at all.
 // It was unmeasured in the first version, which meant a fifth of the discarded
 // bytes in the library had no owner.
+//
+// The book_sig_v1_and_mask half is now the same shape as
+// TestDiscardByField_SegmentsAreChargedOnlyFromLegacyRows, and for the same
+// reason: since the signature moved to the book_sig: sidecar
+// (pebble_store_booksig.go), CreateBook/UpdateBook strip it from the book: row,
+// so the supported write path can no longer produce an inline one. Nothing
+// asserts that the books phase charges a signature for a CURRENTLY-WRITABLE
+// book, because that state does not exist any more.
+//
+// Read a nonzero book_sig_v1_and_mask in production the same way: it measures
+// un-migrated legacy rows draining toward zero as the migration op runs, not
+// ongoing cost that new writes keep re-creating.
 func TestDiscardByField_CoversTheBooksPhaseToo(t *testing.T) {
 	const blob = 4096
 
@@ -216,8 +228,24 @@ func TestDiscardByField_CoversTheBooksPhaseToo(t *testing.T) {
 
 	require.GreaterOrEqual(t, byField[DiscardFieldDescription], int64(blob),
 		"the books phase must charge Description/VersionNotes")
+
+	// Control: Description above proves the books phase IS being walked, so a
+	// zero here is the sidecar strip working, not the phase going unmeasured.
+	require.Zero(t, byField[DiscardFieldBookSignature],
+		"CreateBook writes the signature to the book_sig: sidecar, so the book: row must carry none")
+
+	// Now a legacy-format row, written straight to Pebble the way rows looked
+	// before the sidecar existed.
+	legacy := fmt.Sprintf(
+		`{"id":"01LEGACYSIG","title":"Legacy Sig","file_path":"/tmp/legacy_sig.m4b","book_sig_v1":%q}`,
+		sig)
+	require.NoError(t, store.db.Set([]byte("book:01LEGACYSIG"), []byte(legacy), nil))
+
+	mem = warmBytesFresh(t, store)
+	byField = mem.LastWarmupDiscardedByField()
+
 	require.GreaterOrEqual(t, byField[DiscardFieldBookSignature], int64(blob),
-		"the books phase must charge BookSigV1/BookSigV1Mask")
+		"a legacy row carrying book_sig_v1 inline must be charged to the signature group")
 	require.Less(t, byField[DiscardFieldBookSignature], int64(blob*4/3),
 		"BookSigV1 is already base64; charging it EncodedLen over-states it by 4/3")
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.124.0
+// version: 1.125.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-08-13
 
@@ -614,6 +614,16 @@ func (p *PebbleStore) GetAllBooksFullFrom(afterID string, limit int) ([]Book, er
 		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
 			continue
 		}
+		// This branch decodes the row directly instead of point-getting each
+		// ID, so unlike the memdb branch above it does not inherit
+		// GetBookByID's sidecar hydration and has to do its own. Both branches
+		// must agree: BookSignatureScan filters on BookSigV1 != nil, and a
+		// UseMemDB=false store that silently returned unhydrated books would
+		// scan zero pairs and report success — the same shape as the bug the
+		// getAllPrimaryBooksWithFullFields comment documents.
+		if err := p.hydrateBookSig(&book); err != nil {
+			return nil, err
+		}
 		books = append(books, book)
 		count++
 		if limit > 0 && count >= limit {
@@ -992,6 +1002,17 @@ func (p *PebbleStore) GetBookByID(id string) (*Book, error) {
 	if err := json.Unmarshal(value, &book); err != nil {
 		return nil, err
 	}
+	// Full-fidelity read: fold in the book_sig: sidecar. This is THE hydration
+	// point — every signature consumer in the codebase reaches its Book through
+	// here (dedup's bookSignature and its AcoustID-conflict cache,
+	// dataset/builder's StoreAdapter.GetBook, registry deps' ReqFieldSet
+	// predicate, acoustid's synthesize read-modify-write, both of
+	// booksig_recovery_audit's reads, UpdateBook's own oldBook fetch, and
+	// GetAllBooksFullFrom's memdb branch, which point-gets each ID through this
+	// function). See pebble_store_booksig.go.
+	if err := p.hydrateBookSig(&book); err != nil {
+		return nil, err
+	}
 	return &book, nil
 }
 
@@ -1000,7 +1021,16 @@ func (p *PebbleStore) GetBookByID(id string) (*Book, error) {
 // nil-on-not-found). It reuses GetBookByID's exact read pattern per item —
 // the same book:<id> point-get + json.Unmarshal — so it is full-fidelity,
 // never a memdb-slim projection; heavy fields (AcoustIDFingerprint etc.)
-// survive.
+// survive — including the five BookSig* fields, which now come from the
+// book_sig: sidecar (pebble_store_booksig.go).
+//
+// Hydrating them here costs one extra point-get per id, and this is the search
+// hydration path, called with up to searchPostFilterWindow = 10000 ids. That
+// is still cheaper than what it replaced: the signature used to be read INLINE
+// as part of every row (~22 KB each), so the trade is N bytes-heavy reads for
+// N small seeks against much smaller rows. Skipping it would also quietly drop
+// book_sig_coverage_pct from the search payload, which the web client types and
+// renders as a partial-fingerprint chip.
 //
 // Concurrency: this is a plain sequential loop, not a worker pool. Per
 // CLAUDE.md's concurrency rule, that's correct here because callers bound
@@ -1010,7 +1040,7 @@ func (p *PebbleStore) GetBookByID(id string) (*Book, error) {
 //
 // Error semantics (spec §C3, verbatim contract): a per-item not-found is
 // skipped silently, matching GetBookByID. On the FIRST non-not-found
-// read/unmarshal error, the loop stops and returns the rows read so far
+// read/unmarshal/sidecar-hydrate error, the loop stops and returns the rows read so far
 // ALONGSIDE the error (not a bare nil, err) so the caller can still serve a
 // partial page instead of failing the whole request.
 func (p *PebbleStore) GetBooksByIDs(ids []string) ([]Book, error) {
@@ -1030,6 +1060,14 @@ func (p *PebbleStore) GetBooksByIDs(ids []string) ([]Book, error) {
 		closer.Close()
 		if unmarshalErr != nil {
 			return books, fmt.Errorf("unmarshal book %q: %w", id, unmarshalErr)
+		}
+		// Fold the sidecar back in. Returning the rows read so far ALONGSIDE
+		// the error is this function's existing contract (see the two branches
+		// above), and both search callers treat a non-nil error as fail-open —
+		// they warn and serve the partial page. Aborting outright here would
+		// turn one bad sidecar read into a truncated search page.
+		if err := p.hydrateBookSig(&book); err != nil {
+			return books, fmt.Errorf("hydrate book signature %q: %w", id, err)
 		}
 		books = append(books, book)
 	}
@@ -1898,7 +1936,9 @@ func (p *PebbleStore) CreateBook(book *Book) (*Book, error) {
 	book.CreatedAt = &now
 	book.UpdatedAt = &now
 
-	data, err := json.Marshal(book)
+	// The row is marshalled WITHOUT the five BookSig* fields; they go to the
+	// book_sig: sidecar below, in this same batch. See pebble_store_booksig.go.
+	data, err := json.Marshal(stripBookSigForRow(book))
 	if err != nil {
 		return nil, err
 	}
@@ -1908,6 +1948,14 @@ func (p *PebbleStore) CreateBook(book *Book) (*Book, error) {
 	// Main key
 	key := []byte(fmt.Sprintf("book:%s", book.ID))
 	if err := batch.Set(key, data, nil); err != nil {
+		batch.Close()
+		return nil, err
+	}
+
+	// Signature sidecar, in the SAME batch as the row it belongs to — a book
+	// can never exist with a partially-written signature. Writes nothing when
+	// the book carries no signature, which is the common case on create.
+	if err := writeBookSigToBatch(batch, book); err != nil {
 		batch.Close()
 		return nil, err
 	}
@@ -2079,12 +2127,21 @@ func (p *PebbleStore) UpdateBook(id string, book *Book) (*Book, error) {
 		book.Series = oldBook.Series
 	}
 
-	data, err := json.Marshal(book)
+	// The row is marshalled WITHOUT the five BookSig* fields; they go to the
+	// book_sig: sidecar below, in this same batch. See pebble_store_booksig.go.
+	data, err := json.Marshal(stripBookSigForRow(book))
 	if err != nil {
 		return nil, err
 	}
 
-	// CoW: snapshot old state before overwriting
+	// CoW: snapshot old state before overwriting.
+	//
+	// Deliberately NOT stripped: the snapshot keeps the full inline signature.
+	// booksig_recovery_audit recovers a wiped signature by scanning book_ver:
+	// rows for the newest one that still carries BookSigV1, and that safety net
+	// must not be removed in the same change that moves where the live copy
+	// lives. It does mean book_ver: rows stay large — this change reduces what
+	// STARTUP READS, not what the database stores on disk.
 	oldData, marshalErr := json.Marshal(oldBook)
 	if marshalErr != nil {
 		return nil, fmt.Errorf("failed to marshal old book for version: %w", marshalErr)
@@ -2102,6 +2159,17 @@ func (p *PebbleStore) UpdateBook(id string, book *Book) (*Book, error) {
 	// Update main key
 	key := []byte(fmt.Sprintf("book:%s", id))
 	if err := batch.Set(key, data, nil); err != nil {
+		batch.Close()
+		return nil, err
+	}
+
+	// Signature sidecar, same batch as the row. `book` reaches here already
+	// carrying oldBook's signature whenever the caller passed nil for it (the
+	// preserve-guard above), and oldBook is itself hydrated because it came
+	// from GetBookByID — so a memdb round-trip write re-writes the signature it
+	// read rather than dropping the key. When there is genuinely no signature,
+	// nothing is written and nothing is deleted.
+	if err := writeBookSigToBatch(batch, book); err != nil {
 		batch.Close()
 		return nil, err
 	}
@@ -2470,6 +2538,18 @@ func (p *PebbleStore) DeleteBook(id string) error {
 	// Delete main key
 	key := []byte(fmt.Sprintf("book:%s", id))
 	if err := batch.Delete(key, nil); err != nil {
+		batch.Close()
+		return err
+	}
+
+	// Delete the signature sidecar. Unconditional: gating on
+	// book.BookSigV1 != nil would make the teardown depend on the read that
+	// just hydrated it, so a sidecar that failed to hydrate — or a book whose
+	// row was written by an older build — would leak its key forever. A
+	// Delete of an absent key is a no-op in Pebble, so there is nothing to
+	// gain by checking. Same dangling-row class as the work/hash indexes
+	// below, which were added to this function after a writer got ahead of it.
+	if err := batch.Delete(bookSigKey(id), nil); err != nil {
 		batch.Close()
 		return err
 	}

--- a/internal/database/pebble_store_booksig.go
+++ b/internal/database/pebble_store_booksig.go
@@ -1,0 +1,196 @@
+// file: internal/database/pebble_store_booksig.go
+// version: 1.0.0
+// guid: 4c81f0a7-5e93-4d2b-9a16-7f30c8e51b42
+// last-edited: 2026-08-13
+
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// Book-signature sidecar: the five BookSig* fields live under their own
+// `book_sig:<id>` key instead of inline in the `book:<id>` row.
+//
+// WHY
+//
+// Measured on production 2026-08-13 (warmup byte accounting, #2383):
+//
+//	phase_mb[books]                          = 729
+//	discarded_mb[books]                      = 583
+//	discarded_field_mb[book_sig_v1_and_mask] = 580
+//
+// 80% of every byte the `books` warmup phase reads is a signature that
+// stripBookForMemdb nils out the instant it finishes decoding (memdb_strip.go).
+// Startup pays ~580 MB of Pebble reads, JSON decode and allocation for data
+// it discards by design. The warmup scan is bounded ["book:", "book;") and '_'
+// (0x5F) sorts above ';' (0x3B), so `book_sig:` keys fall outside that range —
+// the scan stops seeing these bytes entirely rather than skipping them.
+//
+// WHY IT IS ALSO SAFER, NOT ONLY FASTER
+//
+// Today the only thing between a bare memdb round-trip write and 67,824 wiped
+// signatures is the preserve-guard in UpdateBook ("if book.BookSigV1 == nil {
+// book.BookSigV1 = oldBook.BookSigV1 }"). That guard exists because the wipe
+// already happened once; booksig_recovery_audit is the op written to undo it,
+// and the guard's own comment asks the next author to "keep both in sync".
+//
+// With a sidecar, "the incoming Book carries no signature" means "do not touch
+// the book_sig: key". Not writing is the default, so the wipe stops depending
+// on anyone remembering a guard. The guard stays anyway — belt and braces, and
+// it is what keeps the re-serialized row correct for legacy inline data.
+//
+// WHY ALL FIVE FIELDS, NOT JUST THE TWO BIG ONES
+//
+// Only BookSigV1 (~22 KB base64) and BookSigV1Mask (~700 B) are large;
+// Segments, BuiltAt and CoveragePct are scalars worth nothing in bytes. They
+// move anyway because splitting them would manufacture a state the codebase
+// treats as damage: booksig_recovery_audit classifies a book as wiped on
+// `BookSigBuiltAt != nil && BookSigV1 == nil` and its remedy is restoring
+// book_ver: snapshot data over the live row. If BuiltAt stayed inline while V1
+// moved, every reader that does not hydrate would present that exact signature
+// and the audit would "recover" healthy books en masse.
+//
+// Keeping the five together also matches the partition the code already
+// enforces in three places — stripBookForMemdb nils all five, UpdateBook's
+// preserve-guard restores all five, restoreRecoverableFields restores all five.
+// The sidecar boundary is that same partition, not a fourth one.
+
+// bookSigKeyPrefix is deliberately NOT under "book:". The warmup scan, and
+// GetAllBooksFullFrom's non-memdb branch, iterate byte ranges anchored on
+// "book:"; a "book:sig:<id>" layout would land inside them and the row would
+// still be read on every startup, which is the entire cost being removed here.
+const bookSigKeyPrefix = "book_sig:"
+
+func bookSigKey(id string) []byte {
+	return []byte(bookSigKeyPrefix + id)
+}
+
+// bookSigSidecar is the stored payload. Field names are short because this key
+// is written once per signature build and read on every full-fidelity book
+// fetch; they are independent of Book's JSON tags and nothing outside this file
+// serializes it.
+type bookSigSidecar struct {
+	V1          *string    `json:"v1,omitempty"`
+	Mask        *string    `json:"mask,omitempty"`
+	Segments    *int       `json:"segments,omitempty"`
+	BuiltAt     *time.Time `json:"built_at,omitempty"`
+	CoveragePct *int       `json:"coverage_pct,omitempty"`
+}
+
+// bookSigOf projects a Book's five signature fields. ok is false when all five
+// are nil, which is what "this book has no signature" looks like and is also
+// what a memdb-stripped or BookCore-projected Book always looks like. Callers
+// use ok to decide whether to write anything at all — see writeBookSigToBatch.
+func bookSigOf(b *Book) (bookSigSidecar, bool) {
+	if b == nil {
+		return bookSigSidecar{}, false
+	}
+	s := bookSigSidecar{
+		V1:          b.BookSigV1,
+		Mask:        b.BookSigV1Mask,
+		Segments:    b.BookSigSegments,
+		BuiltAt:     b.BookSigBuiltAt,
+		CoveragePct: b.BookSigCoveragePct,
+	}
+	empty := s.V1 == nil && s.Mask == nil && s.Segments == nil &&
+		s.BuiltAt == nil && s.CoveragePct == nil
+	return s, !empty
+}
+
+// applyTo writes the sidecar's five fields onto b, replacing whatever was
+// there. The sidecar is authoritative when it exists: a book whose signature
+// was rebuilt has a fresh sidecar and a stale inline copy only if it predates
+// the migration, and in that ordering the sidecar is the newer value.
+func (s bookSigSidecar) applyTo(b *Book) {
+	if b == nil {
+		return
+	}
+	b.BookSigV1 = s.V1
+	b.BookSigV1Mask = s.Mask
+	b.BookSigSegments = s.Segments
+	b.BookSigBuiltAt = s.BuiltAt
+	b.BookSigCoveragePct = s.CoveragePct
+}
+
+// stripBookSigForRow returns a shallow copy of b with the five signature fields
+// cleared, for marshalling the `book:<id>` row. All five are pointers with
+// `omitempty`, so nilling them removes the keys from the JSON rather than
+// writing nulls — the row genuinely shrinks.
+//
+// This is a copy, not an in-place mutation, because CreateBook and UpdateBook
+// both return the *Book they were handed and callers go on reading the
+// signature off it (acoustid's synthesizeBookSignatureForBook sets the five
+// fields, calls UpdateBook, and its caller may keep using the struct).
+// Clearing in place would hand back a book that had just been saved with a
+// signature yet appeared to have none.
+func stripBookSigForRow(b *Book) *Book {
+	if b == nil {
+		return nil
+	}
+	cp := *b
+	cp.BookSigV1 = nil
+	cp.BookSigV1Mask = nil
+	cp.BookSigSegments = nil
+	cp.BookSigBuiltAt = nil
+	cp.BookSigCoveragePct = nil
+	return &cp
+}
+
+// hydrateBookSig fills b's signature fields from the sidecar.
+//
+// FALLBACK-FIRST: when no sidecar key exists, b is left exactly as it was, so a
+// legacy row that still carries the signature inline keeps working untouched
+// and un-migrated. That is what lets the read path ship before any data moves.
+//
+// A read error is returned, never swallowed. Treating a Pebble failure as "no
+// signature" would hand the caller a Book that is byte-identical to a wiped one
+// — and booksig_recovery_audit reads exactly that shape as damage requiring a
+// snapshot restore. Failing loudly is the only safe option here.
+func (p *PebbleStore) hydrateBookSig(b *Book) error {
+	if b == nil || b.ID == "" {
+		return nil
+	}
+	val, closer, err := p.db.Get(bookSigKey(b.ID))
+	if err == pebble.ErrNotFound {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get book signature sidecar %q: %w", b.ID, err)
+	}
+	defer closer.Close()
+
+	var s bookSigSidecar
+	if err := json.Unmarshal(val, &s); err != nil {
+		return fmt.Errorf("unmarshal book signature sidecar %q: %w", b.ID, err)
+	}
+	s.applyTo(b)
+	return nil
+}
+
+// writeBookSigToBatch stages the sidecar write alongside the caller's other
+// writes so the row and its signature land in ONE Pebble batch — there is no
+// window in which a book exists with a half-written signature.
+//
+// A book with no signature writes no key and DELETES nothing. That asymmetry is
+// deliberate and is the structural half of the wipe fix: every caller that
+// sourced its *Book from a memdb projection or a BookCore round-trip arrives
+// here with all five fields nil, and the correct response to that is to leave
+// the stored signature alone. Clearing a signature is not something any current
+// caller does; if one ever needs to, it must delete the key explicitly rather
+// than get it for free by passing nil.
+func writeBookSigToBatch(batch *pebble.Batch, b *Book) error {
+	sig, ok := bookSigOf(b)
+	if !ok {
+		return nil
+	}
+	data, err := json.Marshal(sig)
+	if err != nil {
+		return fmt.Errorf("marshal book signature sidecar %q: %w", b.ID, err)
+	}
+	return batch.Set(bookSigKey(b.ID), data, nil)
+}

--- a/internal/database/pebble_store_booksig_test.go
+++ b/internal/database/pebble_store_booksig_test.go
@@ -1,0 +1,417 @@
+// file: internal/database/pebble_store_booksig_test.go
+// version: 1.0.0
+// guid: b6d2417f-90ce-4a83-b512-8e7c04f9a3d1
+// last-edited: 2026-08-13
+
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// Moving BookSigV1 and its four companions out of the book: row is a storage
+// change with a data-loss failure mode: a book whose signature silently stops
+// coming back looks EXACTLY like a book whose signature was wiped, and this
+// repo already has an op (booksig_recovery_audit) whose job is to detect that
+// state and write book_ver: snapshot data over the live row. So "the read
+// returned a Book" proves nothing here — every test below asserts on the five
+// field VALUES, and the ones that matter most read through a reopened store so
+// an in-process cache cannot manufacture a pass.
+
+// sigFixture returns the five signature fields with distinguishable values, so
+// a test can tell "hydrated the sidecar" from "kept whatever was inline".
+func sigFixture(tag string) (v1, mask string, segments, coverage int, builtAt time.Time) {
+	return "sig-" + tag, "mask-" + tag, 4096, 87,
+		time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+}
+
+// bookWithSig builds an unsaved Book carrying all five signature fields.
+func bookWithSig(tag string) *Book {
+	v1, mask, segments, coverage, builtAt := sigFixture(tag)
+	// NOT "booksig-"+tag: the row legitimately carries file_hash, and a hash
+	// containing the signature's own value as a substring makes the
+	// "row must not contain the signature" assertion fail on the hash instead.
+	hash := "fhash-" + tag
+	return &Book{
+		Title:              "Book Sig " + tag,
+		FilePath:           "/tmp/booksig_" + tag + ".m4b",
+		FileHash:           &hash,
+		BookSigV1:          &v1,
+		BookSigV1Mask:      &mask,
+		BookSigSegments:    &segments,
+		BookSigBuiltAt:     &builtAt,
+		BookSigCoveragePct: &coverage,
+	}
+}
+
+// requireSigPresent asserts all five fields survived, by value. Checking only
+// BookSigV1 would miss the split-group hazard this design exists to avoid: a
+// book carrying V1 but nil BuiltAt (or the reverse) is a state
+// booksig_recovery_audit reads as damage.
+func requireSigPresent(t *testing.T, b *Book, tag string) {
+	t.Helper()
+	require.NotNil(t, b, "book must exist")
+	wantV1, wantMask, wantSegments, wantCoverage, wantBuiltAt := sigFixture(tag)
+
+	require.NotNil(t, b.BookSigV1, "BookSigV1 must survive the round-trip")
+	require.Equal(t, wantV1, *b.BookSigV1)
+	require.NotNil(t, b.BookSigV1Mask, "BookSigV1Mask must survive the round-trip")
+	require.Equal(t, wantMask, *b.BookSigV1Mask)
+	require.NotNil(t, b.BookSigSegments, "BookSigSegments must survive the round-trip")
+	require.Equal(t, wantSegments, *b.BookSigSegments)
+	require.NotNil(t, b.BookSigCoveragePct, "BookSigCoveragePct must survive the round-trip")
+	require.Equal(t, wantCoverage, *b.BookSigCoveragePct)
+	require.NotNil(t, b.BookSigBuiltAt, "BookSigBuiltAt must survive the round-trip")
+	require.True(t, wantBuiltAt.Equal(*b.BookSigBuiltAt),
+		"BookSigBuiltAt: want %v, got %v", wantBuiltAt, *b.BookSigBuiltAt)
+}
+
+// bookSigEnv owns the store lifecycle. It exists because these tests reopen
+// the database mid-test: a fixture that registered its own t.Cleanup close AND
+// a reopen that closed the same handle would double-close it, and Pebble
+// panics ("pebble: closed") rather than returning an error — which then eats
+// the actual assertion failure. The env keeps exactly one live handle and the
+// cleanup closes that one.
+type bookSigEnv struct {
+	store *PebbleStore
+	dir   string
+}
+
+func newBookSigEnv(t *testing.T) *bookSigEnv {
+	t.Helper()
+	env := &bookSigEnv{dir: t.TempDir()}
+	store, err := NewPebbleStore(env.dir)
+	require.NoError(t, err)
+	env.store = store
+	t.Cleanup(func() { _ = env.store.Close() })
+	return env
+}
+
+// reopen closes the live store and opens a NEW one over the same directory.
+//
+// This is not ceremony. Every write path here returns the *Book it was handed,
+// and the store keeps an in-memory layer; a round-trip that never leaves the
+// process can report success while nothing durable was written, which is
+// precisely the failure class this change is meant to remove rather than add.
+// A reopened store can only answer from bytes on disk.
+func (e *bookSigEnv) reopen(t *testing.T) *PebbleStore {
+	t.Helper()
+	require.NoError(t, e.store.Close())
+	fresh, err := NewPebbleStore(e.dir)
+	require.NoError(t, err)
+	e.store = fresh
+	return fresh
+}
+
+// rawBookRow returns the raw bytes stored under book:<id>, bypassing every
+// getter. Tests that assert what is or is not IN the row must read it this way;
+// going through GetBookByID would show the hydrated view and prove nothing
+// about the stored bytes.
+func rawBookRow(t *testing.T, store *PebbleStore, id string) []byte {
+	t.Helper()
+	val, closer, err := store.db.Get([]byte("book:" + id))
+	require.NoError(t, err)
+	defer closer.Close()
+	return append([]byte(nil), val...)
+}
+
+// TestBookSig_RoundTripsThroughGetBookByID is the baseline: the transparency
+// premise of this whole change is that no signature consumer notices it.
+func TestBookSig_RoundTripsThroughGetBookByID(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	created, err := store.CreateBook(bookWithSig("create"))
+	require.NoError(t, err)
+
+	fresh := env.reopen(t)
+	got, err := fresh.GetBookByID(created.ID)
+	require.NoError(t, err)
+	requireSigPresent(t, got, "create")
+}
+
+// TestBookSig_RowNoLongerCarriesTheSignature is the test that proves the
+// performance claim, and it is the reason this is a storage change rather than
+// a caching one.
+//
+// The measured win is 580 MB of the books warmup phase (production
+// 2026-08-13). Warmup scans book: rows and nothing else, so the signature stops
+// costing anything ONLY if it is genuinely absent from the row. A version that
+// wrote the sidecar but left the inline copy in place would pass every
+// round-trip test above while saving exactly zero bytes.
+func TestBookSig_RowNoLongerCarriesTheSignature(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	created, err := store.CreateBook(bookWithSig("rowstrip"))
+	require.NoError(t, err)
+
+	row := string(rawBookRow(t, store, created.ID))
+	for _, field := range []string{
+		"book_sig_v1", "book_sig_v1_mask", "book_sig_segments",
+		"book_sig_built_at", "book_sig_coverage_pct",
+	} {
+		require.NotContains(t, row, field,
+			"the book: row must not carry %q — warmup reads this row and the whole point is that it stops paying for the signature", field)
+	}
+	// And the value itself, in case a future rename keeps the data under a
+	// different JSON key.
+	require.NotContains(t, row, "sig-rowstrip",
+		"the signature VALUE must not appear in the book: row under any key")
+
+	// The sidecar must actually hold it — otherwise this test passes by the
+	// data having been destroyed, which is the opposite of the goal.
+	val, closer, err := store.db.Get(bookSigKey(created.ID))
+	require.NoError(t, err, "the sidecar key must exist")
+	defer closer.Close()
+	require.Contains(t, string(val), "sig-rowstrip")
+}
+
+// TestBookSig_LegacyInlineRowStillReads covers every book already on disk.
+//
+// Nothing has migrated when this ships: 67,824 production rows carry the
+// signature inline and have no sidecar key. The read path must fall back to
+// the inline value, or deploying step 1-4 alone would make every existing
+// signature vanish — the exact incident booksig_recovery_audit exists to
+// repair, caused by the change meant to prevent it.
+//
+// The row is written as raw JSON because the supported write path can no
+// longer produce one: CreateBook now strips these fields on the way in.
+func TestBookSig_LegacyInlineRowStillReads(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	const id = "01LEGACYBOOKSIG0000000000"
+	legacy := `{"id":"` + id + `","title":"Legacy Inline","file_path":"/tmp/legacy_booksig.m4b",` +
+		`"book_sig_v1":"sig-legacy","book_sig_v1_mask":"mask-legacy",` +
+		`"book_sig_segments":4096,"book_sig_coverage_pct":87,` +
+		`"book_sig_built_at":"2026-08-13T12:00:00Z"}`
+	require.NoError(t, store.db.Set([]byte("book:"+id), []byte(legacy), pebble.Sync))
+
+	fresh := env.reopen(t)
+	got, err := fresh.GetBookByID(id)
+	require.NoError(t, err)
+	requireSigPresent(t, got, "legacy")
+
+	// No sidecar was written for it, and the read must not have invented one.
+	_, closer, err := fresh.db.Get(bookSigKey(id))
+	if err == nil {
+		closer.Close()
+		t.Fatal("reading a legacy row must not create a sidecar key — the fallback is a read, not a migration")
+	}
+	require.Equal(t, pebble.ErrNotFound, err)
+}
+
+// TestBookSig_MemdbRoundTripWriteDoesNotWipeIt is the point of the whole
+// exercise.
+//
+// The shape: read a book through a path that strips heavy fields, then write it
+// straight back. That is how 67,824 signatures were destroyed once already, and
+// it is why UpdateBook carries a hand-maintained preserve-guard whose comment
+// asks the next author to "keep both in sync". With the sidecar, a nil incoming
+// signature writes no key and deletes nothing, so the wipe stops depending on
+// anyone remembering the guard.
+func TestBookSig_MemdbRoundTripWriteDoesNotWipeIt(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	created, err := store.CreateBook(bookWithSig("wipe"))
+	require.NoError(t, err)
+
+	// Exactly what a caller gets from the production memdb path.
+	stripped := stripBookForMemdb(created)
+	require.Nil(t, stripped.BookSigV1, "fixture guard: the stripped projection must have no signature")
+
+	stripped.Title = "Retitled By A Projection Write"
+	_, err = store.UpdateBook(created.ID, stripped)
+	require.NoError(t, err)
+
+	fresh := env.reopen(t)
+	got, err := fresh.GetBookByID(created.ID)
+	require.NoError(t, err)
+	require.Equal(t, "Retitled By A Projection Write", got.Title, "the write itself must have landed")
+	requireSigPresent(t, got, "wipe")
+}
+
+// TestBookSig_UpdateReplacesTheSignatureWhenOneIsSupplied is the control for
+// the test above. "Never lose a signature" is trivially satisfied by "never
+// write one", so a rebuild has to be shown to actually take effect —
+// acoustid's synthesizeBookSignatureForBook does exactly this read-set-write.
+func TestBookSig_UpdateReplacesTheSignatureWhenOneIsSupplied(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	created, err := store.CreateBook(bookWithSig("before"))
+	require.NoError(t, err)
+
+	rebuilt, err := store.GetBookByID(created.ID)
+	require.NoError(t, err)
+	v1, mask, segments, coverage, builtAt := sigFixture("after")
+	rebuilt.BookSigV1, rebuilt.BookSigV1Mask = &v1, &mask
+	rebuilt.BookSigSegments, rebuilt.BookSigCoveragePct = &segments, &coverage
+	rebuilt.BookSigBuiltAt = &builtAt
+	_, err = store.UpdateBook(created.ID, rebuilt)
+	require.NoError(t, err)
+
+	fresh := env.reopen(t)
+	got, err := fresh.GetBookByID(created.ID)
+	require.NoError(t, err)
+	requireSigPresent(t, got, "after")
+}
+
+// TestBookSig_GetAllBooksFullFromHydratesOnBothBranches guards the bulk reader
+// that BookSignatureScan depends on.
+//
+// GetAllBooksFullFrom has two implementations: the memdb branch point-gets each
+// ID through GetBookByID (so it inherits hydration), and the direct branch
+// decodes rows itself (so it needs its own). BookSignatureScan filters on
+// BookSigV1 != nil, so a branch that quietly returns unhydrated books makes the
+// scan compare zero pairs and report success — the failure this function's own
+// doc comment records happening before, for the same reason.
+func TestBookSig_GetAllBooksFullFromHydratesOnBothBranches(t *testing.T) {
+	for _, useMemDB := range []bool{true, false} {
+		name := "memdb"
+		if !useMemDB {
+			name = "direct"
+		}
+		t.Run(name, func(t *testing.T) {
+			env := newBookSigEnv(t)
+			store := env.store
+			created, err := store.CreateBook(bookWithSig("bulk"))
+			require.NoError(t, err)
+
+			fresh := env.reopen(t)
+			fresh.UseMemDB = useMemDB
+			if useMemDB {
+				// NewPebbleStore starts the async warmup that publishes the
+				// MemStore; wait for the real thing rather than reaching into
+				// memPtr, which is documented as warmup-path-only. Taking the
+				// production publish path is also what makes this subtest
+				// exercise the branch it claims to.
+				deadline := time.Now().Add(30 * time.Second)
+				for !fresh.IsMemReady() {
+					if time.Now().After(deadline) {
+						t.Fatal("memdb warmup never published; cannot exercise the memdb branch")
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+			}
+
+			books, err := fresh.GetAllBooksFullFrom("", 0)
+			require.NoError(t, err)
+
+			var found *Book
+			for i := range books {
+				if books[i].ID == created.ID {
+					found = &books[i]
+					break
+				}
+			}
+			require.NotNil(t, found, "the seeded book must be returned by the %s branch", name)
+			requireSigPresent(t, found, "bulk")
+		})
+	}
+}
+
+// TestBookSig_DeleteRemovesTheSidecar. DeleteBook has accumulated explicit
+// teardown for the work index and all three hash indexes, each added after a
+// writer got ahead of it and left rows resolving to a hard-deleted book. A
+// sidecar left behind is a smaller problem (bytes nobody reads, not a phantom
+// row) but it is the same omission, so it gets the same test.
+func TestBookSig_DeleteRemovesTheSidecar(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	created, err := store.CreateBook(bookWithSig("delete"))
+	require.NoError(t, err)
+	_, closer, err := store.db.Get(bookSigKey(created.ID))
+	require.NoError(t, err, "fixture guard: the sidecar must exist before the delete")
+	closer.Close()
+
+	require.NoError(t, store.DeleteBook(created.ID))
+
+	_, closer, err = store.db.Get(bookSigKey(created.ID))
+	if err == nil {
+		closer.Close()
+		t.Fatal("DeleteBook left the book_sig: key behind")
+	}
+	require.Equal(t, pebble.ErrNotFound, err)
+}
+
+// TestBookSig_NoBookIsEverBuiltButWiped pins the invariant that justified
+// moving all five fields together rather than only the two large ones.
+//
+// booksig_recovery_audit classifies a book as damaged on
+// `BookSigBuiltAt != nil && BookSigV1 == nil`, and its remedy is writing
+// book_ver: snapshot data over the live row. If BuiltAt had stayed inline while
+// V1 moved to the sidecar, every reader that does not hydrate would present
+// that exact shape and the audit would "recover" healthy books en masse. With
+// the whole group in one place the un-hydrated state is all-five-nil, which the
+// audit correctly reads as "never had one".
+func TestBookSig_NoBookIsEverBuiltButWiped(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	created, err := store.CreateBook(bookWithSig("invariant"))
+	require.NoError(t, err)
+
+	// The un-hydrated view: decode the stored row directly, skipping the
+	// sidecar entirely. This is what any reader that forgets to hydrate sees.
+	var unhydrated Book
+	require.NoError(t, json.Unmarshal(rawBookRow(t, store, created.ID), &unhydrated))
+
+	require.False(t,
+		unhydrated.BookSigBuiltAt != nil && unhydrated.BookSigV1 == nil,
+		"the un-hydrated row reads as built-then-wiped, which booksig_recovery_audit "+
+			"treats as damage and repairs by overwriting the live row from a snapshot")
+	require.Nil(t, unhydrated.BookSigBuiltAt,
+		"BookSigBuiltAt must move to the sidecar with the rest of the group, not stay inline")
+}
+
+// TestBookSig_WarmupNoLongerReadsTheSignature closes the loop on the
+// measurement that motivated this change.
+//
+// The production log reports discarded_field_mb[book_sig_v1_and_mask]=580.
+// That number is charged inside the books-phase callback from the decoded row,
+// so it goes to zero if and only if warmup genuinely stops seeing the
+// signature. This asserts the mechanism the 580 MB was measured with, which is
+// stronger than timing a startup.
+func TestBookSig_WarmupNoLongerReadsTheSignature(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	// A signature big enough that any leak into the row would round up to a
+	// nonzero megabyte rather than hiding under the ceiling division.
+	big := strings.Repeat("s", 3*1024*1024)
+	mask := strings.Repeat("m", 512*1024)
+	segments, coverage := 4096, 87
+	builtAt := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+	hash := "booksig-warmup"
+	_, err := store.CreateBook(&Book{
+		Title:              "Warmup Sig",
+		FilePath:           "/tmp/booksig_warmup.m4b",
+		FileHash:           &hash,
+		BookSigV1:          &big,
+		BookSigV1Mask:      &mask,
+		BookSigSegments:    &segments,
+		BookSigBuiltAt:     &builtAt,
+		BookSigCoveragePct: &coverage,
+	})
+	require.NoError(t, err)
+
+	mem, err := NewMemStore()
+	require.NoError(t, err)
+	require.NoError(t, mem.WarmFromPebble(context.Background(), store))
+
+	byField := mem.LastWarmupDiscardedByField()
+	require.Zero(t, byField[DiscardFieldBookSignature],
+		"warmup still reads %d MB of book signature; the sidecar is not keeping it out of the book: scan",
+		byField[DiscardFieldBookSignature])
+}


### PR DESCRIPTION
## What

The five `BookSig*` fields move from inline in `book:<id>` to their own `book_sig:<id>` key.

## Why

Warmup on production 2026-08-13 read **729 MB** across the books phase, of which **580 MB (80%)** was a signature that `stripBookForMemdb` nils out the instant it finishes decoding. The warmup scan is bounded `["book:", "book;")`, and `_` (0x5F) sorts above `;` (0x3B), so the sidecar falls **outside** the range — the scan stops seeing those bytes rather than decoding and discarding them.

Baseline captured from a real restart, byte-identical across two runs:

```
books=67824  book_files=517660
phase_mb     = book_files:2436  books:729
discarded_field_mb = acoustid_fingerprint:1805  book_sig_v1_and_mask:580 ...
```

## Design notes

- **All five fields move together.** The codebase already treats them as one partition in three places (`stripBookForMemdb`, `UpdateBook`'s preserve-guard, `restoreRecoverableFields`), and `booksig_recovery_audit` classifies damage as `BookSigBuiltAt != nil && BookSigV1 == nil`. Splitting the group would manufacture exactly that state.
- **Nothing is migrated.** Hydration is fallback-first: no sidecar key leaves the inline value untouched, so all 67,824 existing signatures keep working. A real read error is *returned, never swallowed* — a swallowed one produces a Book byte-identical to a wiped one, which the recovery audit would then "repair" from a snapshot.
- **`GetBooksByIDs` hydrates too.** It's the search-results path (up to 10,000 ids). Hydrating is cheaper than the status quo: the signature used to be read *inline* as part of every row at ~22 KB each, so the trade is N bytes-heavy reads for N small seeks. It returns rows-so-far alongside any error, matching its own documented fail-open contract — unlike `GetBookByID`, which fails closed on purpose.
- **`book_ver:` snapshots deliberately keep the full inline signature.** This reduces what startup *reads*, not what is stored; the recovery audit recovers from those snapshots.

## Data-loss angle

The only thing preventing a memdb round-trip write from wiping every signature was a hand-maintained preserve-guard — one that exists *because that wipe already happened once*, and whose own comment asks the next author to keep it in sync. A book carrying no signature now writes no sidecar key and deletes nothing, so not-wiping is the default rather than something someone has to remember.

## Testing

- 9 new tests (`pebble_store_booksig_test.go`), including the wipe test, its control, a legacy raw-JSON row, and an invariant that no book is ever built-but-wiped.
- **7 negative controls, each CAUGHT by the expected tests**, tree restored green after every revert. Notably control B ("the row keeps the signature inline") is caught by 4 tests spanning both the new suite and the repaired discard test.
- `internal/database` green **run to completion** (exit 0, 350 s). `dedup`, `dedup/dataset`, `dedup/unified`, `plugins/maintenance`, `plugins/acoustid`, `organizer`, `operations/registry` all ok.
- `TestGetBooksByIDs_Fidelity` passes **unmodified** — it seeds via `CreateBook` (which now strips the row), so it genuinely exercises hydration.
- `TestDiscardByField_CoversTheBooksPhaseToo` now seeds a raw legacy row for its signature half, mirroring `SegmentsAreChargedOnlyFromLegacyRows`. A nonzero `book_sig_v1_and_mask` in production now measures un-migrated legacy data draining toward zero, not ongoing cost.

## Not in this PR

The backfill op that migrates existing rows. It is the only irreversible step and ships separately behind a dry-run gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp
