### PR TITLE
fix(maintenance): invalidate the authors cache after a repair that wrote

### DIFF
--- a/changelog.d/20260814_042000_author_repair_invalidates_caches.md
+++ b/changelog.d/20260814_042000_author_repair_invalidates_caches.md
@@ -1,0 +1,26 @@
+### Fixed
+
+#### Author repairs are visible on the author list immediately
+
+`maintenance.author-conjunction-repair` now invalidates the cached author list
+(and the author-duplicates dedup cache) after a run that wrote.
+
+Without it the repair was invisible on the one page anyone would check. The
+2026-08-14 apply landed correctly — 30 authors merged, 15 renamed, and all 145
+affected book records verified to carry the corrected links — while
+`/api/v1/authors` kept returning the pre-repair names. That cache holds a
+**24-hour TTL** and was invalidated only by the interactive entities API, so a
+maintenance op that renamed or deleted authors left the list stale for up to a
+day. Reading it straight after the apply showed 48 stranded rows still present
+and nothing deleted, which reads exactly like a repair that silently did
+nothing.
+
+`ServerDeps` gains `InvalidateAuthorsCache()` alongside the existing
+`InvalidateDedupCache()`, so any maintenance op that mutates authors can now say
+so.
+
+A dry run deliberately does **not** invalidate: it changed nothing, and dropping
+a warm cache costs real work for no reason. Nor does a run that matched rows but
+wrote none. Both cases are covered by tests, and both guards were
+mutation-tested — removing the invalidation reds the apply case, and widening it
+to fire unconditionally reds the dry-run case.

--- a/internal/plugins/maintenance/author_conjunction_repair.go
+++ b/internal/plugins/maintenance/author_conjunction_repair.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/author_conjunction_repair.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2f8a41c6-9d73-4e05-b18a-6c4f2e93d70b
 // last-edited: 2026-08-14
 
@@ -250,6 +250,20 @@ func (p *Plugin) runAuthorConjunctionRepair(ctx context.Context, rawParams json.
 				"dry_run", false, "author_id", author.ID, "from", author.Name, "to", cleaned)
 		}
 		prog.StepN(i+1, fmt.Sprintf("%d/%d", i+1, len(matched)))
+	}
+
+	// Drop the cached author list, but only when this run actually wrote.
+	// The cache has a 24-hour TTL and was previously invalidated only by the
+	// entities API, so the 2026-08-14 apply landed correctly in the store and
+	// in all 145 book records while the author list kept serving the old "&"
+	// names -- the one page anyone would check to confirm the repair. A dry
+	// run must NOT invalidate: it changed nothing, and dropping a warm cache
+	// is a real cost to pay for no reason.
+	wrote := outcomes[conjRepairMerged] + outcomes[conjRepairRenamed]
+	if !dryRun && wrote > 0 {
+		p.deps.InvalidateAuthorsCache()
+		p.deps.InvalidateDedupCache()
+		log.Info("author-conjunction-repair: invalidated author caches", "rows_written", wrote)
 	}
 
 	summary := fmt.Sprintf(

--- a/internal/plugins/maintenance/author_conjunction_repair_test.go
+++ b/internal/plugins/maintenance/author_conjunction_repair_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/author_conjunction_repair_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 8e35b7d2-1c40-4f96-a2e7-5b9d0c68a341
 // last-edited: 2026-08-14
 
@@ -22,6 +22,17 @@ type conjRepairWrites struct {
 	updatedBooks    []string
 	getBookAuthorsN int
 }
+
+// conjRepairDeps counts cache invalidations so a test can assert the op tells
+// the read layer its data changed.
+type conjRepairDeps struct {
+	fakeDeps
+	authorsInvalidated int
+	dedupInvalidated   int
+}
+
+func (d *conjRepairDeps) InvalidateAuthorsCache() { d.authorsInvalidated++ }
+func (d *conjRepairDeps) InvalidateDedupCache()   { d.dedupInvalidated++ }
 
 // newConjRepairPlugin wires a MockStore around a fixed author table and a
 // book<->author join table.
@@ -65,6 +76,99 @@ func newConjRepairPlugin(
 		},
 	}
 	return New(&fakeDeps{store: store})
+}
+
+// newConjRepairPluginWithDeps is newConjRepairPlugin with invalidation counting.
+func newConjRepairPluginWithDeps(
+	authors []database.Author,
+	booksByAuthor map[int][]database.BookCore,
+	joins map[string][]database.BookAuthor,
+	w *conjRepairWrites,
+	deps *conjRepairDeps,
+) *Plugin {
+	w.setBookAuthors = map[string][]database.BookAuthor{}
+	w.renamedAuthors = map[int]string{}
+	store := &database.MockStore{
+		GetAllAuthorsFunc: func() ([]database.Author, error) { return authors, nil },
+		GetAuthorByNameFunc: func(name string) (*database.Author, error) {
+			for i := range authors {
+				if authors[i].Name == name {
+					return &authors[i], nil
+				}
+			}
+			return nil, nil
+		},
+		GetBooksByAuthorIDWithRoleFunc: func(authorID int) ([]database.BookCore, error) {
+			return booksByAuthor[authorID], nil
+		},
+		GetBookAuthorsFunc: func(bookID string) ([]database.BookAuthor, error) {
+			return joins[bookID], nil
+		},
+		SetBookAuthorsFunc: func(bookID string, ba []database.BookAuthor) error {
+			w.setBookAuthors[bookID] = ba
+			return nil
+		},
+		DeleteAuthorFunc: func(id int) error {
+			w.deletedAuthors = append(w.deletedAuthors, id)
+			return nil
+		},
+		UpdateAuthorNameFunc: func(id int, name string) error {
+			w.renamedAuthors[id] = name
+			return nil
+		},
+	}
+	deps.fakeDeps = fakeDeps{store: store}
+	return New(deps)
+}
+
+// TestAuthorConjunctionRepair_InvalidatesAuthorsCacheOnWrite pins the gap found
+// on 2026-08-14: the apply landed correctly in the store and in all 145 book
+// records, but the authors list kept serving the pre-repair "&" names because
+// its cache holds a 24-hour TTL and only the entities API invalidated it. The
+// one page anyone would check to confirm the repair showed it had not happened.
+//
+// A dry run must NOT invalidate — it changed nothing, and dropping a warm cache
+// costs real work for no reason.
+func TestAuthorConjunctionRepair_InvalidatesAuthorsCacheOnWrite(t *testing.T) {
+	authors := []database.Author{
+		{ID: 46414, Name: "& Joe Thompson"},
+	}
+
+	t.Run("apply invalidates", func(t *testing.T) {
+		var w conjRepairWrites
+		deps := &conjRepairDeps{}
+		p := newConjRepairPluginWithDeps(authors, nil, nil, &w, deps)
+		if err := p.runAuthorConjunctionRepair(context.Background(), conjRepairParams(false), &fakeReporter{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if deps.authorsInvalidated != 1 {
+			t.Errorf("authors cache invalidated %d times, want 1 — the repair is invisible to the author list without it", deps.authorsInvalidated)
+		}
+	})
+
+	t.Run("dry run does not invalidate", func(t *testing.T) {
+		var w conjRepairWrites
+		deps := &conjRepairDeps{}
+		p := newConjRepairPluginWithDeps(authors, nil, nil, &w, deps)
+		if err := p.runAuthorConjunctionRepair(context.Background(), conjRepairParams(true), &fakeReporter{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if deps.authorsInvalidated != 0 {
+			t.Errorf("dry run invalidated the authors cache %d times, want 0", deps.authorsInvalidated)
+		}
+	})
+
+	t.Run("no matching rows does not invalidate", func(t *testing.T) {
+		var w conjRepairWrites
+		deps := &conjRepairDeps{}
+		p := newConjRepairPluginWithDeps([]database.Author{{ID: 1, Name: "Dan Simmons"}}, nil, nil, &w, deps)
+		if err := p.runAuthorConjunctionRepair(context.Background(), conjRepairParams(false), &fakeReporter{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if deps.authorsInvalidated != 0 {
+			t.Errorf("a run that wrote nothing invalidated the cache %d times, want 0", deps.authorsInvalidated)
+		}
+	})
 }
 
 func conjRepairParams(dryRun bool) json.RawMessage {

--- a/internal/plugins/maintenance/deps.go
+++ b/internal/plugins/maintenance/deps.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/deps.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567891
-// last-edited: 2026-07-18
+// last-edited: 2026-08-14
 
 // Package maintenance is the UOS plugin for all maintenance/janitor operations.
 // It holds 26 OperationDefs migrated from the legacy scheduler_tasks.go.
@@ -71,6 +71,15 @@ type ServerDeps interface {
 	DedupLLMReview(ctx context.Context) error
 	// InvalidateDedupCache invalidates the author-duplicates dedup cache.
 	InvalidateDedupCache()
+	// InvalidateAuthorsCache invalidates the cached author list.
+	//
+	// Any op that renames or deletes an author MUST call this. The cache holds
+	// a 24-hour TTL and only the entities API invalidated it, so a maintenance
+	// op that mutated authors left the author list serving the pre-repair names
+	// for up to a day -- the repair had landed in the store and in every book
+	// record, and the one page a user would check to confirm it still showed
+	// the old names. Measured 2026-08-14 after author-conjunction-repair.
+	InvalidateAuthorsCache()
 	// MetadataUpgradeRun runs the metadata upgrade scan up to limit books.
 	// progress may be nil; when non-nil it is updated every 25 books checked
 	// (M7, 2026-07 error-correction sweep — this is a 120-minute,

--- a/internal/plugins/maintenance/title_backfill_test.go
+++ b/internal/plugins/maintenance/title_backfill_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/title_backfill_test.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: b2c3d4e5-f6a7-8901-bcde-ef0123456789
-// last-edited: 2026-07-18
+// last-edited: 2026-08-14
 
 package maintenance
 
@@ -76,7 +76,8 @@ func (d fakeDeps) DedupLLMReview(_ context.Context) error          { return nil 
 func (d fakeDeps) DedupTriageExactPending(_ context.Context, _ bool) (*TriageReport, error) {
 	return &TriageReport{}, nil
 }
-func (d fakeDeps) InvalidateDedupCache() {}
+func (d fakeDeps) InvalidateDedupCache()   {}
+func (d fakeDeps) InvalidateAuthorsCache() {}
 func (d fakeDeps) MetadataUpgradeRun(_ context.Context, _ int, _ operations.ProgressReporter) (int, int, int, int, error) {
 	return 0, 0, 0, 0, nil
 }

--- a/internal/server/server_maintenance_deps.go
+++ b/internal/server/server_maintenance_deps.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_maintenance_deps.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: b4c5d6e7-f8a9-0123-7890-345678901234
-// last-edited: 2026-07-18
+// last-edited: 2026-08-14
 
 // This file implements the maintenance.ServerDeps interface on *Server, giving
 // the maintenance plugin access to server internals without creating an import
@@ -118,6 +118,16 @@ func (s *Server) DedupLLMReview(ctx context.Context) error {
 func (s *Server) InvalidateDedupCache() {
 	if s.dedupCache != nil {
 		s.dedupCache.Invalidate("author-duplicates")
+	}
+}
+
+// InvalidateAuthorsCache drops the cached author list so a maintenance op that
+// renamed or deleted authors is visible immediately rather than after the
+// cache's 24-hour TTL. Mirrors what entities_ops.go already does on the
+// interactive merge path.
+func (s *Server) InvalidateAuthorsCache() {
+	if s.authorsCache != nil {
+		s.authorsCache.InvalidateAll()
 	}
 }
 

--- a/todo.d/20260814-memdb-pebble-author-link-divergence.md
+++ b/todo.d/20260814-memdb-pebble-author-link-divergence.md
@@ -23,19 +23,30 @@ behind a write.
 - [ ] Identify the 2 books. They are not among `Nicholas Courtney` (43791)'s 7
       books — none of those reference 46627 — so they are books where 46627 is
       a co-author and 43791 is not linked at all.
-- [ ] Find why memdb's loader drops them. Suspects: the junction load skipping
-      rows whose book is soft-deleted, or an author-id index built only from
-      `Book.AuthorID`. Note `/api/v1/authors/46627/books` and the authors-list
-      `book_count` BOTH report 0, so every serving-layer read agrees with memdb
-      and only Pebble sees them.
+- [ ] Find why memdb's loader drops them. Note `/api/v1/authors/46627/books`
+      and the authors-list `book_count` BOTH report 0, so every serving-layer
+      read agrees with memdb and only Pebble sees them.
+      - ❌ **RULED OUT: `safeInsert` skipping rows.** `memdb_warmup.go` skips and
+        counts rows that fail to insert, which looked like the obvious culprit.
+        The 2026-08-14 01:54 warmup reports `skipped_total=0` with
+        `book_authors=290643` loaded. Nothing was dropped at insert time, so the
+        loss is in the index or the query, not the load.
+      - Remaining suspects: the memdb author→book index construction, or
+        `memdb.GetBooksByAuthorID` itself.
+      - ⏱️ Warmup takes **132s** on prod. Any op dispatched sooner than that
+        after a restart runs on Pebble. That is what made the divergence
+        visible at all.
 - [ ] Write the conformance test rather than a per-path assertion — one fixture,
       both implementations, assert equal. This is the third memdb/Pebble
       divergence in a week (see the soft-deleted leak, #2392), and per-path
       expectations cannot catch drift because the path's own author writes the
       expectation.
 - [ ] Once resolved, drop `skip_author_ids: [46627]` from the repair invocation
-      and repair that row. It is currently the ONLY unrepaired stranded-ampersand
-      author.
+      and repair that row. **Applied 2026-08-14 02:0x: 30 merged, 15 renamed, 0
+      failures, 145/145 book links verified. Author 46627 is the ONLY remaining
+      stranded-ampersand row** (the other two survivors, `&#169` and
+      `&#169;2013 by HarperCollinsPublishers`, are the separate HTML-entity
+      defect).
 
 **Why this blocked the repair:** the merge path relinks the books it can see and
 then DELETES the author row. Run through memdb it would relink 0 books for 46627


### PR DESCRIPTION
Third and final follow-up to #2396 / #2398. The repair is **applied and verified in prod**; this closes a gap that made it look like it hadn't been.

## The problem

The apply landed correctly — 30 authors merged, 15 renamed, 0 failures, and **145/145 affected book records verified** to carry the corrected links.

Then `/api/v1/authors` still returned all 48 stranded rows, with nothing deleted.

That is indistinguishable from a repair that silently did nothing, and it's the one page anyone would check to confirm the fix.

## Cause

`authorsCache` holds a **24-hour TTL** and `InvalidateAll()` was called only from `entities_ops.go` — the interactive entities API. A maintenance op that renames or deletes authors had no way to invalidate it, so the author list served pre-repair names for up to a day.

Confirmed by restarting the service: author count immediately went 9,350 → 9,320 and stranded names 48 → 3.

## Fix

`ServerDeps` gains `InvalidateAuthorsCache()` alongside `InvalidateDedupCache()`, and the repair calls both after a run that wrote.

**A dry run deliberately does not invalidate** — it changed nothing, and dropping a warm cache costs real work for no reason. Nor does a run that matched rows but wrote none.

## Verification

Both guards mutation-tested, each with a mutation that **compiles** (my first attempt only broke the build via an unused variable, which proves nothing):

| mutation | result |
|---|---|
| drop `InvalidateAuthorsCache()` | reds `apply invalidates` — *"invalidated 0 times, want 1"* |
| widen to `if wrote >= 0` | reds `dry run does not invalidate` **and** `no matching rows does not invalidate` |

Source restored byte-identical (`f9970d8e…`) and grepped for leftover markers — one mutation run timed out and did leave a mutant in the tree, so the check earned its keep.

## Also corrects a filed hypothesis

The divergence note claimed memdb's `safeInsert` was the likely cause of author 46627's two missing links. **Ruled out**: the 01:54 warmup reports `skipped_total=0` with `book_authors=290643` loaded. Nothing was dropped at insert time; the loss is in the index or the query. Also records that warmup takes **132s** — which is why an op dispatched seconds after a restart runs on Pebble, and is what exposed the divergence at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxigqrwz9WfwN1wx8QhoQW