### PR TITLE
fix(database): make both author book-getters agree across memdb and Pebble

### DIFF
--- a/changelog.d/20260814_053000_author_getter_store_conformance.md
+++ b/changelog.d/20260814_053000_author_getter_store_conformance.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **Author book-lookups disagreed between the two stores, and a merge could orphan
+  junction rows.** `GetBooksByAuthorIDWithRoleCore` is what every merge and delete
+  path calls to find the books it must relink before removing an author. Its memdb
+  implementation silently dropped co-author credits on non-primary versions, so a
+  merge could delete an author while `book_authors` rows still pointed at it. Its
+  sibling `GetBooksByAuthorIDCore` diverged in the opposite direction — the Pebble
+  implementation never opened the junction table at all, so a co-author's books were
+  invisible to listings served during the ~132 s memdb warmup. Two opposite-signed
+  errors kept aggregate counts plausible; only a co-author on a non-primary version
+  exposed either. Detected when the same repair op reported 86 books relinked
+  seconds after a restart and 84 warm against identical data.
+
+  Both methods now agree across both stores: `...WithRoleCore` returns the complete
+  set (junction + legacy, non-primary included), `...Core` returns the listing view
+  (junction + legacy, non-primary excluded). Both exclude soft-deleted books. A new
+  conformance suite holds each method's two implementations to the same answer on
+  one fixture, in the pattern established for the soft-delete contract.

--- a/internal/database/author_getter_conformance_test.go
+++ b/internal/database/author_getter_conformance_test.go
@@ -1,0 +1,301 @@
+// file: internal/database/author_getter_conformance_test.go
+// version: 1.0.0
+// guid: 5b3e9f47-2a81-4c06-b9d3-7e14a8c02f65
+// last-edited: 2026-08-14
+
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// authorGetterConformanceFixture builds a library that separates the four ways
+// a book can be attached to an author, because the two getters under test
+// disagreed on two of them.
+//
+// Helper name is task-unique on purpose: several suites in this package define
+// fixture builders and a generic name collides on rebase.
+type authorGetterConformanceFixture struct {
+	authorID int
+
+	legacyBookID      string // linked via Book.AuthorID only (position 0)
+	coAuthorBookID    string // linked via the book_authors junction only
+	nonPrimaryBookID  string // junction link on a NON-primary version
+	softDeletedBookID string // junction link, but the book is in the trash
+	unrelatedBookID   string // no link at all
+}
+
+func buildAuthorGetterConformanceFixture(t *testing.T, store Store) authorGetterConformanceFixture {
+	t.Helper()
+
+	var fx authorGetterConformanceFixture
+
+	author, err := store.CreateAuthor("Conformance Coauthor")
+	require.NoError(t, err)
+	fx.authorID = author.ID
+
+	// Someone else, so the junction rows we write are realistic credit lists
+	// rather than a single-author degenerate case.
+	primary, err := store.CreateAuthor("Conformance Primary")
+	require.NoError(t, err)
+
+	mk := func(title string, opts func(*Book)) *Book {
+		b := &Book{Title: title, FilePath: "/lib/conf/" + title}
+		if opts != nil {
+			opts(b)
+		}
+		created, cErr := store.CreateBook(b)
+		require.NoError(t, cErr)
+		return created
+	}
+
+	yes := true
+	no := false
+
+	// 1. Legacy attachment: the author IS the book's denormalized primary.
+	legacy := mk("Legacy Primary Link", func(b *Book) {
+		id := fx.authorID
+		b.AuthorID = &id
+		b.IsPrimaryVersion = &yes
+	})
+	fx.legacyBookID = legacy.ID
+
+	// 2. Co-author: the author exists ONLY as a junction row at position 1.
+	//    This is how authors 2..n of a credit list are stored — Book.AuthorID
+	//    holds the first author and nothing else.
+	coAuthor := mk("Coauthor Junction Link", func(b *Book) {
+		id := primary.ID
+		b.AuthorID = &id
+		b.IsPrimaryVersion = &yes
+	})
+	require.NoError(t, store.SetBookAuthors(coAuthor.ID, []BookAuthor{
+		{BookID: coAuthor.ID, AuthorID: primary.ID, Role: "author", Position: 0},
+		{BookID: coAuthor.ID, AuthorID: fx.authorID, Role: "author", Position: 1},
+	}))
+	fx.coAuthorBookID = coAuthor.ID
+
+	// 3. The row that exposes the bug: a co-author credit on a NON-primary
+	//    version. memdb drops it, Pebble keeps it.
+	nonPrimary := mk("Coauthor On NonPrimary Version", func(b *Book) {
+		id := primary.ID
+		b.AuthorID = &id
+		b.IsPrimaryVersion = &no
+	})
+	require.NoError(t, store.SetBookAuthors(nonPrimary.ID, []BookAuthor{
+		{BookID: nonPrimary.ID, AuthorID: primary.ID, Role: "author", Position: 0},
+		{BookID: nonPrimary.ID, AuthorID: fx.authorID, Role: "author", Position: 1},
+	}))
+	fx.nonPrimaryBookID = nonPrimary.ID
+
+	// 4. Trash: linked, but soft-deleted through the real update path so the
+	//    memdb re-index runs. Neither getter may return it.
+	trashed := mk("Coauthor But Trashed", func(b *Book) {
+		id := primary.ID
+		b.AuthorID = &id
+		b.IsPrimaryVersion = &yes
+	})
+	require.NoError(t, store.SetBookAuthors(trashed.ID, []BookAuthor{
+		{BookID: trashed.ID, AuthorID: fx.authorID, Role: "author", Position: 1},
+	}))
+	trashed.MarkedForDeletion = &yes
+	_, err = store.UpdateBook(trashed.ID, trashed)
+	require.NoError(t, err)
+	fx.softDeletedBookID = trashed.ID
+
+	// 5. Control: an implementation that returned everything would pass every
+	//    "contains" assertion below without this.
+	fx.unrelatedBookID = mk("Unrelated Book", func(b *Book) {
+		id := primary.ID
+		b.AuthorID = &id
+		b.IsPrimaryVersion = &yes
+	}).ID
+
+	return fx
+}
+
+// authorGetterIDs runs one getter under both backing implementations and
+// returns the ID set each produced, keyed by UseMemDB.
+//
+// The flag flip is the whole point: both GetBooksByAuthorIDCore and
+// GetBooksByAuthorIDWithRoleCore gate on `p.UseMemDB && p.mem() != nil`, so
+// flipping UseMemDB genuinely selects two different bodies of code. (This was
+// NOT true of ListBooksByITunesPID before 2026-08-14 — it dispatched on memdb
+// publication alone, which would have run the memdb path twice and asserted
+// memdb == memdb. A conformance test is worth exactly as much as the selector
+// that picks between the implementations, so this is checked, not assumed.)
+func authorGetterIDs(
+	t *testing.T,
+	p *PebbleStore,
+	get func() ([]BookCore, error),
+) map[bool]map[string]struct{} {
+	t.Helper()
+
+	out := map[bool]map[string]struct{}{}
+	for _, useMemDB := range []bool{true, false} {
+		p.UseMemDB = useMemDB
+		books, err := get()
+		require.NoError(t, err)
+		ids := make(map[string]struct{}, len(books))
+		for _, b := range books {
+			ids[b.ID] = struct{}{}
+		}
+		out[useMemDB] = ids
+	}
+	p.UseMemDB = true
+	return out
+}
+
+// TestGetBooksByAuthorIDWithRoleCore_MemDBAndPebbleAgree is the conformance gate
+// for the getter every merge and delete path depends on.
+//
+// GetBooksByAuthorIDWithRoleCore is what a caller uses to find the books it must
+// relink BEFORE deleting an author — author_conjunction_repair.go:290,
+// entities_ops.go:89, ai_author_reassign.go:33, maintenance/author.go:169. Its
+// two implementations disagreed: the Pebble junction scan returned co-author
+// credits on non-primary versions, the memdb walk silently dropped them
+// (memdb_reads.go, the IsPrimaryVersion filter).
+//
+// That is not a reporting discrepancy. A merge that cannot see a link deletes
+// the author anyway and ORPHANS the junction row. Measured on prod 2026-08-14:
+// the same repair op reported 86 books relinked 4 s after a restart (Pebble
+// path) and 84 warm (memdb path), and the two missing links belonged to author
+// 46627 — a co-author on non-primary versions.
+//
+// The contract asserted here is COMPLETENESS: for this getter a missed link is
+// data loss, while an extra one is at worst redundant work.
+func TestGetBooksByAuthorIDWithRoleCore_MemDBAndPebbleAgree(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	fx := buildAuthorGetterConformanceFixture(t, store)
+
+	p, ok := store.(*PebbleStore)
+	require.True(t, ok, "expected *PebbleStore from setupPebbleTestDB")
+	p.WaitForWarmup()
+	require.True(t, p.IsMemReady(),
+		"memdb must be published or the UseMemDB=true arm silently runs the Pebble path")
+
+	got := authorGetterIDs(t, p, func() ([]BookCore, error) {
+		return store.GetBooksByAuthorIDWithRoleCore(fx.authorID)
+	})
+
+	for _, useMemDB := range []bool{true, false} {
+		ids := got[useMemDB]
+
+		require.Contains(t, ids, fx.legacyBookID,
+			"book linked via the legacy Book.AuthorID field is missing")
+		require.Contains(t, ids, fx.coAuthorBookID,
+			"co-author linked via the book_authors junction is missing — authors 2..n of a "+
+				"credit list exist ONLY as junction rows")
+		require.Contains(t, ids, fx.nonPrimaryBookID,
+			"co-author credit on a NON-primary version is missing — a merge that cannot see "+
+				"this link deletes the author and orphans the junction row")
+
+		require.NotContains(t, ids, fx.softDeletedBookID,
+			"soft-deleted book leaked into the author's book list")
+		require.NotContains(t, ids, fx.unrelatedBookID,
+			"book with no link to this author was returned")
+		require.Len(t, ids, 3)
+	}
+
+	require.Equal(t, got[true], got[false],
+		"memdb and Pebble implementations of GetBooksByAuthorIDWithRoleCore returned "+
+			"different book sets — this is what made the same repair op report 86 books cold "+
+			"and 84 warm against identical data")
+}
+
+// TestGetBooksByAuthorIDCore_MemDBAndPebbleAgree is the conformance gate for the
+// listing getter.
+//
+// This one diverged in the OPPOSITE direction from the WithRole variant above,
+// which is why the pair stayed plausible for so long: the Pebble path scanned
+// only the legacy Book.AuthorID field and never opened the junction at all, so
+// it under-reported co-authors, while memdb under-reported non-primary versions.
+// Two errors pointing opposite ways keep aggregate counts believable and only a
+// specific row — a co-author on a non-primary version — exposes either.
+//
+// The contract asserted here is the PRIMARY-VERSION VIEW: junction + legacy,
+// soft-deleted excluded, non-primary excluded. That is what memdb already
+// returned, and memdb is what prod serves outside the ~132 s warmup window, so
+// this pins today's steady-state listing behaviour rather than changing it.
+func TestGetBooksByAuthorIDCore_MemDBAndPebbleAgree(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	fx := buildAuthorGetterConformanceFixture(t, store)
+
+	p, ok := store.(*PebbleStore)
+	require.True(t, ok, "expected *PebbleStore from setupPebbleTestDB")
+	p.WaitForWarmup()
+	require.True(t, p.IsMemReady(),
+		"memdb must be published or the UseMemDB=true arm silently runs the Pebble path")
+
+	got := authorGetterIDs(t, p, func() ([]BookCore, error) {
+		return store.GetBooksByAuthorIDCore(fx.authorID)
+	})
+
+	for _, useMemDB := range []bool{true, false} {
+		ids := got[useMemDB]
+
+		require.Contains(t, ids, fx.legacyBookID,
+			"book linked via the legacy Book.AuthorID field is missing")
+		require.Contains(t, ids, fx.coAuthorBookID,
+			"co-author linked via the book_authors junction is missing — the Pebble path "+
+				"never opened the junction table, so a co-author's books never appeared in "+
+				"listings served during warmup")
+
+		require.NotContains(t, ids, fx.nonPrimaryBookID,
+			"non-primary version leaked into the listing view")
+		require.NotContains(t, ids, fx.softDeletedBookID,
+			"soft-deleted book leaked into the author's book list")
+		require.NotContains(t, ids, fx.unrelatedBookID,
+			"book with no link to this author was returned")
+		require.Len(t, ids, 2)
+	}
+
+	require.Equal(t, got[true], got[false],
+		"memdb and Pebble implementations of GetBooksByAuthorIDCore returned different book sets")
+}
+
+// TestAuthorGetters_WithRoleIsASupersetOfCore states the relationship between
+// the two getters directly, so that a future change which quietly re-narrows
+// WithRole fails here even if both of its implementations are changed together
+// and stay self-consistent.
+//
+// The conformance tests above hold each getter's two implementations to each
+// other; nothing in them would notice if BOTH implementations of WithRole
+// started dropping non-primary versions. This does.
+func TestAuthorGetters_WithRoleIsASupersetOfCore(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	fx := buildAuthorGetterConformanceFixture(t, store)
+
+	p, ok := store.(*PebbleStore)
+	require.True(t, ok, "expected *PebbleStore from setupPebbleTestDB")
+	p.WaitForWarmup()
+	require.True(t, p.IsMemReady(), "memdb must be published")
+
+	withRole, err := store.GetBooksByAuthorIDWithRoleCore(fx.authorID)
+	require.NoError(t, err)
+	core, err := store.GetBooksByAuthorIDCore(fx.authorID)
+	require.NoError(t, err)
+
+	inWithRole := make(map[string]struct{}, len(withRole))
+	for _, b := range withRole {
+		inWithRole[b.ID] = struct{}{}
+	}
+	for _, b := range core {
+		require.Contains(t, inWithRole, b.ID,
+			"a book visible to the listing getter was invisible to the getter that merges "+
+				"and deletes consult — that is the shape that orphans junction rows")
+	}
+
+	// Non-vacuity: the two must actually differ, or "superset" is trivially
+	// true and this test would keep passing if both collapsed to the same set.
+	require.Greater(t, len(withRole), len(core),
+		"fixture must contain a book visible only to WithRole (the non-primary co-author "+
+			"credit) or this assertion is vacuous")
+}

--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -1,5 +1,5 @@
 // file: internal/database/memdb_reads.go
-// version: 1.18.0
+// version: 1.19.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000006
 // last-edited: 2026-08-14
 
@@ -527,6 +527,39 @@ func (m *MemStore) GetBooksBySeriesIDCore(seriesID int, limit, offset int) ([]Bo
 // []Book and let each PebbleStore-layer caller project to Core. See
 // docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 func (m *MemStore) GetBooksByAuthorID(authorID int, limit, offset int) ([]Book, error) {
+	return m.getBooksByAuthorID(authorID, limit, offset, true)
+}
+
+// GetBooksByAuthorIDAllVersions is GetBooksByAuthorID without the
+// primary-version filter: it returns EVERY live book the author is attached to,
+// including non-primary versions.
+//
+// This exists because the two PebbleStore getters that share this helper want
+// different sets, and conflating them orphaned junction rows on prod:
+//
+//   - GetBooksByAuthorIDCore is a listing view. Non-primary versions are
+//     duplicates of a book already in the list, so it excludes them.
+//   - GetBooksByAuthorIDWithRoleCore is what merges and deletes consult to find
+//     the links they must rewrite before removing an author. For that caller a
+//     missed link is data loss — the author gets deleted and the junction row
+//     is left pointing at a row that no longer exists — while an extra link is
+//     at worst redundant work. So it needs completeness, not tidiness.
+//
+// Measured 2026-08-14: the author-conjunction-repair op reported 86 books
+// relinked seconds after a restart (Pebble path, no primary filter) and 84 warm
+// (memdb path, filtered) against identical data. The two missing links were
+// co-author credits on non-primary versions belonging to author 46627, and
+// merging that row warm would have deleted the author while they still existed.
+// See internal/database/author_getter_conformance_test.go.
+func (m *MemStore) GetBooksByAuthorIDAllVersions(authorID int, limit, offset int) ([]Book, error) {
+	return m.getBooksByAuthorID(authorID, limit, offset, false)
+}
+
+// getBooksByAuthorID is the shared body. primaryOnly selects the listing view
+// (true) or the complete set (false); see GetBooksByAuthorIDAllVersions for why
+// both are needed. Soft-deleted books are excluded either way — no caller of
+// either getter wants the trash.
+func (m *MemStore) getBooksByAuthorID(authorID int, limit, offset int, primaryOnly bool) ([]Book, error) {
 	txn := m.db.Txn(false)
 	defer txn.Abort()
 
@@ -563,7 +596,7 @@ func (m *MemStore) GetBooksByAuthorID(authorID int, limit, offset int) ([]Book, 
 		if bookIsSoftDeleted(b) {
 			continue
 		}
-		if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
+		if primaryOnly && b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
 			continue
 		}
 		all = append(all, *b)

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.127.0
+// version: 1.128.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-08-14
 
@@ -1813,9 +1813,64 @@ func (p *PebbleStore) GetBooksByAuthorIDCore(authorID int) ([]BookCore, error) {
 	return cores, nil
 }
 
-// getBooksByAuthorIDFull performs a full Pebble book scan filtered by author ID.
-// Fallback path after Task 3.4 index removal.
+// bookIDsInAuthorJunction returns the IDs of every book carrying a book_authors
+// row for this author, at any role or position.
+//
+// Extracted so that both Pebble author getters resolve the junction the same
+// way. They previously did not: this scan lived inline in
+// GetBooksByAuthorIDWithRoleCore and getBooksByAuthorIDFull had no equivalent
+// at all, so the Pebble listing path could only ever see an author through the
+// denormalized Book.AuthorID field. Authors 2..n of a credit list exist ONLY as
+// junction rows, so a co-author's books were invisible to that path entirely.
+func (p *PebbleStore) bookIDsInAuthorJunction(authorID int) (map[string]struct{}, error) {
+	bookIDSet := make(map[string]struct{})
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book_authors:"),
+		UpperBound: []byte("book_authors:~"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	for iter.First(); iter.Valid(); iter.Next() {
+		var authors []BookAuthor
+		if err := json.Unmarshal(iter.Value(), &authors); err != nil {
+			continue
+		}
+		for _, a := range authors {
+			if a.AuthorID == authorID {
+				// Key is "book_authors:<bookID>".
+				bookIDSet[strings.TrimPrefix(string(iter.Key()), "book_authors:")] = struct{}{}
+				break
+			}
+		}
+	}
+	return bookIDSet, nil
+}
+
+// getBooksByAuthorIDFull performs a full Pebble book scan for the author's
+// LISTING view: junction + legacy Book.AuthorID, soft-deleted excluded,
+// non-primary versions excluded.
+//
+// Both exclusions are deliberate and both were missing before 2026-08-14. The
+// junction lookup was absent, and the primary-version filter was absent, which
+// left this path disagreeing with its memdb counterpart in two directions at
+// once — under-reporting co-authors while over-reporting duplicate versions.
+// Opposite-signed errors keep aggregate counts plausible, which is why this
+// survived so long. This path only runs before memdb publishes (~132 s after
+// start on prod), so matching memdb here makes cold behaviour match warm rather
+// than changing what the UI normally shows.
+//
+// Callers needing the COMPLETE set — every merge and delete path — must use
+// GetBooksByAuthorIDWithRoleCore instead. See
+// internal/database/author_getter_conformance_test.go.
 func (p *PebbleStore) getBooksByAuthorIDFull(authorID int) ([]Book, error) {
+	inJunction, err := p.bookIDsInAuthorJunction(authorID)
+	if err != nil {
+		return nil, err
+	}
+
 	var books []Book
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte("book:0"),
@@ -1828,7 +1883,7 @@ func (p *PebbleStore) getBooksByAuthorIDFull(authorID int) ([]Book, error) {
 
 	for iter.First(); iter.Valid(); iter.Next() {
 		key := string(iter.Key())
-		// Skip non-primary book keys (path index etc.)
+		// Skip secondary book keys (path index etc.)
 		if strings.Contains(key, ":path:") {
 			continue
 		}
@@ -1837,10 +1892,15 @@ func (p *PebbleStore) getBooksByAuthorIDFull(authorID int) ([]Book, error) {
 		if err := json.Unmarshal(iter.Value(), &book); err != nil {
 			continue
 		}
-		if book.AuthorID == nil || *book.AuthorID != authorID {
+		_, linkedViaJunction := inJunction[book.ID]
+		linkedViaLegacy := book.AuthorID != nil && *book.AuthorID == authorID
+		if !linkedViaJunction && !linkedViaLegacy {
 			continue
 		}
 		if bookIsSoftDeleted(&book) {
+			continue
+		}
+		if book.IsPrimaryVersion != nil && !*book.IsPrimaryVersion {
 			continue
 		}
 		books = append(books, book)
@@ -1866,7 +1926,13 @@ func (p *PebbleStore) getBooksByAuthorIDFull(authorID int) ([]Book, error) {
 // docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 func (p *PebbleStore) GetBooksByAuthorIDWithRoleCore(authorID int) ([]BookCore, error) {
 	if p.UseMemDB && p.mem() != nil {
-		books, err := p.mem().GetBooksByAuthorID(authorID, 0, 0)
+		// AllVersions, not the plain getter: this method's callers are merges,
+		// deletes and dedup, and a link they cannot see is one they will not
+		// rewrite before deleting the author — which orphans it. The Pebble
+		// branch below has never filtered non-primary versions, so using the
+		// filtered memdb view here also made the two paths disagree. See
+		// internal/database/author_getter_conformance_test.go.
+		books, err := p.mem().GetBooksByAuthorIDAllVersions(authorID, 0, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -1876,32 +1942,16 @@ func (p *PebbleStore) GetBooksByAuthorIDWithRoleCore(authorID int) ([]BookCore, 
 		}
 		return cores, nil
 	}
-	// Collect book IDs from the book_authors junction table.
-	bookIDSet := make(map[string]struct{})
-	iter, err := p.db.NewIter(&pebble.IterOptions{
-		LowerBound: []byte("book_authors:"),
-		UpperBound: []byte("book_authors:~"),
-	})
+	// Collect book IDs from the book_authors junction table. Shared with the
+	// listing path so the two Pebble getters cannot drift apart on what
+	// "linked to this author" means.
+	bookIDSet, err := p.bookIDsInAuthorJunction(authorID)
 	if err != nil {
 		return nil, err
 	}
-	for iter.First(); iter.Valid(); iter.Next() {
-		var authors []BookAuthor
-		if err := json.Unmarshal(iter.Value(), &authors); err != nil {
-			continue
-		}
-		for _, a := range authors {
-			if a.AuthorID == authorID {
-				// Extract bookID from key "book_authors:<bookID>"
-				key := string(iter.Key())
-				bookID := strings.TrimPrefix(key, "book_authors:")
-				bookIDSet[bookID] = struct{}{}
-			}
-		}
-	}
-	iter.Close()
 
-	// Also include books matched via legacy AuthorID field.
+	// Also include books matched via legacy AuthorID field. Note there is
+	// deliberately no IsPrimaryVersion filter here — see the doc comment.
 	var books []Book
 	bookIter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte("book:0"),

--- a/todo.d/20260814-memdb-pebble-author-link-divergence.md
+++ b/todo.d/20260814-memdb-pebble-author-link-divergence.md
@@ -1,4 +1,4 @@
-## memdb and Pebble disagree about author→book links
+## memdb and Pebble disagree about author→book links — ROOT-CAUSED, one step left
 
 Found 2026-08-14 by running `maintenance.author-conjunction-repair` twice in
 dry-run against prod and getting two different answers from the same op, same
@@ -14,43 +14,48 @@ Row counts were identical in both (`authors_matched=46`,
 difference is **author 46627 (`& Nicholas Courtney`)**: the Pebble path finds 2
 book links, memdb finds 0.
 
-`GetBooksByAuthorIDCore` and `GetBooksByAuthorIDWithRoleCore` both take the same
-`p.mem().GetBooksByAuthorID(authorID, 0, 0)` branch when memdb is live, so this
-is not a caller difference — the two *stores* disagree. memdb had been freshly
-loaded at the restart, so its loader is dropping the links rather than lagging
-behind a write.
+### ✅ Root cause (2026-08-14, fixed in `fix/author-getter-conformance`)
 
-- [ ] Identify the 2 books. They are not among `Nicholas Courtney` (43791)'s 7
-      books — none of those reference 46627 — so they are books where 46627 is
-      a co-author and 43791 is not linked at all.
-- [ ] Find why memdb's loader drops them. Note `/api/v1/authors/46627/books`
-      and the authors-list `book_count` BOTH report 0, so every serving-layer
-      read agrees with memdb and only Pebble sees them.
-      - ❌ **RULED OUT: `safeInsert` skipping rows.** `memdb_warmup.go` skips and
-        counts rows that fail to insert, which looked like the obvious culprit.
-        The 2026-08-14 01:54 warmup reports `skipped_total=0` with
-        `book_authors=290643` loaded. Nothing was dropped at insert time, so the
-        loss is in the index or the query, not the load.
-      - Remaining suspects: the memdb author→book index construction, or
-        `memdb.GetBooksByAuthorID` itself.
-      - ⏱️ Warmup takes **132s** on prod. Any op dispatched sooner than that
-        after a restart runs on Pebble. That is what made the divergence
-        visible at all.
-- [ ] Write the conformance test rather than a per-path assertion — one fixture,
-      both implementations, assert equal. This is the third memdb/Pebble
-      divergence in a week (see the soft-deleted leak, #2392), and per-path
-      expectations cannot catch drift because the path's own author writes the
-      expectation.
-- [ ] Once resolved, drop `skip_author_ids: [46627]` from the repair invocation
-      and repair that row. **Applied 2026-08-14 02:0x: 30 merged, 15 renamed, 0
-      failures, 145/145 book links verified. Author 46627 is the ONLY remaining
-      stranded-ampersand row** (the other two survivors, `&#169` and
+**memdb's query filtered out non-primary versions; neither Pebble path did.**
+`memdb.GetBooksByAuthorID` skipped any book with `IsPrimaryVersion == false`.
+Author 46627's 2 links are co-author credits on non-primary versions, so memdb
+returned 0 and Pebble returned 2.
+
+Nothing was wrong with the loader, which is why ruling out `safeInsert` was
+correct and yet led nowhere: the junction rows loaded fine (`skipped_total=0`,
+`book_authors=290643`). The rows were present the whole time and the *query*
+discarded the books they pointed at.
+
+A second, opposite divergence was found in the same read: **the Pebble path of
+`GetBooksByAuthorIDCore` never opened the junction table at all**, so it saw
+only `Book.AuthorID` and was blind to every co-author. One getter under-reported
+non-primary versions, the other under-reported co-authors, and the two errors
+pointing opposite ways is why aggregate counts stayed plausible for so long.
+
+Contract now pinned by `internal/database/author_getter_conformance_test.go`:
+
+- `...WithRoleCore` — the COMPLETE set (junction + legacy, non-primary
+  **included**). Merges and deletes consult this one; a missed link is data loss.
+- `...Core` — the LISTING view (junction + legacy, non-primary **excluded**).
+- Both exclude soft-deleted books.
+
+- [x] Identify why memdb and Pebble disagreed.
+- [x] Write the conformance test rather than a per-path assertion — one fixture,
+      both implementations, assert equal. This was the third memdb/Pebble
+      divergence in a week (see the soft-deleted leak, #2392).
+- [ ] **After this deploys**, drop `skip_author_ids: [46627]` from the repair
+      invocation and repair that row. Everything else already applied
+      2026-08-14 02:0x: 30 merged, 15 renamed, 0 failures, 145/145 book links
+      verified *via the memdb-backed API — the Pebble path was not re-read
+      post-apply*. Author 46627 is the ONLY remaining stranded-ampersand row;
+      the other two survivors, `&#169` and
       `&#169;2013 by HarperCollinsPublishers`, are the separate HTML-entity
-      defect).
+      defect.
 
 **Why this blocked the repair:** the merge path relinks the books it can see and
 then DELETES the author row. Run through memdb it would relink 0 books for 46627
 and delete the author anyway, leaving the 2 Pebble junction rows pointing at an
 author id that no longer exists — the orphaning hazard H8 documents on
 `maintenance.author-split-scan`. The row was excluded by id for the 2026-08-14
-apply rather than papered over with a heuristic.
+apply rather than papered over with a heuristic. With the fix deployed, the warm
+path sees those 2 links and the merge relinks them before deleting.


### PR DESCRIPTION
## What

`GetBooksByAuthorIDCore` and `GetBooksByAuthorIDWithRoleCore` each have two backing implementations, and each pair disagreed — in **opposite directions**.

| getter | Pebble path (before) | memdb path (before) |
|---|---|---|
| `GetBooksByAuthorIDCore` | legacy `Book.AuthorID` **only** — never opened the junction | junction + legacy, **minus non-primary versions** |
| `...WithRoleCore` | junction + legacy, **includes non-primary** | junction + legacy, **minus non-primary versions** |

Opposite-signed errors keep aggregate counts plausible, which is why this survived. Only one shape of row exposes either: **a co-author on a non-primary version.**

## Why it is not cosmetic

`...WithRoleCore` is what every merge and delete path calls to find the books it must relink *before* removing an author — `author_conjunction_repair.go:290`, `entities_ops.go:89`, `ai_author_reassign.go:33`, `maintenance/author.go:169`. If it under-reports, the caller deletes the author anyway and **orphans the junction rows** (the H8 hazard, created by the repair itself).

Meanwhile `...Core`'s Pebble path could not see co-authors at all, since authors 2..n of a credit list exist *only* as junction rows.

## How it was found

Running `maintenance.author-conjunction-repair` twice in dry-run against prod gave two different answers from the same op, same binary, same data:

| run | path | `books_relinked` |
|---|---|---|
| 4s after restart, memdb cold | Pebble | **86** |
| warm | memdb | **84** |

The gap was author 46627 (`& Nicholas Courtney`) — co-author credits on non-primary versions. `safeInsert` was ruled out early and correctly: the junction rows loaded fine (`skipped_total=0`, `book_authors=290643`). The rows were always present; the *query* discarded the books they pointed at.

## The contract, now explicit

- **`...WithRoleCore` = COMPLETE set** (junction + legacy, non-primary **included**). For merges/deletes a missed link is data loss; an extra one is at worst redundant work.
- **`...Core` = LISTING view** (junction + legacy, non-primary **excluded**). This is what memdb already returned, so it is what prod has served outside the ~132 s warmup window. **Only cold behaviour changes, and it changes to match warm.**
- Both exclude soft-deleted books.

Both Pebble getters now resolve the junction through one shared helper, so they cannot drift on what "linked to this author" means again.

## Tests

New `internal/database/author_getter_conformance_test.go` — one fixture, both implementations, assert equal, following the pattern `book_visibility_conformance_test.go` established in #2392. Per-path expectations cannot catch this class of drift, because the path's own author writes the expectation.

**All three tests were confirmed RED before the fix**, each naming its own defect:
- `WithRole` memdb dropped the non-primary co-author
- `Core` Pebble never opened the junction
- the superset check caught the collapse (`"2" is not greater than "2"`)

Green after. Full `go test ./... -short` passes.

The fixture carries non-vacuity guards (it must contain a co-author on a non-primary version, and `WithRole` must strictly exceed `Core`) so the suite cannot quietly become tautological.

## Follow-up

Author 46627 is still excluded via `skip_author_ids`. Once this deploys, the warm path sees its 2 links and the merge can relink them before deleting — tracked in `todo.d/20260814-memdb-pebble-author-link-divergence.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxigqrwz9WfwN1wx8QhoQW