### PR TITLE
fix(database): exclude soft-deleted books from series counts on the Pebble path

### DIFF
--- a/changelog.d/20260814_120000_fix_series_counts_exclude_trash.md
+++ b/changelog.d/20260814_120000_fix_series_counts_exclude_trash.md
@@ -1,0 +1,24 @@
+### Fixed
+
+#### Series book and file counts no longer include trashed books on the Pebble path
+
+`GetAllSeriesBookCounts` and `GetAllSeriesFileCounts` have two implementations,
+and they disagreed. The memdb implementation has always skipped soft-deleted
+books; the Pebble key-scan counted them. A series whose trash held four books
+reported those four in its book count, and their audio files in its file count.
+
+memdb is the production default, so the visible effect was confined to cold
+start — the window after process start but before warmup publishes the in-memory
+index — and to any deployment running with `UseMemDB=false`. In that window a
+series' counts read high and then silently dropped to the correct value once
+warmup completed, with nothing logged to explain the change.
+
+The fix adds the same `bookIsSoftDeleted` skip both scans were missing. In
+`GetAllSeriesFileCounts` the skip goes in phase 1, where the book-to-series map
+is built, rather than in the phase-2 file loop: a book excluded from that map
+never has its `BookFile` rows attributed to the series, so one check covers both.
+
+A new cross-backend conformance test (`TestSeriesCounts_ExcludeTrashOnBothPaths`)
+runs the same fixture through both implementations with `UseMemDB` flipped and
+asserts they agree. Both halves of the fix were mutation-verified — reverting
+either one turns the test red on the specific count it governs.

--- a/internal/database/pebble_store_series.go
+++ b/internal/database/pebble_store_series.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_series.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 29120d16-9add-4efd-81a5-edc1e8951f4d
-// last-edited: 2026-07-03
+// last-edited: 2026-08-14
 
 package database
 
@@ -269,6 +269,12 @@ func (p *PebbleStore) GetAllSeriesBookCounts_Pebble() (map[int]int, error) {
 		if b.SeriesID == nil || (b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion) {
 			continue
 		}
+		// Soft-deleted books are trash awaiting purge, not library content. The
+		// memdb implementation has always skipped them; this path did not, so a
+		// series' book count jumped whenever memdb was unavailable.
+		if bookIsSoftDeleted(&b) {
+			continue
+		}
 		counts[*b.SeriesID]++
 	}
 	return counts, nil
@@ -298,6 +304,12 @@ func (p *PebbleStore) GetAllSeriesFileCounts() (map[int]int, error) {
 		}
 		var b Book
 		if err := json.Unmarshal(iter.Value(), &b); err != nil {
+			continue
+		}
+		// Skip soft-deleted books here rather than when counting files: leaving
+		// them out of bookIDToSeriesID means their BookFile rows are never
+		// attributed to the series in phase 2 either. Matches the memdb path.
+		if bookIsSoftDeleted(&b) {
 			continue
 		}
 		if b.SeriesID != nil && (b.IsPrimaryVersion == nil || *b.IsPrimaryVersion) {

--- a/internal/database/series_counts_conformance_test.go
+++ b/internal/database/series_counts_conformance_test.go
@@ -1,0 +1,156 @@
+// file: internal/database/series_counts_conformance_test.go
+// version: 1.0.0
+// guid: 7c1f4a9e-2b83-4d51-9f6a-0e5c8d3b7a12
+// last-edited: 2026-08-14
+
+package database
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// seriesCountsFixture builds two series whose live/trashed split makes the
+// soft-delete filter falsifiable: if an implementation forgets to skip trashed
+// books, seriesA's book count reads 4 instead of 2 and its file count reads 4
+// instead of 2. seriesB has no trash at all, so a mutation that skips *every*
+// book (rather than just the deleted ones) also fails.
+type seriesCountsFixture struct {
+	seriesA         int
+	seriesB         int
+	liveBookIDs     []string
+	trashedBookIDs  []string
+	wantBookCountsA int
+	wantFileCountsA int
+	wantBookCountsB int
+	wantFileCountsB int
+}
+
+func buildSeriesCountsFixture(t *testing.T, store Store) seriesCountsFixture {
+	t.Helper()
+
+	yes := true
+	var fx seriesCountsFixture
+
+	sa, err := store.CreateSeries("Conformance Series A", nil)
+	require.NoError(t, err)
+	sb, err := store.CreateSeries("Conformance Series B", nil)
+	require.NoError(t, err)
+	fx.seriesA, fx.seriesB = sa.ID, sb.ID
+
+	// mk creates a book in a series with `files` audio files attached.
+	mk := func(title string, seriesID int, files int) *Book {
+		sid := seriesID
+		created, err := store.CreateBook(&Book{
+			Title:    title,
+			FilePath: "/lib/" + title,
+			SeriesID: &sid,
+		})
+		require.NoError(t, err)
+		for i := 0; i < files; i++ {
+			require.NoError(t, store.CreateBookFile(&BookFile{
+				BookID:   created.ID,
+				FilePath: fmt.Sprintf("/lib/%s/part%d.m4b", title, i),
+				Format:   "m4b",
+			}))
+		}
+		return created
+	}
+
+	for _, title := range []string{"Series A Live One", "Series A Live Two"} {
+		fx.liveBookIDs = append(fx.liveBookIDs, mk(title, fx.seriesA, 1).ID)
+	}
+
+	// Soft-delete through UpdateBook so the memdb re-index runs — a row born
+	// deleted would skip the live->trashed transition these methods must survive.
+	for _, title := range []string{"Series A Trashed One", "Series A Trashed Two"} {
+		created := mk(title, fx.seriesA, 1)
+		created.MarkedForDeletion = &yes
+		_, err := store.UpdateBook(created.ID, created)
+		require.NoError(t, err)
+		fx.trashedBookIDs = append(fx.trashedBookIDs, created.ID)
+	}
+
+	fx.liveBookIDs = append(fx.liveBookIDs, mk("Series B Live One", fx.seriesB, 2).ID)
+
+	fx.wantBookCountsA, fx.wantFileCountsA = 2, 2
+	fx.wantBookCountsB, fx.wantFileCountsB = 1, 2
+	return fx
+}
+
+// TestSeriesCounts_ExcludeTrashOnBothPaths is the conformance gate for the two
+// series aggregate counters.
+//
+// These drifted: MemStore.GetAllSeriesBookCounts / GetAllSeriesFileCounts have
+// always skipped soft-deleted books, while the Pebble scans counted them. memdb
+// is the production default, so the visible effect was confined to cold start
+// (before warmup publishes) and to any deployment running with UseMemDB=false --
+// a series' book and file counts would jump by the size of its trash and then
+// settle, with no error anywhere to explain the change.
+//
+// Both methods already gated on `p.UseMemDB && p.mem() != nil`, so unlike
+// ListBooksByITunesPID the flag flip below genuinely selected two paths before
+// this test existed; the IsMemReady guard keeps it that way.
+func TestSeriesCounts_ExcludeTrashOnBothPaths(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	fx := buildSeriesCountsFixture(t, store)
+
+	p, ok := store.(*PebbleStore)
+	require.True(t, ok, "expected *PebbleStore from setupPebbleTestDB")
+	p.WaitForWarmup()
+	require.True(t, p.IsMemReady(),
+		"memdb must be published or the UseMemDB=true arm silently runs the Pebble path")
+
+	// Non-vacuity: with no trashed rows the exclusion assertion is unfalsifiable,
+	// and with no live rows an implementation returning nothing would pass.
+	require.NotEmpty(t, fx.trashedBookIDs, "fixture must contain soft-deleted books in a series")
+	require.NotEmpty(t, fx.liveBookIDs, "fixture must contain live books in a series")
+
+	originalUseMemDB := p.UseMemDB
+	defer func() { p.UseMemDB = originalUseMemDB }()
+
+	bookCounts := map[bool]map[int]int{}
+	fileCounts := map[bool]map[int]int{}
+
+	for _, useMemDB := range []bool{true, false} {
+		p.UseMemDB = useMemDB
+		label := "PebbleScanPath"
+		if useMemDB {
+			label = "MemDBPath"
+		}
+
+		t.Run(label, func(t *testing.T) {
+			bc, err := p.GetAllSeriesBookCounts()
+			require.NoError(t, err)
+			fc, err := p.GetAllSeriesFileCounts()
+			require.NoError(t, err)
+
+			require.Equal(t, fx.wantBookCountsA, bc[fx.seriesA],
+				"series A book count must exclude its %d trashed books", len(fx.trashedBookIDs))
+			require.Equal(t, fx.wantFileCountsA, fc[fx.seriesA],
+				"series A file count must exclude files of trashed books")
+			require.Equal(t, fx.wantBookCountsB, bc[fx.seriesB],
+				"series B has no trash; its count must be unaffected")
+			require.Equal(t, fx.wantFileCountsB, fc[fx.seriesB],
+				"series B file count must be unaffected")
+
+			bookCounts[useMemDB] = bc
+			fileCounts[useMemDB] = fc
+		})
+	}
+
+	// The conformance assertion proper: whatever the numbers are, both
+	// implementations must produce the SAME ones for the series under test.
+	require.Equal(t, bookCounts[true][fx.seriesA], bookCounts[false][fx.seriesA],
+		"memdb and Pebble disagree on series A book count")
+	require.Equal(t, fileCounts[true][fx.seriesA], fileCounts[false][fx.seriesA],
+		"memdb and Pebble disagree on series A file count")
+	require.Equal(t, bookCounts[true][fx.seriesB], bookCounts[false][fx.seriesB],
+		"memdb and Pebble disagree on series B book count")
+	require.Equal(t, fileCounts[true][fx.seriesB], fileCounts[false][fx.seriesB],
+		"memdb and Pebble disagree on series B file count")
+}


### PR DESCRIPTION
## What

`GetAllSeriesBookCounts` and `GetAllSeriesFileCounts` have two implementations and they disagreed. `MemStore` has always skipped soft-deleted books; the Pebble key-scans counted them — so a series reported its trashed books in its book count, and their audio files in its file count.

## Blast radius

memdb is the production default, so the visible effect was confined to:
- **cold start** — the window after process start but before warmup publishes the in-memory index, and
- any deployment running with `UseMemDB=false`.

In that window a series' counts read high and then silently corrected themselves once warmup completed, with nothing logged to explain the change. **This is a display-aggregate defect only** — both call sites (`filesystem.go` folder `BookCount`, `scanner/service.go` import-path count) assign to a count field. Nothing gates a delete or cleanup on these numbers.

Because prod runs memdb, **prod behaviour is unchanged by this PR** and I have not validated it against prod.

## The phase-1 detail

In `GetAllSeriesFileCounts` the skip goes in **phase 1**, where the `bookID → seriesID` map is built, rather than in the phase-2 `book_file:` loop. A book kept out of that map never has its `BookFile` rows attributed to the series, so one check covers both counts and avoids a second book lookup per file.

## Test

New `TestSeriesCounts_ExcludeTrashOnBothPaths` runs one fixture through both implementations with `UseMemDB` flipped and asserts they agree. Fixture is built so the filter is falsifiable: series A has 2 live + 2 trashed books (forgetting the skip reads 4), series B has no trash at all (a mutation skipping *every* book also fails).

It guards non-vacuity with `require.True(t, p.IsMemReady())` — without that, the `UseMemDB=true` arm can silently run the Pebble path and the test asserts memdb == memdb. Both these methods already gated correctly on `p.UseMemDB && p.mem() != nil`, so unlike `ListBooksByITunesPID` in #2399 the flip genuinely selected two paths here.

**Mutation-verified.** Reverting either half turns the test red on the specific count it governs:

| mutation | result |
|---|---|
| drop trash-skip from `GetAllSeriesBookCounts_Pebble` | FAIL — "series A book count must exclude its 2 trashed books" |
| drop trash-skip from `GetAllSeriesFileCounts` | FAIL — "series A file count must exclude files of trashed books" |
| both restored | PASS |

## Provenance

Found by auditing every dual-implementation store method for soft-delete drift, following #2392/#2399. Fourteen candidates were machine-flagged; ten were false positives and were hand-eliminated by reading the code. Three other methods genuinely drift (`ListBookIDs`, `CountBooksByPathPrefix`, plus two ungated memdb dispatches) — those are a **separate PR** because they needed a caller survey to confirm no consumer treats absence-from-the-list as licence to delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t