### PR TITLE
fix(database): exclude soft-deleted books from ListBookIDs on the Pebble path

### DIFF
--- a/changelog.d/20260814_130000_fix_listbookids_pathprefix_exclude_trash.md
+++ b/changelog.d/20260814_130000_fix_listbookids_pathprefix_exclude_trash.md
@@ -1,0 +1,34 @@
+### Fixed
+
+#### Book-ID enumeration no longer includes trashed books on the Pebble path
+
+`ListBookIDs` is how roughly twenty full-library maintenance operations enumerate
+the library — chapter backfill, intro transcription, aggregate recomputation,
+sidecar migration, and others. `MemStore` filtered soft-deleted books out of the
+listing; the Pebble scan did not, because it read keys only and never decoded a
+book at all. That is precisely why the filter was missing there. The fix decodes
+just the deletion flag rather than the whole record, keeping the scan close to
+its original key-only cost.
+
+`computeLibraryStats` dispatched on memdb *publication* alone rather than on
+`UseMemDB`, so its Pebble scan was unreachable whenever memdb was up — including
+in a store with the flag explicitly off — which left it untestable. Both of its
+implementations already agreed about soft-deleted books, so no numbers change;
+the gate is corrected so the Pebble scan can be exercised by a test, since that
+scan is what serves the dashboard during cold start.
+
+`CountBooksByPathPrefix` gains a key-shape guard. Its scan had no check at all
+and relied on secondary-index values happening to fail JSON decoding, unlike
+every sibling scan in the package, which check the key explicitly.
+
+memdb is the production default, so all of this was confined to the cold-start
+window before warmup publishes the in-memory index, and to deployments running
+with `UseMemDB=false`. No caller treats absence from these results as licence to
+delete anything — that was checked across all twenty-odd call sites before
+changing the Pebble behaviour to match memdb.
+
+Two new cross-backend conformance tests run one fixture through both
+implementations with `UseMemDB` flipped. Every change was mutation-verified,
+including mutations that revert the dispatch gate: with the old gate the test
+passes while the defect is present, which is what makes a gate fix a
+prerequisite for its test rather than a tidy-up alongside it.

--- a/internal/database/listbookids_pathprefix_conformance_test.go
+++ b/internal/database/listbookids_pathprefix_conformance_test.go
@@ -1,0 +1,188 @@
+// file: internal/database/listbookids_pathprefix_conformance_test.go
+// version: 1.0.0
+// guid: 4e8b1c07-6d92-4a35-b8f1-2c9a7e40d5b3
+// last-edited: 2026-08-14
+
+package database
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	conformanceAlphaPrefix = "/import/alpha"
+	conformanceBetaPrefix  = "/import/beta"
+)
+
+// idTrashFixture builds books under two import-path prefixes, split live and
+// soft-deleted, so both the ID listing and the prefix count are falsifiable:
+// forgetting the trash filter makes alpha count 5 instead of 3 and puts two
+// extra IDs in the listing. Beta has no trash, so a mutation that drops *every*
+// book also fails.
+type idTrashFixture struct {
+	liveAlphaIDs   []string
+	trashAlphaIDs  []string
+	liveBetaID     string
+	wantAlphaCount int
+	wantBetaCount  int
+}
+
+func buildIDTrashFixture(t *testing.T, store Store) idTrashFixture {
+	t.Helper()
+
+	yes := true
+	var fx idTrashFixture
+
+	mk := func(prefix, title string) *Book {
+		created, err := store.CreateBook(&Book{
+			Title:    title,
+			FilePath: fmt.Sprintf("%s/%s.m4b", prefix, title),
+		})
+		require.NoError(t, err)
+		return created
+	}
+
+	for _, title := range []string{"AlphaLiveOne", "AlphaLiveTwo", "AlphaLiveThree"} {
+		fx.liveAlphaIDs = append(fx.liveAlphaIDs, mk(conformanceAlphaPrefix, title).ID)
+	}
+
+	// Soft-delete via UpdateBook so the memdb re-index runs; a row born deleted
+	// would skip the live->trashed transition these methods have to survive.
+	for _, title := range []string{"AlphaTrashOne", "AlphaTrashTwo"} {
+		created := mk(conformanceAlphaPrefix, title)
+		created.MarkedForDeletion = &yes
+		_, err := store.UpdateBook(created.ID, created)
+		require.NoError(t, err)
+		fx.trashAlphaIDs = append(fx.trashAlphaIDs, created.ID)
+	}
+
+	fx.liveBetaID = mk(conformanceBetaPrefix, "BetaLiveOne").ID
+
+	fx.wantAlphaCount = 3
+	fx.wantBetaCount = 1
+	return fx
+}
+
+// TestListBookIDsAndPathPrefix_ExcludeTrashOnBothPaths is the conformance gate
+// for two more methods whose implementations drifted on soft-delete.
+//
+// ListBookIDs: MemStore filtered soft-deleted books, the Pebble scan did not.
+// The Pebble scan never unmarshalled anything — it read keys only — which is
+// exactly why the filter was missing. ~20 full-library maintenance ops
+// enumerate through this method.
+//
+// CountBooksByPathPrefix: same drift, plus its dispatch gated on memdb
+// PUBLICATION alone rather than UseMemDB, so the Pebble branch was unreachable
+// whenever memdb was up and could not be tested at all. That gate is fixed in
+// the same commit as this test — without the fix the loop below would run the
+// memdb path twice and assert memdb == memdb.
+func TestListBookIDsAndPathPrefix_ExcludeTrashOnBothPaths(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	fx := buildIDTrashFixture(t, store)
+
+	p, ok := store.(*PebbleStore)
+	require.True(t, ok, "expected *PebbleStore from setupPebbleTestDB")
+	p.WaitForWarmup()
+	require.True(t, p.IsMemReady(),
+		"memdb must be published or the UseMemDB=true arm silently runs the Pebble path")
+
+	require.NotEmpty(t, fx.trashAlphaIDs, "fixture must contain soft-deleted books")
+	require.NotEmpty(t, fx.liveAlphaIDs, "fixture must contain live books")
+
+	originalUseMemDB := p.UseMemDB
+	defer func() { p.UseMemDB = originalUseMemDB }()
+
+	idsByPath := map[bool]map[string]bool{}
+	alphaCounts := map[bool]int{}
+
+	for _, useMemDB := range []bool{true, false} {
+		p.UseMemDB = useMemDB
+		label := "PebbleScanPath"
+		if useMemDB {
+			label = "MemDBPath"
+		}
+
+		t.Run(label, func(t *testing.T) {
+			ids, err := p.ListBookIDs()
+			require.NoError(t, err)
+			seen := map[string]bool{}
+			for _, id := range ids {
+				seen[id] = true
+			}
+
+			for _, id := range fx.liveAlphaIDs {
+				require.True(t, seen[id], "live book %s missing from ListBookIDs", id)
+			}
+			require.True(t, seen[fx.liveBetaID], "live beta book missing from ListBookIDs")
+			for _, id := range fx.trashAlphaIDs {
+				require.False(t, seen[id], "soft-deleted book %s must not appear in ListBookIDs", id)
+			}
+
+			alpha, err := p.CountBooksByPathPrefix(conformanceAlphaPrefix)
+			require.NoError(t, err)
+			beta, err := p.CountBooksByPathPrefix(conformanceBetaPrefix)
+			require.NoError(t, err)
+
+			require.Equal(t, fx.wantAlphaCount, alpha,
+				"alpha count must exclude its %d trashed books", len(fx.trashAlphaIDs))
+			require.Equal(t, fx.wantBetaCount, beta,
+				"beta has no trash; its count must be unaffected")
+
+			idsByPath[useMemDB] = seen
+			alphaCounts[useMemDB] = alpha
+		})
+	}
+
+	// Conformance proper: both implementations must agree on every fixture book.
+	for _, id := range append(append([]string{}, fx.liveAlphaIDs...), fx.trashAlphaIDs...) {
+		require.Equal(t, idsByPath[true][id], idsByPath[false][id],
+			"memdb and Pebble disagree on whether ListBookIDs includes %s", id)
+	}
+	require.Equal(t, alphaCounts[true], alphaCounts[false],
+		"memdb and Pebble disagree on CountBooksByPathPrefix")
+}
+
+// TestComputeLibraryStats_MemDBAndPebbleAgree covers the third gate fixed here.
+//
+// computeLibraryStats also dispatched on memdb publication alone, so its Pebble
+// scan was unreachable in any store with memdb up. Both implementations already
+// filtered soft-deleted books correctly — this test exists because making a
+// fallback reachable and then not testing it is its own defect, and because the
+// Pebble scan is what serves the dashboard during the cold-start window.
+func TestComputeLibraryStats_MemDBAndPebbleAgree(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	fx := buildIDTrashFixture(t, store)
+
+	p, ok := store.(*PebbleStore)
+	require.True(t, ok, "expected *PebbleStore from setupPebbleTestDB")
+	p.WaitForWarmup()
+	require.True(t, p.IsMemReady(),
+		"memdb must be published or the UseMemDB=true arm silently runs the Pebble path")
+
+	originalUseMemDB := p.UseMemDB
+	defer func() { p.UseMemDB = originalUseMemDB }()
+
+	wantTotal := len(fx.liveAlphaIDs) + 1 // + beta; trashed books excluded
+
+	totals := map[bool]int{}
+	for _, useMemDB := range []bool{true, false} {
+		p.UseMemDB = useMemDB
+		// computeLibraryStats directly, not GetDashboardStats: the latter serves
+		// from a cache and would return the first path's answer to the second.
+		stats, err := p.computeLibraryStats()
+		require.NoError(t, err)
+		require.NotNil(t, stats)
+		totals[useMemDB] = stats.TotalBooks
+	}
+
+	require.Equal(t, wantTotal, totals[true], "memdb TotalBooks must exclude trashed books")
+	require.Equal(t, wantTotal, totals[false], "Pebble TotalBooks must exclude trashed books")
+	require.Equal(t, totals[true], totals[false], "memdb and Pebble disagree on TotalBooks")
+}

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.129.0
+// version: 1.130.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-08-14
 
@@ -668,6 +668,25 @@ func (p *PebbleStore) ListBookIDs() ([]string, error) {
 		// Defensive: skip any other secondary-index key forms that may slip
 		// through (anything containing another ':' is not a primary key).
 		if strings.IndexByte(id, ':') >= 0 {
+			continue
+		}
+		// MemStore.ListBookIDs filters soft-deleted books out of this listing,
+		// so this path must too — otherwise every full-library maintenance op
+		// that enumerates through it would process trashed books during the
+		// cold-start window before warmup publishes memdb.
+		//
+		// Decoding only the deletion flag rather than the whole Book keeps this
+		// scan close to the key-only cost it had before; a full unmarshal here
+		// is what this path was avoiding.
+		//
+		// probe is declared inside the loop deliberately: MarkedForDeletion is
+		// a pointer and `omitempty` means live books omit the key entirely, so
+		// a reused struct would keep the previous book's flag and drop live
+		// books that happen to follow a trashed one.
+		var probe struct {
+			MarkedForDeletion *bool `json:"marked_for_deletion,omitempty"`
+		}
+		if json.Unmarshal(iter.Value(), &probe) == nil && markedForDeletionFlag(probe.MarkedForDeletion) {
 			continue
 		}
 		ids = append(ids, id)

--- a/internal/database/pebble_store_importpaths.go
+++ b/internal/database/pebble_store_importpaths.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_importpaths.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: eb97f1d9-af89-4dc7-add9-70ab7c30d137
 // last-edited: 2026-08-14
 
@@ -80,6 +80,14 @@ func (p *PebbleStore) CountBooksByPathPrefix(prefix string) (int, error) {
 	}
 	defer iter.Close()
 	for iter.First(); iter.Valid(); iter.Next() {
+		// Skip secondary-index keys. The primary form is "book:<id>"; anything
+		// with a third segment is an index (book:<id>:path:..., :series:, etc).
+		// This scan previously relied on those index values failing to unmarshal
+		// as a Book, which happens to hold today but is not a guarantee — every
+		// sibling scan in this package checks the key shape explicitly.
+		if strings.Count(string(iter.Key()), ":") != 1 {
+			continue
+		}
 		var b Book
 		if json.Unmarshal(iter.Value(), &b) != nil {
 			continue

--- a/internal/database/pebble_store_stats.go
+++ b/internal/database/pebble_store_stats.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_stats.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 8643a893-1898-4098-8e69-c312531d962c
-// last-edited: 2026-08-13
+// last-edited: 2026-08-14
 
 package database
 
@@ -259,9 +259,14 @@ func (p *PebbleStore) computeLibraryStats() (*LibraryStats, error) {
 	// than the Pebble scan below (no JSON unmarshal, no disk I/O). Memdb
 	// can't see the book_file_errors_by_book: index, so we still need a
 	// short Pebble call for BrokenFiles.
-	if mem := p.mem(); mem != nil {
+	//
+	// Gated on UseMemDB as well as publication: dispatching on publication alone
+	// made the Pebble scan below unreachable whenever memdb was up, even with
+	// the flag explicitly off, so it could never be exercised by a test. Same
+	// defect as ListBooksByITunesPID in #2399.
+	if p.UseMemDB && p.mem() != nil {
 		importPaths, _ := p.GetAllImportPaths()
-		stats, err := mem.ComputeLibraryStats(p.rootDir, importPaths)
+		stats, err := p.mem().ComputeLibraryStats(p.rootDir, importPaths)
 		if err == nil {
 			if booksWithErrors, berr := p.ListBooksWithFileErrors(); berr == nil {
 				stats.BrokenFiles = len(booksWithErrors)

--- a/todo.d/2026-08-14-vacuous-store-invariant-marked-primary.md
+++ b/todo.d/2026-08-14-vacuous-store-invariant-marked-primary.md
@@ -1,0 +1,16 @@
+- [ ] **`AssertStoreInvariants` invariant (a) can never fire — it enumerates via `ListBookIDs`, which filters out exactly the rows it checks.**
+  `internal/database/dbtest/invariants.go:56` builds its book set from
+  `store.ListBookIDs()`, then asserts *"live-primary && marked-for-deletion is
+  contradictory"*. But `ListBookIDs` excludes soft-deleted books by design, so a
+  book that is both primary and marked can never reach the assertion. The check
+  is dead code and has been since the memdb filter was added; it is called at the
+  end of merge/combine/delete tests, which is precisely where that contradiction
+  would be introduced.
+  Found while surveying `ListBookIDs` callers for the soft-delete drift fix
+  (#2408). Not fixed there because it is a test-helper correctness issue, not a
+  production data path, and the fix needs a decision: either enumerate with an
+  unfiltered listing inside the helper, or drop invariant (a) as unreachable.
+  **Before changing it, mutation-test the replacement** — construct a book that is
+  both `IsPrimaryVersion=true` and `MarkedForDeletion=true` and confirm the
+  invariant actually goes red. A "fix" that leaves it green is the same defect
+  again.


### PR DESCRIPTION
**Rebased on top of #2411.** That PR landed first and independently fixed two of the four drifts this audit found — the `CountBooksByPathPrefix` soft-delete filter and its `UseMemDB` gate are **from #2411, not from this branch**. My sibling PR #2407 (series counts) was fully superseded by it and is closed. What remains here is what #2411 didn't touch.

## What this PR fixes

**`ListBookIDs`** — how ~20 full-library maintenance ops enumerate the library (chapters backfill, intro transcribe, aggregate recompute, sidecar migrate, relink, probe-directory, …). `MemStore` filtered soft-deleted books out; the Pebble scan did not — because it read **keys only** and never decoded a book. That's exactly why the filter was missing. The fix decodes only the deletion flag, keeping the scan close to its original key-only cost.

**`computeLibraryStats`** — dispatched on memdb *publication* alone rather than `UseMemDB`, so its Pebble scan was unreachable whenever memdb was up, even with the flag explicitly off (same defect as `ListBooksByITunesPID` in #2399). Both implementations already agreed on soft-delete, so **no numbers change**; the gate is corrected so the scan is testable, since it's what serves the dashboard during cold start.

**`CountBooksByPathPrefix` key-shape guard** — its scan has *no* key check, unlike every sibling scan in the package, so it feeds secondary-index values (`book:<id>:path:…`) into `json.Unmarshal` and relies on them *failing* to decode as a `Book`. That holds today (index values are bare ID strings) but is incidental, not guaranteed. #2411 didn't address this.

## The caller survey (this is what gated the PR)

Soft delete is **restorable trash** — the files must survive. Making Pebble exclude trashed books is only safe if no consumer treats "ID not in the enumeration" as "belongs to nothing → garbage."

I read every `ListBookIDs` call site. **None has that shape** — all are per-book iteration via `registry.RunItems`, cursor scans, or read-only audits.

## Blast radius

memdb is the production default, so this is confined to the **cold-start window** before warmup publishes, and to `UseMemDB=false` deployments. **Prod behaviour is unchanged, and I have not validated against prod.**

## The `probe` placement is load-bearing

`MarkedForDeletion` is a `*bool` with `omitempty`, so a live book's JSON omits the key and `Unmarshal` leaves the field untouched. Hoisting `probe` out of the loop "for efficiency" would make every live book following a trashed one inherit `true` and vanish. Mutation-covered.

## Mutation results

| mutation | expected | result |
|---|---|---|
| drop `ListBookIDs` trash skip | FAIL | ✅ "soft-deleted book … must not appear in ListBookIDs" |
| hoist `probe` out of the loop | FAIL | ✅ "live beta book missing from ListBookIDs" |
| drop `computeLibraryStats` Pebble trash skip, gate fixed | FAIL | ✅ "Pebble TotalBooks must exclude trashed books" |
| **↑ that defect + stats gate reverted to publication-only** | **PASS (blind)** | ✅ **PASS** |
| all restored | PASS | ✅ PASS |

Row 4 is the point: with the old gate the test passes *while the defect is present*. A gate fix is a **prerequisite** for its test, not a tidy-up beside it. (#2411 reached the same conclusion independently from a 7-vs-5 count.)

## Verification

`go build ./...` 0 · `go vet` 0 · all three conformance tests pass side by side (mine + #2411's `TestAggregateCounts_MemDBAndPebbleAgree`) · full `internal/database` + `internal/plugins/maintenance` suites exit 0.

## Also filed

`todo.d/` fragment: `dbtest/invariants.go:56` invariant (a) is **vacuous** — it enumerates via `ListBookIDs`, which filters out exactly the marked-for-deletion rows it asserts against, so it can never fire. Filed rather than fixed because the replacement needs mutation-testing.

## Audit provenance

14 candidates machine-flagged across all dual-implementation store methods; 10 were detector false positives eliminated by hand-reading. 4 real — 2 fixed by #2411, 2 here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t