### PR TITLE
fix(server): expect 400, not an empty list, for an unrecognised filter field

### DIFF
--- a/changelog.d/20260814_053000_fix_unknown_field_test_expectation.md
+++ b/changelog.d/20260814_053000_fix_unknown_field_test_expectation.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Repaired the `internal/server` integration test that still asserted the old
+  behaviour for an unrecognised search filter. It expected a 200 with an empty
+  list; that answer was the bug, and rejecting the request with a 400 is the
+  fix. The expectation is inverted rather than deleted — a well-formed request
+  still has to be answered, just answered honestly.

--- a/internal/server/library_enhancement_test.go
+++ b/internal/server/library_enhancement_test.go
@@ -668,7 +668,21 @@ func TestServerSideFieldFiltering(t *testing.T) {
 		assert.Equal(t, "The Great Adventure", titles[0])
 	})
 
-	t.Run("unknown field returns empty", func(t *testing.T) {
+	t.Run("unknown field returns 400", func(t *testing.T) {
+		// This subtest asserted the opposite until 2026-08-14: that an unknown
+		// field answered 200 with an empty list. That behaviour was the bug.
+		//
+		// An unknown field matched nothing, so the endpoint reported count 0 —
+		// an answer indistinguishable from a truthful "no books match". A typo,
+		// a renamed field, and a genuinely empty result all looked identical.
+		// It hid thirteen fields the search bar offers and the backend had never
+		// implemented, including year, isbn13 and duration; measured on
+		// production, duration:1 returned 0 while duration_seconds:1 returned
+		// 25,090 over the same rows.
+		//
+		// The expectation is inverted deliberately rather than deleted, because
+		// the request is still well-formed and still has to be answered — just
+		// answered honestly.
 		filters := buildFiltersParam([]FieldFilter{
 			{Field: "unknown_field", Value: "anything", Negated: false},
 		})
@@ -676,9 +690,13 @@ func TestServerSideFieldFiltering(t *testing.T) {
 		w := httptest.NewRecorder()
 		server.router.ServeHTTP(w, req)
 
-		assert.Equal(t, http.StatusOK, w.Code)
-		titles := extractTitles(t, w)
-		assert.Empty(t, titles, "unknown field should match nothing")
+		assert.Equal(t, http.StatusBadRequest, w.Code,
+			"an unrecognised filter field must be rejected, not answered with an empty list")
+		resp := parseJSONResponse(t, w)
+		errorMsg, ok := resp["error"].(string)
+		require.True(t, ok, "error field should be a string")
+		assert.Contains(t, errorMsg, "unknown_field",
+			"the rejection must name the offending field")
 	})
 
 	t.Run("invalid filters JSON returns 400", func(t *testing.T) {


### PR DESCRIPTION
**Repairs main.** `TestServerSideFieldFiltering/unknown_field_returns_empty` still asserted the behaviour #2402 deliberately changed, so it failed on merge and took `Coverage Floor` and the Minimal CI summary down with it — all three red checks trace to this one subtest.

The subtest asserted that an unknown filter field answers `200` with an empty list. **That answer was the defect.** An unknown field matched nothing, so the endpoint reported `count: 0`, and a count of zero is indistinguishable from a truthful "no books match" — which is how thirteen fields the search bar offers and the backend never implemented stayed hidden.

The expectation is **inverted rather than deleted**: a well-formed request still has to be answered, just answered honestly. The assertion also now checks that the message names the offending field.

Verified it discriminates: fails with the old `200` expectation against current behaviour, passes with the new one.

### On how this got through

My verification for #2402 piped `go test` into `grep` and read the pipeline's exit status — which reports the *last* command's result, not the test run's. So the "full suite green" I reported was never actually measured. Both checks here read `go test`'s own exit status directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t