### PR TITLE
fix(search): make a trailing * and quoted phrases actually work

### DIFF
--- a/changelog.d/20260813_204500_fix_search_wildcard_and_phrases.md
+++ b/changelog.d/20260813_204500_fix_search_wildcard_and_phrases.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **Search: a trailing `*` no longer returns nothing.** Prefix and wildcard queries were
+  built from the raw term, and those Bleve query types bypass the field analyser — so
+  they were compared against already-lowercased index terms without being lowercased
+  themselves. Any capitalised term matched zero documents: on production `Hyperion*`
+  returned 0 while `hyperion*` returned 21, and `Dragon*` returned 0 while `dragon*`
+  returned 1757. The web UI appends `*` to what was typed, so this fired on ordinary
+  capitalised typing.
+- **Search: a bare quoted phrase is now an actual phrase.** The free-text scanner split
+  on whitespace before looking for quotes, so `"All Jobs"` became two tokens, `"All` and
+  `Jobs"`, with the quote characters still attached; the analyser discarded them as
+  punctuation and `Quoted` was never set, leaving the `MatchPhraseQuery` branch in the
+  translator unreachable for bare free text. `"Side Jobs"` no longer matches
+  *Jobs on the Side*. The field-scoped form (`title:"a b"`) was never affected.
+
+  Known limitation, filed separately: a phrase whose distinguishing word is an English
+  stopword still over-matches, because the analyser drops the stopword before matching —
+  `"All Jobs"` reduces to `jobs`. Fixing that needs an analyser change and a full
+  re-index.

--- a/internal/search/bleve_translator.go
+++ b/internal/search/bleve_translator.go
@@ -1,7 +1,7 @@
 // file: internal/search/bleve_translator.go
-// version: 1.2.1
+// version: 1.3.0
 // guid: 9c2a4f1d-5b3e-4f70-a7d6-2e8c0f1b9a47
-// last-edited: 2026-08-11
+// last-edited: 2026-08-13
 //
 // AST → Bleve query translator (spec DES-1 v1.1). Walks the AST
 // produced by ParseQuery and emits a bleve/v2 query.Query suitable
@@ -17,6 +17,7 @@ package search
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/analysis"
@@ -239,7 +240,7 @@ func translateField(n *FieldNode, perUser *[]PerUserFilter, negated bool) (query
 		return fq, nil
 	}
 	if n.Prefix && !n.Wildcard {
-		pq := bleve.NewPrefixQuery(n.Value)
+		pq := bleve.NewPrefixQuery(patternTerm(n.Value))
 		pq.SetField(n.Field)
 		if n.Boost > 0 {
 			pq.SetBoost(n.Boost)
@@ -247,7 +248,7 @@ func translateField(n *FieldNode, perUser *[]PerUserFilter, negated bool) (query
 		return pq, nil
 	}
 	if n.Wildcard {
-		pattern := n.Value
+		pattern := patternTerm(n.Value)
 		if n.Prefix {
 			pattern = "*" + pattern + "*"
 		} else {
@@ -307,9 +308,24 @@ func translateValueAlt(n *ValueAltNode, perUser *[]PerUserFilter, negated bool) 
 	return bleve.NewDisjunctionQuery(children...), nil
 }
 
+// patternTerm normalises a term destined for a PrefixQuery or WildcardQuery.
+//
+// Those two query types match against the index's stored terms WITHOUT running
+// the field analyser over the input, unlike MatchQuery. The text fields are
+// indexed with the English analyser, whose first step lowercases, so a term
+// carrying any uppercase can never equal a stored term and the query silently
+// returns zero hits. Measured on production 2026-08-13: "Hyperion*" -> 0 while
+// "hyperion*" -> 21, "Dragon*" -> 0 while "dragon*" -> 1757. The web UI appends
+// '*' to what the user typed, so this fired on ordinary capitalised typing.
+//
+// Lowercasing is the only analyser step that can be reproduced here: stemming
+// a prefix would change which terms it is allowed to reach ("classe" must
+// still match "classes"), so it is deliberately not applied.
+func patternTerm(s string) string { return strings.ToLower(s) }
+
 func translateFreeText(n *FreeTextNode) query.Query {
 	if n.Prefix {
-		return bleve.NewPrefixQuery(n.Value)
+		return bleve.NewPrefixQuery(patternTerm(n.Value))
 	}
 	if n.Fuzzy {
 		return bleve.NewFuzzyQuery(n.Value)

--- a/internal/search/query_parser.go
+++ b/internal/search/query_parser.go
@@ -1,6 +1,7 @@
 // file: internal/search/query_parser.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 3c4a1d8f-5b2e-4f70-a7c6-2f8d0e1b9a57
+// last-edited: 2026-08-13
 //
 // Parser for the library search DSL (spec 3.4 / DES-1 v1.1).
 //
@@ -221,6 +222,36 @@ func (p *parser) parsePrimary() (Node, error) {
 // as free text. Handles quoting, value-alternation, and the
 // suffix operators * / ~ / ^boost.
 func (p *parser) parseFieldOrToken() (Node, error) {
+	// A bare quoted phrase: "all jobs".
+	//
+	// This must be handled BEFORE the bare-token scan below, which stops at
+	// whitespace and would therefore split `"All Jobs"` into two tokens,
+	// `"All` and `Jobs"`, with the quote characters still attached. The
+	// English analyser then discards those quotes as punctuation, so the
+	// query behaved exactly like the unquoted one and FreeTextNode.Quoted
+	// was never set — leaving the MatchPhraseQuery branch in the translator
+	// unreachable for bare free text. Measured on production 2026-08-13:
+	// `"All Jobs"` returned 300 rows, byte-identical to unquoted `All Jobs`,
+	// topped by "Side Jobs" and "The Icarus Job".
+	//
+	// The field-scoped form (title:"all jobs") was never affected — it goes
+	// through parseFieldValue, which has always handled quotes.
+	if p.peek() == '"' {
+		phrase, err := p.parseQuoted()
+		if err != nil {
+			return nil, err
+		}
+		// Swallow a '*' glued to the closing quote. The web UI appends one
+		// to whatever was typed, and letting it fall through would leave a
+		// lone '*' for the next iteration to parse as an empty-prefix token,
+		// which matches every document. A prefix-of-a-phrase is not a query
+		// Bleve offers, so the phrase itself is the honest interpretation.
+		if p.peek() == '*' {
+			p.pos++
+		}
+		return &FreeTextNode{Value: phrase, Quoted: true}, nil
+	}
+
 	// Read the identifier up to : or whitespace / special char.
 	start := p.pos
 	for p.pos < len(p.input) {

--- a/internal/search/zz_repro_wildcard_phrase_test.go
+++ b/internal/search/zz_repro_wildcard_phrase_test.go
@@ -1,0 +1,174 @@
+// file: internal/search/zz_repro_wildcard_phrase_test.go
+// version: 1.0.0
+// guid: 8c4d1f06-2b93-4a57-91e8-73f5a0c6d284
+// last-edited: 2026-08-13
+
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+// Repro for two defects reported by the owner on 2026-08-13, both reproduced
+// against production first:
+//
+//  1. A trailing '*' returns ZERO results whenever the term is capitalised.
+//     Prod: "Hyperion*" -> 0 but "hyperion*" -> 21; "Dragon*" -> 0 but
+//     "dragon*" -> 1757. Prefix/wildcard queries bypass the field analyser, so
+//     they are compared against already-lowercased index terms without being
+//     lowercased themselves. The web UI appends '*', so this hits ordinary
+//     typing.
+//
+//  2. A quoted phrase is not a phrase. Prod: `"All Jobs"` returned 300 rows,
+//     byte-identical to the unquoted query, topped by "Side Jobs" and "The
+//     Icarus Job" — neither of which contains the phrase.
+//
+// Both assert PRECISION (decoys absent), not merely presence: a MatchAll
+// satisfies a presence-only assertion, which is exactly how these survived.
+
+func wildcardPhraseCorpus(t *testing.T) *BleveIndex {
+	t.Helper()
+	idx := openTestIndex(t)
+	for _, d := range []BookDocument{
+		{BookID: "hyperion", Title: "Hyperion", Author: "Dan Simmons"},
+		{BookID: "alljobs", Title: "All Jobs and Classes", Author: "Comedian0 L"},
+		{BookID: "sidejobs", Title: "Side Jobs", Author: "Jim Butcher"},
+		{BookID: "icarus", Title: "The Icarus Job", Author: "Timothy Zahn"},
+		{BookID: "dragon", Title: "Dragon Conjurer", Author: "Eric Vall"},
+
+		// Word-order decoys. These carry every word of the phrases under
+		// test but never adjacently and in order, so they are matched by a
+		// conjunction and rejected by a true phrase query. WITHOUT them the
+		// phrase assertions pass even when the parser fix is reverted —
+		// verified by mutation — because AND-matching alone happens to
+		// return the same single book. They are what makes this test
+		// measure phrase behaviour rather than mere co-occurrence.
+		{BookID: "decoy_side", Title: "Jobs on the Side", Author: "Nobody"},
+		{BookID: "decoy_dragon", Title: "Conjurer of the Dragon", Author: "Nobody"},
+	} {
+		if err := idx.IndexBook(d); err != nil {
+			t.Fatalf("index %s: %v", d.BookID, err)
+		}
+	}
+	return idx
+}
+
+func runQuery(t *testing.T, idx *BleveIndex, q string) []string {
+	t.Helper()
+	ast, err := ParseQuery(q)
+	if err != nil {
+		t.Fatalf("parse %q: %v", q, err)
+	}
+	bq, _, err := Translate(ast)
+	if err != nil {
+		t.Fatalf("translate %q: %v", q, err)
+	}
+	if bq == nil {
+		t.Fatalf("Translate returned nil for %q — caller turns this into MatchAll", q)
+	}
+	hits, _, err := idx.SearchNative(bq, 0, 50)
+	if err != nil {
+		t.Fatalf("search %q: %v", q, err)
+	}
+	return hitIDs(hits)
+}
+
+// TestWildcardIsCaseInsensitive pins defect 1. A trailing '*' must find the
+// same books regardless of how the user capitalised the term.
+func TestWildcardIsCaseInsensitive(t *testing.T) {
+	idx := wildcardPhraseCorpus(t)
+
+	for _, q := range []string{"hyperion*", "Hyperion*", "HYPERION*", "Hyperio*"} {
+		t.Run(q, func(t *testing.T) {
+			got := runQuery(t, idx, q)
+			if len(got) == 0 {
+				t.Fatalf("%q returned NOTHING; want the hyperion book. "+
+					"A trailing * must not silently empty the result set.", q)
+			}
+			if !contains(got, "hyperion") {
+				t.Errorf("%q did not find hyperion: got %v", q, got)
+			}
+			for _, bad := range []string{"sidejobs", "icarus", "dragon"} {
+				if contains(got, bad) {
+					t.Errorf("IMPRECISE: %q matched unrelated %q: got %v", q, bad, got)
+				}
+			}
+		})
+	}
+}
+
+// TestQuotedPhraseIsAPhrase pins defect 2: a quoted phrase must match only
+// books containing that phrase. "Side Jobs" must not drag in "All Jobs and
+// Classes", and vice versa.
+func TestQuotedPhraseIsAPhrase(t *testing.T) {
+	idx := wildcardPhraseCorpus(t)
+
+	for _, tc := range []struct {
+		query string
+		want  string
+	}{
+		{`"Side Jobs"`, "sidejobs"},
+		{`"Icarus Job"`, "icarus"},
+		{`"Dragon Conjurer"`, "dragon"},
+		{`"Jobs and Classes"`, "alljobs"},
+		{`"Jobs on the Side"`, "decoy_side"},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			got := runQuery(t, idx, tc.query)
+			if len(got) != 1 || !contains(got, tc.want) {
+				t.Errorf("%s should match exactly [%s], got %v", tc.query, tc.want, got)
+			}
+		})
+	}
+}
+
+// TestQuotedPhraseWithLeadingStopword is a CHARACTERIZATION test: it asserts
+// what the code does today, which is NOT what the owner asked for.
+//
+// `"All Jobs"` still returns three books. The phrase machinery above is
+// correct — the cause is that "all" is an English stopword, so the analyser
+// reduces the phrase to the single term "jobs" before it is ever matched, and
+// a one-term phrase is just a term query. Every phrase whose distinguishing
+// word is a stopword degrades the same way.
+//
+// Fixing it means indexing these fields with an analyser that keeps stopwords,
+// which changes the index mapping and requires a full re-index of the library
+// — deliberately out of scope for this change and filed separately.
+//
+// This test exists so the limitation cannot be silently forgotten: when the
+// stopword work lands, this test WILL fail, and that failure is the signal to
+// delete it and fold the case into TestQuotedPhraseIsAPhrase above.
+func TestQuotedPhraseWithLeadingStopword(t *testing.T) {
+	idx := wildcardPhraseCorpus(t)
+
+	got := runQuery(t, idx, `"All Jobs"`)
+	if !contains(got, "alljobs") {
+		t.Errorf(`"All Jobs" must at least find the book containing it: got %v`, got)
+	}
+	if len(got) == 1 {
+		t.Errorf("STOPWORD LIMITATION APPEARS FIXED: %q now matches exactly %v. "+
+			"Delete this characterization test and move the case into "+
+			"TestQuotedPhraseIsAPhrase.", `"All Jobs"`, got)
+	}
+}
+
+// TestUnquotedStillBroad guards the other direction: making quotes strict must
+// NOT make the ordinary unquoted query strict too.
+func TestUnquotedStillBroad(t *testing.T) {
+	idx := wildcardPhraseCorpus(t)
+
+	got := runQuery(t, idx, "Jobs")
+	if !contains(got, "alljobs") || !contains(got, "sidejobs") {
+		t.Errorf("unquoted 'Jobs' should still match both job books broadly, got %v", got)
+	}
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if strings.EqualFold(h, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/todo.d/20260813-search-stopwords-and-fuzzy-case.md
+++ b/todo.d/20260813-search-stopwords-and-fuzzy-case.md
@@ -1,0 +1,19 @@
+### Search follow-ups from the wildcard/phrase fix (2026-08-13)
+
+- [ ] **Phrases containing an English stopword still over-match.** `"All Jobs"` returns
+      three books because `all` is dropped by the analyser before matching, reducing the
+      phrase to the single term `jobs`. The phrase machinery itself is correct —
+      `"Side Jobs"` and `"Jobs on the Side"` now resolve to exactly one book each, and
+      no longer match each other. Fixing the stopword case means indexing the text
+      fields with an analyser that keeps stopwords, which changes the index mapping and
+      requires a full re-index of the library. That re-index is now cheap and proven:
+      the coverage reconciler drained all 67,824 books in ~25 minutes with zero
+      failures. `TestQuotedPhraseWithLeadingStopword` is a characterization test that
+      will FAIL when this is fixed — that failure is the signal to delete it and fold
+      the case into `TestQuotedPhraseIsAPhrase`.
+- [ ] **Fuzzy queries (`~`) have the same case-sensitivity defect the wildcard fix just
+      addressed.** `bleve_translator.go` builds `NewFuzzyQuery` from the raw term, and
+      FuzzyQuery bypasses the analyser exactly as PrefixQuery and WildcardQuery do. Not
+      fixed here because the report was specifically about `*` and expanding the change
+      silently would make both harder to review. The fix is the same one-line
+      `patternTerm()` call already in the file.


### PR DESCRIPTION
Two defects reported by the owner. Both reproduced against production before any code changed.

## 1. A trailing `*` returned nothing

| query | prod count |
|---|---|
| `Hyperion` | 21 |
| `Hyperion*` | **0** |
| `hyperion*` | 21 |
| `Dragon*` | **0** |
| `dragon*` | 1757 |

`PrefixQuery` and `WildcardQuery` match against the index's stored terms **without**
running the field analyser over the input, unlike `MatchQuery`. The text fields are
indexed with the English analyser, whose first step lowercases — so any term carrying
uppercase could never equal a stored term, and the query silently returned zero. **The
web UI appends `*`, so this fired on ordinary capitalised typing.**

Fixed by normalising through `patternTerm()` in both the field-scoped and free-text
paths. Lowercasing is the only analyser step reproducible here — stemming a prefix would
change which terms it is allowed to reach (`classe` must still reach `classes`), so it is
deliberately not applied.

## 2. A bare quoted phrase was not a phrase

`"All Jobs"` returned 300 rows on prod, byte-identical to the unquoted query, topped by
*Side Jobs* and *The Icarus Job* — neither of which contains the phrase.

The free-text scanner stops at whitespace and never looked for quotes, so `"All Jobs"`
became two tokens, `"All` and `Jobs"`, quote characters still attached. The analyser
discarded those as punctuation, so it behaved exactly like the unquoted query and
`FreeTextNode.Quoted` was never set — leaving the `MatchPhraseQuery` branch that
**already existed** in the translator unreachable for bare free text. The field-scoped
form (`title:"a b"`) was never affected.

A `*` glued to the closing quote is swallowed: the UI appends one, and letting it through
would leave a lone `*` to be parsed as an empty-prefix token matching every document.

## Tests, and a mutation catch worth flagging

Tests assert **precision**, not presence. The phrase test carries word-order decoys
(*Jobs on the Side* vs *Side Jobs*).

**Those decoys are load-bearing.** The first version of this test passed *with the parser
fix reverted* — a conjunction alone happens to return the same single book, so the test
was measuring nothing. Mutation testing caught it. Both tests were then confirmed to fail
with their respective fix disabled, and both sources restored byte-identical (sha
verified).

## Known limitation — deliberately not fixed here

A phrase whose distinguishing word is an English **stopword** still over-matches:
`"All Jobs"` reduces to `jobs` because the analyser drops `all` before matching. The
phrase machinery itself is correct — `"Side Jobs"` and `"Jobs on the Side"` now resolve
to exactly one book each and no longer match each other.

Fixing the stopword case needs an analyser change and a full re-index. `TestQuotedPhrase
WithLeadingStopword` is a characterization test that **will fail when that lands**, which
is the signal to delete it and fold the case in. Filed in `todo.d/`, along with the fact
that fuzzy (`~`) queries carry the identical case-sensitivity defect this PR fixes for `*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxigqrwz9WfwN1wx8QhoQW