### PR TITLE
fix(series): invalidate the cached series list after an op that changed rows

### DIFF
--- a/changelog.d/20260814_055500_series_ops_invalidate_series_cache.md
+++ b/changelog.d/20260814_055500_series_ops_invalidate_series_cache.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **A maintenance op that merged or deleted series left the series list showing
+  the pre-op data for up to 24 hours.** The cached series list carries a 24-hour
+  TTL and is warmed at startup, and until now only the interactive entities API
+  invalidated it. Measured on production 2026-08-14: a `maintenance.series-prune`
+  run reported *"17 duplicates merged, 326 orphans deleted, 0 errors"* and
+  `/api/v1/series` kept returning all 14,629 rows with the same 329 zero-book
+  entries — a completed repair that is indistinguishable from one that silently
+  did nothing. `series-prune`, `series-normalize` and `series-denumber` now drop
+  the cached list when, and only when, they actually changed rows; a run that
+  cleaned nothing keeps the warm cache rather than forcing a full recount. Same
+  defect and same fix shape as the authors-cache invalidation.

--- a/docs/executive-summaries/2026-08-14-the-series-that-vanished-from-under-13322-books-executive-summary.md
+++ b/docs/executive-summaries/2026-08-14-the-series-that-vanished-from-under-13322-books-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-08-14-the-series-that-vanished-from-under-13322-books-executive-summary.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 4d81f2ba-6c39-4e17-8a52-9f0b3c7e15d8 -->
 <!-- last-edited: 2026-08-14 -->
 
@@ -82,16 +82,26 @@ are not doing any harm, they still record which books were grouped together, and
 library next reads a series name from a file's own tags it will overwrite them correctly.
 Erasing them would throw away the grouping and gain nothing.
 
-One thing remains open. The damage did not arrive gradually — it came in bursts, on ten
-separate days in total, and the largest by far was **2026-08-11, when 5,367 books were
-added carrying references to series that do not exist**. Those books are loose files
-picked up as "Unknown Author", with titles like *Chapter 06*, so they came in through a
-scan of unsorted audio rather than through the weekly tidy-up. No series-deleting job ran
-on that day at all.
+One thing remains open, though it turned out to be smaller than it first looked. The damage
+did not arrive gradually — it came in bursts, on ten separate days, and the biggest single
+day was **2026-08-11, when 5,367 books appeared carrying references to series that don't
+exist**. That looked at first like something actively breaking new books.
 
-So the weekly job is no longer the cause, and was not the cause of the most recent burst
-either. Whatever ran on 11 August is still unidentified, and it is the thing to find next —
-the fix shipped here stops the bleeding from one source, not from that one.
+It isn't. Every one of those books points at a series that was **already** broken before
+that day — 5,068 series references, and not one of them was new. The last time a genuinely
+new broken reference appeared was **19 July**. What happened in August was copying, not
+breaking: something split existing books into per-chapter pieces (hence titles like
+*Chapter 06*), and each new piece inherited the broken series reference from the book it
+came from.
+
+That also rules out ordinary scanning as a cause, for a simple reason: when a scan reads a
+series name off a file, it looks the series up **by name** and creates it if it's missing.
+It can't end up pointing at something that isn't there. Only copying an existing record can
+do that.
+
+So nothing new is being broken. What's left is to stop the copying from spreading the old
+damage — the places that duplicate a book's record should drop a series reference that no
+longer points anywhere, rather than passing it on.
 
 ## Why it took so long to spot
 

--- a/docs/executive-summaries/2026-08-14-the-series-that-vanished-from-under-13322-books-executive-summary.md
+++ b/docs/executive-summaries/2026-08-14-the-series-that-vanished-from-under-13322-books-executive-summary.md
@@ -1,0 +1,94 @@
+<!-- file: docs/executive-summaries/2026-08-14-the-series-that-vanished-from-under-13322-books-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4d81f2ba-6c39-4e17-8a52-9f0b3c7e15d8 -->
+<!-- last-edited: 2026-08-14 -->
+
+# Executive Summary: The Series That Vanished From Under 13,322 Books
+
+**Date:** 2026-08-14
+**In one line:** A weekly tidy-up job was deleting series that still had books in them,
+and 13,322 books ended up filed under a series that no longer exists.
+
+---
+
+## What you saw
+
+Books with no series. Not an error, not an empty shelf — the book is there, it plays, its
+title and author are right, and the series line is simply blank. And a library with far
+more series than seemed possible: 14,626 series for 31,163 books.
+
+## What was actually happening
+
+There is a weekly job whose whole purpose is to delete series nobody uses any more. Before
+deleting one, it asked a reasonable-sounding question: *how many books are in this series?*
+
+The problem is which counter it asked. That counter was built to fill in the number you see
+next to a series on the website, so it deliberately skips two kinds of book:
+
+- books you have moved to the trash, and
+- alternate versions of a book you already own (the duplicate copies the library hides
+  behind the main one).
+
+For a badge on a web page, skipping those is exactly right. As the test for *"is anything
+still pointing at this series?"* it is dangerous, because those books **are** still pointing
+at it. A series whose books were all trashed, or all alternate versions, counted as zero.
+The job deleted it. The books survived — still carrying a reference to a series that had
+just been erased.
+
+By the time we measured it, books in the library referred to **21,190 different series, and
+only 14,626 of them existed**. The missing 6,893 were held by 13,322 books still in the
+library, plus another 702 in the trash.
+
+## The second problem: the repair looked like it did nothing
+
+The fix went out, and the job was re-run. It reported plainly:
+
+> 17 duplicates merged, 326 orphans deleted, 0 errors
+
+Then the series page was checked — and showed the same 14,629 series it had before, with the
+same 329 empty ones. Nothing had changed.
+
+Everything *had* changed; the page was reading from a stored copy. The series list is cached
+for a full day and rebuilt when the server starts, and until now only the website's own edit
+buttons knew to throw that copy away. A background job could merge and delete all it liked
+and the page would keep showing yesterday's list.
+
+That is the worst possible failure to have while repairing data, because *"the repair worked
+and you can't see it"* and *"the repair silently did nothing"* look identical from the
+outside. The same fault was found and fixed in the author list four hours earlier; this is
+the same fault, one shelf over.
+
+## What was fixed
+
+- **The counting.** The delete check now counts every book pointing at a series, whatever
+  state it is in. If it cannot get that number, it refuses to delete anything rather than
+  guessing — the wrong guess is what caused this.
+- **Proof it works.** After the fix, the job deleted 326 genuinely empty series and *kept*
+  "Queen of Fire: A Raven's Shadow Novel", whose only book is in the trash. That is precisely
+  the row the old code would have destroyed.
+- **The stale page.** The three background jobs that create, rename, merge or delete series
+  now clear the cached list — but only when they actually changed something, so a job that
+  had nothing to do doesn't throw away a good copy for nothing.
+
+## What is not fixed yet
+
+The 13,322 books whose series was deleted still show no series. We can tell **which books
+used to belong together**, because they still carry the same reference — but the series
+*names* are gone for good. They were never stored on the book itself, the deletions were not
+recorded in the operation history, and the folder names on disk don't contain them either.
+
+The deliberate decision was to **leave those references alone rather than erase them**. They
+are not doing any harm, they still record which books were grouped together, and when the
+library next reads a series name from a file's own tags it will overwrite them correctly.
+Erasing them would throw away the grouping and gain nothing.
+
+One thing remains open: 5,500 of the affected books were added to the library this month,
+which means something is still producing these broken references. The weekly job can no
+longer be the cause, so there is another source still to find.
+
+## Why it took so long to spot
+
+A book with a blank series looks like a book whose file never had series information — which
+is common and normal. There was nothing to distinguish "we never knew" from "we knew and
+deleted it". The damage was only visible by counting the series the books *refer to* against
+the series that *exist*, which nothing did until now.

--- a/docs/executive-summaries/2026-08-14-the-series-that-vanished-from-under-13322-books-executive-summary.md
+++ b/docs/executive-summaries/2026-08-14-the-series-that-vanished-from-under-13322-books-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-08-14-the-series-that-vanished-from-under-13322-books-executive-summary.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 4d81f2ba-6c39-4e17-8a52-9f0b3c7e15d8 -->
 <!-- last-edited: 2026-08-14 -->
 
@@ -82,9 +82,16 @@ are not doing any harm, they still record which books were grouped together, and
 library next reads a series name from a file's own tags it will overwrite them correctly.
 Erasing them would throw away the grouping and gain nothing.
 
-One thing remains open: 5,500 of the affected books were added to the library this month,
-which means something is still producing these broken references. The weekly job can no
-longer be the cause, so there is another source still to find.
+One thing remains open. The damage did not arrive gradually — it came in bursts, on ten
+separate days in total, and the largest by far was **2026-08-11, when 5,367 books were
+added carrying references to series that do not exist**. Those books are loose files
+picked up as "Unknown Author", with titles like *Chapter 06*, so they came in through a
+scan of unsorted audio rather than through the weekly tidy-up. No series-deleting job ran
+on that day at all.
+
+So the weekly job is no longer the cause, and was not the cause of the most recent burst
+either. Whatever ran on 11 August is still unidentified, and it is the thing to find next —
+the fix shipped here stops the bleeding from one source, not from that one.
 
 ## Why it took so long to spot
 

--- a/internal/plugins/maintenance/deps.go
+++ b/internal/plugins/maintenance/deps.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/deps.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567891
 // last-edited: 2026-08-14
 
@@ -80,6 +80,11 @@ type ServerDeps interface {
 	// record, and the one page a user would check to confirm it still showed
 	// the old names. Measured 2026-08-14 after author-conjunction-repair.
 	InvalidateAuthorsCache()
+	// InvalidateSeriesCache invalidates the cached series list. Call it from any
+	// op that created, renamed, merged or deleted a series: the cache carries a
+	// 24-hour TTL and is warmed at startup, so without this the op's result is
+	// invisible on /api/v1/series for up to a day and reads as a no-op.
+	InvalidateSeriesCache()
 	// MetadataUpgradeRun runs the metadata upgrade scan up to limit books.
 	// progress may be nil; when non-nil it is updated every 25 books checked
 	// (M7, 2026-07 error-correction sweep — this is a 120-minute,

--- a/internal/plugins/maintenance/series.go
+++ b/internal/plugins/maintenance/series.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/series.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f6a7b8c9-d0e1-2345-f012-567890123456
-// last-edited: 2026-05-07
+// last-edited: 2026-08-14
 
 package maintenance
 
@@ -44,6 +44,13 @@ func (p *Plugin) runSeriesNormalize(ctx context.Context, _ json.RawMessage, repo
 		p.deps.EnqueueWriteBack(bookID)
 	}
 	affected, err := p.deps.ExecuteSeriesNormalizeCore(ctx, store, enqueueWB)
+	// Renaming a series changes the cached series list, which carries a 24-hour
+	// TTL. Without this the normalize lands in the store while /api/v1/series
+	// keeps serving the old names. Only invalidate when rows actually changed;
+	// dropping a warm cache for a no-op run costs a full recount for nothing.
+	if len(affected) > 0 {
+		p.deps.InvalidateSeriesCache()
+	}
 	msg := fmt.Sprintf("Series normalize complete: %d series affected, %d books enqueued for write-back",
 		len(affected), len(affected))
 	_ = reporter.Log(slog.LevelInfo, msg)

--- a/internal/plugins/maintenance/series_denumber_op.go
+++ b/internal/plugins/maintenance/series_denumber_op.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/series_denumber_op.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 3f0b6c84-52d1-4a97-9e35-c8b71d0af426
-// last-edited: 2026-08-06
+// last-edited: 2026-08-14
 
 package maintenance
 
@@ -328,6 +328,14 @@ func (p *Plugin) runSeriesDenumber(ctx context.Context, raw json.RawMessage, rep
 			_ = reporter.UpdateProgress(idx+1, len(plans),
 				fmt.Sprintf("merged %d/%d series (%d books moved)", merged, len(plans), movedBooks))
 		}
+	}
+
+	// Creating base series, moving books between them and deleting the emptied
+	// ones all change the cached series list (24-hour TTL, warmed at startup).
+	// Without this the denumber result is invisible on /api/v1/series until the
+	// next restart, which reads as an op that did nothing.
+	if created > 0 || deleted > 0 || movedBooks > 0 {
+		p.deps.InvalidateSeriesCache()
 	}
 
 	summary := fmt.Sprintf(

--- a/internal/plugins/maintenance/title_backfill_test.go
+++ b/internal/plugins/maintenance/title_backfill_test.go
@@ -78,6 +78,7 @@ func (d fakeDeps) DedupTriageExactPending(_ context.Context, _ bool) (*TriageRep
 }
 func (d fakeDeps) InvalidateDedupCache()   {}
 func (d fakeDeps) InvalidateAuthorsCache() {}
+func (d fakeDeps) InvalidateSeriesCache()  {}
 func (d fakeDeps) MetadataUpgradeRun(_ context.Context, _ int, _ operations.ProgressReporter) (int, int, int, int, error) {
 	return 0, 0, 0, 0, nil
 }

--- a/internal/server/duplicates_helpers.go
+++ b/internal/server/duplicates_helpers.go
@@ -1,7 +1,7 @@
 // file: internal/server/duplicates_helpers.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 550a807d-8c00-4e34-9a8c-52a80710a0b9
-// last-edited: 2026-07-07
+// last-edited: 2026-08-14
 //
 // Shared, non-HTTP helpers that were extracted from duplicates_handlers.go when
 // the 17 duplicates HTTP handlers moved to internal/server/handlers/duplicates.
@@ -300,6 +300,22 @@ func (s *Server) executeSeriesPrune(ctx context.Context, store interface {
 
 	if s.dedupCache != nil {
 		s.dedupCache.InvalidateAll()
+	}
+
+	// Drop the cached series list, but only when this run actually removed rows.
+	// The cache holds a 24-hour TTL and is warmed at startup, and until now it
+	// was invalidated only by the interactive entities API — so a prune that
+	// merged and deleted correctly left /api/v1/series serving the pre-prune
+	// list, which is indistinguishable from a prune that did nothing. Measured
+	// on production 2026-08-14: "17 duplicates merged, 326 orphans deleted, 0
+	// errors" followed by a series list still reporting all 14,629 rows.
+	//
+	// A run that cleaned nothing must NOT invalidate: it changed nothing, and
+	// dropping a warm cache costs a full recount for no reason. Same rule the
+	// author-conjunction repair follows (658d91a2).
+	if totalCleaned > 0 {
+		s.InvalidateSeriesCache()
+		_ = progress.Log("info", fmt.Sprintf("Invalidated the cached series list (%d rows removed)", totalCleaned), nil)
 	}
 
 	return nil

--- a/internal/server/duplicates_series_cache_test.go
+++ b/internal/server/duplicates_series_cache_test.go
@@ -1,0 +1,121 @@
+// file: internal/server/duplicates_series_cache_test.go
+// version: 1.0.0
+// guid: 7c1d94b6-2ea8-4f30-9c57-1b0e6a8d3f42
+// last-edited: 2026-08-14
+
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	audiobookspkg "github.com/falkcorp/audiobook-organizer/internal/audiobooks"
+	"github.com/falkcorp/audiobook-organizer/internal/cache"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// seriesPruneNoopProgress discards every reporting call — executeSeriesPrune is
+// exercised for its cache side effect here, not its progress output.
+type seriesPruneNoopProgress struct{}
+
+func (seriesPruneNoopProgress) UpdateProgress(_, _ int, _ string) error { return nil }
+func (seriesPruneNoopProgress) Log(_, _ string, _ *string) error        { return nil }
+func (seriesPruneNoopProgress) IsCanceled() bool                        { return false }
+
+// seriesRefCountingStore is a MockStore that also answers the unfiltered
+// reference count. executeSeriesPrune refuses to delete anything unless
+// database.AsSeriesBookRefStore(store) succeeds, so a bare MockStore would fail
+// the guard before reaching the code under test.
+type seriesRefCountingStore struct {
+	*database.MockStore
+	refCounts map[int]int
+}
+
+func (s seriesRefCountingStore) GetAllSeriesBookRefCounts() (map[int]int, error) {
+	return s.refCounts, nil
+}
+
+// newSeriesPruneServer builds the minimum Server needed by executeSeriesPrune,
+// with a primed series cache so the test can observe whether it was dropped.
+func newSeriesPruneServer(t *testing.T) *Server {
+	t.Helper()
+	s := &Server{
+		seriesCache: cache.NewWithLimit[*audiobookspkg.SeriesWithCountsResponse]("series-test", time.Hour, 1),
+	}
+	s.seriesCache.Set("all", &audiobookspkg.SeriesWithCountsResponse{Count: 99})
+	return s
+}
+
+func seriesCacheIsPrimed(s *Server) bool {
+	_, ok := s.seriesCache.Get("all")
+	return ok
+}
+
+// TestExecuteSeriesPrune_InvalidatesSeriesCacheWhenRowsRemoved locks the fix for
+// the 2026-08-14 production observation: a prune reported "17 duplicates merged,
+// 326 orphans deleted" while /api/v1/series kept serving the pre-prune list,
+// which is indistinguishable from a prune that did nothing. The cache carries a
+// 24-hour TTL, so "it expires eventually" is not a defence.
+func TestExecuteSeriesPrune_InvalidatesSeriesCacheWhenRowsRemoved(t *testing.T) {
+	s := newSeriesPruneServer(t)
+
+	// Two distinctly-named series (so Phase 1 merges nothing) that NOTHING
+	// references, so Phase 2 deletes both.
+	deleted := []int{}
+	mock := &database.MockStore{}
+	mock.GetAllSeriesFunc = func() ([]database.Series, error) {
+		return []database.Series{{ID: 1, Name: "Discworld"}, {ID: 2, Name: "Safehold"}}, nil
+	}
+	mock.GetBooksBySeriesIDCoreFunc = func(int) ([]database.BookCore, error) { return nil, nil }
+	mock.DeleteSeriesFunc = func(id int) error {
+		deleted = append(deleted, id)
+		return nil
+	}
+	store := seriesRefCountingStore{MockStore: mock, refCounts: map[int]int{}}
+
+	if !seriesCacheIsPrimed(s) {
+		t.Fatal("precondition: series cache should be primed before the prune")
+	}
+	if err := s.executeSeriesPrune(context.Background(), store, seriesPruneNoopProgress{}, ""); err != nil {
+		t.Fatalf("executeSeriesPrune: %v", err)
+	}
+
+	if len(deleted) != 2 {
+		t.Fatalf("expected both orphan series deleted, got %v", deleted)
+	}
+	if seriesCacheIsPrimed(s) {
+		t.Error("series cache still primed after a prune that deleted 2 rows — " +
+			"/api/v1/series would serve the pre-prune list for up to 24h")
+	}
+}
+
+// TestExecuteSeriesPrune_KeepsSeriesCacheWhenNothingRemoved is the other half of
+// the guard. A run that cleaned nothing changed nothing, and dropping a warm
+// cache costs a full recount for no reason — the same rule the author
+// conjunction repair follows. Without this case, "invalidate unconditionally"
+// would pass the test above.
+func TestExecuteSeriesPrune_KeepsSeriesCacheWhenNothingRemoved(t *testing.T) {
+	s := newSeriesPruneServer(t)
+
+	mock := &database.MockStore{}
+	mock.GetAllSeriesFunc = func() ([]database.Series, error) {
+		return []database.Series{{ID: 1, Name: "Discworld"}, {ID: 2, Name: "Safehold"}}, nil
+	}
+	mock.GetBooksBySeriesIDCoreFunc = func(int) ([]database.BookCore, error) { return nil, nil }
+	mock.DeleteSeriesFunc = func(id int) error {
+		t.Errorf("DeleteSeries(%d) called, but every series is referenced", id)
+		return nil
+	}
+	// Both series are referenced, so neither is an orphan and nothing merges.
+	store := seriesRefCountingStore{MockStore: mock, refCounts: map[int]int{1: 3, 2: 5}}
+
+	if err := s.executeSeriesPrune(context.Background(), store, seriesPruneNoopProgress{}, ""); err != nil {
+		t.Fatalf("executeSeriesPrune: %v", err)
+	}
+
+	if !seriesCacheIsPrimed(s) {
+		t.Error("series cache dropped by a prune that removed nothing — " +
+			"a no-op run must not force a full recount")
+	}
+}

--- a/internal/server/server_maintenance_deps.go
+++ b/internal/server/server_maintenance_deps.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_maintenance_deps.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: b4c5d6e7-f8a9-0123-7890-345678901234
 // last-edited: 2026-08-14
 
@@ -128,6 +128,22 @@ func (s *Server) InvalidateDedupCache() {
 func (s *Server) InvalidateAuthorsCache() {
 	if s.authorsCache != nil {
 		s.authorsCache.InvalidateAll()
+	}
+}
+
+// InvalidateSeriesCache drops the cached series list. The series counterpart of
+// InvalidateAuthorsCache, and it exists for the same reason: the cache carries a
+// 24-hour TTL, is warmed at startup by warmSeriesCache, and was invalidated only
+// by the interactive entities API. A maintenance op that merged or deleted
+// series therefore left /api/v1/series serving the pre-op list for up to a day.
+//
+// Measured on production 2026-08-14: a maintenance.series-prune run reported
+// "17 duplicates merged, 326 orphans deleted, 0 errors" and the series list kept
+// returning the same 14,629 rows with the same 329 zero-book entries — a
+// completed repair that is indistinguishable from one that silently did nothing.
+func (s *Server) InvalidateSeriesCache() {
+	if s.seriesCache != nil {
+		s.seriesCache.InvalidateAll()
 	}
 }
 

--- a/todo.d/20260814-series-integrity-followups.md
+++ b/todo.d/20260814-series-integrity-followups.md
@@ -26,9 +26,38 @@
   metadata_candidate_fetch ×1). No scan op is recorded there either, which is
   itself worth explaining. `maintenance.series-prune` is ruled out for this burst.
 
-  Two shapes to test: (a) the creating path assigns a `SeriesID` it never
-  persists, or (b) it copies a `SeriesID` from another record whose series was
-  already gone. Start from whatever created book `01KZSX7TW6BZXJX11F8K6Y0DSZ`.
+  **RESOLVED — it is propagation, not minting.** Dating each phantom series ID by
+  the earliest book that references it:
+
+  | day | ids seen | first appearance | inherited |
+  |---|---|---|---|
+  | 2026-04-04 | 5,261 | 5,261 | 0 |
+  | 2026-04-28 | 932 | 909 | 23 |
+  | 2026-04-29 | 17 | 17 | 0 |
+  | 2026-04-30 | 145 | 139 | 6 |
+  | 2026-05-01 | 1 | 0 | 1 |
+  | 2026-06-18 | 70 | 70 | 0 |
+  | 2026-06-19 | 16 | 16 | 0 |
+  | 2026-07-19 | 481 | 481 | 0 |
+  | **2026-08-11** | **5,068** | **0** | **5,068** |
+  | **2026-08-12** | **121** | **0** | **121** |
+
+  No new phantom series ID has appeared since **2026-07-19**. Both August bursts
+  are 100% inherited — every ID they reference was already dangling.
+
+  The mechanism follows from `resolveSeriesID` (`internal/scanner/scanner.go:2487`):
+  it resolves by **name**, creates the series when absent, and `CreateSeries`
+  commits to Pebble with `pebble.Sync` before returning. **A scan therefore cannot
+  produce a dangling reference** — it would just create a fresh series row. So any
+  book holding a dangling `SeriesID` got it by **copying an existing book's
+  record**, not by scanning.
+
+  So the remaining work is not a hunt for a minting bug. It is: find the paths
+  that copy `SeriesID` onto newly-created book rows and have them drop a reference
+  whose series no longer exists. Prime suspects, given the 08-11 rows are
+  per-chapter books (`Chapter 06`) created inside one minute:
+  `internal/dedup/split_book_detector.go`, `maintenance.regroup-shattered-ai`,
+  `maintenance.itunes-regroup`. Start from book `01KZSX7TW6BZXJX11F8K6Y0DSZ`.
 
 - [ ] **`BulkDeleteSeries` still deletes on a filtered count.**
   `internal/server/handlers/entities/handler.go:1017` guards with

--- a/todo.d/20260814-series-integrity-followups.md
+++ b/todo.d/20260814-series-integrity-followups.md
@@ -1,0 +1,40 @@
+### Series table integrity — follow-ups from the 2026-08-14 prune repair
+
+- [ ] **Find what is still minting phantom series references.** Books reference 6,893
+  series IDs that have no row; 5,500 of the referencing books were created in
+  2026-08 and 507 in 2026-07 (88% of that month's books), so the source is live.
+  `maintenance.series-prune` is ruled out as the *current* cause — it was fixed in
+  #2400 and its two recorded runs never executed. Remaining suspects: the other
+  series deleters that never got the unfiltered-reference guard, listed below.
+  Dating method: ULID prefixes on the book IDs are time-sortable.
+
+- [ ] **`BulkDeleteSeries` still deletes on a filtered count.**
+  `internal/server/handlers/entities/handler.go:1017` guards with
+  `GetBooksBySeriesIDCore`, the same display counter that skips trashed and
+  non-primary books and caused the phantom references. It should use
+  `database.AsSeriesBookRefStore(...).GetAllSeriesBookRefCounts()` like
+  `executeSeriesPrune` now does. Same for the single-delete path at line 1007.
+
+- [ ] **Two more series deleters have no cache invalidation and no ref guard**, and
+  sit in packages with no path to the server's caches:
+  `internal/dedup/series_dedup.go` (`DedupSeries`, `MergeSeries`) and
+  `internal/maintenance/jobs/cleanup_series.go` (`csUnlinkAndDeleteSeries`,
+  `csMergeSeriesGroup`). Consider moving invalidation into the store layer
+  (`PebbleStore.DeleteSeries` already notifies memdb) so no caller can forget.
+
+- [ ] **`WithOpID` is never called in production code**, so `ctxOpID(ctx)` returns ""
+  for all 8 maintenance ops that read it (`series.go`, `cleanup.go` ×2,
+  `write_back.go`, `reconcile.go`, `dedup_ops.go`, `optimize.go`, `metadata.go`).
+  Every `CreateOperationChange` in `executeSeriesPrune` is therefore skipped: the
+  2026-08-14 prune deleted 326 series and recorded zero changes, so there is no
+  audit trail and no revert. `maintenance.purge-deleted` has the same gap while
+  permanently destroying books. Note this also invalidates "0 changes recorded"
+  as evidence that an op did not run.
+
+- [ ] **~2,270 series look like they were created from a book title rather than a real
+  series** (990 where the series name equals its only book's title, 1,280 where one
+  contains the other). Do NOT delete on book-count alone: 2,322 single-book series
+  are real series you own one book from (*Arliss Cutter*, *The Spiderwick
+  Chronicles*, *Star Runners*). Needs a dry-run that emits the list, a hand-audit of
+  ~40 of the "near" bucket, and its own apply gate — the repair must be narrower
+  than the classifier.

--- a/todo.d/20260814-series-integrity-followups.md
+++ b/todo.d/20260814-series-integrity-followups.md
@@ -1,12 +1,34 @@
 ### Series table integrity — follow-ups from the 2026-08-14 prune repair
 
-- [ ] **Find what is still minting phantom series references.** Books reference 6,893
-  series IDs that have no row; 5,500 of the referencing books were created in
-  2026-08 and 507 in 2026-07 (88% of that month's books), so the source is live.
-  `maintenance.series-prune` is ruled out as the *current* cause — it was fixed in
-  #2400 and its two recorded runs never executed. Remaining suspects: the other
-  series deleters that never got the unfiltered-reference guard, listed below.
-  Dating method: ULID prefixes on the book IDs are time-sortable.
+- [ ] **Identify what produced the 2026-08-11 burst of phantom series references.**
+  Books reference 6,893 series IDs that have no row. The damage is EPISODIC, not a
+  steady leak — only 10 distinct days ever, dated by ULID prefix on the book IDs:
+
+  | day | books |
+  |---|---|
+  | 2026-06-18 | 78 |
+  | 2026-06-19 | 16 |
+  | 2026-07-19 | 507 |
+  | **2026-08-11** | **5,367** |
+  | 2026-08-12 | 133 |
+
+  (the rest predate June; 7,220 landed in 2026-04.)
+
+  The 08-11 books were all created within the same minute, 22:36 local, are loose
+  files under `Unknown Author`, and carry titles like `Chapter 06` and
+  `Singularity Online Book 3` — i.e. a scan of unsorted audio, not a maintenance
+  op. Their series IDs are mid-range (153577, 165008, 165695), interleaved with
+  live rows, NOT the contiguous all-dead 180000–184999 block.
+
+  Checked and ruled out: no series-deleting op appears in the operations list for
+  2026-08-11 or 08-12 (41 ops those days: purge-deleted ×18, temp-file-cleanup ×14,
+  isbn-enrichment ×4, cleanup_activity_log ×2, maintenance-window ×2,
+  metadata_candidate_fetch ×1). No scan op is recorded there either, which is
+  itself worth explaining. `maintenance.series-prune` is ruled out for this burst.
+
+  Two shapes to test: (a) the creating path assigns a `SeriesID` it never
+  persists, or (b) it copies a `SeriesID` from another record whose series was
+  already gone. Start from whatever created book `01KZSX7TW6BZXJX11F8K6Y0DSZ`.
 
 - [ ] **`BulkDeleteSeries` still deletes on a filtered count.**
   `internal/server/handlers/entities/handler.go:1017` guards with


### PR DESCRIPTION
## What

A `maintenance.series-prune` run on production today reported:

> Series prune complete: 17 duplicates merged, 326 orphans deleted (343 total cleaned, 0 errors)

…and `/api/v1/series` kept returning all **14,629** rows with the same **329** zero-book entries. Nothing appeared to have happened.

The prune had in fact landed correctly — series 160094 (*Queen of Fire: A Raven's Shadow Novel*), whose only book is trashed, survived exactly as the unfiltered reference guard from #2400 intends. What was stale was the **read path**.

## Why

The series cache carries a **24-hour TTL**, is warmed at startup by `warmSeriesCache`, and was invalidated **only** by the interactive entities API. Every background op that merged, renamed or deleted a series was therefore invisible on the series page until the next restart.

That is the worst failure mode available to a repair: *"it worked and you can't see it"* and *"it silently did nothing"* are indistinguishable from the outside.

This is the **same defect as the authors cache**, fixed four hours earlier in 658d91a2 — one entity over.

## How

`ServerDeps` gains `InvalidateSeriesCache()` alongside `InvalidateAuthorsCache()`, and the three series-mutating ops call it:

| op | invalidates when |
|---|---|
| `series-prune` | `totalCleaned > 0` |
| `series-normalize` | any series affected |
| `series-denumber` | created, deleted, or moved anything |

A run that changed nothing deliberately does **not** invalidate — it changed nothing, and dropping a warm cache costs a full recount for no reason.

## Tests

Both directions covered, and both **mutation-tested with mutations that compile**:

- deleting the invalidation → reds *"invalidates when rows removed"*
- widening the guard to fire unconditionally → reds *"keeps cache when nothing removed"*

Source restored byte-identical afterwards and grepped for leftover markers. `go build ./...` and `go vet` clean; `internal/plugins/maintenance` green.

## Filed, not fixed here (see `todo.d/`)

- `BulkDeleteSeries` (`entities/handler.go:1017`) still guards deletion with the **filtered display counter** that caused the phantom references in the first place.
- Two more series deleters (`internal/dedup/series_dedup.go`, `internal/maintenance/jobs/cleanup_series.go`) have neither guard nor invalidation, and sit in packages with no path to the server caches.
- **`WithOpID` is never called in production code**, so `ctxOpID` returns `""` and every `CreateOperationChange` in the prune is skipped — no audit trail, no revert. This also means *"0 changes recorded"* is **not** evidence that an op did not run.
- ~2,270 series that look derived from a book title rather than a real series — needs its own dry-run and apply gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp