### PR TITLE
feat(maintenance): migrate inline book signatures into the book_sig sidecar

### DIFF
--- a/changelog.d/20260813_added_booksig_sidecar_migrate_op.md
+++ b/changelog.d/20260813_added_booksig_sidecar_migrate_op.md
@@ -1,0 +1,46 @@
+### Added
+
+#### `maintenance.booksig-sidecar-migrate` — realizes the 580 MB startup saving
+
+PR #2387 moved the five `BookSig*` dedup-signature fields out of each `book:`
+row and into a `book_sig:<id>` sidecar, so that startup stops reading data it
+throws away. It shipped with **fallback-first reads**: a row that still carries
+the signature inline keeps working untouched. That is what made the change safe
+to deploy against 67,824 live books — and it is also why the saving was never
+realized. Production warmup on 2026-08-13 still reported
+`discarded_field_mb[book_sig_v1_and_mask] = 580` against `phase_mb[books] = 729`,
+exactly as designed: 80% of every byte the books warmup phase read was a
+signature discarded the instant it finished decoding.
+
+This op moves the data. It walks every `book:` row and, for any row still
+carrying an inline signature, writes the sidecar key and rewrites the row
+without it — **both in one Pebble batch**, so a row is never stripped without
+its sidecar. That pairing is the whole safety story: a book with all five
+fields nil is exactly the shape `booksig-recovery-audit` classifies as "never
+had a signature" rather than as damage, so a half-applied migration would be
+invisible to the very op written to detect signature loss, and dedup would
+simply stop matching those books. A conformance test asserts the pairing across
+a mixed library, and six mutation controls confirm the tests fail when each
+guard is removed.
+
+It is **dry-run by default** — this is the only irreversible step in the sidecar
+design — and reports `migrated / stripped-only / not-candidate / skipped-raced /
+errors` plus an expected-magnitude cross-check, so a detector matching every
+book (or none) is visible before anything is written. A `limit` parameter runs a
+small canary first, as a stable prefix that a later full run resumes from.
+
+Notes on two deliberate choices:
+
+- It does **not** go through `UpdateBook`, which would also have migrated a book
+  correctly. `UpdateBook` writes a `book_ver:` snapshot per call that
+  deliberately keeps the full inline signature, so 67,824 calls would have
+  written roughly 1.5 GB of fresh snapshot data in a migration whose purpose is
+  to stop paying for those bytes — and it would have bumped `UpdatedAt` on every
+  book, churning the search-index dirty set and the aggregate recompute.
+- Books written by another path mid-migration are **skipped and counted**, never
+  half-written. There is no per-book write lock in the store, so a naive
+  read-then-write would have reverted an entire concurrent update — title, path
+  and all — not merely the signature. Since every `UpdateBook` already strips the
+  row it writes, the library migrates organically anyway and this op only
+  accelerates it, which makes skipping always safe. Re-run to pick up the
+  skipped books.

--- a/docs/executive-summaries/2026-08-13-the-580-megabytes-read-and-discarded-executive-summary.md
+++ b/docs/executive-summaries/2026-08-13-the-580-megabytes-read-and-discarded-executive-summary.md
@@ -1,0 +1,141 @@
+<!-- file: docs/executive-summaries/2026-08-13-the-580-megabytes-read-and-discarded-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 1f4c8b02-7e35-4d69-a018-9c26b5e07d31 -->
+<!-- last-edited: 2026-08-13 -->
+
+# Executive Summary: The 580 Megabytes Read and Thrown Away
+
+**Shipped:** 2026-08-13 · **Pull requests:** #2387 (the split) and #2394 (the move)
+**Status:** the code is merged and deployed. The one-off data move it enables is
+**built but not yet run** — see "What has not happened yet" at the bottom.
+
+---
+
+## The short version
+
+Every time the audiobook server restarted, it spent about two minutes reading the
+library into memory before anything worked. Roughly **eighty percent of what it read
+during the biggest part of that startup was data it threw away immediately** — 580
+megabytes, read off disk, decoded, and discarded within microseconds, every single
+restart, by design and entirely unnoticed.
+
+This work stops that. It is in two halves, and the second half is the interesting one,
+because the safe way to do it is not the obvious way.
+
+---
+
+## What the wasted data actually was
+
+Each book carries a **signature** — a compact numeric fingerprint of what the audio
+sounds like, used to work out when two files are really the same book. It is about 22
+kilobytes per book, and with roughly 67,800 books that adds up.
+
+The signature was stored in the same record as the book's title, author, file path and
+everything else. So anything that read a book read its signature too, whether it wanted
+it or not.
+
+The startup routine did not want it. It builds a fast in-memory index of the library for
+searching and browsing, and signatures play no part in that — so the very first thing it
+did with each signature was discard it. It was paying full price to read 580 megabytes
+in order to immediately delete it.
+
+Nobody noticed because nothing was broken. Startup was slow, but it was *consistently*
+slow, and slowness without an error message tends not to get investigated. It surfaced
+only when someone measured where the startup time was actually going, byte by byte.
+
+---
+
+## The first half: give the signature its own drawer
+
+The fix in principle is simple — store the signature separately, so that reading a book
+does not mean reading its signature. Anything that genuinely needs a signature asks for
+it explicitly.
+
+The risk in practice is not simple, and it is worth spelling out, because it shaped
+everything that followed.
+
+**This system has been bitten by exactly this before.** There is already a repair tool
+in the codebase whose entire job is to recover signatures that were silently wiped by an
+earlier bug. That tool decides a book was damaged by checking whether its signature is
+missing. Which means: **a book that has lost its signature and a book that never had one
+look identical.** Get the move wrong and the damage is not just invisible — it is
+invisible *to the one tool built to find it*, and the only symptom would be that
+duplicate detection quietly stopped recognising some books.
+
+So the split shipped in a way that could not break anything: when a book's signature was
+not yet in its new location, the system simply read it from the old one. Every existing
+book kept working, untouched, with no data moved at all. The new path proved itself on
+live traffic before a single byte was migrated.
+
+That safety is also why the saving did not arrive. Nothing had moved, so startup still
+read all 580 megabytes. The measurement after that first release confirmed it precisely:
+still 580 megabytes, exactly as designed.
+
+---
+
+## The second half: actually move it
+
+This release adds the tool that moves the data — and three decisions in it are worth
+recording, because in each case the obvious approach was wrong.
+
+**It does not reuse the normal "save a book" routine.** That routine would have done the
+job correctly, and it would have been three lines of code. But it also keeps a historical
+copy of every book it saves, and those historical copies deliberately keep the full
+signature. Running it across the whole library would have written roughly **1.5 gigabytes
+of new historical copies** — in an operation whose entire purpose was to stop paying for
+those bytes. It would also have marked all 67,800 books as freshly modified, sending the
+search index and several background jobs off to re-process a library that had not
+actually changed.
+
+**It writes each book's two pieces together or not at all.** The old record and the new
+one are updated in a single atomic step, so there is no instant at which a book has had
+its signature removed from one place without it appearing in the other. That is the
+failure mode described above — the one no tool could detect — and a test now asserts the
+pairing across a whole mixed library rather than trusting that it holds.
+
+**It gets out of the way of anything else writing at the same time.** The server does not
+stop for this; scans and imports continue while it runs. Two things writing to the same
+book at once could have meant the migration overwriting an unrelated edit — reverting a
+book's title or file path, not merely its signature. The resolution came from noticing
+something about the problem rather than adding machinery to it: *every ordinary save
+already moves a book to the new layout anyway*, so the library migrates itself gradually
+through normal use, and this tool only speeds that up. That makes **skipping a book
+completely harmless**. So when it detects that a book changed underneath it, it skips it,
+counts it, and moves on. Nothing is ever half-written, and running the tool again picks
+up whatever it skipped.
+
+---
+
+## How we know it works
+
+The tests are not taken at face value. Ten deliberate sabotages were applied one at a
+time — removing each safety check in turn — and in every case the test that should have
+caught it did fail. A test that passes is not evidence; a test that has been watched fail
+for the right reason is. This matters here because an earlier test suite in this project
+passed with its fix removed entirely.
+
+The tool also defaults to **reporting only**. Someone has to explicitly ask it to write.
+And before writing anything it prints a sanity check against the original measurement: if
+it claims every book needs migrating, or almost none do, that disagreement with the known
+580-megabyte figure is visible *before* the irreversible step, not after.
+
+---
+
+## What has not happened yet
+
+**The data has not been moved on the live server.** That is a deliberate hold, not an
+oversight: it is the one step that cannot be undone, so it is an owner's decision rather
+than something scheduled automatically. The procedure is written down — report first,
+check the numbers agree with the original measurement, migrate a hundred books as a trial,
+verify, then run the rest.
+
+Until that happens, **startup is exactly as slow as before**. Everything described here is
+the mechanism being in place, not the improvement being delivered. The improvement arrives
+when the migration runs.
+
+One note on how it will be judged when it does. The obvious check is that the "wasted
+bytes" number drops to zero — but that number would also read zero if the measurement
+itself quietly stopped working, which would look like total success. So the check is
+deliberately a positive one instead: the total startup reading must visibly fall from its
+current 729 megabytes, **and** a named book must still return its signature correctly
+afterwards. Both, or it does not count.

--- a/internal/database/pebble_store_booksig_migrate.go
+++ b/internal/database/pebble_store_booksig_migrate.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_booksig_migrate.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6a4e2f18-7d05-4b93-8c61-9f2a0e75d3b8
 // last-edited: 2026-08-13
 
@@ -64,10 +64,12 @@ const (
 	// the row rewritten without it, in one batch.
 	BookSigMigrateMigrated
 	// BookSigMigrateStrippedOnly: the row carried an inline signature AND a
-	// sidecar already existed. The sidecar is authoritative (see
-	// bookSigSidecar.applyTo), so it is left alone and only the row is
-	// stripped. Writing the stale inline values over a newer sidecar would be
-	// a silent downgrade.
+	// sidecar already existed, so no NEW sidecar was created. The existing one
+	// is authoritative (see bookSigSidecar.applyTo) FIELD BY FIELD: values it
+	// already holds are kept — writing stale inline values over a newer sidecar
+	// would be a silent downgrade — while fields it is MISSING are filled from
+	// inline, so stripping the row cannot delete a field that lived only there.
+	// A sidecar that already covers every inline field is not rewritten at all.
 	BookSigMigrateStrippedOnly
 	// BookSigMigrateSkippedRaced: the row changed under us between read and
 	// commit, so nothing was written. See the CAS note on
@@ -167,6 +169,45 @@ func stripBookSigJSONKeys(row []byte) (out []byte, changed bool, err error) {
 	return out, true, nil
 }
 
+// mergeBookSigSidecar decodes an existing sidecar payload and fills only its
+// NIL fields from inline. Returns filled=false (and out=nil) when the sidecar
+// already covers every field inline has, so the caller can leave the key alone
+// rather than rewriting it byte-for-byte.
+//
+// The asymmetry is the point: a non-nil sidecar value is never replaced, so a
+// newer sidecar cannot be downgraded by a stale inline copy; a nil one is
+// always filled, so stripping the row cannot drop a field that lived only
+// inline. Both directions of loss are closed.
+func mergeBookSigSidecar(existing []byte, inline bookSigSidecar) (out []byte, filled bool, err error) {
+	var cur bookSigSidecar
+	if err := json.Unmarshal(existing, &cur); err != nil {
+		return nil, false, fmt.Errorf("unmarshal existing sidecar: %w", err)
+	}
+	if cur.V1 == nil && inline.V1 != nil {
+		cur.V1, filled = inline.V1, true
+	}
+	if cur.Mask == nil && inline.Mask != nil {
+		cur.Mask, filled = inline.Mask, true
+	}
+	if cur.Segments == nil && inline.Segments != nil {
+		cur.Segments, filled = inline.Segments, true
+	}
+	if cur.BuiltAt == nil && inline.BuiltAt != nil {
+		cur.BuiltAt, filled = inline.BuiltAt, true
+	}
+	if cur.CoveragePct == nil && inline.CoveragePct != nil {
+		cur.CoveragePct, filled = inline.CoveragePct, true
+	}
+	if !filled {
+		return nil, false, nil
+	}
+	out, err = json.Marshal(cur)
+	if err != nil {
+		return nil, false, fmt.Errorf("marshal merged sidecar: %w", err)
+	}
+	return out, true, nil
+}
+
 // MigrateBookSigToSidecar moves book id's inline signature into the
 // `book_sig:<id>` sidecar and rewrites the row without it, in ONE Pebble batch
 // so there is never a moment where the row is stripped and the sidecar is
@@ -244,7 +285,27 @@ func (p *PebbleStore) MigrateBookSigToSidecar(id string, dryRun bool) (BookSigMi
 		return BookSigMigrateNotCandidate, fmt.Errorf("read book signature sidecar %q: %w", id, err)
 	}
 	if existing != nil {
-		return p.commitBookSigMigration(id, rowKey, before, stripped, nil, dryRun, BookSigMigrateStrippedOnly)
+		// ...but "authoritative" is per-FIELD, not per-record. bookSigOf/
+		// writeBookSigToBatch write a sidecar whenever ANY of the five is
+		// non-nil, so a sidecar holding a strict subset of the row's fields is
+		// constructible — most plausibly by a rollback to a pre-#2387 binary,
+		// which writes inline again while an older sidecar lingers. Stripping
+		// all five inline keys and leaving that sidecar alone would delete the
+		// fields it lacks from BOTH places: exactly the undetectable loss this
+		// whole function exists to prevent.
+		//
+		// So fill, don't skip. Present sidecar values still win; only nil ones
+		// are sourced from inline. That cannot downgrade a newer sidecar and
+		// cannot lose an inline field. Counted as stripped_only either way —
+		// the row-side effect is the same.
+		merged, filled, err := mergeBookSigSidecar(existing, sig)
+		if err != nil {
+			return BookSigMigrateNotCandidate, fmt.Errorf("merge book signature sidecar %q: %w", id, err)
+		}
+		if !filled {
+			merged = nil // sidecar already covers every inline field; leave it untouched.
+		}
+		return p.commitBookSigMigration(id, rowKey, before, stripped, merged, dryRun, BookSigMigrateStrippedOnly)
 	}
 
 	payload, err := json.Marshal(sig)

--- a/internal/database/pebble_store_booksig_migrate.go
+++ b/internal/database/pebble_store_booksig_migrate.go
@@ -1,0 +1,293 @@
+// file: internal/database/pebble_store_booksig_migrate.go
+// version: 1.0.0
+// guid: 6a4e2f18-7d05-4b93-8c61-9f2a0e75d3b8
+// last-edited: 2026-08-13
+
+package database
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// Migration of legacy inline book signatures into the `book_sig:` sidecar.
+//
+// #2387 introduced the sidecar with FALLBACK-FIRST reads (hydrateBookSig leaves
+// a book untouched when no sidecar key exists), so every one of the 67,824
+// existing rows kept working un-migrated. That is what let the read path ship
+// safely — and it is also why the ~580 MB/startup saving is not realized until
+// the data actually moves. This file is the primitive that moves it.
+//
+// WHY NOT JUST CALL UpdateBook
+//
+// UpdateBook already strips the row and writes the sidecar, so
+// GetBookByID -> UpdateBook would migrate a book correctly. It is still the
+// wrong tool for a whole-library pass:
+//
+//   - It writes a book_ver: CoW snapshot per call, and that snapshot
+//     DELIBERATELY keeps the full inline signature (it is
+//     booksig_recovery_audit's safety net — see UpdateBook's comment). Doing
+//     that 67,824 times writes roughly 1.5 GB of fresh snapshot data, in a
+//     migration whose entire purpose is to stop paying for those bytes.
+//   - It bumps UpdatedAt on every book, so the whole library looks modified:
+//     search-index dirty set, memdb sync and aggregate recompute all churn.
+//
+// WHY THIS IS INVISIBLE TO MEMDB
+//
+// stripBookForMemdb nils exactly these five fields, so removing them from the
+// stored row changes nothing the memdb ever held. No invalidation is needed and
+// none is performed.
+
+// The five stored JSON keys that carry a book signature. These MUST stay in
+// sync with Book's struct tags (store.go); TestBookSigJSONKeysMatchStructTags
+// asserts that by reflection, so a rename cannot silently turn this migration
+// into a no-op that still reports success.
+var bookSigJSONKeys = [...]string{
+	"book_sig_v1",
+	"book_sig_v1_mask",
+	"book_sig_segments",
+	"book_sig_built_at",
+	"book_sig_coverage_pct",
+}
+
+// BookSigMigrateOutcome classifies what happened to one book.
+type BookSigMigrateOutcome int
+
+const (
+	// BookSigMigrateNotCandidate: the row carries no inline signature. Either
+	// it was already migrated, or the book never had a signature. No write.
+	BookSigMigrateNotCandidate BookSigMigrateOutcome = iota
+	// BookSigMigrateMigrated: inline signature moved to a new sidecar key and
+	// the row rewritten without it, in one batch.
+	BookSigMigrateMigrated
+	// BookSigMigrateStrippedOnly: the row carried an inline signature AND a
+	// sidecar already existed. The sidecar is authoritative (see
+	// bookSigSidecar.applyTo), so it is left alone and only the row is
+	// stripped. Writing the stale inline values over a newer sidecar would be
+	// a silent downgrade.
+	BookSigMigrateStrippedOnly
+	// BookSigMigrateSkippedRaced: the row changed under us between read and
+	// commit, so nothing was written. See the CAS note on
+	// MigrateBookSigToSidecar — skipping is always safe here.
+	BookSigMigrateSkippedRaced
+)
+
+func (o BookSigMigrateOutcome) String() string {
+	switch o {
+	case BookSigMigrateNotCandidate:
+		return "not_candidate"
+	case BookSigMigrateMigrated:
+		return "migrated"
+	case BookSigMigrateStrippedOnly:
+		return "stripped_only"
+	case BookSigMigrateSkippedRaced:
+		return "skipped_raced"
+	}
+	return fmt.Sprintf("unknown(%d)", int(o))
+}
+
+// BookSigMigrateStore is a narrow capability interface, deliberately kept OUT
+// of database.Store — same rationale as SearchIndexDirtyStore: adding methods
+// to database.Store forces every implementation and generated mock to grow with
+// it. Reach it through AsBookSigMigrateStore, which looks through the
+// indexedStore decorator.
+type BookSigMigrateStore interface {
+	// MigrateBookSigToSidecar moves one book's inline signature into its
+	// `book_sig:` sidecar. Safe to call on an already-migrated book (returns
+	// BookSigMigrateNotCandidate) and safe to re-run after a partial pass.
+	MigrateBookSigToSidecar(id string, dryRun bool) (BookSigMigrateOutcome, error)
+}
+
+// AsBookSigMigrateStore returns s as a BookSigMigrateStore if the underlying
+// store supports it (true for *PebbleStore), or nil otherwise. Callers MUST
+// nil-check the result. Use this instead of `store.(*PebbleStore)`: prod always
+// installs the Bleve indexedStore decorator, and a bare assertion against a
+// wrapped store is indistinguishable from an unsupported backend — which is how
+// several ops silently no-opped in prod (see AsPebbleStore's comment).
+func AsBookSigMigrateStore(s any) BookSigMigrateStore {
+	if s == nil {
+		return nil
+	}
+	if ms, ok := AsCapability[BookSigMigrateStore](s); ok {
+		return ms
+	}
+	return nil
+}
+
+// getRowCopy reads key and returns an owned copy of the value, or (nil, nil)
+// when the key is absent. Pebble's Get hands back a slice valid only until the
+// closer runs, so every byte we intend to keep — or later compare — must be
+// copied out first.
+func (p *PebbleStore) getRowCopy(key []byte) ([]byte, error) {
+	val, closer, err := p.db.Get(key)
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+	return bytes.Clone(val), nil
+}
+
+// stripBookSigJSONKeys removes the five signature keys from a stored row's JSON
+// object, preserving every other key EXACTLY as stored.
+//
+// It deliberately does NOT round-trip through the Book struct. json.Unmarshal
+// into Book silently drops any field present in the stored JSON but absent from
+// the struct, so `json.Marshal(stripBookSigForRow(&book))` would rewrite the row
+// with more removed than the five fields we intend to move. UpdateBook already
+// has that property for rows it touches; a migration sweeping all 67,824 rows
+// should not inherit it. Operating on map[string]json.RawMessage means unknown
+// fields survive byte-for-byte.
+//
+// changed reports whether any of the five keys was actually present, so callers
+// can distinguish "nothing to do" from "stripped".
+func stripBookSigJSONKeys(row []byte) (out []byte, changed bool, err error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(row, &obj); err != nil {
+		return nil, false, fmt.Errorf("unmarshal row object: %w", err)
+	}
+	for _, k := range bookSigJSONKeys {
+		if _, ok := obj[k]; ok {
+			delete(obj, k)
+			changed = true
+		}
+	}
+	if !changed {
+		return row, false, nil
+	}
+	out, err = json.Marshal(obj)
+	if err != nil {
+		return nil, false, fmt.Errorf("marshal stripped row: %w", err)
+	}
+	return out, true, nil
+}
+
+// MigrateBookSigToSidecar moves book id's inline signature into the
+// `book_sig:<id>` sidecar and rewrites the row without it, in ONE Pebble batch
+// so there is never a moment where the row is stripped and the sidecar is
+// missing. That pairing is load-bearing: a book with all five fields nil is
+// EXACTLY the shape booksig_recovery_audit classifies as "never had a
+// signature" rather than as damage, so a half-applied migration would be
+// undetectable by the very op written to find signature loss, and dedup would
+// simply stop matching that book.
+//
+// dryRun classifies without writing anything.
+//
+// CONCURRENCY / LOST-UPDATE
+//
+// PebbleStore has no per-book write serialization — none of its mutexes guard
+// the book read-modify-write, and UpdateBook already races with itself. A naive
+// read-then-write here would be worse than losing a signature: read the row at
+// T0, a concurrent UpdateBook lands at T1, our batch at T2 reverts the ENTIRE
+// T1 update (title, path, everything).
+//
+// The reframe that makes this tractable: every UpdateBook already strips the
+// row it writes, so the library migrates organically and this op only
+// accelerates it. Skipping any individual book is therefore always acceptable.
+// So we re-read the raw row immediately before committing and write only if it
+// is byte-identical to what we read; otherwise we report
+// BookSigMigrateSkippedRaced and move on. Pebble offers no true CAS, so the
+// window is not zero — but it is a byte compare rather than the whole
+// unmarshal/strip/marshal span, and a skip costs nothing because a later run
+// (or any UpdateBook) picks the book up.
+func (p *PebbleStore) MigrateBookSigToSidecar(id string, dryRun bool) (BookSigMigrateOutcome, error) {
+	if id == "" {
+		return BookSigMigrateNotCandidate, fmt.Errorf("empty book id")
+	}
+	rowKey := []byte("book:" + id)
+
+	before, err := p.getRowCopy(rowKey)
+	if err != nil {
+		return BookSigMigrateNotCandidate, fmt.Errorf("read book row %q: %w", id, err)
+	}
+	// The book was deleted between ListBookIDs and now. Nothing to migrate;
+	// this is not an error and must not be counted as one.
+	if before == nil {
+		return BookSigMigrateNotCandidate, nil
+	}
+
+	stripped, changed, err := stripBookSigJSONKeys(before)
+	if err != nil {
+		return BookSigMigrateNotCandidate, fmt.Errorf("strip book row %q: %w", id, err)
+	}
+	if !changed {
+		return BookSigMigrateNotCandidate, nil
+	}
+
+	// Read the five values for the sidecar payload. This unmarshal is used ONLY
+	// to source values, never to rewrite the row (see stripBookSigJSONKeys).
+	var book Book
+	if err := json.Unmarshal(before, &book); err != nil {
+		return BookSigMigrateNotCandidate, fmt.Errorf("unmarshal book row %q: %w", id, err)
+	}
+	sig, ok := bookSigOf(&book)
+	if !ok {
+		// The keys were present but every value decoded to nil — e.g. all five
+		// stored as explicit JSON null. There is no signature to preserve, so
+		// stripping the row alone is correct and creating a sidecar would
+		// manufacture an empty one.
+		return p.commitBookSigMigration(id, rowKey, before, stripped, nil, dryRun, BookSigMigrateStrippedOnly)
+	}
+
+	// Sidecar already present? Then it is authoritative (bookSigSidecar.applyTo)
+	// and the inline copy is stale by construction: post-#2387 every UpdateBook
+	// writes a fresh sidecar AND strips the row, so a row still carrying inline
+	// data alongside a sidecar means the sidecar is the newer value. Overwriting
+	// it from the stale inline copy would be a silent downgrade.
+	existing, err := p.getRowCopy(bookSigKey(id))
+	if err != nil {
+		return BookSigMigrateNotCandidate, fmt.Errorf("read book signature sidecar %q: %w", id, err)
+	}
+	if existing != nil {
+		return p.commitBookSigMigration(id, rowKey, before, stripped, nil, dryRun, BookSigMigrateStrippedOnly)
+	}
+
+	payload, err := json.Marshal(sig)
+	if err != nil {
+		return BookSigMigrateNotCandidate, fmt.Errorf("marshal book signature sidecar %q: %w", id, err)
+	}
+	return p.commitBookSigMigration(id, rowKey, before, stripped, payload, dryRun, BookSigMigrateMigrated)
+}
+
+// commitBookSigMigration performs the CAS re-read and the single-batch write.
+// sidecar may be nil, meaning "write the stripped row only, create no sidecar
+// key" — the stripped_only path. It NEVER deletes a sidecar key.
+func (p *PebbleStore) commitBookSigMigration(
+	id string,
+	rowKey, before, stripped, sidecar []byte,
+	dryRun bool,
+	outcome BookSigMigrateOutcome,
+) (BookSigMigrateOutcome, error) {
+	if dryRun {
+		return outcome, nil
+	}
+
+	after, err := p.getRowCopy(rowKey)
+	if err != nil {
+		return BookSigMigrateNotCandidate, fmt.Errorf("re-read book row %q: %w", id, err)
+	}
+	if after == nil || !bytes.Equal(before, after) {
+		return BookSigMigrateSkippedRaced, nil
+	}
+
+	batch := p.db.NewBatch()
+	defer batch.Close()
+
+	if sidecar != nil {
+		if err := batch.Set(bookSigKey(id), sidecar, nil); err != nil {
+			return BookSigMigrateNotCandidate, fmt.Errorf("stage sidecar %q: %w", id, err)
+		}
+	}
+	if err := batch.Set(rowKey, stripped, nil); err != nil {
+		return BookSigMigrateNotCandidate, fmt.Errorf("stage stripped row %q: %w", id, err)
+	}
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return BookSigMigrateNotCandidate, fmt.Errorf("commit book signature migration %q: %w", id, err)
+	}
+	return outcome, nil
+}

--- a/internal/database/pebble_store_booksig_migrate_test.go
+++ b/internal/database/pebble_store_booksig_migrate_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_booksig_migrate_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9e51c0d3-2a87-4f16-b74e-5c8203f9a1d6
 // last-edited: 2026-08-13
 
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/stretchr/testify/require"
@@ -78,6 +79,86 @@ func migrateRequireRowStripped(t *testing.T, store *PebbleStore, id, tag string)
 	v1, _, _, _, _ := sigFixture(tag)
 	require.NotContains(t, row, v1,
 		"the signature VALUE must not survive in the row under any key")
+}
+
+// TestMigrateBookSigToSidecar_PartialSidecarIsHealedNotSkipped covers the one
+// way this migration could still delete data: a sidecar holding a STRICT SUBSET
+// of the row's five fields. bookSigOf writes a sidecar when ANY field is
+// non-nil, so a partial one is constructible — a rollback to a pre-#2387 binary
+// writes inline again while an older sidecar lingers. If "sidecar exists" meant
+// "leave it alone", stripping the row would drop the fields it lacks from BOTH
+// places, and booksig_recovery_audit cannot see that: nil reads as
+// "never had one", not as damage.
+//
+// The seeded sidecar carries only V1+Mask; the row carries all five. Correct
+// behaviour is to fill the three missing fields from inline while leaving the
+// two it already has at their (authoritative, DIFFERENT) values.
+func TestMigrateBookSigToSidecar_PartialSidecarIsHealedNotSkipped(t *testing.T) {
+	env := newBookSigEnv(t)
+	const id = "partial-sidecar-1"
+	migrateSeedLegacyRow(t, env.store, id, "inline", nil)
+
+	// Sidecar predates the row's inline values and covers only two fields.
+	newerV1, newerMask, _, _, _ := sigFixture("newer")
+	partial, err := json.Marshal(map[string]any{"v1": newerV1, "mask": newerMask})
+	require.NoError(t, err)
+	require.NoError(t, env.store.db.Set(bookSigKey(id), partial, pebble.Sync))
+
+	outcome, err := env.store.MigrateBookSigToSidecar(id, false)
+	require.NoError(t, err)
+	require.Equal(t, BookSigMigrateStrippedOnly, outcome)
+
+	migrateRequireRowStripped(t, env.store, id, "inline")
+
+	var got bookSigSidecar
+	require.NoError(t, json.Unmarshal(migrateSidecarRaw(t, env.store, id), &got))
+
+	// Present sidecar fields win: NOT overwritten by the inline copy.
+	require.NotNil(t, got.V1)
+	require.Equal(t, newerV1, *got.V1, "an existing sidecar value must not be downgraded to the inline one")
+	require.NotNil(t, got.Mask)
+	require.Equal(t, newerMask, *got.Mask)
+
+	// Absent sidecar fields are filled from inline rather than lost with the row.
+	_, _, wantSegments, wantCoverage, wantBuiltAt := sigFixture("inline")
+	require.NotNil(t, got.Segments, "segments lived ONLY inline; stripping the row must not delete it")
+	require.Equal(t, wantSegments, *got.Segments)
+	require.NotNil(t, got.CoveragePct, "coverage_pct lived ONLY inline")
+	require.Equal(t, wantCoverage, *got.CoveragePct)
+	require.NotNil(t, got.BuiltAt, "built_at lived ONLY inline")
+	require.True(t, wantBuiltAt.Equal(*got.BuiltAt))
+
+	// And the whole book still reads back intact through the normal path.
+	book, err := env.store.GetBookByID(id)
+	require.NoError(t, err)
+	require.NotNil(t, book.BookSigSegments)
+	require.Equal(t, wantSegments, *book.BookSigSegments)
+}
+
+// TestMigrateBookSigToSidecar_CompleteSidecarIsLeftByteIdentical is the other
+// half of the pair above: when the sidecar already covers every inline field,
+// nothing is filled and the key must not be rewritten at all. Without this, the
+// heal path could quietly churn every already-migrated book's sidecar.
+func TestMigrateBookSigToSidecar_CompleteSidecarIsLeftByteIdentical(t *testing.T) {
+	env := newBookSigEnv(t)
+	const id = "complete-sidecar-1"
+	migrateSeedLegacyRow(t, env.store, id, "inline", nil)
+
+	newerV1, newerMask, segments, coverage, builtAt := sigFixture("newer")
+	complete, err := json.Marshal(map[string]any{
+		"v1": newerV1, "mask": newerMask, "segments": segments,
+		"coverage_pct": coverage, "built_at": builtAt.Format(time.RFC3339),
+	})
+	require.NoError(t, err)
+	require.NoError(t, env.store.db.Set(bookSigKey(id), complete, pebble.Sync))
+
+	outcome, err := env.store.MigrateBookSigToSidecar(id, false)
+	require.NoError(t, err)
+	require.Equal(t, BookSigMigrateStrippedOnly, outcome)
+
+	migrateRequireRowStripped(t, env.store, id, "inline")
+	require.Equal(t, complete, migrateSidecarRaw(t, env.store, id),
+		"a sidecar that already covers every inline field must be left untouched, not rewritten")
 }
 
 // TestBookSigJSONKeysMatchStructTags is the instrument check for the whole

--- a/internal/database/pebble_store_booksig_migrate_test.go
+++ b/internal/database/pebble_store_booksig_migrate_test.go
@@ -1,0 +1,426 @@
+// file: internal/database/pebble_store_booksig_migrate_test.go
+// version: 1.0.0
+// guid: 9e51c0d3-2a87-4f16-b74e-5c8203f9a1d6
+// last-edited: 2026-08-13
+
+package database
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// The migration is the only irreversible step in the #2387 sidecar design, and
+// its worst failure mode is silent: a row stripped of its signature with no
+// sidecar written leaves all five fields nil, which is EXACTLY the shape
+// booksig_recovery_audit classifies as "never had a signature" rather than as
+// damage. The op written to detect signature loss cannot see this class. Dedup
+// would simply stop matching those books, with nothing logged and nothing to
+// audit. So these tests assert the row/sidecar PAIRING, by value, not merely
+// that a migration ran.
+
+// migrateSeedLegacyRow writes a pre-#2387 row directly: signature inline, no
+// sidecar key. The supported write paths can no longer produce one (CreateBook
+// and UpdateBook both strip on the way in), so raw JSON is the only way to
+// reconstruct the state all 67,824 production rows are actually in.
+//
+// extra keys are merged into the row verbatim, so a test can plant a field the
+// Book struct does not know about.
+func migrateSeedLegacyRow(t *testing.T, store *PebbleStore, id, tag string, extra map[string]any) {
+	t.Helper()
+	v1, mask, segments, coverage, builtAt := sigFixture(tag)
+	row := map[string]any{
+		"id":                    id,
+		"title":                 "Legacy " + tag,
+		"file_path":             "/tmp/migrate_" + tag + ".m4b",
+		"book_sig_v1":           v1,
+		"book_sig_v1_mask":      mask,
+		"book_sig_segments":     segments,
+		"book_sig_coverage_pct": coverage,
+		"book_sig_built_at":     builtAt.Format("2006-01-02T15:04:05Z"),
+	}
+	for k, v := range extra {
+		row[k] = v
+	}
+	data, err := json.Marshal(row)
+	require.NoError(t, err)
+	require.NoError(t, store.db.Set([]byte("book:"+id), data, pebble.Sync))
+}
+
+// migrateSidecarRaw returns the raw sidecar bytes, or nil when the key is
+// absent. Tests assert on these bytes rather than on a hydrated Book so that
+// "the sidecar exists" and "the read fell back to inline" cannot be confused.
+func migrateSidecarRaw(t *testing.T, store *PebbleStore, id string) []byte {
+	t.Helper()
+	val, closer, err := store.db.Get(bookSigKey(id))
+	if err == pebble.ErrNotFound {
+		return nil
+	}
+	require.NoError(t, err)
+	defer closer.Close()
+	return append([]byte(nil), val...)
+}
+
+// migrateRequireRowStripped asserts none of the five signature keys, nor the
+// signature value itself, survives in the book: row. Warmup reads this row and
+// nothing else, so anything left here is a byte the migration failed to save.
+func migrateRequireRowStripped(t *testing.T, store *PebbleStore, id, tag string) {
+	t.Helper()
+	row := string(rawBookRow(t, store, id))
+	for _, k := range bookSigJSONKeys {
+		require.NotContains(t, row, k,
+			"book:%s must not carry %q after migration — warmup pays for every byte in this row", id, k)
+	}
+	v1, _, _, _, _ := sigFixture(tag)
+	require.NotContains(t, row, v1,
+		"the signature VALUE must not survive in the row under any key")
+}
+
+// TestBookSigJSONKeysMatchStructTags is the instrument check for the whole
+// migration. bookSigJSONKeys is a hand-maintained list of stored key names; if
+// a Book field's json tag is ever renamed, the migration would stop recognizing
+// candidates and report "0 books migrated" as SUCCESS — a silent no-op with a
+// green result, which is the exact failure family this repo keeps hitting.
+// Reflection makes the list impossible to drift from the struct.
+func TestBookSigJSONKeysMatchStructTags(t *testing.T) {
+	fields := []string{
+		"BookSigV1", "BookSigV1Mask", "BookSigSegments",
+		"BookSigBuiltAt", "BookSigCoveragePct",
+	}
+	typ := reflect.TypeOf(Book{})
+
+	want := make(map[string]bool, len(fields))
+	for _, name := range fields {
+		sf, ok := typ.FieldByName(name)
+		require.Truef(t, ok, "Book has no field %s — the sidecar field group changed", name)
+		tag := sf.Tag.Get("json")
+		require.NotEmpty(t, tag, "Book.%s must have a json tag", name)
+		// Strip ",omitempty" and friends.
+		for i := 0; i < len(tag); i++ {
+			if tag[i] == ',' {
+				tag = tag[:i]
+				break
+			}
+		}
+		want[tag] = true
+	}
+
+	got := make(map[string]bool, len(bookSigJSONKeys))
+	for _, k := range bookSigJSONKeys {
+		got[k] = true
+	}
+	require.Equal(t, want, got,
+		"bookSigJSONKeys has drifted from Book's struct tags; the migration would silently match nothing")
+}
+
+// TestBookSigMigrate_LegacyInlineRowMigrates is the happy path, asserted on
+// both sides of the pairing: the row must lose the signature AND the sidecar
+// must gain it, with the same values.
+func TestBookSigMigrate_LegacyInlineRowMigrates(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	const id = "01MIGRATEHAPPY0000000000"
+	migrateSeedLegacyRow(t, store, id, "happy", nil)
+
+	outcome, err := store.MigrateBookSigToSidecar(id, false)
+	require.NoError(t, err)
+	require.Equal(t, BookSigMigrateMigrated, outcome)
+
+	migrateRequireRowStripped(t, store, id, "happy")
+	require.NotNil(t, migrateSidecarRaw(t, store, id), "the sidecar key must exist after migration")
+
+	// Read through a REOPENED store: an in-process cache must not be able to
+	// manufacture a pass for a change whose whole subject is durable bytes.
+	fresh := env.reopen(t)
+	got, err := fresh.GetBookByID(id)
+	require.NoError(t, err)
+	requireSigPresent(t, got, "happy")
+}
+
+// TestBookSigMigrate_PreservesUnknownRowFields guards the surgical strip.
+//
+// The tempting implementation is json.Marshal(stripBookSigForRow(&book)) — but
+// unmarshalling into Book silently DROPS any stored field the struct does not
+// declare, so that version would rewrite 67,824 rows with more removed than the
+// five fields it intends to move. This test plants a field Book knows nothing
+// about and requires it to survive byte-for-byte.
+func TestBookSigMigrate_PreservesUnknownRowFields(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	const id = "01MIGRATEUNKNOWN00000000"
+	migrateSeedLegacyRow(t, store, id, "unknown", map[string]any{
+		"a_field_the_struct_does_not_know": "keep-me-42",
+	})
+
+	outcome, err := store.MigrateBookSigToSidecar(id, false)
+	require.NoError(t, err)
+	require.Equal(t, BookSigMigrateMigrated, outcome)
+
+	var row map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rawBookRow(t, store, id), &row))
+	raw, ok := row["a_field_the_struct_does_not_know"]
+	require.True(t, ok,
+		"migration must not drop stored fields the Book struct does not declare — it is moving a signature, not rewriting the schema")
+	require.JSONEq(t, `"keep-me-42"`, string(raw))
+}
+
+// TestBookSigMigrate_NewerSidecarSurvivesStaleInline covers the one ordering
+// that loses data if handled naively.
+//
+// Post-#2387 every UpdateBook writes a fresh sidecar AND strips the row, so a
+// row still carrying inline data alongside an existing sidecar means the
+// sidecar is the NEWER value (bookSigSidecar.applyTo says so explicitly).
+// Copying the stale inline copy over it would be a silent downgrade. Reading
+// through GetBookByID would make this safe by accident; reading raw bytes,
+// which the migration must do, does not.
+func TestBookSigMigrate_NewerSidecarSurvivesStaleInline(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	const id = "01MIGRATESTALE0000000000"
+	migrateSeedLegacyRow(t, store, id, "stale", nil)
+
+	// A newer sidecar, written independently of the row.
+	newV1, newMask, newSegments, newCoverage, newBuiltAt := sigFixture("fresh")
+	payload, err := json.Marshal(bookSigSidecar{
+		V1: &newV1, Mask: &newMask, Segments: &newSegments,
+		BuiltAt: &newBuiltAt, CoveragePct: &newCoverage,
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.db.Set(bookSigKey(id), payload, pebble.Sync))
+
+	outcome, err := store.MigrateBookSigToSidecar(id, false)
+	require.NoError(t, err)
+	require.Equal(t, BookSigMigrateStrippedOnly, outcome,
+		"a row with an existing sidecar must be stripped only, never re-sourced from the stale inline copy")
+
+	// The row loses the stale signature...
+	migrateRequireRowStripped(t, store, id, "stale")
+	// ...and the sidecar still holds the NEWER values, untouched.
+	fresh := env.reopen(t)
+	got, err := fresh.GetBookByID(id)
+	require.NoError(t, err)
+	requireSigPresent(t, got, "fresh")
+}
+
+// TestBookSigMigrate_NoSignatureCreatesNoSidecar is the negative control that
+// catches a candidate detector matching everything.
+//
+// If the detector returned true unconditionally, every test above would still
+// pass while the op reported all 67,824 books "migrated" and littered the
+// database with empty sidecars. The dry-run count is the field instrument for
+// this (expected: low tens of thousands, from 580 MB / ~22 KB per signature);
+// this is the unit-level one.
+func TestBookSigMigrate_NoSignatureCreatesNoSidecar(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	created, err := store.CreateBook(&Book{
+		Title:    "No Signature At All",
+		FilePath: "/tmp/migrate_nosig.m4b",
+	})
+	require.NoError(t, err)
+
+	outcome, err := store.MigrateBookSigToSidecar(created.ID, false)
+	require.NoError(t, err)
+	require.Equal(t, BookSigMigrateNotCandidate, outcome)
+
+	require.Nil(t, migrateSidecarRaw(t, store, created.ID),
+		"a book with no signature must not get a book_sig: key — an empty sidecar is indistinguishable from a real one to every reader")
+}
+
+// TestBookSigMigrate_AllNullValuesStripsOnly covers a row whose five keys are
+// present but explicitly null. There is no signature to preserve, so the
+// correct action is to strip the keys and create nothing.
+func TestBookSigMigrate_AllNullValuesStripsOnly(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	const id = "01MIGRATENULLS0000000000"
+	row := `{"id":"` + id + `","title":"Null Sig","file_path":"/tmp/migrate_nulls.m4b",` +
+		`"book_sig_v1":null,"book_sig_v1_mask":null,"book_sig_segments":null,` +
+		`"book_sig_built_at":null,"book_sig_coverage_pct":null}`
+	require.NoError(t, store.db.Set([]byte("book:"+id), []byte(row), pebble.Sync))
+
+	outcome, err := store.MigrateBookSigToSidecar(id, false)
+	require.NoError(t, err)
+	require.Equal(t, BookSigMigrateStrippedOnly, outcome)
+	require.Nil(t, migrateSidecarRaw(t, store, id),
+		"all-null signature fields must not manufacture a sidecar")
+
+	stripped := string(rawBookRow(t, store, id))
+	for _, k := range bookSigJSONKeys {
+		require.NotContains(t, stripped, k)
+	}
+}
+
+// TestBookSigMigrate_DryRunWritesNothing. The op is dry-run gated because this
+// is the irreversible step; a dry run that mutated anything would make the gate
+// decorative.
+func TestBookSigMigrate_DryRunWritesNothing(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	const id = "01MIGRATEDRYRUN000000000"
+	migrateSeedLegacyRow(t, store, id, "dryrun", nil)
+	before := rawBookRow(t, store, id)
+
+	outcome, err := store.MigrateBookSigToSidecar(id, true)
+	require.NoError(t, err)
+	require.Equal(t, BookSigMigrateMigrated, outcome,
+		"a dry run must still CLASSIFY the book, or the reported counts mean nothing")
+
+	require.Equal(t, before, rawBookRow(t, store, id),
+		"dry run must leave the row byte-identical")
+	require.Nil(t, migrateSidecarRaw(t, store, id),
+		"dry run must not create a sidecar key")
+}
+
+// TestBookSigMigrate_IsIdempotent. The op must be safe to re-run: the first
+// pass leaves skipped_raced books behind by design, and a second pass is how
+// they get picked up.
+func TestBookSigMigrate_IsIdempotent(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	const id = "01MIGRATEIDEMPOTENT00000"
+	migrateSeedLegacyRow(t, store, id, "idem", nil)
+
+	first, err := store.MigrateBookSigToSidecar(id, false)
+	require.NoError(t, err)
+	require.Equal(t, BookSigMigrateMigrated, first)
+	afterFirst := migrateSidecarRaw(t, store, id)
+
+	second, err := store.MigrateBookSigToSidecar(id, false)
+	require.NoError(t, err)
+	require.Equal(t, BookSigMigrateNotCandidate, second,
+		"an already-migrated row carries no inline signature and must not be touched again")
+	require.Equal(t, afterFirst, migrateSidecarRaw(t, store, id),
+		"a re-run must not rewrite the sidecar")
+
+	fresh := env.reopen(t)
+	got, err := fresh.GetBookByID(id)
+	require.NoError(t, err)
+	requireSigPresent(t, got, "idem")
+}
+
+// TestBookSigMigrate_SkipsRacedRow exercises the CAS directly.
+//
+// PebbleStore has no per-book write serialization, so a concurrent UpdateBook
+// between our read and our commit would otherwise see its ENTIRE update
+// reverted — title, path, everything — not merely the signature. The guard is a
+// byte compare immediately before commit. Here the `before` snapshot
+// deliberately disagrees with what is stored, which is what a raced row looks
+// like from the committer's point of view.
+func TestBookSigMigrate_SkipsRacedRow(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	const id = "01MIGRATERACED0000000000"
+	migrateSeedLegacyRow(t, store, id, "raced", nil)
+	stored := rawBookRow(t, store, id)
+
+	stale := append([]byte(nil), stored...)
+	stale = append(stale, ' ') // any difference at all must abort the write
+
+	outcome, err := store.commitBookSigMigration(
+		id, []byte("book:"+id), stale, []byte(`{"id":"`+id+`"}`), []byte(`{"v1":"x"}`),
+		false, BookSigMigrateMigrated)
+	require.NoError(t, err)
+	require.Equal(t, BookSigMigrateSkippedRaced, outcome)
+
+	require.Equal(t, stored, rawBookRow(t, store, id),
+		"a raced row must be left completely untouched, not partially written")
+	require.Nil(t, migrateSidecarRaw(t, store, id),
+		"a raced book must not get a sidecar either — the row and sidecar move together or not at all")
+}
+
+// TestBookSigMigrate_ConformancePairing is the invariant that makes the
+// migration safe to run on production data: across a mixed library, EVERY book
+// that had an inline signature ends with a sidecar carrying the same five
+// values, and every book that had none ends with no sidecar at all.
+//
+// The failure this guards — row stripped, sidecar absent — is invisible to
+// booksig_recovery_audit, which reads all-five-nil as "never had a signature".
+// Nothing else in the system would report it.
+func TestBookSigMigrate_ConformancePairing(t *testing.T) {
+	env := newBookSigEnv(t)
+	store := env.store
+
+	withSig := map[string]string{
+		"01MIGRATECONF00000000001": "conf1",
+		"01MIGRATECONF00000000002": "conf2",
+		"01MIGRATECONF00000000003": "conf3",
+	}
+	for id, tag := range withSig {
+		migrateSeedLegacyRow(t, store, id, tag, nil)
+	}
+
+	withoutSig := make([]string, 0, 2)
+	for _, title := range []string{"Plain A", "Plain B"} {
+		b, err := store.CreateBook(&Book{Title: title, FilePath: "/tmp/" + title + ".m4b"})
+		require.NoError(t, err)
+		withoutSig = append(withoutSig, b.ID)
+	}
+
+	migrated := 0
+	for id := range withSig {
+		outcome, err := store.MigrateBookSigToSidecar(id, false)
+		require.NoError(t, err)
+		require.Equal(t, BookSigMigrateMigrated, outcome)
+		migrated++
+	}
+	for _, id := range withoutSig {
+		outcome, err := store.MigrateBookSigToSidecar(id, false)
+		require.NoError(t, err)
+		require.Equal(t, BookSigMigrateNotCandidate, outcome)
+	}
+	require.Equal(t, len(withSig), migrated)
+
+	fresh := env.reopen(t)
+
+	// had-signature => stripped row AND sidecar with the SAME five values.
+	for id, tag := range withSig {
+		migrateRequireRowStripped(t, fresh, id, tag)
+		require.NotNilf(t, migrateSidecarRaw(t, fresh, id),
+			"book %s had a signature; a stripped row with no sidecar is silent data loss no audit can detect", id)
+		got, err := fresh.GetBookByID(id)
+		require.NoError(t, err)
+		requireSigPresent(t, got, tag)
+	}
+
+	// no-signature => still no sidecar.
+	for _, id := range withoutSig {
+		require.Nilf(t, migrateSidecarRaw(t, fresh, id),
+			"book %s never had a signature and must not have gained a sidecar", id)
+	}
+}
+
+// TestAsBookSigMigrateStore_ResolvesPebbleStore. Prod always installs the Bleve
+// indexedStore decorator, and a bare `store.(*PebbleStore)` against a wrapped
+// store is indistinguishable from an unsupported backend — which is how several
+// ops silently no-opped in production. The op must resolve through the helper.
+func TestAsBookSigMigrateStore_ResolvesPebbleStore(t *testing.T) {
+	env := newBookSigEnv(t)
+
+	require.NotNil(t, AsBookSigMigrateStore(env.store),
+		"a *PebbleStore must resolve as a BookSigMigrateStore")
+	require.Nil(t, AsBookSigMigrateStore(nil))
+	require.Nil(t, AsBookSigMigrateStore(struct{}{}),
+		"an unrelated value must not resolve — the op fails loudly rather than reporting 0 books migrated")
+}
+
+// TestBookSigMigrateOutcome_String keeps the reported bucket names stable; they
+// are what the operator reads to decide whether the apply behaved.
+func TestBookSigMigrateOutcome_String(t *testing.T) {
+	require.Equal(t, "not_candidate", BookSigMigrateNotCandidate.String())
+	require.Equal(t, "migrated", BookSigMigrateMigrated.String())
+	require.Equal(t, "stripped_only", BookSigMigrateStrippedOnly.String())
+	require.Equal(t, "skipped_raced", BookSigMigrateSkippedRaced.String())
+}

--- a/internal/plugins/maintenance/booksig_sidecar_migrate.go
+++ b/internal/plugins/maintenance/booksig_sidecar_migrate.go
@@ -1,0 +1,234 @@
+// file: internal/plugins/maintenance/booksig_sidecar_migrate.go
+// version: 1.0.0
+// guid: 2c8f6a90-4b17-4e35-9d82-1a5e703c6f84
+// last-edited: 2026-08-13
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sync/atomic"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// maintenance.booksig-sidecar-migrate finishes the job PR #2387 started.
+//
+// #2387 moved the five BookSig* fields to a `book_sig:<id>` sidecar with
+// FALLBACK-FIRST reads, so all 67,824 existing rows kept working un-migrated.
+// That is what made the read path safe to ship — and it is also why the saving
+// is not realized: production warmup on 2026-08-13 21:15 still reported
+//
+//	discarded_field_mb[book_sig_v1_and_mask] = 580
+//	phase_mb[books]                          = 729
+//
+// exactly as designed. Startup still reads, decodes and allocates ~580 MB of
+// signature that stripBookForMemdb discards on the spot. This op walks the
+// `book:` rows and moves the data, which is the only irreversible step in the
+// design — hence the dry-run gate and the Limit canary below.
+//
+// The per-book primitive, its CAS-and-skip race handling, and the reasoning for
+// not doing this via UpdateBook all live in
+// internal/database/pebble_store_booksig_migrate.go.
+
+// bookSigSidecarMigrateParams controls the migration. DryRun defaults to true:
+// callers must explicitly pass dryRun=false to write anything.
+type bookSigSidecarMigrateParams struct {
+	DryRun bool `json:"dryRun"`
+	// Limit caps how many books are examined (0 = the whole library). It exists
+	// so the first apply can be a small canary — migrate 100 books, verify the
+	// pairing held, then run the rest — rather than an all-or-nothing 67,824-row
+	// write. Books are examined in ListBookIDs order, which is stable, so a
+	// limited run is a prefix and a later full run picks up where it left off.
+	Limit int `json:"limit"`
+}
+
+// bookSigMigratePageSize batches IDs into pages so RunItems dispatches a
+// reasonable number of work units rather than one goroutine hop per book.
+// Pages partition the ID list into DISJOINT sets, so no two workers can ever
+// touch the same row — which matters because PebbleStore has no per-book write
+// lock (see MigrateBookSigToSidecar's concurrency note).
+const bookSigMigratePageSize = 200
+
+// bookSigInlineBytesPerBook is the measured average cost of one inline
+// signature: 580 MB of discarded_field_mb spread across the books that actually
+// carry one. It is used ONLY to print an expected-magnitude cross-check next to
+// the dry-run candidate count. If the op reports all 67,824 books as candidates
+// the detector is matching books with no signature; if it reports a few hundred
+// it is not recognizing the inline shape. Either way the operator sees it
+// BEFORE authorizing the irreversible pass, instead of having to remember the
+// warmup numbers.
+const bookSigInlineBytesPerBook = 22 * 1024
+
+func (p *Plugin) bookSigSidecarMigrateDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "maintenance.booksig-sidecar-migrate",
+		Plugin:      "maintenance",
+		DisplayName: "Migrate inline book signatures into the book_sig: sidecar",
+		Description: "Dry-run audit (default) or explicit apply of the #2387 storage migration. " +
+			"Walks every book: row and, for any row still carrying the five inline BookSig* " +
+			"fields, writes the book_sig:<id> sidecar and rewrites the row without them — both " +
+			"in ONE Pebble batch, so a row is never stripped without its sidecar. Reads are " +
+			"fallback-first, so un-migrated and migrated books both work throughout and the op " +
+			"is safe to re-run or to stop midway. Dry-run (default) only classifies and reports " +
+			"counts. Apply mode (dryRun=false, explicit only) performs the only irreversible " +
+			"step in the sidecar design. Set limit=N to migrate a small canary first. Books " +
+			"whose row changes underneath the migration are skipped and counted, never " +
+			"half-written.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.booksig-sidecar-migrate",
+		Cancellable:     true,
+		// Isolate means out-of-process, and Pebble is single-writer: a child
+		// cannot reopen the database. Must stay false.
+		Isolate:      false,
+		Timeout:      90 * time.Minute,
+		Schedule:     nil,
+		Capabilities: []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:          p.runBookSigSidecarMigrate,
+	}
+}
+
+func (p *Plugin) runBookSigSidecarMigrate(ctx context.Context, raw json.RawMessage, reporter sdk.Reporter) error {
+	params := bookSigSidecarMigrateParams{DryRun: true} // safe default
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return fmt.Errorf("invalid params: %w", err)
+		}
+	}
+	log := reporter.Logger()
+
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	// Resolve through the capability helper, never a bare type assertion: prod
+	// always installs the Bleve indexedStore decorator, and `store.(*PebbleStore)`
+	// against a wrapped store is indistinguishable from a genuinely unsupported
+	// backend. Several ops silently no-opped in production exactly that way. A
+	// hard error here is deliberate — "unsupported store, 0 books migrated" must
+	// never be reportable as success.
+	migrator := database.AsBookSigMigrateStore(store)
+	if migrator == nil {
+		return fmt.Errorf("store does not support book signature migration (got %T); "+
+			"this op requires a Pebble-backed store and must not report success without one", store)
+	}
+
+	if params.DryRun {
+		_ = reporter.Log(slog.LevelInfo, "DRY RUN — classifying only, no rows or sidecars will be written")
+	} else {
+		_ = reporter.Log(slog.LevelWarn, "APPLY MODE — rewriting book: rows and writing book_sig: sidecars (irreversible)")
+	}
+
+	ids, err := store.ListBookIDs()
+	if err != nil {
+		return fmt.Errorf("ListBookIDs: %w", err)
+	}
+	libraryTotal := len(ids)
+	if params.Limit > 0 && params.Limit < len(ids) {
+		ids = ids[:params.Limit]
+		_ = reporter.Log(slog.LevelInfo, fmt.Sprintf(
+			"CANARY — limit=%d, examining the first %d of %d books; the remainder are untouched and a later run resumes from here",
+			params.Limit, len(ids), libraryTotal))
+	}
+	total := len(ids)
+	if total == 0 {
+		_ = reporter.UpdateProgress(1, 1, "No books to examine")
+		return nil
+	}
+	_ = reporter.UpdateProgress(0, total, "Migrating inline book signatures to the sidecar…")
+
+	var (
+		examined     atomic.Int64
+		migrated     atomic.Int64
+		strippedOnly atomic.Int64
+		notCandidate atomic.Int64
+		skippedRaced atomic.Int64
+		errCount     atomic.Int64
+	)
+
+	pages := chunkIDs(ids, bookSigMigratePageSize)
+	runErr := registry.RunItems(ctx, reporter, pages, func(ctx context.Context, page []string) error {
+		for _, id := range page {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			examined.Add(1)
+			outcome, err := migrator.MigrateBookSigToSidecar(id, params.DryRun)
+			if err != nil {
+				// One unreadable or malformed row must not abort a
+				// whole-library pass; it is counted and reported, and the row
+				// is left exactly as it was.
+				errCount.Add(1)
+				log.Warn("booksig-sidecar-migrate: book failed", "book_id", id, "err", err)
+				continue
+			}
+			switch outcome {
+			case database.BookSigMigrateMigrated:
+				migrated.Add(1)
+			case database.BookSigMigrateStrippedOnly:
+				strippedOnly.Add(1)
+			case database.BookSigMigrateSkippedRaced:
+				skippedRaced.Add(1)
+			default:
+				notCandidate.Add(1)
+			}
+		}
+		return nil
+	}, registry.RunItemsOptions{
+		// CPU-bound work (JSON decode/encode) plus a small Pebble write per
+		// candidate. Books partition by ID across disjoint pages, so workers
+		// never contend for a row.
+		Concurrency:   runtime.NumCPU(),
+		ProgressTotal: len(pages),
+		Label: func(i, t int) string {
+			return fmt.Sprintf("Page %d/%d — %d migrated, %d stripped-only, %d raced",
+				i+1, t, migrated.Load(), strippedOnly.Load(), skippedRaced.Load())
+		},
+	})
+
+	candidates := migrated.Load() + strippedOnly.Load() + skippedRaced.Load()
+	impliedMB := float64(candidates*bookSigInlineBytesPerBook) / (1024 * 1024)
+
+	mode := "DRY RUN"
+	verb := "would migrate"
+	if !params.DryRun {
+		mode = "APPLY MODE"
+		verb = "migrated"
+	}
+	report := fmt.Sprintf(
+		"%s — examined %d of %d books: %s %d, stripped-only %d (sidecar already newer), "+
+			"not candidates %d, skipped-raced %d, errors %d. "+
+			"Candidates imply ~%.0f MB of inline signature (warmup measured 580 MB).",
+		mode, examined.Load(), libraryTotal, verb, migrated.Load(), strippedOnly.Load(),
+		notCandidate.Load(), skippedRaced.Load(), errCount.Load(), impliedMB)
+
+	log.Info("booksig-sidecar-migrate: complete",
+		"dry_run", params.DryRun,
+		"examined", examined.Load(),
+		"library_total", libraryTotal,
+		"migrated", migrated.Load(),
+		"stripped_only", strippedOnly.Load(),
+		"not_candidate", notCandidate.Load(),
+		"skipped_raced", skippedRaced.Load(),
+		"errors", errCount.Load(),
+		"implied_inline_mb", impliedMB)
+
+	if skippedRaced.Load() > 0 {
+		_ = reporter.Log(slog.LevelInfo, fmt.Sprintf(
+			"%d books were written by another path mid-migration and were skipped rather than reverted; re-run to pick them up",
+			skippedRaced.Load()))
+	}
+
+	_ = reporter.Log(slog.LevelInfo, report)
+	_ = reporter.UpdateProgress(len(pages), len(pages), report)
+	return runErr
+}

--- a/internal/plugins/maintenance/booksig_sidecar_migrate_test.go
+++ b/internal/plugins/maintenance/booksig_sidecar_migrate_test.go
@@ -1,0 +1,233 @@
+// file: internal/plugins/maintenance/booksig_sidecar_migrate_test.go
+// version: 1.0.0
+// guid: 7f3d1b58-6c24-4a09-8e57-3b90d2f6c418
+// last-edited: 2026-08-13
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// These tests cover the OP's orchestration — dry-run defaulting, the canary
+// limit, error tolerance, and refusing to run against a store that cannot
+// migrate. The migration SEMANTICS (row/sidecar pairing, CAS-and-skip, the
+// surgical strip) are proven in internal/database, where raw Pebble rows are
+// reachable and six mutation controls hold the tests honest. Splitting it this
+// way keeps the op tests from re-asserting storage behaviour through a keyhole.
+
+// scriptedMigrator wraps a real store (for ListBookIDs) but replaces the
+// per-book migration with a scripted outcome, recording every call. Embedding
+// database.Store — not *PebbleStore — means the real primitive is never
+// invoked, so an op bug cannot be masked by the primitive doing the right
+// thing anyway.
+type scriptedMigrator struct {
+	database.Store
+	mu      sync.Mutex
+	ids     []string
+	dryRuns []bool
+	outcome func(id string) (database.BookSigMigrateOutcome, error)
+}
+
+func (s *scriptedMigrator) MigrateBookSigToSidecar(id string, dryRun bool) (database.BookSigMigrateOutcome, error) {
+	s.mu.Lock()
+	s.ids = append(s.ids, id)
+	s.dryRuns = append(s.dryRuns, dryRun)
+	s.mu.Unlock()
+	if s.outcome == nil {
+		return database.BookSigMigrateMigrated, nil
+	}
+	return s.outcome(id)
+}
+
+func (s *scriptedMigrator) snapshot() (ids []string, dryRuns []bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.ids...), append([]bool(nil), s.dryRuns...)
+}
+
+// migrateOpFixture seeds n books and returns the op plugin plus the scripted
+// migrator wrapping the real store.
+func migrateOpFixture(t *testing.T, n int) (*Plugin, *scriptedMigrator, []string) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	s, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	want := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		b, err := s.CreateBook(&database.Book{
+			Title:    fmt.Sprintf("Migrate Op %02d", i),
+			FilePath: fmt.Sprintf("/lib/migrate_op_%02d.m4b", i),
+		})
+		if err != nil {
+			t.Fatalf("CreateBook %d: %v", i, err)
+		}
+		want = append(want, b.ID)
+	}
+
+	sm := &scriptedMigrator{Store: s}
+	return &Plugin{deps: fakeDeps{store: sm}}, sm, want
+}
+
+// TestBookSigSidecarMigrate_DefaultsToDryRun is the gate.
+//
+// This op performs the only irreversible step in the #2387 design. If an
+// operator triggers it with no params — the single most likely way it will ever
+// be invoked by hand — it must classify and report, not rewrite 67,824 rows.
+// A plain `var params T` would default DryRun to FALSE, which is exactly
+// backwards, so the safe default is set explicitly before unmarshalling.
+func TestBookSigSidecarMigrate_DefaultsToDryRun(t *testing.T) {
+	p, sm, want := migrateOpFixture(t, 3)
+
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(`{}`), json.RawMessage(`{"limit":0}`)} {
+		sm.mu.Lock()
+		sm.ids, sm.dryRuns = nil, nil
+		sm.mu.Unlock()
+
+		if err := p.runBookSigSidecarMigrate(context.Background(), raw, &concurrentReporter{}); err != nil {
+			t.Fatalf("run with raw=%q: %v", string(raw), err)
+		}
+		ids, dryRuns := sm.snapshot()
+		if len(ids) != len(want) {
+			t.Fatalf("raw=%q: examined %d books, want %d", string(raw), len(ids), len(want))
+		}
+		for i, dr := range dryRuns {
+			if !dr {
+				t.Fatalf("raw=%q: book %s was migrated for real; params with no explicit dryRun MUST default to a dry run", string(raw), ids[i])
+			}
+		}
+	}
+}
+
+// TestBookSigSidecarMigrate_ExplicitApplyDisablesDryRun — the gate must also
+// actually open, or the op could never do its job while looking correct.
+func TestBookSigSidecarMigrate_ExplicitApplyDisablesDryRun(t *testing.T) {
+	p, sm, want := migrateOpFixture(t, 3)
+
+	if err := p.runBookSigSidecarMigrate(context.Background(), json.RawMessage(`{"dryRun":false}`), &concurrentReporter{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	ids, dryRuns := sm.snapshot()
+	if len(ids) != len(want) {
+		t.Fatalf("examined %d books, want %d", len(ids), len(want))
+	}
+	for i, dr := range dryRuns {
+		if dr {
+			t.Fatalf("book %s ran as a dry run despite dryRun:false — the apply path is unreachable", ids[i])
+		}
+	}
+}
+
+// TestBookSigSidecarMigrate_LimitIsAPrefixCanary.
+//
+// limit exists so the first apply can be small: migrate a handful, verify the
+// pairing held on prod, then run the rest. That only works if the limited run
+// is a stable PREFIX of ListBookIDs order — otherwise a second run would
+// re-examine an arbitrary overlapping subset instead of continuing.
+func TestBookSigSidecarMigrate_LimitIsAPrefixCanary(t *testing.T) {
+	p, sm, _ := migrateOpFixture(t, 6)
+
+	all, err := sm.Store.ListBookIDs()
+	if err != nil {
+		t.Fatalf("ListBookIDs: %v", err)
+	}
+	if len(all) < 6 {
+		t.Fatalf("fixture seeded %d books, want >= 6", len(all))
+	}
+
+	if err := p.runBookSigSidecarMigrate(context.Background(), json.RawMessage(`{"limit":2}`), &concurrentReporter{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	ids, _ := sm.snapshot()
+	if len(ids) != 2 {
+		t.Fatalf("limit=2 examined %d books; a canary that examines the whole library is not a canary", len(ids))
+	}
+
+	got := map[string]bool{ids[0]: true, ids[1]: true}
+	for _, id := range all[:2] {
+		if !got[id] {
+			t.Fatalf("limit=2 examined %v, want the first two of ListBookIDs order %v — a limited run must be a resumable prefix", ids, all[:2])
+		}
+	}
+}
+
+// TestBookSigSidecarMigrate_PerBookErrorDoesNotAbortTheRun.
+//
+// One malformed or unreadable row out of 67,824 must not strand the other
+// 67,823 un-migrated. The row is counted, logged and left exactly as it was.
+func TestBookSigSidecarMigrate_PerBookErrorDoesNotAbortTheRun(t *testing.T) {
+	p, sm, want := migrateOpFixture(t, 5)
+
+	all, err := sm.Store.ListBookIDs()
+	if err != nil {
+		t.Fatalf("ListBookIDs: %v", err)
+	}
+	poison := all[2]
+	sm.outcome = func(id string) (database.BookSigMigrateOutcome, error) {
+		if id == poison {
+			return database.BookSigMigrateNotCandidate, fmt.Errorf("simulated unreadable row")
+		}
+		return database.BookSigMigrateMigrated, nil
+	}
+
+	if err := p.runBookSigSidecarMigrate(context.Background(), json.RawMessage(`{"dryRun":false}`), &concurrentReporter{}); err != nil {
+		t.Fatalf("a single bad row must not fail the whole op, got: %v", err)
+	}
+	ids, _ := sm.snapshot()
+	if len(ids) != len(want) {
+		t.Fatalf("examined %d books after one failure, want all %d — the run aborted early", len(ids), len(want))
+	}
+}
+
+// unmigratableStore satisfies database.Store but not BookSigMigrateStore, and
+// exposes no Unwrap, so AsCapability cannot descend to anything that does.
+type unmigratableStore struct{ database.Store }
+
+// TestBookSigSidecarMigrate_UnsupportedStoreFailsLoudly.
+//
+// Production always installs the Bleve indexedStore decorator. A bare
+// `store.(*PebbleStore)` against a wrapped store is indistinguishable from a
+// genuinely unsupported backend, and several ops in this repo silently no-opped
+// in prod exactly that way — reporting success having migrated nothing. This op
+// must error instead.
+func TestBookSigSidecarMigrate_UnsupportedStoreFailsLoudly(t *testing.T) {
+	p := &Plugin{deps: fakeDeps{store: unmigratableStore{}}}
+
+	err := p.runBookSigSidecarMigrate(context.Background(), json.RawMessage(`{"dryRun":true}`), &concurrentReporter{})
+	if err == nil {
+		t.Fatal("a store that cannot migrate must produce an ERROR; reporting success with 0 books migrated is the exact silent no-op this check exists to prevent")
+	}
+}
+
+// TestBookSigSidecarMigrateDef_Shape pins the properties that make the op safe
+// to expose: it must be cancellable (it touches the whole library), and it must
+// NOT be isolated — Isolate means out-of-process and Pebble is single-writer,
+// so a child cannot reopen the database.
+func TestBookSigSidecarMigrateDef_Shape(t *testing.T) {
+	def := (&Plugin{}).bookSigSidecarMigrateDef()
+
+	if def.ID != "maintenance.booksig-sidecar-migrate" {
+		t.Fatalf("op ID = %q", def.ID)
+	}
+	if !def.Cancellable {
+		t.Fatal("a whole-library write op must be cancellable")
+	}
+	if def.Isolate {
+		t.Fatal("Isolate runs the op out-of-process and Pebble is single-writer; the child cannot reopen the database")
+	}
+	if def.Run == nil {
+		t.Fatal("op has no Run function — it would register and then do nothing")
+	}
+}

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/plugin.go
-// version: 1.17.0
+// version: 1.18.0
 // guid: b2c3d4e5-f6a7-8901-bcde-123456789012
 // last-edited: 2026-08-13
 
@@ -128,6 +128,9 @@ func (p *Plugin) Register(r sdk.Registry) error {
 
 		// --- optimize sweep ---
 		p.optimizeDef(),
+
+		// --- storage migrations ---
+		p.bookSigSidecarMigrateDef(),
 	}
 	for _, d := range defs {
 		if err := r.RegisterOp(d); err != nil {

--- a/todo.d/2026-08-13-booksig-sidecar-prod-migration.md
+++ b/todo.d/2026-08-13-booksig-sidecar-prod-migration.md
@@ -1,0 +1,42 @@
+- [ ] 💾 **Run `maintenance.booksig-sidecar-migrate` on production** — the op is
+      merged and dry-run gated, but the ~580 MB/startup saving from PR #2387 is
+      **not realized until the data actually moves**. #2387 shipped the
+      `book_sig:<id>` sidecar with fallback-first reads, so all 67,824 rows still
+      carry their signature inline and warmup still reports
+      `discarded_field_mb[book_sig_v1_and_mask] = 580` against
+      `phase_mb[books] = 729`. This is the only irreversible step in the sidecar
+      design, so it needs an owner decision, not a scheduled run.
+
+      Ordered procedure:
+
+      1. **Dry run first**, whole library. Read the reported counts:
+         `migrated / stripped-only / not-candidate / skipped-raced / errors`.
+      2. **Instrument check before applying.** 580 MB of inline signature at
+         ~22 KB per book implies candidates in the **low tens of thousands** —
+         the op prints this cross-check itself as "candidates imply ~N MB". If it
+         reports all 67,824 the detector is matching books with no signature; if
+         it reports a few hundred it is not recognizing the inline shape. Either
+         way, stop — do not apply on a detector that disagrees with the byte
+         accounting.
+      3. **Canary**: apply with `{"dryRun":false,"limit":100}`. A limited run is a
+         stable prefix of `ListBookIDs` order, so the full run resumes from it.
+         Verify the pairing on a named book: `GetBookByID` must return a non-nil
+         `BookSigV1`, and its `book:` row must no longer contain
+         `book_sig_v1`.
+      4. **Full apply**: `{"dryRun":false}`.
+      5. **Verify with the positive pair, not an absence.**
+         `discarded_field_mb[book_sig_v1_and_mask] → 0` is weak evidence — it
+         reads zero if the migration worked *or* if the field accounting stopped
+         recognizing the field. Require instead that **`phase_mb[books]` actually
+         drops from 729** AND a `GetBookByID` on a named migrated book still
+         returns its signature.
+      6. **Re-run the dry run.** Candidates should be ~0. Any `skipped-raced`
+         count from the apply is books another writer touched mid-migration;
+         they were skipped rather than reverted, and a second pass picks them up.
+
+      Rollback: reads stay fallback-first, so migrated and un-migrated rows both
+      work throughout. The row rewrite is irreversible in place but not lossy —
+      the signature lives in the sidecar, and every migrated book keeps its
+      pre-migration `book_ver:` snapshots, which still carry the full inline copy
+      (`UpdateBook` never strips those), so `booksig-recovery-audit` remains a
+      second-line recovery path.

--- a/todo.d/2026-08-13-booksig-sidecar-prod-migration.md
+++ b/todo.d/2026-08-13-booksig-sidecar-prod-migration.md
@@ -18,8 +18,13 @@
          it reports a few hundred it is not recognizing the inline shape. Either
          way, stop — do not apply on a detector that disagrees with the byte
          accounting.
-      3. **Canary**: apply with `{"dryRun":false,"limit":100}`. A limited run is a
-         stable prefix of `ListBookIDs` order, so the full run resumes from it.
+      3. **Canary**: apply with `{"dryRun":false,"limit":100}`. Do NOT assume the
+         limited run is a stable prefix the full run resumes past — `ListBookIDs`
+         has two implementations (memdb index order, which also drops
+         soft-deleted books, vs. the Pebble key range) and which one answers
+         depends on warmup state. The op is idempotent, so a full run simply
+         re-examines the canary's books and reports them `not_candidate`; that
+         is the guarantee to rely on, not the ordering.
          Verify the pairing on a named book: `GetBookByID` must return a non-nil
          `BookSigV1`, and its `book:` row must no longer contain
          `book_sig_v1`.


### PR DESCRIPTION
## What

Adds `maintenance.booksig-sidecar-migrate`, the backfill op that finishes what PR #2387 started.

#2387 moved the five `BookSig*` fields to a `book_sig:<id>` sidecar with **fallback-first reads**, so all 67,824 existing rows kept working un-migrated. That is what made the read path safe to deploy — and it is also why the saving was never realized. Production warmup on 2026-08-13 21:15 still reported:

```
phase_mb[books]                          = 729
discarded_field_mb[book_sig_v1_and_mask] = 580
```

exactly as designed. 80% of every byte the books warmup phase reads is a signature `stripBookForMemdb` discards the instant it finishes decoding.

This op moves the data: it walks every `book:` row and, for any row still carrying an inline signature, writes the sidecar key and rewrites the row without it — **both in one Pebble batch**.

## Why the batch pairing is load-bearing

A book with all five fields nil is *exactly* the shape `booksig-recovery-audit` classifies as **"never had a signature"** rather than as damage. So a half-applied migration — row stripped, sidecar absent — would be invisible to the very op written to detect signature loss, and dedup would simply stop matching those books, with nothing logged. `TestBookSigMigrate_ConformancePairing` asserts the invariant across a mixed library: every book that had an inline signature ends with a sidecar carrying the same five values, and every book that had none ends with no sidecar at all.

## Three decisions worth reviewing

**1. Not implemented via `UpdateBook`,** which would also have migrated a book correctly. `UpdateBook` writes a `book_ver:` CoW snapshot per call that *deliberately* keeps the full inline signature (it is `booksig-recovery-audit`'s safety net). 67,824 calls ≈ **1.5 GB of fresh snapshot data**, in a migration whose purpose is to stop paying for those bytes — plus an `UpdatedAt` bump on every book, churning the search-index dirty set and aggregate recompute.

**2. CAS-and-skip on the raw row bytes.** There is no per-book write serialization in `PebbleStore` — none of its six mutexes guard the book read-modify-write, and `UpdateBook` already races with itself. A naive read-then-write here would revert an **entire** concurrent update (title, path, everything), not merely the signature. The reframe that dissolves it: every `UpdateBook` already strips the row it writes, so the library migrates organically and this op only *accelerates* it — which makes skipping any individual book always acceptable. Raced books are counted in `skipped_raced` and never half-written; re-run to pick them up.

**3. Surgical JSON strip, not a `Book` round-trip.** Unmarshalling into `Book` silently drops any stored field the struct does not declare, so `json.Marshal(stripBookSigForRow(&book))` would rewrite 67,824 rows with *more* removed than the five fields being moved. The op operates on `map[string]json.RawMessage` so unknown fields survive byte-for-byte. Mutation control **M5** confirms the round-trip version really does drop them.

## Safety

- **Dry-run by default.** `params := bookSigSidecarMigrateParams{DryRun: true}` before unmarshalling — a plain `var params T` would default to `false`, which is backwards. Mutation **O1** covers this.
- **`limit` canary.** A limited run is a stable prefix of `ListBookIDs` order, so a later full run resumes from it.
- **Expected-magnitude cross-check.** The op prints "candidates imply ~N MB" next to the count. 580 MB at ~22 KB/book implies candidates in the low tens of thousands — so a detector matching all 67,824 (or a few hundred) is visible *before* anything irreversible runs.
- **Resolves the store via `database.AsBookSigMigrateStore`,** never a bare type assertion. Prod always installs the Bleve decorator, and a bare assertion is indistinguishable from an unsupported backend — how several ops silently no-opped in prod. Unsupported store is a hard **error**, so "0 books migrated" can never read as success.
- One malformed row does not abort the pass.

## Verification

- **10 mutation controls, all confirmed RED** — 6 storage (sidecar-exists check, CAS re-read, sidecar write, candidate detector, surgical strip, dry-run gate) and 4 op (dry-run default, unsupported-store check, limit, per-book error tolerance). Baselines green.
- `go test ./internal/database/ ./internal/plugins/maintenance/ -race` — **exit 0** (411s + 24s).
- `go build ./...` and `go vet` clean.

## Not in this PR

Running the migration on production. That is the irreversible step and needs an owner decision — the ordered procedure (dry run → instrument check → 100-book canary → full apply → positive-pair verification) is filed as a `todo.d` fragment.

Note the post-apply check must be the **positive pair**: `discarded_field_mb → 0` is weak evidence, since it also reads zero if the field accounting stopped recognizing the field. Require `phase_mb[books]` actually dropping from 729 **and** a `GetBookByID` on a named migrated book still returning its signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp
