### PR TITLE
docs(todo): give the booksig-migrate apply gate a number to check

### DIFF
--- a/changelog.d/20260813_docs_booksig_migrate_expected_candidates.md
+++ b/changelog.d/20260813_docs_booksig_migrate_expected_candidates.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Made the `maintenance.booksig-sidecar-migrate` prod procedure's pre-apply
+  instrument check compare against an explicit expected candidate count
+  (~27,000, from 580 MB ÷ ~22 KB) instead of "low tens of thousands", and
+  recorded that a full apply may need more than one pass because memdb's
+  `ListBookIDs` skips soft-deleted books. The completion signal is
+  "candidates ≈ 0 on re-run", not "the apply reported no errors".

--- a/todo.d/2026-08-13-booksig-sidecar-prod-migration.md
+++ b/todo.d/2026-08-13-booksig-sidecar-prod-migration.md
@@ -11,13 +11,22 @@
 
       1. **Dry run first**, whole library. Read the reported counts:
          `migrated / stripped-only / not-candidate / skipped-raced / errors`.
-      2. **Instrument check before applying.** 580 MB of inline signature at
-         ~22 KB per book implies candidates in the **low tens of thousands** —
-         the op prints this cross-check itself as "candidates imply ~N MB". If it
-         reports all 67,824 the detector is matching books with no signature; if
-         it reports a few hundred it is not recognizing the inline shape. Either
-         way, stop — do not apply on a detector that disagrees with the byte
-         accounting.
+      2. **Instrument check before applying.** Compare against a NUMBER, not a
+         vibe. 580 MB of inline signature at ~22 KB per book implies roughly
+         **27,000 candidates** — i.e. well under half the library, because most
+         books never had a signature. The op prints this cross-check itself as
+         "candidates imply ~N MB", computed from the CANDIDATE count, so a
+         healthy dry run should land near **~580 MB**. Two failure shapes:
+
+         - reports all 67,824 as candidates → implies ~1,459 MB, which
+           disagrees with the 580 MB warmup measurement by 2.5×: the detector is
+           matching books that have no signature.
+         - reports a few hundred → implies single-digit MB: the detector is not
+           recognizing the inline shape at all.
+
+         Either way, stop — do not apply on a detector that disagrees with the
+         byte accounting. Note the 22 KB figure is itself derived from the
+         580 MB total, so this checks the detector's population, not the size.
       3. **Canary**: apply with `{"dryRun":false,"limit":100}`. Do NOT assume the
          limited run is a stable prefix the full run resumes past — `ListBookIDs`
          has two implementations (memdb index order, which also drops
@@ -28,7 +37,11 @@
          Verify the pairing on a named book: `GetBookByID` must return a non-nil
          `BookSigV1`, and its `book:` row must no longer contain
          `book_sig_v1`.
-      4. **Full apply**: `{"dryRun":false}`.
+      4. **Full apply**: `{"dryRun":false}`. Expect to need MORE THAN ONE pass.
+         Besides raced rows, the memdb `ListBookIDs` skips soft-deleted books,
+         so a single run is not guaranteed to have enumerated every row still
+         carrying an inline signature. Step 6's "candidates ≈ 0 on re-run" is
+         the completion signal — not "the apply finished without errors".
       5. **Verify with the positive pair, not an absence.**
          `discarded_field_mb[book_sig_v1_and_mask] → 0` is weak evidence — it
          reads zero if the migration worked *or* if the field accounting stopped


### PR DESCRIPTION
Follow-up to #2394. Docs-only — no code changes.

The pre-apply instrument check in the prod procedure told the operator to expect candidates in the "low tens of thousands" and to stop if the op disagreed with the 580 MB warmup measurement. That is a vibe, not a threshold, and it is the only gate standing between an operator and the one irreversible step in the #2387 sidecar design.

## What changed

**Step 2 now states the arithmetic.** 580 MB at ~22 KB per signature implies roughly **27,000 candidates** — well under half the 67,824-book library, because most books never had a signature. Both failure shapes now carry the figure they would actually print:

| Shape | Implied MB | Meaning |
|---|---|---|
| Healthy | ~580 MB | agrees with the warmup measurement |
| All 67,824 matched | ~1,459 MB | detector is matching books with no signature |
| A few hundred matched | single-digit MB | detector is not recognizing the inline shape |

**Verified while doing this** that the op's own cross-check multiplies the *candidate* count (`booksig_sidecar_migrate.go:198`), not the library total — so a healthy dry run lands near 580 MB instead of tripping its own alarm at 1.4 GB.

**Step 4 now says a full apply may need more than one pass.** memdb's `ListBookIDs` skips soft-deleted books, so a single run is not guaranteed to have enumerated every row still carrying an inline signature. The completion signal is step 6's "candidates ≈ 0 on re-run", not "the apply reported no errors".

## Testing

Docs-only; `todo.d/` and `changelog.d/` fragments are header-exempt and the `TODO Fragment Headers` check enforces that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp