### PR TITLE
fix(series): stop pruning series that still have books

### DIFF
--- a/changelog.d/20260814_fixed_series_prune_unfiltered_orphan_test.md
+++ b/changelog.d/20260814_fixed_series_prune_unfiltered_orphan_test.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **Series prune no longer strands books.** `executeSeriesPrune` (behind both
+  `dedup.series-prune`, which the scheduler runs nightly, and
+  `maintenance.series-prune`) decided a series was an orphan using
+  `GetBooksBySeriesIDCore`, which skips trashed and non-primary books. A series
+  whose books were all in the trash, or all secondary versions, counted 0 and
+  was deleted while those books kept its `series_id`. On production 2026-08-14
+  this had already produced **6,893 series IDs referenced by 13,322 live books
+  (plus 702 trashed) with no series row** — those books render with no series at
+  all. Orphan detection now uses a new unfiltered reference count
+  (`GetAllSeriesBookRefCounts`) that counts every book naming a series whatever
+  its deletion or primary-version state, computed once per run rather than per
+  series. If the store cannot answer the unfiltered question the op now fails
+  loudly instead of falling back to the filtered counter.

--- a/internal/database/series_bookref.go
+++ b/internal/database/series_bookref.go
@@ -1,0 +1,135 @@
+// file: internal/database/series_bookref.go
+// version: 1.0.0
+// guid: 3b9d7c41-5e02-4a86-9f13-6c8ad20b47e5
+// last-edited: 2026-08-14
+
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// Unfiltered series reference counting, for DELETION decisions.
+//
+// WHY THIS EXISTS SEPARATELY FROM GetAllSeriesBookCounts
+//
+// GetAllSeriesBookCounts (and GetBooksBySeriesIDCore) skip two categories of
+// book:
+//
+//	if b.MarkedForDeletion != nil && *b.MarkedForDeletion { continue }
+//	if b.IsPrimaryVersion  != nil && !*b.IsPrimaryVersion  { continue }
+//
+// That is CORRECT for a display count — the trash and secondary versions must
+// not inflate a badge. It is WRONG as an existence test for deletion, and
+// executeSeriesPrune used it as exactly that: a series whose books are all
+// trashed, or all non-primary, counted 0 and was deleted while those books
+// stayed on disk pointing at a series ID that no longer resolves.
+//
+// Measured on production 2026-08-14, before this fix: 21,190 distinct series
+// IDs were referenced by books but only 14,626 series rows existed — 6,893
+// phantom IDs held by 13,322 live books plus 702 trashed ones, all rendering
+// with no series at all. The op runs in the NIGHTLY maintenance window
+// (scheduler task "series_prune" -> dedup.series-prune), so the damage
+// accumulated a night at a time.
+//
+// These counters therefore apply NO filters. Every book row that names a
+// series counts, whatever its deletion or primary-version state. "Is anything
+// still pointing at this row?" is a different question from "how many books
+// should I show the user", and conflating them is what caused the damage.
+
+// SeriesBookRefStore is a narrow capability interface, deliberately kept OUT of
+// database.Store — same rationale as BookSigMigrateStore: widening Store forces
+// every implementation and generated mock to grow with it. Reach it through
+// AsSeriesBookRefStore, which looks through the indexedStore decorator.
+type SeriesBookRefStore interface {
+	// GetAllSeriesBookRefCounts returns seriesID -> number of book rows that
+	// reference it, counting trashed and non-primary books. A series absent
+	// from the map is referenced by NOTHING and is safe to delete.
+	GetAllSeriesBookRefCounts() (map[int]int, error)
+}
+
+// AsSeriesBookRefStore returns s as a SeriesBookRefStore, or nil if the backing
+// store cannot answer the unfiltered question. Callers MUST nil-check and MUST
+// fail rather than falling back to the filtered counter — that fallback is the
+// bug this file exists to remove, and it would be silent.
+func AsSeriesBookRefStore(s any) SeriesBookRefStore {
+	if s == nil {
+		return nil
+	}
+	if rs, ok := AsCapability[SeriesBookRefStore](s); ok {
+		return rs
+	}
+	return nil
+}
+
+// GetAllSeriesBookRefCounts counts every book in the memdb that names a series,
+// with NO deletion or primary-version filtering. Contrast
+// GetAllSeriesBookCounts directly above, which scans only the
+// memIdxIsPrimaryVersion=true index and skips trashed rows.
+func (m *MemStore) GetAllSeriesBookRefCounts() (map[int]int, error) {
+	txn := m.db.Txn(false)
+	defer txn.Abort()
+
+	iter, err := txn.Get(memTableBooks, memIdxID)
+	if err != nil {
+		return nil, fmt.Errorf("memdb books scan: %w", err)
+	}
+	out := make(map[int]int)
+	for obj := iter.Next(); obj != nil; obj = iter.Next() {
+		b := obj.(*Book)
+		if b.SeriesID == nil {
+			continue
+		}
+		out[*b.SeriesID]++
+	}
+	return out, nil
+}
+
+// GetAllSeriesBookRefCounts prefers the memdb when it is warm (the prod
+// default) and otherwise scans Pebble directly.
+func (p *PebbleStore) GetAllSeriesBookRefCounts() (map[int]int, error) {
+	if p.UseMemDB && p.mem() != nil {
+		return p.mem().GetAllSeriesBookRefCounts()
+	}
+	return p.getAllSeriesBookRefCountsPebble()
+}
+
+// getAllSeriesBookRefCountsPebble mirrors GetAllSeriesBookCounts_Pebble's key
+// range and row-shape guard, minus the IsPrimaryVersion filter, and without
+// skipping trashed rows.
+func (p *PebbleStore) getAllSeriesBookRefCountsPebble() (map[int]int, error) {
+	counts := make(map[int]int)
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book:0"),
+		UpperBound: []byte("book:;"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := string(iter.Key())
+		if !strings.HasPrefix(key, "book:") {
+			continue
+		}
+		// Exactly one colon: skip the secondary indexes (book:path:, book:hash:,
+		// book:versiongroup:) that share the prefix.
+		if strings.Count(key, ":") != 1 {
+			continue
+		}
+		var b Book
+		if err := json.Unmarshal(iter.Value(), &b); err != nil {
+			continue
+		}
+		if b.SeriesID == nil {
+			continue
+		}
+		counts[*b.SeriesID]++
+	}
+	return counts, nil
+}

--- a/internal/database/series_bookref_test.go
+++ b/internal/database/series_bookref_test.go
@@ -1,0 +1,146 @@
+// file: internal/database/series_bookref_test.go
+// version: 1.0.0
+// guid: 8f2c14ba-6d97-4e35-b0a1-72e5c9d38a04
+// last-edited: 2026-08-14
+
+package database
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exist because a DISPLAY counter was used as an EXISTENCE test.
+// GetAllSeriesBookCounts skips trashed and non-primary books — correct for a
+// badge, catastrophic for "is it safe to delete this row". On production
+// 2026-08-14 that had already stranded 13,322 live books on 6,893 series IDs
+// that no longer resolved. Every assertion below is about the difference
+// between the two questions.
+
+func boolp(b bool) *bool { return &b }
+func intp(i int) *int    { return &i }
+
+// seedRefStore writes books through the normal path, then applies raw flag
+// updates. Books are created with CreateBook so the memdb and Pebble both see
+// them exactly as production does.
+func seedRefStore(t *testing.T, dir string) *PebbleStore {
+	t.Helper()
+	store, err := NewPebbleStore(dir)
+	require.NoError(t, err)
+	store.WaitForWarmup()
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func mkBook(t *testing.T, s *PebbleStore, title string, seriesID int, primary, trashed bool) *Book {
+	t.Helper()
+	b, err := s.CreateBook(&Book{
+		Title:             title,
+		FilePath:          "/ref/" + title,
+		SeriesID:          intp(seriesID),
+		IsPrimaryVersion:  boolp(primary),
+		MarkedForDeletion: boolp(trashed),
+	})
+	require.NoError(t, err)
+	return b
+}
+
+// TestSeriesBookRefCounts_CountsTrashedAndNonPrimary is the core assertion: the
+// unfiltered counter must see books the display counter deliberately hides.
+// Without this, a series holding only trash reads as "referenced by nothing".
+func TestSeriesBookRefCounts_CountsTrashedAndNonPrimary(t *testing.T) {
+	store := seedRefStore(t, t.TempDir())
+
+	const onlyTrashed = 900   // every book in the trash
+	const onlyNonPrim = 901   // every book a secondary version
+	const healthy = 902       // an ordinary series
+	mkBook(t, store, "trashed-a", onlyTrashed, true, true)
+	mkBook(t, store, "trashed-b", onlyTrashed, true, true)
+	mkBook(t, store, "secondary", onlyNonPrim, false, false)
+	mkBook(t, store, "normal", healthy, true, false)
+
+	refs, err := store.GetAllSeriesBookRefCounts()
+	require.NoError(t, err)
+
+	require.Equal(t, 2, refs[onlyTrashed],
+		"a series whose books are all trashed is still REFERENCED — deleting it strands them")
+	require.Equal(t, 1, refs[onlyNonPrim],
+		"a non-primary version still holds the series_id")
+	require.Equal(t, 1, refs[healthy])
+
+	// And prove the OLD instrument disagrees — otherwise this test would pass
+	// even if the fix were a no-op.
+	display, err := store.GetAllSeriesBookCounts()
+	require.NoError(t, err)
+	require.Zero(t, display[onlyTrashed],
+		"precondition: the display counter must report 0 here, which is exactly why it must not drive deletion")
+	require.Zero(t, display[onlyNonPrim], "precondition: display counter hides non-primary")
+}
+
+// TestSeriesBookRefCounts_UnreferencedSeriesAreAbsent — the safe-to-delete
+// signal is absence from the map, so absence must actually mean "nothing points
+// here", not "no book passed a filter".
+func TestSeriesBookRefCounts_UnreferencedSeriesAreAbsent(t *testing.T) {
+	store := seedRefStore(t, t.TempDir())
+	mkBook(t, store, "somewhere", 910, true, false)
+
+	refs, err := store.GetAllSeriesBookRefCounts()
+	require.NoError(t, err)
+	require.Equal(t, 1, refs[910])
+	_, present := refs[911]
+	require.False(t, present, "a series nothing references must be absent from the map")
+}
+
+// TestSeriesBookRefCounts_MemDBAndPebbleAgree is the conformance test. Two
+// implementations answer this question — memdb (the prod default) and the
+// Pebble scan — and per-path hardcoded expectations cannot catch drift between
+// them, because whoever writes a path also writes its expectation. One fixture,
+// both implementations, assert EQUAL.
+func TestSeriesBookRefCounts_MemDBAndPebbleAgree(t *testing.T) {
+	store := seedRefStore(t, t.TempDir())
+
+	// A deliberately mixed population: trashed, non-primary, both, neither,
+	// nil-flags, and books with no series at all.
+	for i := 0; i < 40; i++ {
+		sid := 920 + (i % 7)
+		mkBook(t, store, fmt.Sprintf("mix-%02d", i), sid, i%2 == 0, i%3 == 0)
+	}
+	// nil flags — the pointer-nil branch each filter treats differently.
+	_, err := store.CreateBook(&Book{Title: "nilflags", FilePath: "/ref/nilflags", SeriesID: intp(927)})
+	require.NoError(t, err)
+	// no series at all — must not appear under any key.
+	_, err = store.CreateBook(&Book{Title: "noseries", FilePath: "/ref/noseries"})
+	require.NoError(t, err)
+
+	fromMem, err := store.mem().GetAllSeriesBookRefCounts()
+	require.NoError(t, err)
+	fromPebble, err := store.getAllSeriesBookRefCountsPebble()
+	require.NoError(t, err)
+
+	require.Equal(t, fromPebble, fromMem,
+		"memdb and Pebble must agree on unfiltered series references; drift here means "+
+			"the answer depends on warmup state, and deletion decisions ride on it")
+	require.NotEmpty(t, fromMem, "fixture must actually produce references, or this asserts nothing")
+	require.Equal(t, 41, sumCounts(fromMem), "every seeded book with a series must be counted exactly once")
+}
+
+func sumCounts(m map[int]int) int {
+	t := 0
+	for _, v := range m {
+		t += v
+	}
+	return t
+}
+
+// TestAsSeriesBookRefStore_ResolvesPebbleStore guards the capability lookup.
+// prod wraps the store in the Bleve indexedStore decorator, and a bare type
+// assertion against a wrapped store is indistinguishable from an unsupported
+// backend — which is how several ops silently no-opped in production.
+func TestAsSeriesBookRefStore_ResolvesPebbleStore(t *testing.T) {
+	store := seedRefStore(t, t.TempDir())
+	require.NotNil(t, AsSeriesBookRefStore(store))
+	require.Nil(t, AsSeriesBookRefStore(nil))
+	require.Nil(t, AsSeriesBookRefStore(struct{}{}))
+}

--- a/internal/server/duplicates_helpers.go
+++ b/internal/server/duplicates_helpers.go
@@ -219,8 +219,34 @@ func (s *Server) executeSeriesPrune(ctx context.Context, store interface {
 	orphanStep := len(allSeries) + 1
 	_ = progress.UpdateProgress(orphanStep, totalSteps, fmt.Sprintf("Scanning for orphan series... (%d/%d %.2f%%)", orphanStep, totalSteps, float64(orphanStep)/float64(totalSteps)*100))
 
-	// Phase 2: Delete orphan series (0 books)
+	// Phase 2: Delete orphan series — series NOTHING references.
+	//
+	// This used to ask GetBooksBySeriesIDCore, which skips trashed and
+	// non-primary books. Those books still hold the series_id, so deleting on a
+	// zero from that counter left them pointing at a row that no longer exists.
+	// On production 2026-08-14 that had already produced 6,893 phantom series
+	// IDs held by 13,322 live books (+702 trashed), every one of them rendering
+	// with no series. See internal/database/series_bookref.go.
+	//
+	// The reference counts are computed ONCE for the whole library rather than
+	// per series: it turns 14,626 scans into one, and more importantly it is the
+	// only form in which "referenced by nothing" is actually answerable.
 	orphansDeleted := 0
+	refCounter := database.AsSeriesBookRefStore(store)
+	if refCounter == nil {
+		// Deliberately fatal. Falling back to the filtered counter is precisely
+		// the bug being removed, and it would delete rows while reporting
+		// success — the failure family this repo keeps rediscovering.
+		return fmt.Errorf("series prune: store cannot count unfiltered series references (got %T); "+
+			"refusing to delete orphans from a filtered count, which silently drops "+
+			"series whose books are trashed or non-primary", store)
+	}
+	refCounts, refErr := refCounter.GetAllSeriesBookRefCounts()
+	if refErr != nil {
+		return fmt.Errorf("series prune: failed to count series references: %w", refErr)
+	}
+	_ = progress.Log("info", fmt.Sprintf("Reference scan: %d series are referenced by at least one book (any state)", len(refCounts)), nil)
+
 	// Re-fetch series to account for merges
 	refreshedSeries, err := store.GetAllSeries()
 	if err != nil {
@@ -230,11 +256,7 @@ func (s *Server) executeSeriesPrune(ctx context.Context, store interface {
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
-			books, err := store.GetBooksBySeriesIDCore(ser.ID)
-			if err != nil {
-				continue
-			}
-			if len(books) == 0 {
+			if refCounts[ser.ID] == 0 {
 				if err := store.DeleteSeries(ser.ID); err != nil {
 					mergeErrors = append(mergeErrors, fmt.Sprintf("failed to delete orphan series %d: %v", ser.ID, err))
 				} else {
@@ -246,7 +268,7 @@ func (s *Server) executeSeriesPrune(ctx context.Context, store interface {
 							ChangeType:  "series_delete",
 							FieldName:   "orphan_series",
 							OldValue:    fmt.Sprintf("%d: %s", ser.ID, ser.Name),
-							NewValue:    "deleted (0 books)",
+							NewValue:    "deleted (0 book references, any state)",
 						})
 					}
 				}


### PR DESCRIPTION
## The bug

`executeSeriesPrune` decided a series was an orphan with `GetBooksBySeriesIDCore`, which skips two categories of book:

```go
if b.MarkedForDeletion != nil && *b.MarkedForDeletion { continue }
if b.IsPrimaryVersion  != nil && !*b.IsPrimaryVersion  { continue }
```

That filtering is correct for a **display** count — the trash and secondary versions must not inflate a badge. It is wrong as an **existence** test for deletion. A series whose books were all trashed, or all non-primary, counted zero and was deleted. The books kept its `series_id` and were left pointing at a row that no longer resolves.

Both entry points share this one function: `dedup.series-prune`, which the scheduler enqueues in the **nightly** maintenance window, and `maintenance.series-prune`. The damage accumulated a night at a time.

## Production impact, measured before the fix

| | |
|---|---|
| Series rows that exist | 14,626 |
| Distinct series IDs referenced by books | 21,190 |
| **Phantom IDs (referenced, no row)** | **6,893** |
| **Live books stranded on them** | **13,322** (+702 trashed) |

Those books render with **no series at all**. Verified against the warmup log (`series=14626 skipped_total=0`), so the phantoms are genuinely missing rows, not an incomplete memdb load.

## The fix

Phase 2 now asks a new unfiltered counter, `GetAllSeriesBookRefCounts`, which counts every book naming a series whatever its deletion or primary-version state. **Absence from that map is the only safe-to-delete signal.** It is computed once for the whole library rather than once per series, which also collapses 14,626 scans into one.

If the store cannot answer the unfiltered question, the op now returns an error instead of falling back to the filtered counter — a silent fallback would delete rows while reporting success.

This PR **stops new damage**. It does not repair the existing 13,322 stranded books; that is a separate repair pass.

## Testing

`go build` / `go vet` clean. All three mutations watched go red for the right reason:

| Mutation | Test that caught it |
|---|---|
| Re-add the trashed filter | trashed-only series reads 0 — *the original bug* |
| Re-add the non-primary filter | secondary-only series reads 0 — *the original bug* |
| Drift the Pebble impl from memdb | conformance test |

The conformance test runs **one** fixture through **both** implementations (memdb — the prod default — and the Pebble scan) and asserts equality, because per-path hardcoded expectations cannot catch drift: whoever writes a path also writes its expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp