### PR TITLE
feat(maintenance): skip_author_ids on the stranded-ampersand repair

### DIFF
--- a/changelog.d/20260814_013000_author_conjunction_repair_skip_ids.md
+++ b/changelog.d/20260814_013000_author_conjunction_repair_skip_ids.md
@@ -1,0 +1,28 @@
+### Added
+
+#### `skip_author_ids` on the stranded-ampersand repair
+
+`maintenance.author-conjunction-repair` now accepts `skip_author_ids`, excluding
+specific author rows from a run. Excluded rows stay in the matched total and are
+reported as `skip_explicitly_excluded`, so a partial run cannot be mistaken for a
+complete one.
+
+This exists because two dry runs of the same op against the same prod data
+returned different numbers. The first ran four seconds after a service restart,
+fell through to the Pebble junction scan, and reported `books_relinked=86`. The
+second ran against a warm memdb and reported `84`. Row counts were identical in
+both (`authors_matched=46`, 31 merge, 15 rename); the whole difference was author
+46627, `& Nicholas Courtney`, where Pebble holds two book links memdb does not.
+memdb had been freshly loaded, so its loader drops those links rather than
+lagging a write.
+
+That matters because the merge path relinks what it can see and then **deletes**
+the author row. Run through memdb it would relink zero books for 46627 and delete
+the author anyway, leaving two Pebble junction rows pointing at an author id that
+no longer exists — the orphaning hazard H8 documents on
+`maintenance.author-split-scan`.
+
+Excluding by id, rather than by a heuristic like "skip rows that report zero
+books", keeps the exclusion visible in the op's params and in its summary. The
+underlying divergence is filed separately; once it is understood the flag comes
+off and that row gets repaired with the rest.

--- a/internal/plugins/maintenance/author_conjunction_repair.go
+++ b/internal/plugins/maintenance/author_conjunction_repair.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/author_conjunction_repair.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2f8a41c6-9d73-4e05-b18a-6c4f2e93d70b
 // last-edited: 2026-08-14
 
@@ -56,6 +56,26 @@ type authorConjunctionRepairParams struct {
 	// full per-row plan is readable, and merges delete author rows — a
 	// destructive step that deserves to be read before it runs.
 	DryRun *bool `json:"dry_run,omitempty"`
+
+	// SkipAuthorIDs excludes specific author rows from the run, reported as
+	// their own outcome bucket rather than silently dropped.
+	//
+	// This exists because a merge DELETES an author row, and the op can only
+	// relink the books it can see. On 2026-08-14 two dry runs of this same op
+	// disagreed: the first ran four seconds after a restart and fell through to
+	// the Pebble junction scan, reporting books_relinked=86; the second ran
+	// against a warm memdb and reported 84. The whole difference was author
+	// 46627 ("& Nicholas Courtney"), where Pebble holds two book links memdb
+	// does not — and memdb had been freshly loaded, so its loader drops them
+	// rather than merely lagging.
+	//
+	// Merging such a row via the memdb path would relink zero books and then
+	// delete the author, leaving those Pebble junction rows pointing at an
+	// author id that no longer exists. That is the same orphaning hazard H8
+	// documents on the author split scan. Until the divergence is understood,
+	// the affected row is excluded by id rather than by a clever heuristic, so
+	// the exclusion is visible in the op's params and in its summary.
+	SkipAuthorIDs []int `json:"skip_author_ids,omitempty"`
 }
 
 // Repair outcomes — every matched author lands in exactly one bucket and all
@@ -67,6 +87,7 @@ const (
 	conjRepairWouldMerge  = "would_merge_into_existing"
 	conjRepairWouldRename = "would_rename_in_place"
 	conjRepairSkipNoop    = "skip_strip_changed_nothing"
+	conjRepairSkipListed  = "skip_explicitly_excluded"
 	conjRepairFailed      = "failed"
 )
 
@@ -80,7 +101,8 @@ func (p *Plugin) authorConjunctionRepairDef() sdk.OperationDef {
 			"branch could run. Merges each row into the correctly-named author when one already " +
 			"exists, otherwise renames it in place. Matches '&' only — rows beginning with 'and ' " +
 			"are book-title fragments and are deliberately left alone. Defaults to dry_run=true; " +
-			"pass dry_run=false to write.",
+			"pass dry_run=false to write. skip_author_ids excludes specific rows, reported as " +
+			"skip_explicitly_excluded rather than dropped from the totals.",
 		ResumePolicy:    sdk.ResumeRestart,
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.author-conjunction-repair",
@@ -107,6 +129,10 @@ func (p *Plugin) runAuthorConjunctionRepair(ctx context.Context, rawParams json.
 		}
 	}
 	dryRun := params.DryRun == nil || *params.DryRun
+	skip := make(map[int]struct{}, len(params.SkipAuthorIDs))
+	for _, id := range params.SkipAuthorIDs {
+		skip[id] = struct{}{}
+	}
 
 	log := reporter.Logger()
 
@@ -129,7 +155,8 @@ func (p *Plugin) runAuthorConjunctionRepair(ctx context.Context, rawParams json.
 	}
 
 	log.Info("author-conjunction-repair: starting",
-		"dry_run", dryRun, "authors_total", len(authors), "authors_matched", len(matched))
+		"dry_run", dryRun, "authors_total", len(authors), "authors_matched", len(matched),
+		"skip_author_ids", params.SkipAuthorIDs)
 
 	outcomes := map[string]int{}
 	booksRelinked := 0
@@ -150,6 +177,18 @@ func (p *Plugin) runAuthorConjunctionRepair(ctx context.Context, rawParams json.
 	for i, author := range matched {
 		if ctx.Err() != nil {
 			return ctx.Err()
+		}
+
+		// Excluded rows stay in `matched` and get their own bucket, so the
+		// summary still adds up to the number of rows the pattern selected. A
+		// row filtered out of the selection instead would make a partial run
+		// indistinguishable from a smaller library.
+		if _, ok := skip[author.ID]; ok {
+			outcomes[conjRepairSkipListed]++
+			log.Info("author-conjunction-repair: skipped by request",
+				"author_id", author.ID, "name", author.Name)
+			prog.StepN(i+1, fmt.Sprintf("%d/%d", i+1, len(matched)))
+			continue
 		}
 
 		// Use the same normalizer the forward fix installed, so a repaired name

--- a/internal/plugins/maintenance/author_conjunction_repair_test.go
+++ b/internal/plugins/maintenance/author_conjunction_repair_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/author_conjunction_repair_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8e35b7d2-1c40-4f96-a2e7-5b9d0c68a341
 // last-edited: 2026-08-14
 
@@ -72,8 +72,76 @@ func conjRepairParams(dryRun bool) json.RawMessage {
 	return b
 }
 
+func conjRepairParamsSkip(dryRun bool, skip ...int) json.RawMessage {
+	b, _ := json.Marshal(authorConjunctionRepairParams{DryRun: &dryRun, SkipAuthorIDs: skip})
+	return b
+}
+
+// TestAuthorConjunctionRepair_SkipAuthorIDs pins the exclusion added for author
+// 46627 ("& Nicholas Courtney"), where Pebble holds two book links memdb does
+// not. Merging it would relink zero books and then DELETE the author row,
+// orphaning those links.
+//
+// The excluded row must be neither merged nor renamed, the rows around it must
+// still be repaired, and the skip must be REPORTED — a run that quietly
+// processed 45 of 46 and said "46" would be the exact failure this bucket
+// exists to prevent.
+func TestAuthorConjunctionRepair_SkipAuthorIDs(t *testing.T) {
+	authors := []database.Author{
+		{ID: 46627, Name: "& Nicholas Courtney"},
+		{ID: 43791, Name: "Nicholas Courtney"},
+		{ID: 46751, Name: "& Conrad Westmaas"},
+		{ID: 44001, Name: "Conrad Westmaas"},
+		{ID: 46414, Name: "& Joe Thompson"}, // no twin → rename
+	}
+	booksByAuthor := map[int][]database.BookCore{
+		46627: {{ID: "skipbook"}},
+		46751: {{ID: "b1"}},
+	}
+	joins := map[string][]database.BookAuthor{
+		"skipbook": {{BookID: "skipbook", AuthorID: 46627, Role: "author", Position: 0}},
+		"b1":       {{BookID: "b1", AuthorID: 46751, Role: "author", Position: 0}},
+	}
+
+	var w conjRepairWrites
+	p := newConjRepairPlugin(authors, booksByAuthor, joins, &w)
+	if err := p.runAuthorConjunctionRepair(context.Background(), conjRepairParamsSkip(false, 46627), &fakeReporter{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The excluded row survives untouched.
+	for _, id := range w.deletedAuthors {
+		if id == 46627 {
+			t.Errorf("excluded author 46627 was deleted")
+		}
+	}
+	if _, renamed := w.renamedAuthors[46627]; renamed {
+		t.Errorf("excluded author 46627 was renamed to %q", w.renamedAuthors[46627])
+	}
+	if _, touched := w.setBookAuthors["skipbook"]; touched {
+		t.Errorf("excluded author's book was relinked: %v", w.setBookAuthors["skipbook"])
+	}
+
+	// Its neighbours are still repaired — the skip must not abort the run.
+	if _, ok := w.setBookAuthors["b1"]; !ok {
+		t.Errorf("non-excluded merge did not run; skip must not halt the loop")
+	}
+	if got := w.renamedAuthors[46414]; got != "Joe Thompson" {
+		t.Errorf("non-excluded rename did not run: got %q", got)
+	}
+	found := false
+	for _, id := range w.deletedAuthors {
+		if id == 46751 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("non-excluded merge did not delete its stranded row: %v", w.deletedAuthors)
+	}
+}
+
 // TestAuthorConjunctionRepair_MergesIntoExistingTwin covers the majority case:
-// 31 of the 48 production rows have a correctly-named twin already in the table.
+// 31 of the 46 production rows have a correctly-named twin already in the table.
 // The stranded row must lose its book links to the twin and then be deleted.
 //
 // The assertion that matters is on SetBookAuthors, not on Book.AuthorID: every
@@ -135,7 +203,7 @@ func TestAuthorConjunctionRepair_MergesIntoExistingTwin(t *testing.T) {
 	}
 }
 
-// TestAuthorConjunctionRepair_RenamesWhenNoTwin covers the other 17 rows. A
+// TestAuthorConjunctionRepair_RenamesWhenNoTwin covers the other 15 rows. A
 // rename keeps the row id, so no book link is touched at all — asserting that
 // SetBookAuthors stays silent is the point of the test.
 func TestAuthorConjunctionRepair_RenamesWhenNoTwin(t *testing.T) {

--- a/todo.d/20260814-memdb-pebble-author-link-divergence.md
+++ b/todo.d/20260814-memdb-pebble-author-link-divergence.md
@@ -1,0 +1,45 @@
+## memdb and Pebble disagree about author→book links
+
+Found 2026-08-14 by running `maintenance.author-conjunction-repair` twice in
+dry-run against prod and getting two different answers from the same op, same
+binary, same data.
+
+| run | started | path taken | `books_relinked` |
+|---|---|---|---|
+| 1 | 4s after service restart, memdb not yet warm | Pebble junction scan | **86** |
+| 2 | memdb warm | memdb | **84** |
+
+Row counts were identical in both (`authors_matched=46`,
+`would_merge_into_existing=31`, `would_rename_in_place=15`). The entire
+difference is **author 46627 (`& Nicholas Courtney`)**: the Pebble path finds 2
+book links, memdb finds 0.
+
+`GetBooksByAuthorIDCore` and `GetBooksByAuthorIDWithRoleCore` both take the same
+`p.mem().GetBooksByAuthorID(authorID, 0, 0)` branch when memdb is live, so this
+is not a caller difference — the two *stores* disagree. memdb had been freshly
+loaded at the restart, so its loader is dropping the links rather than lagging
+behind a write.
+
+- [ ] Identify the 2 books. They are not among `Nicholas Courtney` (43791)'s 7
+      books — none of those reference 46627 — so they are books where 46627 is
+      a co-author and 43791 is not linked at all.
+- [ ] Find why memdb's loader drops them. Suspects: the junction load skipping
+      rows whose book is soft-deleted, or an author-id index built only from
+      `Book.AuthorID`. Note `/api/v1/authors/46627/books` and the authors-list
+      `book_count` BOTH report 0, so every serving-layer read agrees with memdb
+      and only Pebble sees them.
+- [ ] Write the conformance test rather than a per-path assertion — one fixture,
+      both implementations, assert equal. This is the third memdb/Pebble
+      divergence in a week (see the soft-deleted leak, #2392), and per-path
+      expectations cannot catch drift because the path's own author writes the
+      expectation.
+- [ ] Once resolved, drop `skip_author_ids: [46627]` from the repair invocation
+      and repair that row. It is currently the ONLY unrepaired stranded-ampersand
+      author.
+
+**Why this blocked the repair:** the merge path relinks the books it can see and
+then DELETES the author row. Run through memdb it would relink 0 books for 46627
+and delete the author anyway, leaving the 2 Pebble junction rows pointing at an
+author id that no longer exists — the orphaning hazard H8 documents on
+`maintenance.author-split-scan`. The row was excluded by id for the 2026-08-14
+apply rather than papered over with a heuristic.


### PR DESCRIPTION
Follow-up to #2396. Needed before the prod apply can run.

## Why

Two dry runs of the **same op**, same binary, same data, returned different numbers:

| run | started | path taken | `books_relinked` |
|---|---|---|---|
| 1 | 4s after restart, memdb cold | Pebble junction scan | **86** |
| 2 | memdb warm | memdb | **84** |

Row counts were identical in both — `authors_matched=46`, 31 merge, 15 rename. The entire difference is **author 46627, `& Nicholas Courtney`**: Pebble holds 2 book links memdb does not.

`GetBooksByAuthorIDCore` and `GetBooksByAuthorIDWithRoleCore` both take the same `p.mem().GetBooksByAuthorID(...)` branch when memdb is live, so this is the two **stores** disagreeing, not the callers. memdb was freshly loaded at that restart, so its loader is dropping the links rather than lagging a write.

## Why it blocks the apply

The merge path relinks what it can see and then **deletes** the author row. Through memdb it would relink 0 books for 46627 and delete the author anyway, leaving 2 Pebble junction rows pointing at an author id that no longer exists — the orphaning hazard H8 documents on `author-split-scan`.

## What this adds

`skip_author_ids: [46627]`. Excluded rows **stay in the matched total** and report as `skip_explicitly_excluded`, so a run that processed 45 of 46 cannot be read as having done all of them.

Excluding by explicit id rather than a heuristic (`skip rows reporting zero books`) keeps the decision visible in the op params and summary, and avoids baking a guess about the divergence into the repair. When the divergence is understood the flag comes off and that row gets repaired with the rest.

## Verification

- Mutation-tested: deleting the skip check reds the new test with `excluded author 46627 was deleted`. Source restored byte-identical (sha `2858b141…` both sides).
- The new test also asserts the skip does **not** halt the loop — neighbouring merge and rename rows still run.
- `go vet` clean; `internal/plugins/maintenance` passes.

The divergence itself is filed in `todo.d/20260814-memdb-pebble-author-link-divergence.md`. It is the third memdb/Pebble disagreement this week and wants a conformance test, not another per-path assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxigqrwz9WfwN1wx8QhoQW