### PR TITLE
fix(search): index stopwords so quoted phrases are exact

### DIFF
--- a/changelog.d/20260813_214500_fix_search_stopword_phrases.md
+++ b/changelog.d/20260813_214500_fix_search_stopword_phrases.md
@@ -1,0 +1,34 @@
+### Fixed
+
+- **Search: quoted phrases containing common words are now exact.** `"All Jobs"` returned
+  300 rows on production — a set byte-identical to the unquoted query, topped by *Side
+  Jobs* and *The Icarus Job*, neither of which contains the phrase. The free-text fields
+  were indexed with Bleve's stock English analyser, whose stopword filter deletes tokens
+  **without renumbering the positions of the survivors**, and `MatchPhraseQuery`
+  reconstructs the phrase from those positions. So `"All Jobs"` analysed to the single
+  token `jobs` at position 2 and became a one-term phrase — that is, a plain term query
+  with no adjacency constraint at all. Interior stopwords degraded differently but from
+  the same cause: `"Lord of the Rings"` became a four-slot phrase with slots 2 and 3
+  empty, which Bleve treats as wildcards, matching *Lord of All Rings* just as happily.
+
+  The text fields now use a stopword-preserving analyser (unicode tokenizer, possessive
+  stripper, lowercase, Porter stemmer). Ordinary unquoted search is deliberately
+  unchanged: stopwords are still dropped from unquoted conjunctions, so
+  `shards of oblivion` keeps working exactly as before.
+
+- **Search: the index is rebuilt automatically when its mapping changes.** Bleve stores
+  the index mapping inside the index and reuses the stored copy on open, so an analyser
+  change would otherwise have no effect on an existing index — silently, and
+  indefinitely. The index now records the mapping version that built it and is recreated
+  when that no longer matches.
+
+  On recreate the server skips the bulk backfill and seeds the durable dirty set instead.
+  That distinction matters: the bulk backfill is not resumable and stops on shutdown,
+  which is what left the index missing 24.7% of the library earlier the same day. The
+  dirty-set marks are written to disk, so an interrupted rebuild resumes rather than
+  leaving a permanent gap.
+
+  **Operational note:** the first start after this change rebuilds the whole search
+  index. Search results are incomplete until the reconciler drains — roughly 25 minutes
+  for a 68,000-book library. Reverting this change triggers a second rebuild for the same
+  reason.

--- a/internal/search/bleve_index.go
+++ b/internal/search/bleve_index.go
@@ -1,7 +1,7 @@
 // file: internal/search/bleve_index.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 3c8e1a2f-4d9b-4f70-a5c6-2f8d0e1b9a47
-// last-edited: 2026-07-11
+// last-edited: 2026-08-13
 //
 // BleveIndex is the single-package wrapper around a Bleve v2 scorch
 // index backing library search (spec DES-1 / backlog §4.7). The
@@ -20,12 +20,19 @@ package search
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/blevesearch/bleve/v2"
+	"github.com/blevesearch/bleve/v2/analysis/analyzer/custom"
 	"github.com/blevesearch/bleve/v2/analysis/analyzer/standard"
 	"github.com/blevesearch/bleve/v2/analysis/lang/en"
+	"github.com/blevesearch/bleve/v2/analysis/token/lowercase"
+	"github.com/blevesearch/bleve/v2/analysis/token/porter"
+	"github.com/blevesearch/bleve/v2/analysis/tokenizer/unicode"
 	"github.com/blevesearch/bleve/v2/mapping"
 	"github.com/blevesearch/bleve/v2/search/query"
 )
@@ -39,28 +46,142 @@ type BleveIndex struct {
 	mu   sync.RWMutex
 	idx  bleve.Index
 	path string
+
+	// recreatedForMapping records that Open threw away an existing index
+	// because its mapping version was stale. Read via
+	// RecreatedForMappingChange; set once at Open and never mutated after.
+	recreatedForMapping bool
 }
 
-// Open creates or opens the on-disk Bleve index at path using the
-// scorch backend. Index mapping is set up once at creation time;
-// reopening an existing index uses the mapping stored alongside it.
+// bookTextAnalyzerName is the analyzer every free-text field is indexed
+// with. It is bleve's stock English chain MINUS the stopword filter:
+// unicode tokenizer, possessive stripper, lowercase, porter stemmer.
+//
+// WHY NOT THE STOCK `en` ANALYZER
+//
+// The stop filter deletes tokens without renumbering the positions of the
+// survivors, and MatchPhraseQuery rebuilds the phrase from those positions
+// (tokenStreamToPhrase, bleve search/query/match_phrase.go), sizing it
+// lastPosition-firstPosition+1 and leaving unfilled slots nil. So under the
+// stock analyzer:
+//
+//	"All Jobs"          -> [jobs@2]          -> phrase of length 1, i.e. NO
+//	                                            adjacency constraint at all
+//	"Lord of the Rings" -> [lord@1, ring@4]  -> length 4 with slots 2-3 nil,
+//	                                            i.e. "Lord ANY ANY Rings"
+//
+// Measured on production 2026-08-13: `"All Jobs"` returned 300 rows, a set
+// byte-identical to the unquoted query. A leading stopword collapses a
+// phrase to a bare term; an interior one turns into a wildcard.
+//
+// Keeping stopwords in the index costs term-dictionary space and makes
+// unquoted conjunctions stricter in principle — but only in principle here,
+// because dropStopwordOnlyConjuncts (bleve_translator.go) still removes them
+// from unquoted queries, and it detects them with the STOCK analyzer resolved
+// by name, independently of this mapping. That decoupling is load-bearing:
+// it is what keeps unquoted recall identical across this change.
+const bookTextAnalyzerName = "book_en_nostop"
+
+// bookMappingVersion identifies the on-disk index mapping. Bleve persists the
+// mapping inside the index and bleve.Open uses the STORED one, so changing
+// bookIndexMapping() has no effect on an index that already exists — the
+// change only takes hold on a freshly created index. Bump this whenever
+// bookIndexMapping changes in a way that alters indexed terms, and Open will
+// recreate the index.
+//
+//	1 (implicit, unmarked) — stock `en` analyzer on all text fields
+//	2                      — bookTextAnalyzerName, stopwords preserved
+const bookMappingVersion = "2"
+
+// mappingMarkerPath returns the sibling file recording which mapping version
+// built the index. Deliberately a SIBLING of the index directory rather than a
+// file inside it: bleve owns that directory's contents and scorch enumerates
+// its segment files, so an unexpected entry there is asking for trouble.
+func mappingMarkerPath(indexPath string) string {
+	return filepath.Join(filepath.Dir(indexPath),
+		filepath.Base(indexPath)+".mapping")
+}
+
+// Open creates or opens the on-disk Bleve index at path using the scorch
+// backend.
+//
+// When an existing index was built by a different mapping version it is
+// DELETED and recreated empty, and RecreatedForMappingChange reports true.
+// Callers must react to that: see server_lifecycle.go, which uses it to skip
+// the non-resumable bulk backfill and seed the durable dirty set instead.
 func Open(path string) (*BleveIndex, error) {
-	// Try opening an existing index first. If it doesn't exist,
-	// create a new one with the book mapping.
 	if info, err := os.Stat(path); err == nil && info.IsDir() {
-		idx, err := bleve.Open(path)
-		if err != nil {
-			return nil, fmt.Errorf("bleve open existing at %s: %w", path, err)
+		stored := readMappingMarker(path)
+		if stored == bookMappingVersion {
+			idx, err := bleve.Open(path)
+			if err != nil {
+				return nil, fmt.Errorf("bleve open existing at %s: %w", path, err)
+			}
+			return &BleveIndex{idx: idx, path: path}, nil
 		}
-		return &BleveIndex{idx: idx, path: path}, nil
+		slog.Warn("search index mapping version changed; recreating index. "+
+			"Search will be incomplete until the reconciler drains the "+
+			"dirty set.",
+			"path", path, "stored", stored, "want", bookMappingVersion)
+		if err := os.RemoveAll(path); err != nil {
+			return nil, fmt.Errorf("bleve remove stale index at %s: %w", path, err)
+		}
+		b, err := createIndex(path)
+		if err != nil {
+			return nil, err
+		}
+		b.recreatedForMapping = true
+		return b, nil
 	}
 
-	m := bookIndexMapping()
-	idx, err := bleve.NewUsing(path, m, "scorch", "scorch", nil)
+	return createIndex(path)
+}
+
+// createIndex builds a new index and records its mapping version.
+//
+// The marker is written only AFTER a successful create. Writing it first
+// would, on a create failure, leave a marker with no index — and writing it
+// unconditionally on failure would be worse still: a marker that cannot be
+// written must not be treated as written, or every boot recreates the index
+// forever.
+func createIndex(path string) (*BleveIndex, error) {
+	idx, err := bleve.NewUsing(path, bookIndexMapping(), "scorch", "scorch", nil)
 	if err != nil {
 		return nil, fmt.Errorf("bleve create at %s: %w", path, err)
 	}
+	marker := mappingMarkerPath(path)
+	if err := os.WriteFile(marker, []byte(bookMappingVersion+"\n"), 0o644); err != nil {
+		// Not fatal — the index is valid and usable. But it WILL be
+		// recreated on every restart until this succeeds, so it must be
+		// loud rather than a debug line nobody reads.
+		slog.Error("search: failed to write index mapping marker; the index "+
+			"will be rebuilt on EVERY restart until this is fixed",
+			"marker", marker, "err", err)
+	}
 	return &BleveIndex{idx: idx, path: path}, nil
+}
+
+// readMappingMarker returns the recorded mapping version, or "" when the
+// marker is absent or unreadable. "" is the correct answer for an index built
+// before markers existed (mapping version 1) and forces a recreate.
+func readMappingMarker(indexPath string) string {
+	b, err := os.ReadFile(mappingMarkerPath(indexPath))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// RecreatedForMappingChange reports whether Open discarded an existing index
+// because it had been built with an older mapping. When true the index is
+// EMPTY and every book needs re-indexing.
+func (b *BleveIndex) RecreatedForMappingChange() bool {
+	if b == nil {
+		return false
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.recreatedForMapping
 }
 
 // Close releases the underlying index handle. Safe to call multiple
@@ -269,18 +390,36 @@ var textFieldBoosts = []struct {
 func bookIndexMapping() mapping.IndexMapping {
 	im := bleve.NewIndexMapping()
 
-	// Use bleve's stock English analyzer — lowercases, drops stop
-	// words, stems, and (via the registered `en` package) ascii-folds.
-	// Building a custom analyzer at mapping construction time is
-	// brittle because the registry lookup happens at index open, so
-	// we stick to the guaranteed-available built-in.
+	// Register the stopword-preserving analyzer this mapping uses for
+	// every free-text field. See bookTextAnalyzerName for why the stock
+	// `en` analyzer is not used. A failure here can only mean a bleve
+	// upgrade renamed one of the built-in components, so fall back to
+	// the stock analyzer rather than shipping an index with no analyzer
+	// at all — degraded phrase precision beats unusable search.
+	textAnalyzerName := bookTextAnalyzerName
+	if err := im.AddCustomAnalyzer(bookTextAnalyzerName, map[string]any{
+		"type":      custom.Name,
+		"tokenizer": unicode.Name,
+		"token_filters": []string{
+			en.PossessiveName, // strip trailing 's
+			lowercase.Name,
+			porter.Name, // stem; NOTE: no en.StopName — that is the point
+		},
+	}); err != nil {
+		slog.Error("search: custom analyzer registration failed; "+
+			"falling back to stock English analyzer, quoted phrases "+
+			"containing stopwords will stay imprecise",
+			"analyzer", bookTextAnalyzerName, "err", err)
+		textAnalyzerName = en.AnalyzerName
+	}
+
 	// textAnalyzed no longer takes a boost: bleve v2 has no index-time
 	// field boost, so that parameter was dead. Query-time weighting for
 	// free-text search lives in textFieldBoosts (bleve_index.go) and is
 	// applied by translateFreeText in bleve_translator.go.
 	textAnalyzed := func() *mapping.FieldMapping {
 		f := bleve.NewTextFieldMapping()
-		f.Analyzer = en.AnalyzerName
+		f.Analyzer = textAnalyzerName
 		f.Store = true
 		f.IncludeInAll = true
 		return f
@@ -350,7 +489,7 @@ func bookIndexMapping() mapping.IndexMapping {
 	book.AddFieldMappingsAt("has_cover", boolean())
 
 	im.AddDocumentMapping(BookDocType, book)
-	im.DefaultAnalyzer = en.AnalyzerName
+	im.DefaultAnalyzer = textAnalyzerName
 	im.TypeField = "_type"
 	im.DefaultType = BookDocType
 

--- a/internal/search/bleve_translator.go
+++ b/internal/search/bleve_translator.go
@@ -104,14 +104,27 @@ func translateAnd(n *AndNode, perUser *[]PerUserFilter, negated bool) (query.Que
 	return bleve.NewConjunctionQuery(children...), nil
 }
 
-// freeTextAnalyzer is the analyzer the index applies to free-text fields
-// (bleve_index.go sets im.DefaultAnalyzer = en.AnalyzerName). It is resolved
-// from the same registry Bleve itself uses, so it cannot drift from the index's
-// notion of a stopword the way a hand-maintained word list would.
+// stopwordDetector is the STOCK English analyzer, used here purely as an
+// oracle for "is this word a stopword?" — never to analyze anything destined
+// for the index.
+//
+// It deliberately no longer matches the index's own analyzer. The fields are
+// mapped to bookTextAnalyzerName (bleve_index.go), which keeps stopwords so
+// that quoted phrases can be exact. Detection must nevertheless keep answering
+// the ORIGINAL question, and answering it with the field analyzer would be
+// impossible: under that analyzer nothing is stopword-only, so
+// dropStopwordOnlyConjuncts would stop firing and every unquoted query
+// containing of/the/a would become strict. That would trade the phrase bug for
+// a recall regression across most multi-word titles.
+//
+// So: index keeps stopwords (precision for quoted phrases), unquoted queries
+// still drop them (recall unchanged). This split is the entire design, and it
+// works only because this lookup is by NAME from the registry rather than from
+// the field mapping. Do not "fix" it to follow the mapping.
 //
 // nil if the registry lookup ever fails; every caller treats nil as "cannot
 // tell", which degrades to the old behaviour rather than to a wrong answer.
-var freeTextAnalyzer = func() analysis.Analyzer {
+var stopwordDetector = func() analysis.Analyzer {
 	a, err := registry.NewCache().AnalyzerNamed(en.AnalyzerName)
 	if err != nil {
 		return nil
@@ -119,14 +132,16 @@ var freeTextAnalyzer = func() analysis.Analyzer {
 	return a
 }()
 
-// isStopwordOnly reports whether a term survives analysis. The English analyzer
-// strips stopwords, so "of" produces zero tokens and therefore appears in no
-// document's term dictionary.
+// isStopwordOnly reports whether a term is an English stopword. Note this is
+// now a statement about the ENGLISH LANGUAGE, not about the index: since the
+// mapping switched to a stopword-preserving analyzer, such a term DOES appear
+// in the term dictionary. It is still the right thing to drop from an unquoted
+// conjunction — see dropStopwordOnlyConjuncts.
 func isStopwordOnly(term string) bool {
-	if freeTextAnalyzer == nil || term == "" {
+	if stopwordDetector == nil || term == "" {
 		return false
 	}
-	return len(freeTextAnalyzer.Analyze([]byte(term))) == 0
+	return len(stopwordDetector.Analyze([]byte(term))) == 0
 }
 
 // dropStopwordOnlyConjuncts removes free-text conjuncts that analyze to nothing,

--- a/internal/search/mapping_version_test.go
+++ b/internal/search/mapping_version_test.go
@@ -1,0 +1,197 @@
+// file: internal/search/mapping_version_test.go
+// version: 1.0.0
+// guid: 6b1f83d7-4e29-4c05-9a3b-27d6c8e10f45
+// last-edited: 2026-08-13
+
+package search
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The mapping-version marker is the riskiest part of the stopword change, and
+// the part that unit tests of bookIndexMapping() cannot reach: bleve persists
+// the mapping INSIDE the index and bleve.Open uses the stored copy, so a
+// mapping edit is inert until the index is recreated. These tests drive the
+// real Open() against a real on-disk index.
+//
+// Two failure modes matter more than the happy path:
+//
+//   - never recreating  => the analyzer change silently does nothing in prod
+//   - always recreating => a full re-index on EVERY restart, forever
+
+func indexAt(t *testing.T, path string) *BleveIndex {
+	t.Helper()
+	idx, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open(%s): %v", path, err)
+	}
+	t.Cleanup(func() { _ = idx.Close() })
+	return idx
+}
+
+func docCount(t *testing.T, idx *BleveIndex) uint64 {
+	t.Helper()
+	n, err := idx.DocCount()
+	if err != nil {
+		t.Fatalf("DocCount: %v", err)
+	}
+	return n
+}
+
+// seedOne indexes a single book so an index has content worth preserving —
+// which is what makes "was it recreated?" observable via DocCount.
+func seedOne(t *testing.T, idx *BleveIndex) {
+	t.Helper()
+	if err := idx.IndexBook(BookDocument{BookID: "b1", Title: "Persisted"}); err != nil {
+		t.Fatalf("IndexBook: %v", err)
+	}
+	if got := docCount(t, idx); got != 1 {
+		t.Fatalf("seed: DocCount = %d, want 1", got)
+	}
+}
+
+func TestOpenWritesMappingMarkerOnCreate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "library.bleve")
+	idx := indexAt(t, path)
+
+	if idx.RecreatedForMappingChange() {
+		t.Error("a brand-new index must not report itself as recreated; " +
+			"the server would skip the first-time bulk backfill")
+	}
+	got, err := os.ReadFile(mappingMarkerPath(path))
+	if err != nil {
+		t.Fatalf("marker not written on create: %v", err)
+	}
+	if string(got) != bookMappingVersion+"\n" {
+		t.Errorf("marker = %q, want %q", got, bookMappingVersion+"\n")
+	}
+}
+
+// TestOpenPreservesIndexWhenMarkerMatches is the guard against rebuilding the
+// library on every restart. If this fails, prod re-indexes 67k books forever.
+func TestOpenPreservesIndexWhenMarkerMatches(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "library.bleve")
+
+	first, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	seedOne(t, first)
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	second := indexAt(t, path)
+	if second.RecreatedForMappingChange() {
+		t.Fatal("REBUILD LOOP: reopening a current-version index reported a " +
+			"mapping change; every restart would wipe and re-index the library")
+	}
+	if got := docCount(t, second); got != 1 {
+		t.Errorf("existing documents lost on reopen: DocCount = %d, want 1", got)
+	}
+}
+
+// TestOpenRecreatesOnStaleMarker covers both stale shapes: an explicitly older
+// version, and NO marker at all — the latter being every index built before
+// this change, i.e. the exact state of production at deploy time.
+func TestOpenRecreatesOnStaleMarker(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		stale func(t *testing.T, path string)
+	}{
+		{
+			name: "older version recorded",
+			stale: func(t *testing.T, path string) {
+				if err := os.WriteFile(mappingMarkerPath(path), []byte("1\n"), 0o644); err != nil {
+					t.Fatalf("write stale marker: %v", err)
+				}
+			},
+		},
+		{
+			// This is production on the day this ships.
+			name: "no marker at all (pre-marker index)",
+			stale: func(t *testing.T, path string) {
+				if err := os.Remove(mappingMarkerPath(path)); err != nil {
+					t.Fatalf("remove marker: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "library.bleve")
+
+			first, err := Open(path)
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			seedOne(t, first)
+			if err := first.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+			tc.stale(t, path)
+
+			second := indexAt(t, path)
+			if !second.RecreatedForMappingChange() {
+				t.Fatal("stale mapping was NOT detected: the index kept its old " +
+					"analyzer, so the stopword fix would silently do nothing in " +
+					"production while every test here still passed")
+			}
+			if got := docCount(t, second); got != 0 {
+				t.Errorf("recreated index should be empty, DocCount = %d", got)
+			}
+			// The marker must be rewritten, or the next boot recreates again.
+			if got := readMappingMarker(path); got != bookMappingVersion {
+				t.Errorf("marker after recreate = %q, want %q — without this the "+
+					"index is rebuilt on every restart", got, bookMappingVersion)
+			}
+		})
+	}
+}
+
+// TestOpenRecreateIsNotRepeated pins the settle-down behaviour: one recreate,
+// then stability. A recreate that repeats is worse than no fix at all, because
+// search would be permanently mid-rebuild.
+func TestOpenRecreateIsNotRepeated(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "library.bleve")
+
+	first, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := os.Remove(mappingMarkerPath(path)); err != nil {
+		t.Fatalf("remove marker: %v", err)
+	}
+
+	second, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open (recreate): %v", err)
+	}
+	if !second.RecreatedForMappingChange() {
+		t.Fatal("expected the first reopen to recreate")
+	}
+	if err := second.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	third := indexAt(t, path)
+	if third.RecreatedForMappingChange() {
+		t.Error("REBUILD LOOP: the index recreated itself a second time; the " +
+			"marker written during recreate is not being honoured")
+	}
+}
+
+// TestRecreatedFlagFalseOnNil documents the nil-receiver contract. The server
+// calls this on s.searchIndex, which is nil whenever search is disabled or
+// failed to open, and must not panic during startup.
+func TestRecreatedFlagFalseOnNil(t *testing.T) {
+	var idx *BleveIndex
+	if idx.RecreatedForMappingChange() {
+		t.Error("nil index must report false")
+	}
+}

--- a/internal/search/zz_repro_wildcard_phrase_test.go
+++ b/internal/search/zz_repro_wildcard_phrase_test.go
@@ -1,5 +1,5 @@
 // file: internal/search/zz_repro_wildcard_phrase_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8c4d1f06-2b93-4a57-91e8-73f5a0c6d284
 // last-edited: 2026-08-13
 
@@ -46,6 +46,34 @@ func wildcardPhraseCorpus(t *testing.T) *BleveIndex {
 		// measure phrase behaviour rather than mere co-occurrence.
 		{BookID: "decoy_side", Title: "Jobs on the Side", Author: "Nobody"},
 		{BookID: "decoy_dragon", Title: "Conjurer of the Dragon", Author: "Nobody"},
+
+		// Stopword decoys, for the mapping change that stopped the analyser
+		// deleting stopwords. Each is chosen to be indistinguishable from
+		// the target UNLESS the stopword itself is indexed and positioned:
+		//
+		//   decoy_jobsforall — carries "Jobs" and "All" but not adjacent
+		//                      and in that order, so it separates a real
+		//                      `"All Jobs"` phrase from a bare `jobs` term.
+		//                      Under the old mapping "All Jobs" analysed to
+		//                      the single token [jobs@2] and matched this.
+		//   decoy_oddjobs    — carries "Jobs" with NO "All" at all: the
+		//                      cheapest possible witness that the phrase
+		//                      degraded to a term query.
+		//   lotr / decoy_lotr — differ only in the INTERIOR stopword. The
+		//                      old mapping produced [lord@1, ring@4], a
+		//                      four-slot phrase with slots 2-3 left nil,
+		//                      which bleve treats as wildcards — so "Lord
+		//                      ANY ANY Rings" matched both. This pair is
+		//                      the only assertion here that can detect the
+		//                      interior-wildcard behaviour.
+		{BookID: "decoy_jobsforall", Title: "Jobs for All", Author: "Nobody"},
+		{BookID: "decoy_oddjobs", Title: "Odd Jobs", Author: "Nobody"},
+		{BookID: "lotr", Title: "Lord of the Rings", Author: "J R R Tolkien"},
+		{BookID: "decoy_lotr", Title: "Lord of All Rings", Author: "Nobody"},
+
+		// Recall guard for the 2026-08-11 "shards of oblivion" bug. Keeping
+		// stopwords in the index must NOT make unquoted queries strict.
+		{BookID: "shards", Title: "Shards of Oblivion", Author: "Nobody"},
 	} {
 		if err := idx.IndexBook(d); err != nil {
 			t.Fatalf("index %s: %v", d.BookID, err)
@@ -123,33 +151,87 @@ func TestQuotedPhraseIsAPhrase(t *testing.T) {
 	}
 }
 
-// TestQuotedPhraseWithLeadingStopword is a CHARACTERIZATION test: it asserts
-// what the code does today, which is NOT what the owner asked for.
+// TestQuotedPhraseWithStopword covers the owner's original example, which the
+// phrase fix alone did NOT solve: `"All Jobs"` returned 300 rows on prod
+// because "all" was a stopword the analyser deleted before matching.
 //
-// `"All Jobs"` still returns three books. The phrase machinery above is
-// correct — the cause is that "all" is an English stopword, so the analyser
-// reduces the phrase to the single term "jobs" before it is ever matched, and
-// a one-term phrase is just a term query. Every phrase whose distinguishing
-// word is a stopword degrades the same way.
+// This was a characterization test pinning that limitation until 2026-08-13,
+// when the index mapping moved to a stopword-preserving analyzer
+// (bookTextAnalyzerName). It now asserts the intended behaviour.
 //
-// Fixing it means indexing these fields with an analyser that keeps stopwords,
-// which changes the index mapping and requires a full re-index of the library
-// — deliberately out of scope for this change and filed separately.
+// The two cases are different failure modes of one cause, and each needs its
+// own decoy to be detectable at all — see the corpus comments:
 //
-// This test exists so the limitation cannot be silently forgotten: when the
-// stopword work lands, this test WILL fail, and that failure is the signal to
-// delete it and fold the case into TestQuotedPhraseIsAPhrase above.
-func TestQuotedPhraseWithLeadingStopword(t *testing.T) {
+//	leading  — "All Jobs" collapsed to a 1-token phrase == a bare term query
+//	interior — "Lord of the Rings" became "Lord ANY ANY Rings"
+func TestQuotedPhraseWithStopword(t *testing.T) {
 	idx := wildcardPhraseCorpus(t)
 
-	got := runQuery(t, idx, `"All Jobs"`)
-	if !contains(got, "alljobs") {
-		t.Errorf(`"All Jobs" must at least find the book containing it: got %v`, got)
+	t.Run("leading stopword", func(t *testing.T) {
+		got := runQuery(t, idx, `"All Jobs"`)
+		if !contains(got, "alljobs") {
+			t.Errorf(`"All Jobs" must find the book containing it: got %v`, got)
+		}
+		// The whole point: a phrase whose first word is a stopword must
+		// still constrain word order.
+		if contains(got, "decoy_jobsforall") {
+			t.Errorf(`"All Jobs" matched "Jobs for All" — the stopword is not `+
+				`constraining order, so the phrase is behaving as a `+
+				`conjunction: got %v`, got)
+		}
+		if contains(got, "decoy_oddjobs") || contains(got, "sidejobs") {
+			t.Errorf(`"All Jobs" matched a book with no "all" at all — the `+
+				`phrase degraded to a bare "jobs" term query: got %v`, got)
+		}
+		if len(got) != 1 {
+			t.Errorf(`"All Jobs" should match exactly [alljobs], got %v`, got)
+		}
+	})
+
+	t.Run("interior stopwords are not wildcards", func(t *testing.T) {
+		got := runQuery(t, idx, `"Lord of the Rings"`)
+		if !contains(got, "lotr") {
+			t.Errorf(`"Lord of the Rings" must find lotr: got %v`, got)
+		}
+		if contains(got, "decoy_lotr") {
+			t.Errorf(`"Lord of the Rings" matched "Lord of All Rings" — the `+
+				`dropped stopwords left wildcard slots in the phrase `+
+				`instead of exact terms: got %v`, got)
+		}
+		if len(got) != 1 {
+			t.Errorf(`"Lord of the Rings" should match exactly [lotr], got %v`, got)
+		}
+	})
+}
+
+// TestUnquotedStopwordRecallUnchanged is the counterweight to the mapping
+// change: indexing stopwords must not make ORDINARY unquoted search strict.
+//
+// Regression guard for the 2026-08-11 "shards of oblivion returns nothing"
+// bug. Whitespace parses as AND, so an unquoted three-word query becomes a
+// conjunction; if "of" survives as a required conjunct that the target does
+// not satisfy in every field, recall collapses again. dropStopwordOnlyConjuncts
+// still removes it because it detects stopwords with the STOCK English
+// analyzer, deliberately decoupled from the field mapping.
+func TestUnquotedStopwordRecallUnchanged(t *testing.T) {
+	idx := wildcardPhraseCorpus(t)
+
+	for _, q := range []string{
+		"shards of oblivion",
+		"lord of the rings",
+		"all jobs and classes",
+	} {
+		t.Run(q, func(t *testing.T) {
+			got := runQuery(t, idx, q)
+			if len(got) == 0 {
+				t.Fatalf("unquoted %q returned NOTHING — a stopword conjunct "+
+					"is taking the whole query down", q)
+			}
+		})
 	}
-	if len(got) == 1 {
-		t.Errorf("STOPWORD LIMITATION APPEARS FIXED: %q now matches exactly %v. "+
-			"Delete this characterization test and move the case into "+
-			"TestQuotedPhraseIsAPhrase.", `"All Jobs"`, got)
+
+	if got := runQuery(t, idx, "shards of oblivion"); !contains(got, "shards") {
+		t.Errorf("unquoted 'shards of oblivion' lost its book: got %v", got)
 	}
 }
 

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 3.14.0
+// version: 3.15.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-08-13
 
@@ -1100,7 +1100,26 @@ func (s *Server) startBackfills() {
 		s.bgWG.Add("build-search-index")
 		go func() {
 			defer s.bgWG.Done("build-search-index")
-			s.buildSearchIndexIfEmpty()
+			if s.searchIndex.RecreatedForMappingChange() {
+				// The index was just deleted and recreated empty because the
+				// mapping version changed. An empty index is precisely what
+				// buildSearchIndexIfEmpty triggers on — and that build is
+				// non-resumable and bgCtx-cancellable, which is exactly how a
+				// permanent 24.7% coverage gap was created on 2026-08-13.
+				// Running it here would deliberately re-enter that bug at
+				// full library scale.
+				//
+				// Skip it and let reconcileSearchIndexCoverage seed the
+				// DURABLE dirty set instead: a cancellation mid-sweep then
+				// costs nothing, because the marks survive the restart.
+				// "The index is empty" must not be the signal to bulk-build;
+				// only a genuinely first-time index should take that path.
+				slog.Warn("search index was recreated for a mapping change; " +
+					"skipping bulk backfill and seeding the durable dirty " +
+					"set instead")
+			} else {
+				s.buildSearchIndexIfEmpty()
+			}
 			// buildSearchIndexIfEmpty only runs on an EMPTY index, so a
 			// build that was cancelled by a previous shutdown leaves a
 			// permanent gap it will never revisit. Seed the dirty set for

--- a/todo.d/20260813-keyword-fields-use-stopword-analyzer.md
+++ b/todo.d/20260813-keyword-fields-use-stopword-analyzer.md
@@ -1,0 +1,32 @@
+## Search: "keyword" fields are not exact-match at all
+
+`bookIndexMapping`'s `keyword()` helper (`internal/search/bleve_index.go`) sets
+`f.Analyzer = standard.Name`. Bleve's *standard* analyser is not a keyword
+analyser — it tokenizes on unicode boundaries and **carries a stopword filter**.
+So every field intended as exact-match is being tokenized and stopword-stripped:
+
+- `genre`, `language`, `library_state`, `format`
+- `tags` (array)
+- `isbn10`, `isbn13`, `asin`
+- `_type` — which is the document-type discriminator
+
+Consequences to measure before fixing:
+
+- A genre like `"Science Fiction"` is indexed as two terms, so a filter for it
+  can match `"Fiction"` alone.
+- Identifier fields (`isbn*`, `asin`) are case-folded and tokenized rather than
+  stored verbatim; whether that breaks lookups depends on the query path, which
+  has not been checked.
+- `_type` is used for document routing. Worth confirming it still resolves
+  correctly before changing anything.
+
+The fix is `keyword.Name` (`analysis/analyzer/keyword`), which emits the input as
+a single unanalyzed term.
+
+**This requires a full re-index**, same as the stopword change — bump
+`bookMappingVersion` and the existing recreate path handles it.
+
+Deliberately NOT bundled with the stopword fix (2026-08-13): moving a second
+axis of the mapping in the same rebuild would have made the mutation test for
+the phrase behaviour ambiguous, and these fields need their own before/after
+measurement on production rather than being carried along silently.


### PR DESCRIPTION
## The bug

`"All Jobs"` returned **300 rows** on production — a set byte-identical to the unquoted query, topped by *Side Jobs* and *The Icarus Job*, neither of which contains the phrase.

## Root cause (read out of bleve's source, not inferred)

Text fields were indexed with bleve's stock English analyzer. Its stop filter deletes tokens **without renumbering the positions of the survivors**, and `MatchPhraseQuery` rebuilds the phrase from those positions — `tokenStreamToPhrase`, `search/query/match_phrase.go:109` — sizing it `lastPosition-firstPosition+1` and leaving unfilled slots `nil`:

| query | surviving tokens | resulting phrase | effect |
|---|---|---|---|
| `"All Jobs"` | `[jobs@2]` | len 1 | **no adjacency at all** — a plain term query |
| `"Lord of the Rings"` | `[lord@1, ring@4]` | len 4, slots 2–3 `nil` | `Lord ANY ANY Rings` |

A leading stopword collapses the phrase to a bare term; an interior one becomes a wildcard. One cause, two visible behaviours.

## The fix

Free-text fields now use a stopword-preserving analyzer: unicode tokenizer → possessive stripper → lowercase → porter stemmer.

**Unquoted search is deliberately unchanged.** `dropStopwordOnlyConjuncts` still strips stopwords from unquoted conjunctions, because it detects them with the *stock* analyzer resolved **by name from the registry**, not from the field mapping. That decoupling is load-bearing and is now commented as such — without it this would trade the phrase bug for a recall regression across most multi-word titles (the 2026-08-11 *"shards of oblivion returns nothing"* bug).

## Why a mapping-version marker

Bleve persists the mapping **inside** the index and `bleve.Open` uses the stored copy, so an analyzer change is otherwise inert on an existing index — silently, and forever. The index now records the mapping version that built it and is recreated on mismatch.

**On recreate the server skips `buildSearchIndexIfEmpty` and seeds the durable dirty set instead.** An empty index is precisely what that bulk build triggers on, and it is non-resumable and `bgCtx`-cancellable — the exact property that left the index missing 24.7% of the library earlier today (#2381). *"The index is empty"* must not be the signal; *"the marker mismatched"* is.

## Verification

Tests use **word-order and wildcard decoys** — *Jobs for All*, *Odd Jobs*, *Lord of All Rings* — chosen so a weaker mechanism can't satisfy them. Presence-only fixtures would pass under the old analyzer; that mistake shipped a meaningless green test yesterday.

Mutation-tested: reverting **only** the analyzer (restored byte-identical, sha-verified) produced exactly the intended failures —

```
"All Jobs" matched "Jobs for All" — the stopword is not constraining order
    got [decoy_jobsforall decoy_side decoy_oddjobs alljobs sidejobs icarus]
"Lord of the Rings" matched "Lord of All Rings" — dropped stopwords left wildcard slots
    got [decoy_lotr lotr]
```

— while `TestQuotedPhraseIsAPhrase` and `TestWildcardIsCaseInsensitive` **stayed green**, proving this and the #2389 parser fix are not accidentally coupled.

The recreate path has its own tests, including the two failure modes that unit-testing the mapping alone cannot reach: never recreating (fix silently does nothing in prod) and always recreating (rebuild loop on every restart).

`go build ./...` exit 0. `internal/search`, `internal/playlist`, `internal/audiobooks` all green.

## ⚠️ Operational note

**The first start after this rebuilds the whole search index.** Results are incomplete until the reconciler drains — roughly 25 min for 68,000 books, proven tonight at zero failures. **Reverting triggers a second rebuild** for the same reason. No data loss risk either way: the Bleve index is derived state, rebuilt from Pebble.

## Not bundled (filed)

`keyword()` maps to `standard.Name`, which *also* carries a stop filter — so `genre`/`tags`/`language`/`isbn*`/`_type` are not exact-match fields at all. Real defect, tempting because a rebuild is already happening, but moving a second axis of the mapping in the same rebuild would have made the phrase mutation test ambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxigqrwz9WfwN1wx8QhoQW