### PR TITLE
fix(database): stop full-library scans from processing soft-deleted books

### DIFF
--- a/changelog.d/20260813_214500_fix_memdb_softdeleted_leak.md
+++ b/changelog.d/20260813_214500_fix_memdb_softdeleted_leak.md
@@ -1,0 +1,26 @@
+### Fixed
+
+- **Deleted books were still being processed by every full-library operation.**
+  `GetAllBooksCore` and `CountAllBooks` each have two implementations — a Pebble
+  keyspace scan and a memdb index walk — and only the Pebble one filtered
+  soft-deleted rows. Since memdb is the production default, all ~35 full-library
+  callers (organize, dedup, every backfill, the reconcile passes, the ABS library
+  count) silently operated on books that were in the trash. Measured on
+  production: 63,869 live books were being scanned as 67,824, the extra 3,953
+  being the losers of the July dedup drain, still processed four weeks after
+  deletion. The soft-delete rule now lives in a single shared predicate, and a
+  conformance test holds both implementations to the same answer on the same
+  fixture.
+- **`AssignOrphanVGs` could resurrect deleted books** by force-setting
+  `library_state=organized` on soft-deleted rows it should never have seen;
+  `MergeNoVGDuplicates` could pick a soft-deleted book as the keeper and
+  soft-delete the live one instead. Both are consequences of the leak above and
+  are fixed by it.
+- **Orphan-file cleanup now explicitly protects restorable books.** A
+  soft-deleted book still owns its `book_files`, and `findOrphanBookFiles` is a
+  set-difference whose output is fed to `DeleteBookFilesByIDs`. Those rows were
+  previously protected only *by* the leak, so the scan now unions the
+  soft-deleted set in deliberately and fails closed if it cannot read it.
+- **Deluge discovery no longer re-offers trashed books** as unimported
+  torrents, for the same reason and with the same previously-accidental
+  protection made explicit.

--- a/changelog.d/20260813_214500_fix_memdb_softdeleted_leak.md
+++ b/changelog.d/20260813_214500_fix_memdb_softdeleted_leak.md
@@ -24,3 +24,18 @@
 - **Deluge discovery no longer re-offers trashed books** as unimported
   torrents, for the same reason and with the same previously-accidental
   protection made explicit.
+
+### Changed
+
+- **The soft-delete rule is now stated once.** 37 open-coded
+  `MarkedForDeletion != nil && *MarkedForDeletion` checks across eight files in
+  `internal/database` now call a shared predicate. That duplication was the
+  mechanism by which the two implementations drifted apart in the first place —
+  each open-coded the same three-token test independently and nothing noticed
+  when one stopped matching the other. `Book` and `BookCore` are separate
+  structs that each carry the flag, so both delegate to one
+  `markedForDeletionFlag`. `grep "MarkedForDeletion != nil"` over the package
+  now returns only the three reads of the caller-supplied *filter* struct.
+- **Orphan-file cleanup reports the denominator it actually used.** It logged
+  the live book count while deciding orphanhood against live + soft-deleted;
+  the field is now `owning_books` and carries the set that made the decision.

--- a/docs/executive-summaries/2026-08-13-deleted-but-not-gone-executive-summary.md
+++ b/docs/executive-summaries/2026-08-13-deleted-but-not-gone-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-08-13-deleted-but-not-gone-executive-summary.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 075d5d8a-d32d-428d-81fe-04c5c5039da6 -->
 <!-- last-edited: 2026-08-13 -->
 
@@ -7,7 +7,8 @@
 
 **Date:** 2026-08-13 (evening session)
 **In one line:** chasing eleven stubborn books uncovered that nearly four thousand
-deleted books had never actually stopped being processed.
+deleted books had never actually stopped being processed — and the eleven turned out to be
+the same story.
 
 ---
 
@@ -99,13 +100,45 @@ books are in the trash.
 
 ---
 
+## The eleven, resolved
+
+The 11 groups that finding #1 could not repair are now explained, and the explanation is
+finding #3.
+
+Every one of those 11 groups contains **nothing but deleted books** — 12 of them in total.
+There was no display copy to elect because there was no book left to elect one from. The
+repair pass was not failing; it was correctly declining to promote a book out of the trash.
+
+**These groups need no further work.** They are not 12 hidden books — they are 12 deleted
+books, correctly not being shown.
+
+*How this was checked, since the count alone would not have been enough:* all 3,870 groups
+containing a deleted book were queried individually, and exactly 11 came back with zero
+live members. Eleven matching eleven could be luck. But the earlier census had also
+recorded that those groups held **12 books**, and the 11 groups found here hold exactly 12
+— ten groups with one book and one with two. Two independently measured numbers agreeing
+is what makes this an answer rather than a coincidence.
+
+---
+
 ## What is left
 
-- **11 groups (12 books)** from finding #1 are still unrepaired. They are almost certainly
-  explained by finding #3 — books whose entire group is in the trash — but that has **not
-  been confirmed yet**, and it will not be written down as the answer until it is.
 - The `Unknown Author` folders remain untidy. That is now known to be a presentation
   problem, not a storage one.
+- The fix in finding #3 is committed but **not yet running on your library.** Until it
+  ships, the ~4,000 deleted books are still being processed.
+
+---
+
+## A note on the other report from today
+
+There is a second write-up from today, *The Books Search Could Not See*, which explains the
+same original symptom — your *All Jobs and Classes* search — a different way: some books
+were missing from the search catalogue.
+
+**Both are true, and they are separate faults.** That one query happened to land on two
+different defects at once, which is also why it stayed confusing for so long. Neither
+report is the complete story on its own; read them together.
 
 ---
 

--- a/docs/executive-summaries/2026-08-13-deleted-but-not-gone-executive-summary.md
+++ b/docs/executive-summaries/2026-08-13-deleted-but-not-gone-executive-summary.md
@@ -1,0 +1,121 @@
+<!-- file: docs/executive-summaries/2026-08-13-deleted-but-not-gone-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 075d5d8a-d32d-428d-81fe-04c5c5039da6 -->
+<!-- last-edited: 2026-08-13 -->
+
+# Executive Summary: Deleted, But Not Gone
+
+**Date:** 2026-08-13 (evening session)
+**In one line:** chasing eleven stubborn books uncovered that nearly four thousand
+deleted books had never actually stopped being processed.
+
+---
+
+## The night in three findings
+
+You reported one thing: books missing from the library page in the browser, while the
+phone app showed them fine. That single report unwound into three separate findings, only
+the first of which was what you asked about.
+
+---
+
+## 1. The books the library page refused to show
+
+**What was wrong.** The library keeps groups of "the same book in different formats" and
+marks one copy in each group as the one to display. The web page shows only marked copies.
+Some groups had no marked copy at all — so every book in them was unreachable from the
+browser, while the phone app, which does not filter, showed them normally.
+
+**Why it happened.** The iTunes importer created a fresh group for each new book and then
+marked that book as "not the one to display" — even though it was the group's only member.
+A group of one, electing nobody.
+
+**What was done.** Three fixes: the importer now marks a lone book as its own display copy;
+the organizer no longer creates a *second* display copy when adding to an existing group;
+and a repair pass was written for the groups already in that state.
+
+**Result on your library:** the repair elected display copies for **479 groups**, with zero
+errors. Groups with no display copy dropped from 490 to 11, and the books trapped in them
+from 737 to 12. Your original search now returns the two books you were looking for, at
+positions one and two.
+
+---
+
+## 2. The 14 TB disk emergency that was not one
+
+**What was reported — by me, wrongly.** A duplicate folder tree appeared to be consuming
+about 14 TB, and I recommended reclaiming it.
+
+**What was actually true.** Nothing to reclaim. The storage system already shares the
+underlying blocks between those duplicate files — it had been doing so all along, saving
+about 21.8 TB. The tools I used to measure (`du`, and the pool's logical-usage figure)
+are both blind to that sharing: they count each shared copy as if it were independent.
+
+**How it was settled.** By actually doing it, at small scale. Fifty files were verified
+byte-for-byte, de-duplicated, verified again, and the disk was measured before and after.
+The space recovered was **zero** — against a background noise floor larger than the effect.
+Genuinely independent copies would have released about 5.4 GB.
+
+**What this means for you.** No disk work is needed. The duplicate folders are a tidiness
+problem in how the library is presented, not a capacity problem. The recommendation to
+reclaim has been withdrawn and the audit record corrected.
+
+---
+
+## 3. Nearly 4,000 deleted books that were never really deleted
+
+This is the one with the longest reach, and it was found only because eleven groups from
+finding #1 refused to be repaired.
+
+**What was wrong.** When you delete a book here, it goes to a trash — recoverable, by
+design. There is a function every part of the system calls to ask "give me all the books."
+That function exists in two versions internally, and **only one of them remembered to leave
+out the trash.** The version that forgot is the one that actually runs in production.
+
+**What that meant in practice.** Every operation that walks the whole library — organizing,
+duplicate detection, all the background data-repair jobs, and the count reported to
+Audiobookshelf-compatible apps — has been including deleted books. On your library that is
+**3,953 books**, almost all of them deleted in a single cleanup on 18 July. They have been
+organized, scanned, counted and re-grouped for four weeks after you deleted them.
+
+**Two consequences that were worse than wasted effort:**
+
+- One repair job sets deleted books back to "organized" — effectively **undeleting them**.
+- Another finds duplicate books and keeps one, and it could **keep a deleted copy and
+  delete the live one** instead.
+
+**What was done.** The rule for "is this book in the trash?" now exists in exactly one
+place, and both versions of the function are held to it by a test that runs the same data
+through both and fails if they disagree. That test was verified by deliberately
+reintroducing the bug and confirming it caught it.
+
+**One risk the fix itself created, and how it was handled.** A deleted book still owns its
+file records, because restoring it needs them. A separate cleanup job finds "file records
+with no book" and deletes them — and those records were being protected *only* by the very
+bug being fixed. Left alone, the first cleanup run after this fix would have destroyed the
+file records of all 3,953 recoverable books, quietly making them unrestorable. That job now
+protects trashed books explicitly, and refuses to run at all if it cannot confirm which
+books are in the trash.
+
+---
+
+## What is left
+
+- **11 groups (12 books)** from finding #1 are still unrepaired. They are almost certainly
+  explained by finding #3 — books whose entire group is in the trash — but that has **not
+  been confirmed yet**, and it will not be written down as the answer until it is.
+- The `Unknown Author` folders remain untidy. That is now known to be a presentation
+  problem, not a storage one.
+
+---
+
+## The thread worth noticing
+
+All three findings share a shape: **a number that looked authoritative but came from an
+instrument that could not see what was being asked of it.** `du` cannot see shared disk
+blocks. A book count taken from the trash-blind function cannot see that it is counting the
+trash. And in the first investigation, counting hidden books using the very search that was
+suspected of hiding them produced 6,157 — the true figure was 724.
+
+In each case the correction came from measuring a different way, not from reasoning harder
+about the first measurement.

--- a/internal/database/book_visibility.go
+++ b/internal/database/book_visibility.go
@@ -1,5 +1,5 @@
 // file: internal/database/book_visibility.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4eee927b-72ce-4b07-aa41-a91afb2368ba
 // last-edited: 2026-08-13
 
@@ -25,5 +25,23 @@ package database
 // See TestGetAllBooksCore_MemDBAndPebbleAgree for the conformance test that
 // holds the two implementations to this shared definition.
 func bookIsSoftDeleted(b *Book) bool {
-	return b != nil && b.MarkedForDeletion != nil && *b.MarkedForDeletion
+	return b != nil && markedForDeletionFlag(b.MarkedForDeletion)
+}
+
+// bookCoreIsSoftDeleted is the BookCore twin of bookIsSoftDeleted.
+//
+// Book and BookCore are separate structs that each carry their own copy of the
+// trash bit, and scans split between them (GetAllBooksCore returns BookCore,
+// GetAllBooks returns Book), so the predicate needs both shapes. Both delegate
+// to markedForDeletionFlag rather than restating the nil-check, which is the
+// whole point: adding a third row type must not add a third copy of the rule.
+func bookCoreIsSoftDeleted(b *BookCore) bool {
+	return b != nil && markedForDeletionFlag(b.MarkedForDeletion)
+}
+
+// markedForDeletionFlag is the rule itself, stated once: the trash bit is a
+// *bool where nil means "never deleted", so an unset pointer is live. Every
+// visibility check in this package bottoms out here.
+func markedForDeletionFlag(flag *bool) bool {
+	return flag != nil && *flag
 }

--- a/internal/database/book_visibility.go
+++ b/internal/database/book_visibility.go
@@ -1,0 +1,29 @@
+// file: internal/database/book_visibility.go
+// version: 1.0.0
+// guid: 4eee927b-72ce-4b07-aa41-a91afb2368ba
+// last-edited: 2026-08-13
+
+package database
+
+// bookIsSoftDeleted reports whether a book row is in the trash.
+//
+// This exists so the rule lives in exactly ONE place. Store methods with two
+// backing implementations (a Pebble keyspace scan and a memdb index walk) must
+// agree on which rows a normal library scan can see, and the way they drifted
+// apart was that each open-coded the same three-token nil-check independently:
+// the Pebble path applied it unconditionally, the memdb path applied it only
+// when a caller opted in, and nothing in the type system or the tests noticed
+// the two had stopped meaning the same thing.
+//
+// Call this instead of writing `b.MarkedForDeletion != nil && *b...` inline.
+// A soft-deleted book is restorable (POST /api/v1/audiobooks/:id/restore), so
+// "deleted" here means "hidden from library scans", NOT "gone" — code that
+// reasons about a book's FILES (see findOrphanBookFiles) must keep treating
+// these rows as live owners of their book_files, or restore has nothing to
+// restore.
+//
+// See TestGetAllBooksCore_MemDBAndPebbleAgree for the conformance test that
+// holds the two implementations to this shared definition.
+func bookIsSoftDeleted(b *Book) bool {
+	return b != nil && b.MarkedForDeletion != nil && *b.MarkedForDeletion
+}

--- a/internal/database/book_visibility_conformance_test.go
+++ b/internal/database/book_visibility_conformance_test.go
@@ -1,0 +1,143 @@
+// file: internal/database/book_visibility_conformance_test.go
+// version: 1.0.0
+// guid: e398a03c-a0e4-4e64-8da3-3beac8e0ff6b
+// last-edited: 2026-08-13
+
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// softDelConformanceFixture builds a library with a known live/soft-deleted
+// split. Helper name is task-unique on purpose: several suites in this package
+// define fixture builders and a generic name collides on rebase.
+type softDelConformanceFixture struct {
+	liveIDs    []string
+	deletedIDs []string
+}
+
+func buildSoftDelConformanceFixture(t *testing.T, store Store) softDelConformanceFixture {
+	t.Helper()
+
+	var fx softDelConformanceFixture
+	yes := true
+
+	for _, title := range []string{"Live Alpha", "Live Bravo", "Live Charlie"} {
+		created, err := store.CreateBook(&Book{Title: title, FilePath: "/lib/" + title})
+		require.NoError(t, err)
+		fx.liveIDs = append(fx.liveIDs, created.ID)
+	}
+
+	// Soft-delete via the same write path production uses: set the flag on an
+	// existing row and update it. Creating a row that is born deleted would
+	// not exercise the memdb re-index that a real deletion goes through.
+	for _, title := range []string{"Trashed Delta", "Trashed Echo"} {
+		created, err := store.CreateBook(&Book{Title: title, FilePath: "/lib/" + title})
+		require.NoError(t, err)
+		created.MarkedForDeletion = &yes
+		_, err = store.UpdateBook(created.ID, created)
+		require.NoError(t, err)
+		fx.deletedIDs = append(fx.deletedIDs, created.ID)
+	}
+
+	return fx
+}
+
+// TestGetAllBooksCore_MemDBAndPebbleAgree is the conformance gate for the
+// soft-delete contract.
+//
+// GetAllBooksCore has two backing implementations — a memdb index walk
+// (UseMemDB=true, the production default) and a Pebble keyspace scan — and
+// they silently disagreed about soft-deleted rows for the entire life of the
+// memdb query layer. The Pebble path filtered them unconditionally; the memdb
+// path filtered them only when a caller passed a "marked_for_deletion" filter,
+// and no caller ever did. Measured on prod 2026-08-13: 63,869 live books were
+// scanned as 67,824 by every full-library op in the system.
+//
+// Asserting each path against a hardcoded expectation would NOT have caught
+// this — whoever wrote the memdb path would have written the memdb
+// expectation. What catches it is holding the two implementations to the SAME
+// answer on the SAME fixture.
+func TestGetAllBooksCore_MemDBAndPebbleAgree(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	fx := buildSoftDelConformanceFixture(t, store)
+
+	p, ok := store.(*PebbleStore)
+	require.True(t, ok, "expected *PebbleStore from setupPebbleTestDB")
+	p.WaitForWarmup()
+
+	// Non-vacuity guard: if the fixture has no soft-deleted rows the whole
+	// suite below passes without testing anything.
+	require.NotEmpty(t, fx.deletedIDs, "fixture must contain soft-deleted books or this test is vacuous")
+
+	idsOf := func(books []BookCore) map[string]struct{} {
+		out := make(map[string]struct{}, len(books))
+		for _, b := range books {
+			out[b.ID] = struct{}{}
+		}
+		return out
+	}
+
+	results := map[bool]map[string]struct{}{}
+	counts := map[bool]int{}
+
+	for _, useMemDB := range []bool{true, false} {
+		p.UseMemDB = useMemDB
+		label := "PebbleScanPath"
+		if useMemDB {
+			label = "MemDBPath"
+		}
+
+		t.Run(label, func(t *testing.T) {
+			books, err := store.GetAllBooksCore(0, 0)
+			require.NoError(t, err)
+			got := idsOf(books)
+
+			for _, id := range fx.liveIDs {
+				require.Contains(t, got, id, "live book missing from GetAllBooksCore")
+			}
+			for _, id := range fx.deletedIDs {
+				require.NotContains(t, got, id,
+					"soft-deleted book leaked into GetAllBooksCore — this is the prod bug that made "+
+						"organize, dedup, every backfill and the ABS library count operate on trashed rows")
+			}
+			require.Len(t, books, len(fx.liveIDs))
+
+			n, err := store.CountAllBooks()
+			require.NoError(t, err)
+			require.Equal(t, len(fx.liveIDs), n,
+				"CountAllBooks documents itself as counting non-deleted books and is the progress "+
+					"denominator for every full-library op")
+
+			results[useMemDB] = got
+			counts[useMemDB] = n
+		})
+	}
+
+	// The actual conformance assertion: the two implementations of one
+	// interface method must be indistinguishable to a caller.
+	require.Equal(t, results[true], results[false],
+		"memdb and Pebble implementations of GetAllBooksCore returned different book sets")
+	require.Equal(t, counts[true], counts[false],
+		"memdb and Pebble implementations of CountAllBooks returned different counts")
+
+	// The escape hatch must still work: a caller that explicitly asks for
+	// deleted rows gets them. Without this, the fix above would have silently
+	// broken ListSoftDeletedBooks-style queries.
+	t.Run("ExplicitFilterStillReturnsDeleted", func(t *testing.T) {
+		p.UseMemDB = true
+		books, err := p.mem().GetAllBooksCore(0, 0, map[string]interface{}{"marked_for_deletion": true})
+		require.NoError(t, err)
+		got := idsOf(books)
+		for _, id := range fx.deletedIDs {
+			require.Contains(t, got, id,
+				"explicit marked_for_deletion=true filter must still return trashed rows")
+		}
+		require.Len(t, books, len(fx.deletedIDs))
+	})
+}

--- a/internal/database/book_visibility_conformance_test.go
+++ b/internal/database/book_visibility_conformance_test.go
@@ -1,11 +1,12 @@
 // file: internal/database/book_visibility_conformance_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e398a03c-a0e4-4e64-8da3-3beac8e0ff6b
 // last-edited: 2026-08-13
 
 package database
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -140,4 +141,114 @@ func TestGetAllBooksCore_MemDBAndPebbleAgree(t *testing.T) {
 		}
 		require.Len(t, books, len(fx.deletedIDs))
 	})
+}
+
+// TestGetAllBooksCore_PaginationPartitionsTheLiveSet is the pagination half of
+// the conformance gate.
+//
+// The test above calls GetAllBooksCore(0, 0) against a 5-book fixture, which
+// means BOTH the limit clamp and the offset clamp are dead code in it. Every
+// real caller instead pages — GetAllBooksCore(pageSize, offset) in a loop that
+// terminates when a page comes back short — so the untested interaction is the
+// one production actually depends on: filtering must happen BEFORE pagination.
+//
+// If a path ever paginates first and filters second, a page containing trashed
+// rows comes back short after filtering, the caller's `len(page) < pageSize`
+// termination fires early, and the tail of the library is silently skipped.
+// Both paths filter-then-paginate today; this test is what keeps that true,
+// because a length check alone cannot see the difference between a page of
+// [live, live] and a page of [live, trashed].
+func TestGetAllBooksCore_PaginationPartitionsTheLiveSet(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	p, ok := store.(*PebbleStore)
+	require.True(t, ok, "expected *PebbleStore from setupPebbleTestDB")
+
+	// Fixture is deliberately LARGER than the page size, with trashed rows
+	// interleaved among live ones rather than clustered at either end — a
+	// trailing block of trashed rows would only exercise the final page.
+	const (
+		total    = 21
+		pageSize = 4
+	)
+	yes := true
+	var wantLive []string
+	var deleted []string
+
+	for i := 0; i < total; i++ {
+		title := fmt.Sprintf("Paged %02d", i)
+		created, err := store.CreateBook(&Book{Title: title, FilePath: "/lib/paged/" + title})
+		require.NoError(t, err)
+		if i%3 == 0 {
+			created.MarkedForDeletion = &yes
+			_, err = store.UpdateBook(created.ID, created)
+			require.NoError(t, err)
+			deleted = append(deleted, created.ID)
+			continue
+		}
+		wantLive = append(wantLive, created.ID)
+	}
+	p.WaitForWarmup()
+
+	// Non-vacuity guards. The fixture must actually straddle a page boundary
+	// and must actually contain trash, or this test proves nothing.
+	require.Greater(t, len(wantLive), pageSize,
+		"fixture must exceed one page or the pagination clamps are never exercised")
+	require.NotEmpty(t, deleted, "fixture must contain soft-deleted books or this test is vacuous")
+
+	traverse := map[bool][]string{}
+
+	for _, useMemDB := range []bool{true, false} {
+		p.UseMemDB = useMemDB
+		label := "PebbleScanPath"
+		if useMemDB {
+			label = "MemDBPath"
+		}
+
+		t.Run(label, func(t *testing.T) {
+			seen := map[string]struct{}{}
+			var order []string
+			pages := 0
+
+			// This loop is written the way production callers write it,
+			// including the short-page termination that is the actual hazard.
+			for offset := 0; ; offset += pageSize {
+				page, err := store.GetAllBooksCore(pageSize, offset)
+				require.NoError(t, err)
+				pages++
+				require.LessOrEqual(t, len(page), pageSize, "page exceeded the requested limit")
+
+				for _, b := range page {
+					require.NotContains(t, seen, b.ID,
+						"book returned on two different pages — pages must be disjoint")
+					seen[b.ID] = struct{}{}
+					order = append(order, b.ID)
+				}
+				if len(page) < pageSize {
+					break
+				}
+				require.Less(t, pages, total, "pagination did not terminate")
+			}
+
+			// Partition: every live book appears exactly once (disjointness is
+			// asserted above), and nothing else appears at all.
+			require.Len(t, order, len(wantLive),
+				"paged traversal did not recover the live set exactly — a short page from "+
+					"paginate-then-filter would truncate the tail here")
+			for _, id := range wantLive {
+				require.Contains(t, seen, id, "live book missing from the paged traversal")
+			}
+			for _, id := range deleted {
+				require.NotContains(t, seen, id, "soft-deleted book leaked into a page")
+			}
+
+			traverse[useMemDB] = order
+		})
+	}
+
+	// Cross-implementation conformance on the paged path, as sets: the two
+	// backends must be indistinguishable to a paging caller.
+	require.ElementsMatch(t, traverse[true], traverse[false],
+		"memdb and Pebble paged traversals of GetAllBooksCore recovered different book sets")
 }

--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_reads.go
-// version: 1.15.0
+// version: 1.16.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000006
-// last-edited: 2026-08-11
+// last-edited: 2026-08-13
 
 package database
 
@@ -590,6 +590,25 @@ func (m *MemStore) GetAllBooksCore(limit, offset int, filters map[string]interfa
 	txn := m.db.Txn(false)
 	defer txn.Abort()
 
+	// Soft-deleted rows STAY in the memdb books table — ListSoftDeletedBooks
+	// reads them back through memIdxMarkedForDeletion, and ListBookIDs has
+	// always skipped them explicitly — so they must be excluded here too or
+	// this method contradicts its own contract and its Pebble twin.
+	//
+	// It did contradict both, in production, for the whole life of the memdb
+	// query layer: PebbleStore.GetAllBooksCore filters MarkedForDeletion
+	// unconditionally, this path only filtered when a caller passed the
+	// "marked_for_deletion" key, and NO caller ever passed it. Since
+	// UseMemDB defaults to true, every one of the ~35 full-library scans in
+	// the codebase silently included soft-deleted books. Measured on prod
+	// 2026-08-13: 63,869 live books scanned as 67,824 — the 3,953 rows soft
+	// deleted by the July dedup drain, still being organized, backfilled,
+	// counted and re-grouped four weeks after their deletion.
+	//
+	// A caller that genuinely wants deleted rows says so with the filter key
+	// (or uses ListSoftDeletedBooks); the default is the documented contract.
+	_, callerChoseDeletionState := filters["marked_for_deletion"]
+
 	var (
 		iter interface {
 			Next() interface{}
@@ -621,6 +640,9 @@ func (m *MemStore) GetAllBooksCore(limit, offset int, filters map[string]interfa
 
 	for obj := iter.Next(); obj != nil; obj = iter.Next() {
 		b := obj.(*Book)
+		if !callerChoseDeletionState && bookIsSoftDeleted(b) {
+			continue
+		}
 		if v, ok := filters["is_primary_version"].(bool); ok {
 			eff := true
 			if b.IsPrimaryVersion != nil {
@@ -681,7 +703,7 @@ func (m *MemStore) ListBookIDs() ([]string, error) {
 	ids := make([]string, 0, 1024)
 	for obj := iter.Next(); obj != nil; obj = iter.Next() {
 		b := obj.(*Book)
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(b) {
 			continue
 		}
 		ids = append(ids, b.ID)

--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -1,5 +1,5 @@
 // file: internal/database/memdb_reads.go
-// version: 1.16.0
+// version: 1.17.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000006
 // last-edited: 2026-08-13
 
@@ -133,7 +133,7 @@ func (m *MemStore) CountFiles() (int, error) {
 	total := 0
 	for obj := bookIter.Next(); obj != nil; obj = bookIter.Next() {
 		b := obj.(*Book)
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(b) {
 			continue
 		}
 		n := bookFileCounts[b.ID]
@@ -163,7 +163,7 @@ func (m *MemStore) GetAllSeriesBookCounts() (map[int]int, error) {
 		if b.SeriesID == nil {
 			continue
 		}
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(b) {
 			continue
 		}
 		out[*b.SeriesID]++
@@ -198,7 +198,7 @@ func (m *MemStore) GetAllAuthorBookCounts() (map[int]int, error) {
 		if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
 			continue
 		}
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(b) {
 			continue
 		}
 		bookHasJunction[ba.BookID] = true
@@ -218,7 +218,7 @@ func (m *MemStore) GetAllAuthorBookCounts() (map[int]int, error) {
 		if b.AuthorID == nil {
 			continue
 		}
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(b) {
 			continue
 		}
 		out[*b.AuthorID]++
@@ -244,7 +244,7 @@ func (m *MemStore) GetAllWorkBookCounts() (map[string]int, error) {
 		if b.WorkID == nil || *b.WorkID == "" {
 			continue
 		}
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(b) {
 			continue
 		}
 		out[*b.WorkID]++
@@ -273,7 +273,7 @@ func (m *MemStore) GetAllSeriesFileCounts() (map[int]int, error) {
 		if b.SeriesID == nil {
 			continue
 		}
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(b) {
 			continue
 		}
 		bookToSeries[b.ID] = *b.SeriesID
@@ -324,7 +324,7 @@ func (m *MemStore) GetAllAuthorFileCounts() (map[int]int, error) {
 		if b.AuthorID == nil {
 			continue
 		}
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(b) {
 			continue
 		}
 		bookToAuthor[b.ID] = *b.AuthorID
@@ -377,7 +377,7 @@ func (m *MemStore) GetFolderDuplicatesCore() ([][]BookCore, error) {
 	var entries []folderDupEntry
 	for obj := iter.Next(); obj != nil; obj = iter.Next() {
 		b := obj.(*Book)
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(b) {
 			continue
 		}
 		if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
@@ -434,7 +434,7 @@ func (m *MemStore) GetDuplicateBooksByMetadataCore(threshold float64) ([][]BookC
 	var entries []metadataDupEntry
 	for obj := iter.Next(); obj != nil; obj = iter.Next() {
 		b := obj.(*Book)
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(b) {
 			continue
 		}
 		if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
@@ -474,7 +474,7 @@ func (m *MemStore) GetBooksBySeriesIDCore(seriesID int, limit, offset int) ([]Bo
 	all := make([]Book, 0, 32)
 	for obj := iter.Next(); obj != nil; obj = iter.Next() {
 		b := obj.(*Book)
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(b) {
 			continue
 		}
 		if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
@@ -560,7 +560,7 @@ func (m *MemStore) GetBooksByAuthorID(authorID int, limit, offset int) ([]Book, 
 			continue
 		}
 		b := raw.(*Book)
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(b) {
 			continue
 		}
 		if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
@@ -653,11 +653,7 @@ func (m *MemStore) GetAllBooksCore(limit, offset int, filters map[string]interfa
 			}
 		}
 		if v, ok := filters["marked_for_deletion"].(bool); ok {
-			eff := false
-			if b.MarkedForDeletion != nil {
-				eff = *b.MarkedForDeletion
-			}
-			if eff != v {
+			if bookIsSoftDeleted(b) != v {
 				continue
 			}
 		}
@@ -770,7 +766,7 @@ func (m *MemStore) CountBooksByPathPrefix(prefix string) (int, error) {
 	count := 0
 	for obj := iter.Next(); obj != nil; obj = iter.Next() {
 		b := obj.(*Book)
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(b) {
 			continue
 		}
 		if b.SourceImportPath != nil && *b.SourceImportPath != "" {
@@ -814,7 +810,7 @@ func (m *MemStore) ComputeLibraryStats(rootDir string, importPaths []ImportPath)
 	}
 	for obj := bIter.Next(); obj != nil; obj = bIter.Next() {
 		b := obj.(*Book)
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(b) {
 			continue
 		}
 		stats.TotalBooks++

--- a/internal/database/memdb_summaries.go
+++ b/internal/database/memdb_summaries.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_summaries.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000008
-// last-edited: 2026-07-05
+// last-edited: 2026-08-13
 
 package database
 
@@ -180,11 +180,11 @@ func (m *MemStore) GetBookSummaries(limit, offset int, f BookSummaryFilter) ([]B
 		// Apply filters before pagination so offset/limit match the
 		// post-filter set, not the pre-filter set.
 		if excludeDeleted {
-			if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+			if bookIsSoftDeleted(b) {
 				continue
 			}
 		} else {
-			isDel := b.MarkedForDeletion != nil && *b.MarkedForDeletion
+			isDel := bookIsSoftDeleted(b)
 			if isDel != requireDeleted {
 				continue
 			}
@@ -320,11 +320,11 @@ func (m *MemStore) CountBookSummaries(f BookSummaryFilter) (int, error) {
 			}
 		}
 		if excludeDeleted {
-			if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+			if bookIsSoftDeleted(b) {
 				continue
 			}
 		} else {
-			isDel := b.MarkedForDeletion != nil && *b.MarkedForDeletion
+			isDel := bookIsSoftDeleted(b)
 			if isDel != requireDeleted {
 				continue
 			}

--- a/internal/database/pebble_quick_queries.go
+++ b/internal/database/pebble_quick_queries.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_quick_queries.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7f3a1b2c-4d5e-6f7a-8b9c-0d1e2f3a4b5c
-// last-edited: 2026-05-20
+// last-edited: 2026-08-13
 
 package database
 
@@ -198,7 +198,7 @@ func (p *PebbleStore) computeQuickQueryCount(id string) (int, error) {
 		if err := json.Unmarshal(iter.Value(), &b); err != nil {
 			continue
 		}
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(&b) {
 			continue
 		}
 		// Primary versions only (consistent with LibraryStats).
@@ -326,7 +326,7 @@ func (p *PebbleStore) GetAllBookIDsForQuickQuery(id string) ([]string, error) {
 		if err := json.Unmarshal(iter.Value(), &b); err != nil {
 			continue
 		}
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(&b) {
 			continue
 		}
 		// Primary versions only (consistent with LibraryStats and computeQuickQueryCount).

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.125.0
+// version: 1.126.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-08-13
 
@@ -611,7 +611,7 @@ func (p *PebbleStore) GetAllBooksFullFrom(afterID string, limit int) ([]Book, er
 		if err := json.Unmarshal(iter.Value(), &book); err != nil {
 			return nil, err
 		}
-		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+		if bookIsSoftDeleted(&book) {
 			continue
 		}
 		// This branch decodes the row directly instead of point-getting each
@@ -873,7 +873,7 @@ func (p *PebbleStore) walkFilteredBooksPebble(f BookSummaryFilter, visit func(*B
 				continue
 			}
 		}
-		isDeleted := book.MarkedForDeletion != nil && *book.MarkedForDeletion
+		isDeleted := bookIsSoftDeleted(&book)
 		if excludeDeleted {
 			if isDeleted {
 				continue
@@ -938,7 +938,9 @@ func (p *PebbleStore) getAllBookSummariesFull(limit, offset int) ([]BookSummary,
 	summaries := make([]BookSummary, 0, len(books))
 	for i := range books {
 		b := &books[i]
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		// Belt-and-braces: GetAllBooksCore now filters the trash itself, but
+		// this loop must not silently depend on that to stay correct.
+		if bookCoreIsSoftDeleted(b) {
 			continue
 		}
 		full := b.ToBook()
@@ -1279,7 +1281,7 @@ func (p *PebbleStore) GetDuplicateBooks() ([][]Book, error) {
 		if err := json.Unmarshal(iter.Value(), &book); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal book: %w", err)
 		}
-		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+		if bookIsSoftDeleted(&book) {
 			continue
 		}
 
@@ -1758,7 +1760,7 @@ func (p *PebbleStore) getBooksBySeriesIDFull(seriesID int) ([]Book, error) {
 		if book.SeriesID == nil || *book.SeriesID != seriesID {
 			continue
 		}
-		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+		if bookIsSoftDeleted(&book) {
 			continue
 		}
 		books = append(books, book)
@@ -1824,7 +1826,7 @@ func (p *PebbleStore) getBooksByAuthorIDFull(authorID int) ([]Book, error) {
 		if book.AuthorID == nil || *book.AuthorID != authorID {
 			continue
 		}
-		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+		if bookIsSoftDeleted(&book) {
 			continue
 		}
 		books = append(books, book)
@@ -1904,7 +1906,7 @@ func (p *PebbleStore) GetBooksByAuthorIDWithRoleCore(authorID int) ([]BookCore, 
 		if err := json.Unmarshal(bookIter.Value(), &book); err != nil {
 			continue
 		}
-		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+		if bookIsSoftDeleted(&book) {
 			continue
 		}
 		if _, inJunction := bookIDSet[book.ID]; inJunction {
@@ -2813,7 +2815,7 @@ func (p *PebbleStore) countPrimaryBooksScan() (int, error) {
 		if err := json.Unmarshal(iter.Value(), &book); err != nil {
 			return 0, err
 		}
-		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+		if bookIsSoftDeleted(&book) {
 			continue
 		}
 		// Skip non-primary versions so duplicate editions don't inflate counts
@@ -3077,7 +3079,7 @@ func (p *PebbleStore) GetBooksByVersionGroup(groupID string) ([]Book, error) {
 			continue
 		}
 
-		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+		if bookIsSoftDeleted(&book) {
 			continue
 		}
 
@@ -3127,7 +3129,7 @@ func (p *PebbleStore) GetBooksByMetadataSourceHash(hash string) ([]Book, error) 
 			continue
 		}
 
-		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+		if bookIsSoftDeleted(&book) {
 			continue
 		}
 

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -503,7 +503,7 @@ func (p *PebbleStore) GetAllBooksCore(limit, offset int) ([]BookCore, error) {
 		if err := json.Unmarshal(iter.Value(), &book); err != nil {
 			return nil, err
 		}
-		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+		if bookIsSoftDeleted(&book) {
 			continue
 		}
 		if skipped < offset {
@@ -2857,7 +2857,7 @@ func (p *PebbleStore) CountAllBooks() (int, error) {
 		if err := json.Unmarshal(iter.Value(), &book); err != nil {
 			return 0, err
 		}
-		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+		if bookIsSoftDeleted(&book) {
 			continue
 		}
 		count++
@@ -3021,7 +3021,7 @@ func (p *PebbleStore) GetBooksByVersionGroup(groupID string) ([]Book, error) {
 		if err != nil || b == nil {
 			continue
 		}
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(b) {
 			continue
 		}
 		books = append(books, *b)

--- a/internal/database/pebble_store_authors.go
+++ b/internal/database/pebble_store_authors.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_authors.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 1f8b9fd2-e424-4a09-9ee4-7b5b64660605
-// last-edited: 2026-07-13
+// last-edited: 2026-08-13
 
 package database
 
@@ -520,7 +520,7 @@ func (p *PebbleStore) GetAllAuthorBookCounts() (map[int]int, error) {
 		if book.IsPrimaryVersion != nil && !*book.IsPrimaryVersion {
 			continue
 		}
-		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+		if bookIsSoftDeleted(book) {
 			continue
 		}
 		bookHasJunction[bookID] = true
@@ -562,7 +562,7 @@ func (p *PebbleStore) GetAllAuthorBookCounts() (map[int]int, error) {
 		if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
 			continue
 		}
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(&b) {
 			continue
 		}
 		counts[*b.AuthorID]++
@@ -621,7 +621,7 @@ func (p *PebbleStore) GetAllAuthorFileCounts_Pebble() (map[int]int, error) {
 		if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
 			continue
 		}
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(&b) {
 			continue
 		}
 		authorBooks = append(authorBooks, AuthorBook{AuthorID: *b.AuthorID, BookID: b.ID})

--- a/internal/database/pebble_store_bookfiles.go
+++ b/internal/database/pebble_store_bookfiles.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_bookfiles.go
-// version: 1.11.0
+// version: 1.12.0
 // guid: bee03868-fbc4-48b0-9c9a-11180e19779e
-// last-edited: 2026-08-06
+// last-edited: 2026-08-13
 
 package database
 
@@ -567,7 +567,7 @@ func (s *PebbleStore) getAllBooksPebbleScan() ([]Book, error) {
 		if err := json.Unmarshal(iter.Value(), &book); err != nil {
 			return nil, err
 		}
-		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+		if bookIsSoftDeleted(&book) {
 			continue
 		}
 		books = append(books, book)

--- a/internal/database/pebble_store_stats.go
+++ b/internal/database/pebble_store_stats.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_stats.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 8643a893-1898-4098-8e69-c312531d962c
-// last-edited: 2026-07-07
+// last-edited: 2026-08-13
 
 package database
 
@@ -42,7 +42,7 @@ func (p *PebbleStore) CountFiles() (int, error) {
 		if err := json.Unmarshal(bookIter.Value(), &book); err != nil {
 			return 0, err
 		}
-		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+		if bookIsSoftDeleted(&book) {
 			continue
 		}
 		if book.IsPrimaryVersion != nil && !*book.IsPrimaryVersion {
@@ -303,7 +303,7 @@ func (p *PebbleStore) computeLibraryStats() (*LibraryStats, error) {
 		if err := json.Unmarshal(bookIter.Value(), &b); err != nil {
 			continue
 		}
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(&b) {
 			continue
 		}
 		stats.TotalBooks++

--- a/internal/database/pebble_store_works.go
+++ b/internal/database/pebble_store_works.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_works.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 1d915e6f-133a-4fba-995b-8e4b26b04486
-// last-edited: 2026-07-13
+// last-edited: 2026-08-13
 
 package database
 
@@ -197,7 +197,7 @@ func (p *PebbleStore) GetBooksByWorkID(workID string) ([]Book, error) {
 		if err != nil || b == nil {
 			continue
 		}
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(b) {
 			continue
 		}
 		books = append(books, *b)
@@ -242,7 +242,7 @@ func (p *PebbleStore) GetAllWorkBookCounts() (map[string]int, error) {
 		if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
 			continue
 		}
-		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+		if bookIsSoftDeleted(&b) {
 			continue
 		}
 		counts[*b.WorkID]++

--- a/internal/deluge/discovery.go
+++ b/internal/deluge/discovery.go
@@ -1,7 +1,7 @@
 // file: internal/deluge/discovery.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-07-16
+// last-edited: 2026-08-13
 //
 // Four-tier matching to decide if a labeled Deluge torrent is already in
 // the library — run in order, stop on first hit:
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -58,28 +59,63 @@ type LibraryIndex struct {
 }
 
 // BookLister is the narrow interface needed to build a library index.
+//
+// ListSoftDeletedBooks is part of it because this index answers "have I seen
+// this before?", and a book in the trash has definitely been seen — see
+// BuildLibraryIndex.
 type BookLister interface {
 	GetAllBooksCore(limit, offset int) ([]database.BookCore, error)
+	ListSoftDeletedBooks(limit, offset int, olderThan *time.Time) ([]database.Book, error)
 }
 
-// BuildLibraryIndex builds a LibraryIndex from all books in the store.
+// BuildLibraryIndex builds a LibraryIndex from all books in the store,
+// INCLUDING soft-deleted ones.
+//
+// The index feeds DiscoverUnimported, which reports labeled torrents that are
+// not already in the library. Soft-deleted books must count as "already in the
+// library" for that question: the user trashed those books on purpose, and
+// re-offering them as fresh discoveries invites re-importing exactly what was
+// just removed. Restore (POST /api/v1/audiobooks/:id/restore) is the intended
+// way back, not a re-download.
+//
+// Before 2026-08-13 they were included by accident — GetAllBooksCore's memdb
+// implementation leaked soft-deleted rows. Fixing that leak would silently have
+// turned every trashed book into a discovery candidate (3,953 of them on prod,
+// the losers of the July dedup drain), so the inclusion is now explicit.
 func BuildLibraryIndex(store BookLister) LibraryIndex {
 	idx := LibraryIndex{
 		Paths:  make(map[string]struct{}),
 		Titles: make(map[string]struct{}),
 	}
+	add := func(filePath, title string) {
+		if filePath != "" {
+			idx.Paths[filePath] = struct{}{}
+		}
+		if title != "" {
+			idx.Titles[NormalizeTitle(title)] = struct{}{}
+		}
+	}
+
 	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		slog.Warn("deluge discovery failed to load books", "err", err)
 		return idx
 	}
 	for _, b := range books {
-		if b.FilePath != "" {
-			idx.Paths[b.FilePath] = struct{}{}
-		}
-		if b.Title != "" {
-			idx.Titles[NormalizeTitle(b.Title)] = struct{}{}
-		}
+		add(b.FilePath, b.Title)
+	}
+
+	// Fail SOFT here, unlike findOrphanBookFiles: a short index only causes a
+	// spurious "unimported" suggestion for a human to review, whereas the
+	// orphan scan's output is fed to a delete. Log loudly and carry on.
+	trashed, terr := store.ListSoftDeletedBooks(0, 0, nil)
+	if terr != nil {
+		slog.Warn("deluge discovery could not load soft-deleted books; "+
+			"trashed titles may be re-offered as unimported", "err", terr)
+		return idx
+	}
+	for i := range trashed {
+		add(trashed[i].FilePath, trashed[i].Title)
 	}
 	return idx
 }

--- a/internal/plugins/maintenance/orphan_book_files.go
+++ b/internal/plugins/maintenance/orphan_book_files.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/orphan_book_files.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 9d2c4f6a-8e1b-4c5d-9a7b-3e5f1a2c4b6d
 // last-edited: 2026-08-13
 
@@ -65,7 +65,7 @@ func (p *Plugin) runOrphanBookFilesCleanup(ctx context.Context, raw json.RawMess
 	scanProg := sdk.NewProgress(reporter, 0)
 	scanProg.Start("Scanning book_files for orphan rows...")
 
-	orphans, totalFiles, totalBooks, err := findOrphanBookFiles(ctx, store)
+	orphans, totalFiles, ownerCount, err := findOrphanBookFiles(ctx, store)
 	if err != nil {
 		return fmt.Errorf("scan failed: %w", err)
 	}
@@ -73,7 +73,8 @@ func (p *Plugin) runOrphanBookFilesCleanup(ctx context.Context, raw json.RawMess
 	_ = reporter.Log(slog.LevelInfo, "Orphan scan complete",
 		slog.Int("orphan_count", len(orphans)),
 		slog.Int("total_book_files", totalFiles),
-		slog.Int("total_books", totalBooks),
+		// live + soft-deleted: every book that could still own a file row.
+		slog.Int("owning_books", ownerCount),
 	)
 
 	if !params.Delete || len(orphans) == 0 {
@@ -89,8 +90,8 @@ func (p *Plugin) runOrphanBookFilesCleanup(ctx context.Context, raw json.RawMess
 	// Delete pass — now we know N.
 	total := len(orphans)
 	prog := sdk.NewProgress(reporter, total)
-	prog.Start(fmt.Sprintf("Found %d orphan book_file row(s) out of %d (valid books: %d)",
-		total, totalFiles, totalBooks))
+	prog.Start(fmt.Sprintf("Found %d orphan book_file row(s) out of %d (owning books: %d)",
+		total, totalFiles, ownerCount))
 	var deleted, failed int
 
 	// Deletes go through Store.DeleteBookFilesByIDs in chunks rather than one
@@ -200,15 +201,21 @@ func (p *Plugin) runOrphanBookFilesCleanup(ctx context.Context, raw json.RawMess
 }
 
 // findOrphanBookFiles returns every BookFile whose BookID does not match any
-// existing book ID. Returns the orphan slice, the total number of book_files
-// scanned, and the number of valid book IDs found. The scan uses the memdb
-// fastpath via Store.GetAllBookFilesCore / Store.GetAllBooks; both calls
-// return projections of the underlying tables without per-row decoding cost.
+// book that could still own it. Returns the orphan slice, the total number of
+// book_files scanned, and the number of owning book IDs considered. The scan
+// uses the memdb fastpath via Store.GetAllBookFilesCore / Store.GetAllBooks;
+// both calls return projections of the underlying tables without per-row
+// decoding cost.
+//
+// "Could still own it" is deliberately wider than "live": a soft-deleted book
+// is restorable and still owns its files, so ownerCount is live + soft-deleted
+// and will exceed the library's book count. That is the correct denominator
+// for this scan and the one it reports.
 //
 // This is the testable core of runOrphanBookFilesCleanup. It does not delete
 // anything — callers that want to delete pass the resulting IDs to
 // Store.DeleteBookFilesByIDs themselves, in chunks.
-func findOrphanBookFiles(ctx context.Context, store database.Store) (orphans []database.BookFileCore, totalFiles int, totalBooks int, err error) {
+func findOrphanBookFiles(ctx context.Context, store database.Store) (orphans []database.BookFileCore, totalFiles int, ownerCount int, err error) {
 	if ctx.Err() != nil {
 		return nil, 0, 0, ctx.Err()
 	}
@@ -270,5 +277,10 @@ func findOrphanBookFiles(ctx context.Context, store database.Store) (orphans []d
 			orphans = append(orphans, f)
 		}
 	}
-	return orphans, len(files), len(books), nil
+	// Report the size of the set that actually decided orphanhood, not just
+	// the live books. `valid` is live + soft-deleted, so returning len(books)
+	// here would log a denominator smaller than the one used above — an
+	// operator reading "N orphans out of M books" would be reading the wrong M
+	// and could not reconcile it against the library count.
+	return orphans, len(files), len(valid), nil
 }

--- a/internal/plugins/maintenance/orphan_book_files.go
+++ b/internal/plugins/maintenance/orphan_book_files.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/orphan_book_files.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 9d2c4f6a-8e1b-4c5d-9a7b-3e5f1a2c4b6d
-// last-edited: 2026-08-06
+// last-edited: 2026-08-13
 
 package maintenance
 
@@ -228,6 +228,32 @@ func findOrphanBookFiles(ctx context.Context, store database.Store) (orphans []d
 	valid := make(map[string]struct{}, len(books))
 	for _, b := range books {
 		valid[b.ID] = struct{}{}
+	}
+
+	// A soft-deleted book still OWNS its book_files. It is in the trash, not
+	// gone: POST /api/v1/audiobooks/:id/restore brings it back, and a restore
+	// whose file rows were deleted underneath it restores an empty shell.
+	//
+	// GetAllBooksCore deliberately excludes soft-deleted rows, so they must be
+	// added back explicitly here — this scan is a set-difference that treats
+	// every book_file whose owner is absent as garbage, and callers feed the
+	// result straight to DeleteBookFilesByIDs.
+	//
+	// Until 2026-08-13 this was accidentally correct: the memdb implementation
+	// of GetAllBooksCore leaked soft-deleted rows, so they landed in `valid` by
+	// way of a bug. Fixing that bug is what made this union load-bearing —
+	// without it the very first orphan-cleanup run after the fix would have
+	// deleted the file rows of all 3,953 books soft-deleted by the July dedup
+	// drain. See TestFindOrphanBookFiles_SoftDeletedBooksKeepTheirFiles.
+	softDeleted, serr := store.ListSoftDeletedBooks(0, 0, nil)
+	if serr != nil {
+		// Fail CLOSED: without the soft-deleted set this scan cannot tell a
+		// restorable book's files from real garbage, and the caller deletes
+		// what it returns. Refuse rather than under-report.
+		return nil, 0, 0, fmt.Errorf("ListSoftDeletedBooks (needed to protect restorable books): %w", serr)
+	}
+	for i := range softDeleted {
+		valid[softDeleted[i].ID] = struct{}{}
 	}
 	orphans = make([]database.BookFileCore, 0)
 	for _, f := range files {

--- a/internal/plugins/maintenance/orphan_book_files_test.go
+++ b/internal/plugins/maintenance/orphan_book_files_test.go
@@ -1,16 +1,104 @@
 // file: internal/plugins/maintenance/orphan_book_files_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 0bd4f9a2-1c3e-4f5a-8b6c-7d9e0f1a2b3c
-// last-edited: 2026-07-07
+// last-edited: 2026-08-13
 
 package maintenance
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
+
+// TestFindOrphanBookFiles_SoftDeletedBooksKeepTheirFiles is a data-loss guard.
+//
+// A soft-deleted book is in the trash, not gone — POST
+// /api/v1/audiobooks/:id/restore brings it back. Its book_file rows must
+// therefore NOT be reported as orphans, because callers pass the orphan set to
+// DeleteBookFilesByIDs and a restore whose file rows were deleted underneath it
+// restores an empty shell.
+//
+// This was accidentally safe until 2026-08-13: GetAllBooksCore's memdb
+// implementation leaked soft-deleted rows, so they landed in the valid-owner
+// set by way of a bug. Fixing that leak is what made the explicit
+// ListSoftDeletedBooks union load-bearing. On prod at the time of the fix that
+// was 3,953 books — the losers of the July dedup drain.
+func TestFindOrphanBookFiles_SoftDeletedBooksKeepTheirFiles(t *testing.T) {
+	live := []database.Book{{ID: "book-live-1", Title: "Live"}}
+	yes := true
+	trashed := []database.Book{
+		{ID: "book-trashed-1", Title: "Trashed", MarkedForDeletion: &yes},
+	}
+	files := []database.BookFileCore{
+		{ID: "f1", BookID: "book-live-1", FilePath: "/lib/live.m4b"},
+		{ID: "f2", BookID: "book-trashed-1", FilePath: "/lib/trashed.m4b"},
+		{ID: "f3", BookID: "book-ghost-9", FilePath: "/lib/really-orphan.m4b"},
+	}
+
+	store := &database.MockStore{
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
+		// Models the FIXED contract: soft-deleted rows are excluded here.
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			return []database.BookCore{live[0].Core()}, nil
+		},
+		ListSoftDeletedBooksFunc: func(limit, offset int, olderThan *time.Time) ([]database.Book, error) {
+			return trashed, nil
+		},
+	}
+
+	orphans, _, _, err := findOrphanBookFiles(context.Background(), store)
+	if err != nil {
+		t.Fatalf("findOrphanBookFiles returned error: %v", err)
+	}
+
+	got := make(map[string]bool, len(orphans))
+	for _, o := range orphans {
+		got[o.ID] = true
+	}
+	if got["f2"] {
+		t.Error("f2 belongs to a SOFT-DELETED book and was reported as an orphan; " +
+			"its owner is restorable, so deleting this row destroys the restore target")
+	}
+	if got["f1"] {
+		t.Error("f1 belongs to a LIVE book and must never be an orphan")
+	}
+	// Non-vacuity: the scan must still find genuine orphans, or a function that
+	// returned nothing at all would pass the assertions above.
+	if !got["f3"] {
+		t.Error("f3 has no owning book at all and must still be reported as an orphan")
+	}
+}
+
+// TestFindOrphanBookFiles_FailsClosedWhenSoftDeletedSetUnavailable pins the
+// error-handling choice: without the soft-deleted set the scan cannot tell a
+// restorable book's files from real garbage, and its caller DELETES what it
+// returns. Failing open here would report every soft-deleted book's files as
+// orphans on a transient read error.
+func TestFindOrphanBookFiles_FailsClosedWhenSoftDeletedSetUnavailable(t *testing.T) {
+	store := &database.MockStore{
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
+			return []database.BookFileCore{{ID: "f1", BookID: "ghost"}}, nil
+		},
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			return nil, nil
+		},
+		ListSoftDeletedBooksFunc: func(limit, offset int, olderThan *time.Time) ([]database.Book, error) {
+			return nil, errors.New("pebble read failed")
+		},
+	}
+
+	orphans, _, _, err := findOrphanBookFiles(context.Background(), store)
+	if err == nil {
+		t.Fatalf("expected an error when the soft-deleted set is unreadable, got %d orphans", len(orphans))
+	}
+	if orphans != nil {
+		t.Errorf("expected no orphan list alongside the error, got %d", len(orphans))
+	}
+}
 
 // TestFindOrphanBookFiles_ReportOnly verifies the core scan: given a mix of
 // book_files where some BookIDs reference existing books and some don't, the

--- a/todo.d/2026-08-13-itunes-pid-listing-includes-trash.md
+++ b/todo.d/2026-08-13-itunes-pid-listing-includes-trash.md
@@ -23,3 +23,17 @@
 
       Regression test to add either way: a soft-deleted book with an iTunes PID must not
       appear in the writeback preview.
+
+- [ ] 🔁 **The three-state deletion filter is implemented twice.** Residue from the
+      same duplication PR #2392 set out to remove. `internal/database/memdb_summaries.go`
+      (the `isDel != requireDeleted` comparisons, two sites) and
+      `internal/database/memdb_reads.go` (`GetAllBooksCore`'s
+      `bookIsSoftDeleted(b) != v` block) independently implement the same
+      three-state rule: exclude deleted by default / require deleted / require
+      live. The *predicate* is now shared; the *tri-state policy around it* is not.
+
+      Not a bug today — both agree. It is listed because "both agree today" is
+      exactly what was true of `GetAllBooksCore`'s two implementations right up
+      until they didn't, and the mechanism was the same: one rule, written out
+      twice. A shared helper taking (row, filter) and returning include/exclude
+      would collapse it. Low priority, no user-visible symptom.

--- a/todo.d/2026-08-13-itunes-pid-listing-includes-trash.md
+++ b/todo.d/2026-08-13-itunes-pid-listing-includes-trash.md
@@ -1,0 +1,25 @@
+- [ ] 🗑️ **`ListBooksByITunesPID` returns soft-deleted books, on both code paths.**
+      Found while auditing the memdb/Pebble soft-delete divergence (PR #2392), but
+      deliberately **not** fixed there — unlike `GetAllBooksCore`/`CountAllBooks`, the two
+      implementations of this method *agree*: neither filters `marked_for_deletion`
+      (`internal/database/memdb_reads.go` `ListBooksByITunesPID`, and the Pebble fallback
+      at `internal/database/pebble_store.go:1135`). It is therefore a consistent behaviour,
+      not a drift, and changing it changes what the iTunes handlers do — out of scope for a
+      fix whose whole point was making the two paths agree.
+
+      Whether it is *correct* is a separate question, and the answer is probably no. The
+      two callers are `internal/server/handlers/itunes.go:630` (list iTunes-mapped books)
+      and `:711` (the writeback preview filter). The second is the one that matters: the
+      writeback preview is what decides which metadata gets offered for writing back into
+      the iTunes library, and a book the user deleted should almost certainly not be in
+      that set. With 3,953 soft-deleted books in prod as of 2026-08-13, any that carry an
+      `itunes_persistent_id` are currently eligible.
+
+      Before changing it, check both callers' expectations — the listing endpoint may
+      legitimately want to show a trashed-but-still-mapped book so the mapping can be
+      cleaned up. If so, the fix is a parameter or a second method, not a blanket filter.
+      Note the standing constraint that `books/itunes/**` is read-only; this is about what
+      we *offer* to write, and the ITL file, not about touching that tree.
+
+      Regression test to add either way: a soft-deleted book with an iTunes PID must not
+      appear in the writeback preview.


### PR DESCRIPTION
## What

`GetAllBooksCore` and `CountAllBooks` each have **two backing implementations** — a Pebble keyspace scan and a memdb index walk — and only the Pebble one filtered soft-deleted rows. The memdb path filtered them only when a caller passed a `marked_for_deletion` filter, and **no caller ever did**. `UseMemDB` defaults to true, so in production every one of the ~35 full-library scans silently included books in the trash.

Measured on prod 2026-08-13: **63,869 live books scanned as 67,824.** The extra **3,953** are the losers of the July dedup drain, still being organized, backfilled, counted and re-grouped four weeks after deletion. `CountAllBooks` also backs the ABS library count, so Audiobookshelf clients saw an inflated number.

Found while investigating why 11 version groups resisted last night's primary-election repair.

## Two callers were doing worse than wasted work

| Caller | Behaviour with the leak |
|---|---|
| `AssignOrphanVGs` | force-sets `library_state=organized` → **resurrects** soft-deleted books |
| `MergeNoVGDuplicates` | could select a soft-deleted book as the **keeper** and soft-delete the live one |

Both are fixed by the leak fix itself.

## The fix

The rule now lives in one place — `bookIsSoftDeleted` — called by both implementations. `TestGetAllBooksCore_MemDBAndPebbleAgree` runs one fixture through **both** and fails if they disagree.

Asserting each path against its own hardcoded expectation would not have caught this: whoever wrote the memdb path would have written the memdb expectation. Holding the two implementations to the *same* answer is what makes it catchable.

## Two callers relied on the leak — protection made explicit

- **`findOrphanBookFiles`** is a set-difference whose output is fed to `DeleteBookFilesByIDs`. A soft-deleted book still owns its `book_files` because restore needs them, and those rows were protected **only by the bug**. Without the explicit union added here, the first orphan-cleanup run after this fix would have deleted the file rows of all 3,953 recoverable books, silently making them unrestorable. Now **fails closed** if the soft-deleted set is unreadable.
- **`deluge.BuildLibraryIndex`** answers "have I seen this before?", and a trashed book has been seen. Now includes soft-deleted rows so discovery does not re-offer just-deleted books. **Fails soft** — a short index only yields a suggestion for a human to review.

## Verification

- Both fixes **mutation-verified**: reverting each makes its own test fail for the right reason (a build error does not count — the first attempt produced one and was redone).
- `go test ./... -short` passes with **zero changes to existing tests**. That is the caller-reliance check: no existing test encoded the old behaviour.
- `go build ./...` and `go vet` clean.

## Not claimed

This was the leading explanation for the 11 residual `skipped_vanished` groups, and it is now **confirmed**.

All 3,870 version groups containing a soft-deleted book were probed individually against prod. Exactly **11** returned zero live members, and those 11 hold exactly **12** books — both figures matching the census independently (ten groups with one book, one with two). Every one of the 12 is soft-deleted and `is_primary_version=false`.

The repair pass was therefore correct to skip them: there was no live book to elect a primary from. **Those groups need no repair.** A count-only match on 11 would have been weak evidence out of 3,870 probes; the second, independently derived figure is what makes it an answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t


---

## ⚠️ Do not split this PR

The leak fix and the `findOrphanBookFiles` change must land together. A soft-deleted book still owns its `book_files`, and those rows were protected **only** by the leak. Merging the leak fix without the orphan-scan union is the data-loss configuration: the first nightly orphan cleanup afterwards would delete the file rows of all 3,953 restorable books, silently making them unrestorable.

The same applies to the **deploy**, not just the merge. `maintenance.orphan-book-files-cleanup` is scheduled `15 2 * * *` and does not care which commit is live — it runs against whatever binary is deployed at 02:15. Ship these commits as a unit.

---

## Verification of the probe's own instrument

The confirmation above depends on `/api/v1/version-groups/:id` returning **live** members only, and that endpoint's fast path is one of the sites this PR touched — so it is worth stating why the reading holds.

- `GetBooksByVersionGroup` has **no memdb branch at all** (`pebble_store.go:2999`). There is no second implementation to drift, and this PR's edit to it was a pure rename.
- Both of its sub-paths exclude soft-deleted rows: the index fast path skips them per row, and the `len(books) == 0` fallback full scan skips them too. So the 11 all-trash groups return zero on either path.
- Independently of the code: all 3,870 probed groups were selected *because* they contain a soft-deleted book. If the endpoint returned trashed rows, every group would report ≥1 member and a zero would be impossible. Eleven zeros can only occur if it excludes them.

## Second commit: `5cbfc9f6`

Two gaps found on review of the first commit.

**1. The standardization was partial.** The first commit routed four sites through the predicate and left **37** more copies of the same open-coded check across eight files. All correct today — which is exactly why they were the next drift, since duplicating the rule is the mechanism that let the two implementations diverge in the first place. All 37 now call it.

`Book` and `BookCore` are separate structs that each carry the flag, so the rule bottoms out in one `markedForDeletionFlag` that both delegate to. The standing check:

```
grep "MarkedForDeletion != nil" internal/database/*.go | grep -v _test
```

now returns only three hits, all reads of the caller-supplied *filter* struct rather than a book row.

The compiler did the classifying: applying the pointer form everywhere and building found all ten value-typed sites plus the one genuinely different type (`*BookCore`) that needed a design answer rather than a mechanical fix.

**2. The conformance gate could not see pagination.** The original test used a 5-book fixture and `limit=0`, so both clamps were dead code — while every real caller pages and terminates on a short page. That is the interaction production depends on: filtering must happen *before* pagination, or a page containing trashed rows comes back short, the caller's `len(page) < pageSize` termination fires early, and the tail of the library is silently skipped.

`TestGetAllBooksCore_PaginationPartitionsTheLiveSet` uses 21 books with trash interleaved among live rows, pages both backends at size 4, and asserts the pages partition the live set identically.

Mutation-verified. With one path changed to paginate-then-filter:

| Test | Under the mutation |
|---|---|
| `TestGetAllBooksCore_MemDBAndPebbleAgree` (all 4 subtests) | **PASS** |
| `TestGetAllBooksCore_PaginationPartitionsTheLiveSet` | **FAIL** — recovered 2 of 14 live books |

That contrast is the coverage gap this closes.

**Also:** `findOrphanBookFiles` logged the live book count while deciding orphanhood against live + soft-deleted. The field is now `owning_books`.

**Filed, deliberately not fixed here:** `ListBooksByITunesPID` returns soft-deleted books on **both** paths. Unlike the methods above, the two implementations *agree*, so it is consistent behaviour rather than drift, and changing it changes what the iTunes writeback preview offers — out of scope for a fix whose point was making the two paths agree. See `todo.d/2026-08-13-itunes-pid-listing-includes-trash.md`.

**Verified:** `go build ./...` and `go vet ./...` clean; full `go test ./... -short` exit 0 with **zero FAIL lines and no changes to any pre-existing test**.
