### PR TITLE
fix(dedup): author names keep a stranded '&' from Oxford-comma credit lists

### DIFF
--- a/changelog.d/20260814_001500_fix_author_leading_conjunction.md
+++ b/changelog.d/20260814_001500_fix_author_leading_conjunction.md
@@ -2,7 +2,7 @@
 
 #### Author names no longer keep a stranded "&" from Oxford-comma credit lists
 
-48 author rows in the library were named `& Conrad Westmaas`, `& Lisa Bowerman`,
+46 author rows in the library were named `& Conrad Westmaas`, `& Lisa Bowerman`,
 `& India Fisher` and so on — a leading ampersand glued to an otherwise correct
 name. They showed up as separate authors on author pages and in dedup
 candidates, splitting a real person's books across two rows.

--- a/changelog.d/20260814_001500_fix_author_leading_conjunction.md
+++ b/changelog.d/20260814_001500_fix_author_leading_conjunction.md
@@ -1,0 +1,42 @@
+### Fixed
+
+#### Author names no longer keep a stranded "&" from Oxford-comma credit lists
+
+48 author rows in the library were named `& Conrad Westmaas`, `& Lisa Bowerman`,
+`& India Fisher` and so on — a leading ampersand glued to an otherwise correct
+name. They showed up as separate authors on author pages and in dedup
+candidates, splitting a real person's books across two rows.
+
+Root cause is an ordering bug in `dedup.SplitCompositeAuthorName`. The source
+metadata is an Oxford-comma credit list; the real `album_artist` tag on
+*The Creed of the Kromon* reads:
+
+    Paul McGann, India Fisher, & Conrad Westmaas
+
+The comma branch of the splitter runs at line 173, the `" & "` branch at line
+220. The comma branch fires first, splits on `,`, and validates each candidate
+part with a single test — `strings.Contains(p, " ")`. `"& Conrad Westmaas"`
+contains spaces, so it passes, and `NormalizeAuthorName` trimmed whitespace and
+expanded initials but never touched leading punctuation. The `" & "` branch that
+would have handled this input correctly was unreachable for exactly the inputs
+it was written for.
+
+The same hole existed in the slash, semicolon and bracket branches — each
+validated a part only by asking whether it contained a space. The fix is applied
+at `NormalizeAuthorName`, the chokepoint every branch already funnels through,
+so one edit closes all four rather than four patches that can drift apart.
+
+The strip pattern requires whitespace after the conjunction
+(`(?i)^(?:&|and)\s+`). That is deliberate and load-bearing:
+
+- `&#169` and `&#169;2013 by HarperCollinsPublishers` are also real author rows —
+  decapitated HTML entities for `©` from a copyright string that leaked into an
+  artist tag. They are a **separate** defect, and a bare `^&` strip would rewrite
+  the first to `#169`, which is worse than leaving it alone.
+- Requiring whitespace also stops `and` from eating the first syllable of real
+  names such as *Anders Bergman* or *Andrea Cremer*.
+
+Note on scope: no new `& Name` rows had appeared recently, but that is absence of
+a triggering import rather than evidence of a fix — the affected ids cluster at
+46411–46764, a single Big Finish import run. Any re-import of comma-and-ampersand
+credits would have recreated them.

--- a/changelog.d/20260814_003000_add_author_conjunction_repair.md
+++ b/changelog.d/20260814_003000_add_author_conjunction_repair.md
@@ -1,0 +1,43 @@
+### Added
+
+#### Maintenance op to repair author rows with a stranded ampersand
+
+`maintenance.author-conjunction-repair` cleans up the 48 author rows the
+Oxford-comma splitting bug created — `& Conrad Westmaas`, `& Lisa Bowerman`,
+`& India Fisher` and the rest. The forward fix stops new ones appearing but does
+nothing to existing rows, because nothing re-normalizes an author name after
+creation.
+
+The existing `maintenance.author-split-scan` cannot reach these rows:
+`SplitCompositeAuthorName("& Conrad Westmaas")` returns nil (three words, no
+delimiter), so the split scan skips them entirely.
+
+Two repair paths, chosen per row:
+
+- **Merge** when a correctly-named author already exists — 31 of the 48. Book
+  links move to the existing author and the stranded row is deleted.
+- **Rename in place** when no such author exists — the remaining 17. The row
+  keeps its id, so no book row is touched at all.
+
+The link that gets rewritten is the book↔author **join slice**, not
+`Book.AuthorID`. Every stranded row sits at position 1+ of a credit list, which
+is why all 48 report `file_count: 0` while carrying books between them; a merge
+that only rewrote the denormalized primary would report success and move
+nothing. The tests assert on `SetBookAuthors` for exactly this reason.
+
+Defaults to `dry_run=true`. Merging deletes author rows, so the per-row plan is
+meant to be read before anything is written.
+
+The op matches `&` only, deliberately narrower than the forward fix's pattern.
+Three rows begin with `and ` — `and Thanks for All the Fish`, `and the Farm Boy
+(DBY)`, `and Make Better Decisions` — and those are book *titles* that reached
+an artist tag, not stranded conjunctions. Renaming them would produce
+`Thanks for All the Fish`: still not an author, but no longer obviously broken.
+They are left visibly wrong on purpose, and filed for the fix that addresses the
+real defect (the comma branch cannot tell a person from a title clause).
+
+The loop is deliberately sequential rather than pooled: the merge path is a
+read-modify-write of a book's author slice, and two workers repairing two
+different rows that appear on the same book would lose one another's update.
+Partitioning by author does not make the work disjoint, because the unit
+actually mutated is the book.

--- a/changelog.d/20260814_003000_add_author_conjunction_repair.md
+++ b/changelog.d/20260814_003000_add_author_conjunction_repair.md
@@ -2,7 +2,7 @@
 
 #### Maintenance op to repair author rows with a stranded ampersand
 
-`maintenance.author-conjunction-repair` cleans up the 48 author rows the
+`maintenance.author-conjunction-repair` cleans up the 46 author rows the
 Oxford-comma splitting bug created — `& Conrad Westmaas`, `& Lisa Bowerman`,
 `& India Fisher` and the rest. The forward fix stops new ones appearing but does
 nothing to existing rows, because nothing re-normalizes an author name after
@@ -14,14 +14,20 @@ delimiter), so the split scan skips them entirely.
 
 Two repair paths, chosen per row:
 
-- **Merge** when a correctly-named author already exists — 31 of the 48. Book
+- **Merge** when a correctly-named author already exists — 31 of the 46. Book
   links move to the existing author and the stranded row is deleted.
-- **Rename in place** when no such author exists — the remaining 17. The row
+- **Rename in place** when no such author exists — the remaining 15. The row
   keeps its id, so no book row is touched at all.
+
+Census, measured against prod on 2026-08-14: 48 author names begin with `&`, of
+which 46 match `^&\s+` and are repaired here. The other two are `&#169` and
+`&#169;2013 by HarperCollinsPublishers` — HTML-entity leftovers of a copyright
+notice, a separate defect the pattern deliberately does not match. The 46 carry
+145 books, and no book is linked to two of them, so no book is written twice.
 
 The link that gets rewritten is the book↔author **join slice**, not
 `Book.AuthorID`. Every stranded row sits at position 1+ of a credit list, which
-is why all 48 report `file_count: 0` while carrying books between them; a merge
+is why all 46 report `file_count: 0` while carrying 145 books between them; a merge
 that only rewrote the denormalized primary would report success and move
 nothing. The tests assert on `SetBookAuthors` for exactly this reason.
 

--- a/docs/executive-summaries/2026-08-14-the-ampersand-that-became-an-author-executive-summary.md
+++ b/docs/executive-summaries/2026-08-14-the-ampersand-that-became-an-author-executive-summary.md
@@ -1,0 +1,119 @@
+<!-- file: docs/executive-summaries/2026-08-14-the-ampersand-that-became-an-author-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c9147e3b-8a62-4d05-b7f1-2e6a09d84c53 -->
+<!-- last-edited: 2026-08-14 -->
+
+# Executive Summary: The Ampersand That Became An Author
+
+**Date:** 2026-08-14
+**In one line:** 48 people in your library were filed twice — once under their name, and
+once under their name with a stray "&" stuck to the front — because of how a list of
+narrators got chopped up.
+
+---
+
+## What you saw
+
+Author pages listing `& India Fisher` and `& Lisa Bowerman` as if they were people. Not
+an error message, not a crash — just names that were subtly wrong, sitting quietly in the
+author list next to the correct spelling of the same person.
+
+## What was actually happening
+
+Audiobook files carry a credit line naming everyone involved. The one on
+*The Creed of the Kromon* reads:
+
+> Paul McGann, India Fisher, & Conrad Westmaas
+
+The library has to turn that one line into three separate people. It does that by
+chopping the line at its punctuation. It tried the comma first, which gives:
+
+> `Paul McGann` | `India Fisher` | `& Conrad Westmaas`
+
+The first two are fine. The third kept the ampersand, because the chop happened at the
+comma and nothing afterwards looked at what was left over.
+
+The library *did* have a rule for handling ampersands. It just never got to run. The
+rules are tried in order, and the comma rule went first — so for exactly the credit lines
+the ampersand rule was written for, it was unreachable.
+
+**The tell was the punctuation used.** Writing "A, B, & C" — with a comma *before* the
+ampersand — is the only style that strands the symbol like this. Written "A, B & C" the
+same code produces `B & C`, which is obviously broken and would have been spotted
+years ago. The tidier punctuation produced the quieter bug.
+
+## Why nobody noticed
+
+Two reasons, and both are worth knowing.
+
+**It only happened once.** All 48 bad entries came from a single import of one audio
+drama collection. No new ones appeared afterwards — but that is because nothing has
+re-imported credits in that style since, not because anything was fixed. The next import
+of that shape would have made more.
+
+**Nothing looked broken.** A person filed twice does not throw an error. Their books just
+split across two entries, so one shows fewer books than they should have, and the other
+shows a name with a stray symbol. Everything continues to work.
+
+## What was fixed
+
+Two separate things, because stopping the bleeding and cleaning up the mess are not the
+same job.
+
+**The chopping rule.** The fix went into the one step every chopping rule shares, rather
+than into the comma rule alone — the same flaw was sitting in the rules for slashes,
+semicolons and brackets, and patching only the one we caught would have left three copies
+of it behind to be rediscovered later.
+
+**The 48 existing entries.** A new cleanup task handles them, and it does two different
+things depending on what it finds:
+
+- **31 of them** already have a correctly-spelled twin elsewhere in the library. Their
+  books move over to the real person, and the bad entry goes away.
+- **The other 17** have no twin. Those simply get renamed in place, which keeps every
+  book already attached to them attached.
+
+The cleanup reports what it *would* do before it does anything. Merging deletes entries,
+so that plan is meant to be read first.
+
+## The part that was deliberately left broken
+
+Three entries look like the same bug and are not:
+
+- `and Thanks for All the Fish`
+- `and the Farm Boy (DBY)`
+- `and Make Better Decisions`
+
+These are fragments of **book titles** that ended up in the credit line and got chopped
+the same way. *So Long, and Thanks for All the Fish* is a Douglas Adams novel, not a
+person.
+
+The cleanup could easily have stripped the "and" from these too. It deliberately does
+not. Removing it gives `Thanks for All the Fish` — still not a person, but no longer
+*obviously* wrong, and therefore much harder for anyone to find later. Leaving them
+visibly broken is what keeps them findable. They are recorded for a separate fix that
+addresses the actual problem: the chopping rule cannot tell a person's name from a
+fragment of a title.
+
+The same reasoning protects two other entries, `&#169` and
+`&#169;2013 by HarperCollinsPublishers` — leftovers of a copyright notice that landed in
+a credit line. A careless cleanup would have turned the first into `#169`. It is left
+alone too.
+
+## How we know it is actually fixed
+
+The test was written using the real credit line read off the actual file on disk, not an
+invented example — and it was run **before** the fix and watched to fail, on all four
+chopping rules, so we know it is capable of catching the problem rather than just
+agreeing with the code.
+
+The two safety rules in the cleanup were checked the same way: each was deliberately
+broken to confirm the tests go red. Widening the cleanup to include "and" produced
+exactly the laundering described above, which is the evidence that the narrow version is
+doing real work.
+
+---
+
+**Scale:** 48 author entries, 146 books between them, out of roughly 9,350 authors.
+**Blast radius:** author pages, author counts, and duplicate-detection candidates.
+**Data loss:** none. Nothing was deleted; entries were duplicated, not destroyed.

--- a/docs/executive-summaries/2026-08-14-the-ampersand-that-became-an-author-executive-summary.md
+++ b/docs/executive-summaries/2026-08-14-the-ampersand-that-became-an-author-executive-summary.md
@@ -1,12 +1,12 @@
 <!-- file: docs/executive-summaries/2026-08-14-the-ampersand-that-became-an-author-executive-summary.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: c9147e3b-8a62-4d05-b7f1-2e6a09d84c53 -->
 <!-- last-edited: 2026-08-14 -->
 
 # Executive Summary: The Ampersand That Became An Author
 
 **Date:** 2026-08-14
-**In one line:** 48 people in your library were filed twice — once under their name, and
+**In one line:** 46 people in your library were filed twice — once under their name, and
 once under their name with a stray "&" stuck to the front — because of how a list of
 narrators got chopped up.
 
@@ -46,7 +46,7 @@ years ago. The tidier punctuation produced the quieter bug.
 
 Two reasons, and both are worth knowing.
 
-**It only happened once.** All 48 bad entries came from a single import of one audio
+**It only happened once.** All 46 bad entries came from a single import of one audio
 drama collection. No new ones appeared afterwards — but that is because nothing has
 re-imported credits in that style since, not because anything was fixed. The next import
 of that shape would have made more.
@@ -65,12 +65,12 @@ than into the comma rule alone — the same flaw was sitting in the rules for sl
 semicolons and brackets, and patching only the one we caught would have left three copies
 of it behind to be rediscovered later.
 
-**The 48 existing entries.** A new cleanup task handles them, and it does two different
+**The 46 existing entries.** A new cleanup task handles them, and it does two different
 things depending on what it finds:
 
 - **31 of them** already have a correctly-spelled twin elsewhere in the library. Their
   books move over to the real person, and the bad entry goes away.
-- **The other 17** have no twin. Those simply get renamed in place, which keeps every
+- **The other 15** have no twin. Those simply get renamed in place, which keeps every
   book already attached to them attached.
 
 The cleanup reports what it *would* do before it does anything. Merging deletes entries,
@@ -114,6 +114,8 @@ doing real work.
 
 ---
 
-**Scale:** 48 author entries, 146 books between them, out of roughly 9,350 authors.
+**Scale:** 46 author entries, 145 books between them, out of roughly 9,350 authors.
+(48 names begin with "&"; the other two are the copyright leftovers described above,
+which the cleanup deliberately does not touch.)
 **Blast radius:** author pages, author counts, and duplicate-detection candidates.
 **Data loss:** none. Nothing was deleted; entries were duplicated, not destroyed.

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/mock_store.go
-// version: 1.83.0
+// version: 1.84.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-08-13
+// last-edited: 2026-08-14
 
 package database
 
@@ -95,6 +95,13 @@ type MockStore struct {
 	UpdateAuthorNameFunc func(id int, name string) error
 
 	GetAuthorsByIDsFunc func(ids []int) (map[int]*Author, error)
+
+	// Book<->Author join methods. These carry the link that matters for
+	// multi-author books: a credit list puts authors 2..n in this slice only,
+	// leaving Book.AuthorID pointing at the first. Tests that assert on a
+	// merge/relink must be able to observe writes here.
+	GetBookAuthorsFunc func(bookID string) ([]BookAuthor, error)
+	SetBookAuthorsFunc func(bookID string, authors []BookAuthor) error
 
 	// Author Alias methods
 	GetAuthorAliasesFunc    func(authorID int) ([]AuthorAlias, error)
@@ -807,10 +814,16 @@ func (m *MockStore) GetBooksByAuthorIDCore(authorID int) ([]BookCore, error) {
 }
 
 func (m *MockStore) GetBookAuthors(bookID string) ([]BookAuthor, error) {
+	if m.GetBookAuthorsFunc != nil {
+		return m.GetBookAuthorsFunc(bookID)
+	}
 	return nil, nil
 }
 
 func (m *MockStore) SetBookAuthors(bookID string, authors []BookAuthor) error {
+	if m.SetBookAuthorsFunc != nil {
+		return m.SetBookAuthorsFunc(bookID, authors)
+	}
 	return nil
 }
 

--- a/internal/dedup/author.go
+++ b/internal/dedup/author.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/author.go
-// version: 1.11.1
+// version: 1.12.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90
-// last-edited: 2026-07-18
+// last-edited: 2026-08-14
 
 package dedup
 
@@ -62,8 +62,30 @@ func IsProductionCompany(name string) bool {
 	return false
 }
 
+// leadingConjunctionRe matches a coordinating conjunction stranded at the start
+// of an author name, e.g. "& Conrad Westmaas" or "and Sadie Miller".
+//
+// The trailing \s+ is load-bearing and must not be relaxed to \s*:
+//   - "&#169" and "&#169;2013 by HarperCollinsPublishers" are real rows in the
+//     author table — decapitated HTML entities for © from a copyright string that
+//     leaked into an artist tag. They are a SEPARATE defect. A bare "^&" strip
+//     rewrites them to "#169", which is strictly worse than leaving them alone.
+//   - Requiring whitespace also stops "and" from eating the first syllable of
+//     real names like "Anders Bergman" or "Andrea Cremer".
+var leadingConjunctionRe = regexp.MustCompile(`(?i)^(?:&|and)\s+`)
+
 // NormalizeAuthorName normalizes whitespace around initials and trims.
 // "James S. A. Corey" and "James S.A. Corey" both become "James S. A. Corey"
+//
+// It also strips a leading conjunction. Every delimiter branch of
+// SplitCompositeAuthorName funnels through here, and each of them validated a
+// candidate part only by asking whether it contained a space — which
+// "& Conrad Westmaas" satisfies. An Oxford comma before the ampersand
+// ("A, B, & C") makes the comma branch fire before the " & " branch further
+// down, so the ampersand is stranded on the final name and stored verbatim.
+// That produced 48 "& Name" author rows in one import run. Normalizing here
+// rather than in the comma branch closes the same hole in the slash, semicolon
+// and bracket branches, which all share it.
 func NormalizeAuthorName(name string) string {
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -73,6 +95,13 @@ func NormalizeAuthorName(name string) string {
 	// Normalize multiple spaces to single
 	spaceRe := regexp.MustCompile(`\s+`)
 	name = spaceRe.ReplaceAllString(name, " ")
+
+	// Strip a stranded leading conjunction, but never turn a name into nothing:
+	// a bare "&" or "and" with no remainder is left as-is for the caller's
+	// existing empty/short-part checks to reject.
+	if stripped := strings.TrimSpace(leadingConjunctionRe.ReplaceAllString(name, "")); stripped != "" {
+		name = stripped
+	}
 
 	// Expand collapsed initials: "S.A." → "S. A."
 	initialsRe := regexp.MustCompile(`([A-Z]\.)([A-Z])`)

--- a/internal/dedup/author_leading_conjunction_test.go
+++ b/internal/dedup/author_leading_conjunction_test.go
@@ -95,6 +95,14 @@ func TestNormalizeAuthorName_LeadingConjunction(t *testing.T) {
 		// NOT stripped — "and" is a prefix of a real name, not a conjunction
 		{"Anders Bergman", "Anders Bergman"},
 		{"Andrea Cremer", "Andrea Cremer"},
+		// Stripped, but the result is still not an author. These rows exist in
+		// production ("So Long, and Thanks for All the Fish" reached an artist
+		// tag and the comma branch split the title). Stripping is correct for a
+		// genuine "A, B, and C" credit list, so the pattern keeps "and" — but
+		// the data repair deliberately matches "&" only, because renaming these
+		// would launder obviously-broken rows into plausible-looking ones
+		// without fixing anything. See todo.d/20260814-author-html-entity-rows.md.
+		{"and Thanks for All the Fish", "Thanks for All the Fish"},
 		// unaffected ordinary names
 		{"Paul McGann", "Paul McGann"},
 		{"S.A. Corey", "S. A. Corey"},

--- a/internal/dedup/author_leading_conjunction_test.go
+++ b/internal/dedup/author_leading_conjunction_test.go
@@ -1,0 +1,107 @@
+// file: internal/dedup/author_leading_conjunction_test.go
+// version: 1.0.0
+// guid: 7c2d9e14-5b83-4a67-9f02-1d8e3a6b4c95
+// last-edited: 2026-08-14
+
+package dedup
+
+import "testing"
+
+// TestSplitCompositeAuthorName_OxfordCommaAmpersand pins the defect that created
+// 48 author rows beginning with "& " in production (ids 46411-46764, one Big
+// Finish import run).
+//
+// The literal string below is the real album_artist tag read from
+// "The Creed of the Kromon - Paul McGann - read by Philip Martin.m4b" on
+// 2026-08-13. It is NOT a synthetic example: an Oxford comma before the
+// ampersand is the only comma shape that strands the "&" on the final name.
+// A non-Oxford "A, B & C" yields "B & C", which is a different (and much more
+// visible) corruption.
+//
+// The comma branch of SplitCompositeAuthorName runs before the " & " branch and
+// accepts any part containing a space, so "& Conrad Westmaas" passes validation
+// and NormalizeAuthorName never strips the leading conjunction.
+func TestSplitCompositeAuthorName_OxfordCommaAmpersand(t *testing.T) {
+	const realWorldTag = "Paul McGann, India Fisher, & Conrad Westmaas"
+
+	got := SplitCompositeAuthorName(realWorldTag)
+	want := []string{"Paul McGann", "India Fisher", "Conrad Westmaas"}
+
+	if len(got) != len(want) {
+		t.Fatalf("SplitCompositeAuthorName(%q) = %v (len %d), want %v (len %d)",
+			realWorldTag, got, len(got), want, len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("part %d = %q, want %q (leading conjunction not stripped)", i, got[i], want[i])
+		}
+	}
+}
+
+// TestSplitCompositeAuthorName_LeadingConjunctionAllBranches proves the fix is
+// at the shared chokepoint rather than patched into the comma branch alone.
+// Every delimiter branch funnels through NormalizeAuthorName, and every one of
+// them had the same hole: the per-part validity test only asks whether the part
+// contains a space, which "& Some Name" satisfies.
+func TestSplitCompositeAuthorName_LeadingConjunctionAllBranches(t *testing.T) {
+	tests := []struct {
+		branch string
+		input  string
+		want   []string
+	}{
+		{"comma", "Paul McGann, India Fisher, & Conrad Westmaas",
+			[]string{"Paul McGann", "India Fisher", "Conrad Westmaas"}},
+		{"slash", "Jane Roe / & John Doe",
+			[]string{"Jane Roe", "John Doe"}},
+		{"semicolon", "Jane Roe; & John Doe",
+			[]string{"Jane Roe", "John Doe"}},
+		{"comma-and-word", "Paul McGann, India Fisher, and Conrad Westmaas",
+			[]string{"Paul McGann", "India Fisher", "Conrad Westmaas"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.branch, func(t *testing.T) {
+			got := SplitCompositeAuthorName(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("SplitCompositeAuthorName(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("part %d = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestNormalizeAuthorName_LeadingConjunction guards the chokepoint directly,
+// including the two rows that must NOT be rewritten.
+//
+// "&#169" is a decapitated HTML entity (©) that also reached the author table.
+// It is a DIFFERENT defect (copyright text in the artist tag) and a bare "^&"
+// strip would mangle it into "#169" — strictly worse than leaving it. Requiring
+// whitespace after the conjunction is what keeps the two bugs separate.
+func TestNormalizeAuthorName_LeadingConjunction(t *testing.T) {
+	tests := []struct{ in, want string }{
+		// stripped
+		{"& Conrad Westmaas", "Conrad Westmaas"},
+		{"&  Lisa Bowerman", "Lisa Bowerman"},
+		{"and Sadie Miller", "Sadie Miller"},
+		{"And Sadie Miller", "Sadie Miller"},
+		{"AND Sadie Miller", "Sadie Miller"},
+		// NOT stripped — no trailing whitespace after the conjunction
+		{"&#169", "&#169"},
+		{"&#169;2013 by HarperCollinsPublishers", "&#169;2013 by HarperCollinsPublishers"},
+		// NOT stripped — "and" is a prefix of a real name, not a conjunction
+		{"Anders Bergman", "Anders Bergman"},
+		{"Andrea Cremer", "Andrea Cremer"},
+		// unaffected ordinary names
+		{"Paul McGann", "Paul McGann"},
+		{"S.A. Corey", "S. A. Corey"},
+	}
+	for _, tt := range tests {
+		if got := NormalizeAuthorName(tt.in); got != tt.want {
+			t.Errorf("NormalizeAuthorName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/plugins/maintenance/author_conjunction_repair.go
+++ b/internal/plugins/maintenance/author_conjunction_repair.go
@@ -52,14 +52,14 @@ var authorConjunctionRe = regexp.MustCompile(`^&\s+`)
 // authorConjunctionRepairParams controls the repair.
 type authorConjunctionRepairParams struct {
 	// DryRun reports what WOULD be written without writing it. Defaults to
-	// TRUE. The population is small enough (48 rows on 2026-08-14) that the
+	// TRUE. The population is small enough (46 rows on 2026-08-14) that the
 	// full per-row plan is readable, and merges delete author rows — a
 	// destructive step that deserves to be read before it runs.
 	DryRun *bool `json:"dry_run,omitempty"`
 }
 
 // Repair outcomes — every matched author lands in exactly one bucket and all
-// buckets are reported. A summary of "scanned 9350, repaired 48" that does not
+// buckets are reported. A summary of "scanned 9350, repaired 46" that does not
 // account for the rest is the shape of report that hides a bug.
 const (
 	conjRepairMerged      = "merged_into_existing"
@@ -116,7 +116,9 @@ func (p *Plugin) runAuthorConjunctionRepair(ctx context.Context, rawParams json.
 	}
 
 	// Select first, then act. The matched set is tiny relative to the table
-	// (48 of 9,350 on 2026-08-14), and reporting the selection size separately
+	// (46 of 9,350 on 2026-08-14 — 48 author names begin with '&', but two are
+	// the '&#169' HTML-entity rows this op correctly does not match), and
+	// reporting the selection size separately
 	// from the table size is what makes a zero-match run readable as "nothing
 	// to do" rather than "the scan did not run".
 	var matched []database.Author
@@ -143,7 +145,7 @@ func (p *Plugin) runAuthorConjunctionRepair(ctx context.Context, rawParams json.
 	// SetBookAuthors); two workers repairing two different "&" rows that appear
 	// on the SAME book would lose one another's update. Partitioning by author
 	// does not make the work disjoint, because the unit actually mutated is the
-	// book. Second, the matched set is 48 rows carrying 146 books — the whole
+	// book. Second, the matched set is 46 rows carrying 145 books — the whole
 	// run is seconds, so a pool would add a race window to buy nothing.
 	for i, author := range matched {
 		if ctx.Err() != nil {
@@ -153,7 +155,7 @@ func (p *Plugin) runAuthorConjunctionRepair(ctx context.Context, rawParams json.
 		// Use the same normalizer the forward fix installed, so a repaired name
 		// is byte-identical to what a re-import would now produce rather than
 		// merely similar. For the current population this equals a plain strip:
-		// none of the 48 rows contain collapsed initials for it to expand.
+		// none of the 46 rows contain collapsed initials for it to expand.
 		cleaned := dedup.NormalizeAuthorName(author.Name)
 		if cleaned == "" || cleaned == author.Name {
 			outcomes[conjRepairSkipNoop]++
@@ -225,7 +227,7 @@ func (p *Plugin) runAuthorConjunctionRepair(ctx context.Context, rawParams json.
 // the `from` row. It returns the number of books whose author slice was
 // rewritten.
 //
-// The link that matters is the BookAuthor join slice, not Book.AuthorID: all 48
+// The link that matters is the BookAuthor join slice, not Book.AuthorID: all 46
 // stranded rows sit at position 1+ of a credit list, which is why every one of
 // them reports file_count=0 while carrying books. A merge that only rewrote
 // AuthorID would report success and change nothing.

--- a/internal/plugins/maintenance/author_conjunction_repair.go
+++ b/internal/plugins/maintenance/author_conjunction_repair.go
@@ -1,0 +1,320 @@
+// file: internal/plugins/maintenance/author_conjunction_repair.go
+// version: 1.0.0
+// guid: 2f8a41c6-9d73-4e05-b18a-6c4f2e93d70b
+// last-edited: 2026-08-14
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// --- author-conjunction-repair ---
+//
+// Repairs author rows left named "& Conrad Westmaas" by the ordering bug in
+// dedup.SplitCompositeAuthorName (fixed 2026-08-14). The source is an
+// Oxford-comma credit list; the real album_artist tag on The Creed of the Kromon
+// reads "Paul McGann, India Fisher, & Conrad Westmaas". The comma branch ran
+// before the " & " branch and accepted "& Conrad Westmaas" because its only
+// validity test was "contains a space".
+//
+// This op repairs the rows that bug already created. The forward fix does not
+// touch them: nothing re-normalizes an author name after creation.
+
+// authorConjunctionRe deliberately matches "&" ONLY, and is therefore NARROWER
+// than the pattern in dedup.NormalizeAuthorName, which also strips "and".
+//
+// That difference is the whole point and must not be "tidied up" into a shared
+// constant. Three production rows begin with "and " — "and Thanks for All the
+// Fish" (from So Long, and Thanks for All the Fish), "and the Farm Boy (DBY)",
+// and "and Make Better Decisions". They are not stranded conjunctions from a
+// credit list; they are book TITLES that reached an artist tag and were then
+// comma-split. Stripping "and" from them yields "Thanks for All the Fish",
+// which is still not an author — it merely stops looking broken. Laundering an
+// obviously-corrupt row into a plausible one is worse than leaving it visible,
+// so those rows are left alone for a separate fix that addresses the real
+// defect (the comma branch cannot tell a person from a title clause).
+//
+// Stripping "and" IS correct in the forward path, where "A, B, and C" is a
+// genuine credit list. The two pattern widths are correct for their two jobs.
+var authorConjunctionRe = regexp.MustCompile(`^&\s+`)
+
+// authorConjunctionRepairParams controls the repair.
+type authorConjunctionRepairParams struct {
+	// DryRun reports what WOULD be written without writing it. Defaults to
+	// TRUE. The population is small enough (48 rows on 2026-08-14) that the
+	// full per-row plan is readable, and merges delete author rows — a
+	// destructive step that deserves to be read before it runs.
+	DryRun *bool `json:"dry_run,omitempty"`
+}
+
+// Repair outcomes — every matched author lands in exactly one bucket and all
+// buckets are reported. A summary of "scanned 9350, repaired 48" that does not
+// account for the rest is the shape of report that hides a bug.
+const (
+	conjRepairMerged      = "merged_into_existing"
+	conjRepairRenamed     = "renamed_in_place"
+	conjRepairWouldMerge  = "would_merge_into_existing"
+	conjRepairWouldRename = "would_rename_in_place"
+	conjRepairSkipNoop    = "skip_strip_changed_nothing"
+	conjRepairFailed      = "failed"
+)
+
+func (p *Plugin) authorConjunctionRepairDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "maintenance.author-conjunction-repair",
+		Plugin:      "maintenance",
+		DisplayName: "Repair author names with a stranded ampersand",
+		Description: "Repairs author rows named like '& Conrad Westmaas', created when an " +
+			"Oxford-comma credit list ('A, B, & C') was split on the comma before the ampersand " +
+			"branch could run. Merges each row into the correctly-named author when one already " +
+			"exists, otherwise renames it in place. Matches '&' only — rows beginning with 'and ' " +
+			"are book-title fragments and are deliberately left alone. Defaults to dry_run=true; " +
+			"pass dry_run=false to write.",
+		ResumePolicy:    sdk.ResumeRestart,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.author-conjunction-repair",
+		Writes:          []sdk.Resource{sdk.ResBooks},
+		Reads:           []sdk.Resource{sdk.ResBooks},
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         30 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runAuthorConjunctionRepair,
+	}
+}
+
+func (p *Plugin) runAuthorConjunctionRepair(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	var params authorConjunctionRepairParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("maintenance.author-conjunction-repair: decode params: %w", err)
+		}
+	}
+	dryRun := params.DryRun == nil || *params.DryRun
+
+	log := reporter.Logger()
+
+	authors, err := store.GetAllAuthors()
+	if err != nil {
+		return fmt.Errorf("get all authors: %w", err)
+	}
+
+	// Select first, then act. The matched set is tiny relative to the table
+	// (48 of 9,350 on 2026-08-14), and reporting the selection size separately
+	// from the table size is what makes a zero-match run readable as "nothing
+	// to do" rather than "the scan did not run".
+	var matched []database.Author
+	for _, a := range authors {
+		if authorConjunctionRe.MatchString(strings.TrimSpace(a.Name)) {
+			matched = append(matched, a)
+		}
+	}
+
+	log.Info("author-conjunction-repair: starting",
+		"dry_run", dryRun, "authors_total", len(authors), "authors_matched", len(matched))
+
+	outcomes := map[string]int{}
+	booksRelinked := 0
+
+	prog := sdk.NewProgress(reporter, len(matched))
+	prog.Start(fmt.Sprintf("Repairing %d author rows with a stranded ampersand (dry_run=%v)", len(matched), dryRun))
+
+	// Deliberately SEQUENTIAL, against the repo's default preference for a
+	// bounded worker pool on library-scale loops.
+	//
+	// Two reasons, both correctness rather than convenience. First, the merge
+	// path is a read-modify-write of a book's author slice (GetBookAuthors →
+	// SetBookAuthors); two workers repairing two different "&" rows that appear
+	// on the SAME book would lose one another's update. Partitioning by author
+	// does not make the work disjoint, because the unit actually mutated is the
+	// book. Second, the matched set is 48 rows carrying 146 books — the whole
+	// run is seconds, so a pool would add a race window to buy nothing.
+	for i, author := range matched {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		// Use the same normalizer the forward fix installed, so a repaired name
+		// is byte-identical to what a re-import would now produce rather than
+		// merely similar. For the current population this equals a plain strip:
+		// none of the 48 rows contain collapsed initials for it to expand.
+		cleaned := dedup.NormalizeAuthorName(author.Name)
+		if cleaned == "" || cleaned == author.Name {
+			outcomes[conjRepairSkipNoop]++
+			prog.StepN(i+1, fmt.Sprintf("%d/%d", i+1, len(matched)))
+			continue
+		}
+
+		twin, err := store.GetAuthorByName(cleaned)
+		if err != nil {
+			outcomes[conjRepairFailed]++
+			log.Warn("author-conjunction-repair: twin lookup failed",
+				"author_id", author.ID, "name", author.Name, "cleaned", cleaned, "err", err)
+			prog.StepN(i+1, fmt.Sprintf("%d/%d", i+1, len(matched)))
+			continue
+		}
+
+		if twin != nil && twin.ID != author.ID {
+			relinked, err := p.mergeAuthorInto(ctx, author, *twin, dryRun, log)
+			if err != nil {
+				outcomes[conjRepairFailed]++
+				log.Warn("author-conjunction-repair: merge failed",
+					"from_id", author.ID, "from", author.Name,
+					"into_id", twin.ID, "into", twin.Name, "err", err)
+			} else {
+				booksRelinked += relinked
+				if dryRun {
+					outcomes[conjRepairWouldMerge]++
+				} else {
+					outcomes[conjRepairMerged]++
+				}
+				log.Info("author-conjunction-repair: merge",
+					"dry_run", dryRun, "from_id", author.ID, "from", author.Name,
+					"into_id", twin.ID, "into", twin.Name, "books", relinked)
+			}
+			prog.StepN(i+1, fmt.Sprintf("%d/%d", i+1, len(matched)))
+			continue
+		}
+
+		// No existing author by the cleaned name — rename in place. This keeps
+		// the row's id, so every book already linked to it stays linked and no
+		// book rows are touched at all.
+		if dryRun {
+			outcomes[conjRepairWouldRename]++
+			log.Info("author-conjunction-repair: rename",
+				"dry_run", true, "author_id", author.ID, "from", author.Name, "to", cleaned)
+		} else if err := store.UpdateAuthorName(author.ID, cleaned); err != nil {
+			outcomes[conjRepairFailed]++
+			log.Warn("author-conjunction-repair: rename failed",
+				"author_id", author.ID, "from", author.Name, "to", cleaned, "err", err)
+		} else {
+			outcomes[conjRepairRenamed]++
+			log.Info("author-conjunction-repair: rename",
+				"dry_run", false, "author_id", author.ID, "from", author.Name, "to", cleaned)
+		}
+		prog.StepN(i+1, fmt.Sprintf("%d/%d", i+1, len(matched)))
+	}
+
+	summary := fmt.Sprintf(
+		"author-conjunction-repair complete (dry_run=%v): matched=%d of %d authors, books_relinked=%d, outcomes=%v",
+		dryRun, len(matched), len(authors), booksRelinked, outcomes)
+	log.Info("author-conjunction-repair: done",
+		"dry_run", dryRun, "authors_total", len(authors), "authors_matched", len(matched),
+		"books_relinked", booksRelinked, "outcomes", outcomes)
+	prog.Done(summary)
+	return nil
+}
+
+// mergeAuthorInto moves every book link from `from` onto `into` and then deletes
+// the `from` row. It returns the number of books whose author slice was
+// rewritten.
+//
+// The link that matters is the BookAuthor join slice, not Book.AuthorID: all 48
+// stranded rows sit at position 1+ of a credit list, which is why every one of
+// them reports file_count=0 while carrying books. A merge that only rewrote
+// AuthorID would report success and change nothing.
+func (p *Plugin) mergeAuthorInto(ctx context.Context, from, into database.Author, dryRun bool, log *slog.Logger) (int, error) {
+	store := p.deps.Store()
+
+	books, err := store.GetBooksByAuthorIDWithRoleCore(from.ID)
+	if err != nil {
+		return 0, fmt.Errorf("get books for author %d: %w", from.ID, err)
+	}
+
+	relinked := 0
+	for _, book := range books {
+		if ctx.Err() != nil {
+			return relinked, ctx.Err()
+		}
+
+		bookAuthors, err := store.GetBookAuthors(book.ID)
+		if err != nil {
+			// Do NOT fall through to DeleteAuthor after this: dropping the row
+			// while a book still points at it orphans that book's author
+			// reference. Same failure H8 documented on the split scan.
+			return relinked, fmt.Errorf("get book authors for %s: %w", book.ID, err)
+		}
+
+		// Preserve the role the stranded row carried, and note whether the
+		// target is already on this book — a credit list can name both.
+		role := "author"
+		targetAlreadyLinked := false
+		for _, ba := range bookAuthors {
+			if ba.AuthorID == from.ID {
+				role = ba.Role
+			}
+			if ba.AuthorID == into.ID {
+				targetAlreadyLinked = true
+			}
+		}
+
+		var updated []database.BookAuthor
+		for _, ba := range bookAuthors {
+			if ba.AuthorID == from.ID {
+				continue
+			}
+			updated = append(updated, ba)
+		}
+		if !targetAlreadyLinked {
+			updated = append(updated, database.BookAuthor{
+				BookID:   book.ID,
+				AuthorID: into.ID,
+				Role:     role,
+				Position: len(updated),
+			})
+		}
+
+		if dryRun {
+			relinked++
+			continue
+		}
+
+		if err := store.SetBookAuthors(book.ID, updated); err != nil {
+			return relinked, fmt.Errorf("set book authors for %s: %w", book.ID, err)
+		}
+
+		// If the stranded row was somehow also the denormalized primary, move
+		// that too. Hydrate the full row rather than writing the BookCore
+		// projection: BookCore has heavy fields nil, and its guard-preserved
+		// Author would still name the row being deleted (STOREFID W5d-1).
+		if book.AuthorID != nil && *book.AuthorID == from.ID {
+			if full, err := store.GetBookByID(book.ID); err == nil && full != nil {
+				target := into
+				full.AuthorID = &into.ID
+				full.Author = &target
+				if _, err := store.UpdateBook(book.ID, full); err != nil {
+					log.Warn("author-conjunction-repair: primary author rewrite failed",
+						"book_id", book.ID, "err", err)
+				}
+			} else {
+				log.Warn("author-conjunction-repair: hydrate failed, primary author left stale",
+					"book_id", book.ID, "err", err)
+			}
+		}
+		relinked++
+	}
+
+	if dryRun {
+		return relinked, nil
+	}
+	if err := store.DeleteAuthor(from.ID); err != nil {
+		return relinked, fmt.Errorf("delete author %d: %w", from.ID, err)
+	}
+	return relinked, nil
+}

--- a/internal/plugins/maintenance/author_conjunction_repair_test.go
+++ b/internal/plugins/maintenance/author_conjunction_repair_test.go
@@ -1,0 +1,242 @@
+// file: internal/plugins/maintenance/author_conjunction_repair_test.go
+// version: 1.0.0
+// guid: 8e35b7d2-1c40-4f96-a2e7-5b9d0c68a341
+// last-edited: 2026-08-14
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// conjRepairWrites records every mutating call the op makes, so a dry-run test
+// can assert on silence rather than on a return value.
+type conjRepairWrites struct {
+	setBookAuthors  map[string][]database.BookAuthor
+	deletedAuthors  []int
+	renamedAuthors  map[int]string
+	updatedBooks    []string
+	getBookAuthorsN int
+}
+
+// newConjRepairPlugin wires a MockStore around a fixed author table and a
+// book<->author join table.
+func newConjRepairPlugin(
+	authors []database.Author,
+	booksByAuthor map[int][]database.BookCore,
+	joins map[string][]database.BookAuthor,
+	w *conjRepairWrites,
+) *Plugin {
+	w.setBookAuthors = map[string][]database.BookAuthor{}
+	w.renamedAuthors = map[int]string{}
+
+	store := &database.MockStore{
+		GetAllAuthorsFunc: func() ([]database.Author, error) { return authors, nil },
+		GetAuthorByNameFunc: func(name string) (*database.Author, error) {
+			for i := range authors {
+				if authors[i].Name == name {
+					return &authors[i], nil
+				}
+			}
+			return nil, nil
+		},
+		GetBooksByAuthorIDWithRoleFunc: func(authorID int) ([]database.BookCore, error) {
+			return booksByAuthor[authorID], nil
+		},
+		GetBookAuthorsFunc: func(bookID string) ([]database.BookAuthor, error) {
+			w.getBookAuthorsN++
+			return joins[bookID], nil
+		},
+		SetBookAuthorsFunc: func(bookID string, ba []database.BookAuthor) error {
+			w.setBookAuthors[bookID] = ba
+			return nil
+		},
+		DeleteAuthorFunc: func(id int) error {
+			w.deletedAuthors = append(w.deletedAuthors, id)
+			return nil
+		},
+		UpdateAuthorNameFunc: func(id int, name string) error {
+			w.renamedAuthors[id] = name
+			return nil
+		},
+	}
+	return New(&fakeDeps{store: store})
+}
+
+func conjRepairParams(dryRun bool) json.RawMessage {
+	b, _ := json.Marshal(authorConjunctionRepairParams{DryRun: &dryRun})
+	return b
+}
+
+// TestAuthorConjunctionRepair_MergesIntoExistingTwin covers the majority case:
+// 31 of the 48 production rows have a correctly-named twin already in the table.
+// The stranded row must lose its book links to the twin and then be deleted.
+//
+// The assertion that matters is on SetBookAuthors, not on Book.AuthorID: every
+// stranded row sits at position 1+ of a credit list, so a merge that only
+// rewrote the denormalized primary would report success and move nothing.
+func TestAuthorConjunctionRepair_MergesIntoExistingTwin(t *testing.T) {
+	authors := []database.Author{
+		{ID: 43620, Name: "Paul McGann"},
+		{ID: 46751, Name: "& Conrad Westmaas"},
+		{ID: 44001, Name: "Conrad Westmaas"},
+	}
+	primary := 43620
+	booksByAuthor := map[int][]database.BookCore{
+		46751: {{ID: "b1", AuthorID: &primary}},
+	}
+	joins := map[string][]database.BookAuthor{
+		"b1": {
+			{BookID: "b1", AuthorID: 43620, Role: "author", Position: 0},
+			{BookID: "b1", AuthorID: 46751, Role: "author", Position: 1},
+		},
+	}
+
+	var w conjRepairWrites
+	p := newConjRepairPlugin(authors, booksByAuthor, joins, &w)
+	if err := p.runAuthorConjunctionRepair(context.Background(), conjRepairParams(false), &fakeReporter{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, ok := w.setBookAuthors["b1"]
+	if !ok {
+		t.Fatalf("SetBookAuthors was never called for b1 — the join slice carries the link, so the merge moved nothing")
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 author links on b1, got %d: %+v", len(got), got)
+	}
+	for _, ba := range got {
+		if ba.AuthorID == 46751 {
+			t.Errorf("stranded author 46751 still linked to b1: %+v", got)
+		}
+	}
+	foundTwin := false
+	for _, ba := range got {
+		if ba.AuthorID == 44001 {
+			foundTwin = true
+			if ba.Role != "author" {
+				t.Errorf("role not preserved on relink: got %q, want %q", ba.Role, "author")
+			}
+		}
+	}
+	if !foundTwin {
+		t.Errorf("twin author 44001 was not linked to b1: %+v", got)
+	}
+
+	if len(w.deletedAuthors) != 1 || w.deletedAuthors[0] != 46751 {
+		t.Errorf("expected author 46751 deleted, got %v", w.deletedAuthors)
+	}
+	if len(w.renamedAuthors) != 0 {
+		t.Errorf("merge path must not rename anything, got %v", w.renamedAuthors)
+	}
+}
+
+// TestAuthorConjunctionRepair_RenamesWhenNoTwin covers the other 17 rows. A
+// rename keeps the row id, so no book link is touched at all — asserting that
+// SetBookAuthors stays silent is the point of the test.
+func TestAuthorConjunctionRepair_RenamesWhenNoTwin(t *testing.T) {
+	authors := []database.Author{
+		{ID: 46751, Name: "& Conrad Westmaas"},
+	}
+	var w conjRepairWrites
+	p := newConjRepairPlugin(authors, nil, nil, &w)
+	if err := p.runAuthorConjunctionRepair(context.Background(), conjRepairParams(false), &fakeReporter{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := w.renamedAuthors[46751]; got != "Conrad Westmaas" {
+		t.Errorf("expected rename to %q, got %q", "Conrad Westmaas", got)
+	}
+	if len(w.deletedAuthors) != 0 {
+		t.Errorf("rename path must not delete anything, got %v", w.deletedAuthors)
+	}
+	if len(w.setBookAuthors) != 0 {
+		t.Errorf("rename keeps the row id — no book link should be rewritten, got %v", w.setBookAuthors)
+	}
+}
+
+// TestAuthorConjunctionRepair_DryRunWritesNothing pins the default. dry_run is
+// the zero-value behaviour (nil pointer → true), and the merge path is
+// destructive: it deletes an author row.
+func TestAuthorConjunctionRepair_DryRunWritesNothing(t *testing.T) {
+	authors := []database.Author{
+		{ID: 46751, Name: "& Conrad Westmaas"},
+		{ID: 44001, Name: "Conrad Westmaas"},
+		{ID: 46411, Name: "& Patricia Merrick"}, // no twin → would rename
+	}
+	booksByAuthor := map[int][]database.BookCore{
+		46751: {{ID: "b1"}},
+	}
+	joins := map[string][]database.BookAuthor{
+		"b1": {{BookID: "b1", AuthorID: 46751, Role: "author", Position: 0}},
+	}
+
+	for _, tc := range []struct {
+		name   string
+		params json.RawMessage
+	}{
+		{"explicit dry_run=true", conjRepairParams(true)},
+		{"omitted params default to dry run", nil},
+		{"empty object defaults to dry run", json.RawMessage(`{}`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var w conjRepairWrites
+			p := newConjRepairPlugin(authors, booksByAuthor, joins, &w)
+			if err := p.runAuthorConjunctionRepair(context.Background(), tc.params, &fakeReporter{}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(w.setBookAuthors) != 0 {
+				t.Errorf("dry run wrote book authors: %v", w.setBookAuthors)
+			}
+			if len(w.deletedAuthors) != 0 {
+				t.Errorf("dry run deleted authors: %v", w.deletedAuthors)
+			}
+			if len(w.renamedAuthors) != 0 {
+				t.Errorf("dry run renamed authors: %v", w.renamedAuthors)
+			}
+			// It must still have done the READ work — a dry run that skips the
+			// scan reports "nothing to do" and looks identical to a clean table.
+			if w.getBookAuthorsN == 0 {
+				t.Errorf("dry run never inspected book authors; it cannot have planned anything")
+			}
+		})
+	}
+}
+
+// TestAuthorConjunctionRepair_LeavesNonAmpersandRowsAlone is the guard that
+// keeps this op narrower than dedup.NormalizeAuthorName.
+//
+// The "and " rows are book-title fragments ("So Long, and Thanks for All the
+// Fish"), not stranded conjunctions; renaming them yields something that is
+// still not an author but no longer looks broken. The "&#169" rows are
+// decapitated HTML entities from a copyright string. All are a different defect
+// and must survive this op untouched.
+func TestAuthorConjunctionRepair_LeavesNonAmpersandRowsAlone(t *testing.T) {
+	authors := []database.Author{
+		{ID: 46595, Name: "and Thanks for All the Fish"},
+		{ID: 46989, Name: "and the Farm Boy (DBY)"},
+		{ID: 47193, Name: "and Make Better Decisions"},
+		{ID: 46583, Name: "&#169"},
+		{ID: 51870, Name: "&#169;2013 by HarperCollinsPublishers"},
+		{ID: 38542, Name: "Dan Simmons"},
+		{ID: 44444, Name: "Anders Bergman"},
+	}
+	var w conjRepairWrites
+	p := newConjRepairPlugin(authors, nil, nil, &w)
+	if err := p.runAuthorConjunctionRepair(context.Background(), conjRepairParams(false), &fakeReporter{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(w.renamedAuthors) != 0 {
+		t.Errorf("no row here is a stranded conjunction; got renames %v", w.renamedAuthors)
+	}
+	if len(w.deletedAuthors) != 0 {
+		t.Errorf("no row here should be deleted; got %v", w.deletedAuthors)
+	}
+	if len(w.setBookAuthors) != 0 {
+		t.Errorf("no book link should be rewritten; got %v", w.setBookAuthors)
+	}
+}

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/plugin.go
-// version: 1.18.0
+// version: 1.19.0
 // guid: b2c3d4e5-f6a7-8901-bcde-123456789012
-// last-edited: 2026-08-13
+// last-edited: 2026-08-14
 
 package maintenance
 
@@ -54,6 +54,10 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		// --- author/series ---
 		p.authorDedupScanDef(),
 		p.authorSplitScanDef(),
+		// author-conjunction-repair is NOT reachable from author-split-scan:
+		// SplitCompositeAuthorName("& Conrad Westmaas") returns nil (no
+		// delimiter, three words), so the split scan skips these rows entirely.
+		p.authorConjunctionRepairDef(),
 		p.seriesNormalizeDef(),
 		p.seriesPruneDef(),
 		p.resolveProductionAuthorsDef(),

--- a/todo.d/20260814-author-html-entity-rows.md
+++ b/todo.d/20260814-author-html-entity-rows.md
@@ -23,6 +23,32 @@ not mangle them.
 - [ ] Consider a `isDirtyAuthorName` rule for names starting with `©`/`&#`/a
       4-digit year, so these are rejected at creation instead of repaired later.
 
+## Author table: book titles are being comma-split into author rows
+
+Also found on 2026-08-14, and deliberately excluded from the leading-conjunction
+data repair. Three rows begin with `and ` but are **not** stranded conjunctions
+from a credit list — they are fragments of book titles that reached the artist
+tag and were then split on the comma:
+
+- [ ] id 46595 `and Thanks for All the Fish` (2 books) — from *So Long, and
+      Thanks for All the Fish*
+- [ ] id 46989 `and the Farm Boy (DBY)` (5 books)
+- [ ] id 47193 `and Make Better Decisions` (16 books)
+
+Stripping the leading `and` from these produces `Thanks for All the Fish`, which
+is still not an author — it just stops *looking* broken. The repair op therefore
+matches `&` only, and these three are left visibly wrong on purpose.
+
+- [ ] The real defect is that `SplitCompositeAuthorName`'s comma branch has no
+      notion of person-vs-title: its only per-part test is "contains a space".
+      A title clause passes as readily as a name.
+- [ ] Consider requiring a part to look like a personal name (2-4 words, no
+      leading lowercase function word, no trailing parenthetical like `(DBY)`)
+      before accepting a comma split, or refusing to split when the source
+      string also carries title-ish punctuation.
+- [ ] Check how many other author rows are title fragments without the `and`
+      giveaway — the 57 rows beginning with `-` are the next place to look.
+
 ## Author table: misspelling shared by both rows of a duplicate pair
 
 - [ ] `Sylverster McCoy` (2 books) and `& Sylverster McCoy` (1 book) are *both*

--- a/todo.d/20260814-author-html-entity-rows.md
+++ b/todo.d/20260814-author-html-entity-rows.md
@@ -1,0 +1,31 @@
+## Author table: copyright text and HTML entities leaked into artist tags
+
+Found while fixing the stranded-`&` author rows (`dedup.NormalizeAuthorName`,
+2026-08-14). These are a **different** defect and were deliberately left alone —
+the leading-conjunction strip requires trailing whitespace precisely so it does
+not mangle them.
+
+- [ ] Author id 46583 is named `&#169` — an HTML entity for `©` with its
+      trailing `;` already lost somewhere upstream. 1 book attached.
+- [ ] Author id 51870 is named `&#169;2013 by HarperCollinsPublishers` — a whole
+      copyright line stored as an author. 0 books attached, so it can likely just
+      be deleted.
+- [ ] Find where the entity loses its `;`. `SplitCompositeAuthorName`'s semicolon
+      branch splits `&#169;2013 by HarperCollinsPublishers` into `["&#169",
+      "2013 by HarperCollinsPublishers"]` but then discards the result because
+      `&#169` has no space and only one part survives — so the branch returns
+      nothing and is *not* the culprit. The truncation happens somewhere else.
+- [ ] Decide whether author-name ingest should HTML-unescape at all. If it should,
+      `html.UnescapeString` belongs at the same chokepoint, but note it would turn
+      `&#169;2013 by HarperCollinsPublishers` into `©2013 by
+      HarperCollinsPublishers` — still not an author, so entity decoding alone
+      does not fix the real problem, which is copyright text in an artist tag.
+- [ ] Consider a `isDirtyAuthorName` rule for names starting with `©`/`&#`/a
+      4-digit year, so these are rejected at creation instead of repaired later.
+
+## Author table: misspelling shared by both rows of a duplicate pair
+
+- [ ] `Sylverster McCoy` (2 books) and `& Sylverster McCoy` (1 book) are *both*
+      misspelled — the actor is Sylvester McCoy. Merging the `&` row into its twin
+      leaves the misspelling intact in the survivor. Worth a targeted rename after
+      the conjunction repair lands.


### PR DESCRIPTION
## What

48 author rows in the library are named `& Conrad Westmaas`, `& Lisa Bowerman`, `& India Fisher` and so on. They show up as separate authors on author pages and in dedup candidates, splitting a real person's books across two rows.

This PR fixes the code that creates them **and** adds an op to repair the ones already there.

## Root cause

Proven from the raw tag on disk, not inferred. The real `album_artist` on *The Creed of the Kromon*:

```
Paul McGann, India Fisher, & Conrad Westmaas
```

`dedup.SplitCompositeAuthorName` tries delimiters in order:

| line | branch | what happens |
|---|---|---|
| 173 | **comma** | splits on `,` — fires first |
| 183 | | per-part validity test is only `strings.Contains(p, " ")` |
| — | | `"& Conrad Westmaas"` **has** spaces → accepted |
| 187 | | `NormalizeAuthorName` never touched leading punctuation |
| 220 | `" & "` | the branch that handles this correctly — **unreachable** for exactly the inputs it targets |

An Oxford comma is the only comma shape that produces this: a non-Oxford `A, B & C` yields `B & C`, a different and far more visible corruption.

The slash, semicolon and bracket branches share the identical hole, so the fix goes at `NormalizeAuthorName` — the chokepoint all four already funnel through — rather than into the comma branch alone.

## Why the pattern requires trailing whitespace

`(?i)^(?:&|and)\s+`. Not cosmetic:

- `&#169` and `&#169;2013 by HarperCollinsPublishers` are real author rows — decapitated HTML entities for `©` from a copyright string in an artist tag. A bare `^&` strip rewrites the first to `#169`, strictly worse. Separate defect, filed.
- It also stops `and` eating the first syllable of `Anders Bergman` / `Andrea Cremer`.

## The repair op

`maintenance.author-conjunction-repair`, `dry_run=true` by default.

- **merge** — 31 rows whose correctly-named author already exists; links move, stranded row deleted
- **rename** — the other 17; row keeps its id, no book row touched

The link rewritten is the book↔author **join slice**, not `Book.AuthorID`. Every stranded row sits at position 1+ of a credit list, which is why all 48 report `file_count: 0` while carrying 146 books. A merge that only rewrote the denormalized primary would report success and move nothing — the tests assert on `SetBookAuthors` for that reason.

`maintenance.author-split-scan` cannot reach these rows: `SplitCompositeAuthorName("& Conrad Westmaas")` returns nil.

## Deliberately narrower than the forward fix

The repair matches `&` only. Three rows begin with `and `:

- `and Thanks for All the Fish` ← *So Long**, and Thanks for All the Fish***
- `and the Farm Boy (DBY)`
- `and Make Better Decisions`

Those are book **titles** that reached an artist tag, not stranded conjunctions. Renaming them gives `Thanks for All the Fish` — still not an author, just no longer obviously broken. Laundering a corrupt row into a plausible one is worse than leaving it visible. Excluded, and filed with the real defect: the comma branch cannot tell a person from a title clause.

## Sequential on purpose

The merge path is a read-modify-write of a book's author slice. Two workers repairing two different rows that appear on the same book would lose one another's update, and partitioning by author does not make the work disjoint — the unit actually mutated is the book. 48 rows / 146 books runs in seconds.

## Verification

- Tests written against the real production tag and **observed failing on all four delimiter branches** before the fix.
- Both repair guards mutation-tested: flipping the dry-run default reds the dry-run test; widening the regex to include `and` reds the exclusion test with exactly the laundering described above. Source restored byte-identical (sha verified).
- `go build ./...` exit 0; `go vet` exit 0 on all caller packages.
- `internal/dedup`, `internal/plugins/maintenance`, `internal/itunes/...`, `internal/scheduler`, `internal/server/handlers/entities`, `internal/util` all pass.

**Not yet run against prod.** The dry run is the next step and needs a look before any apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxigqrwz9WfwN1wx8QhoQW