### PR TITLE
fix(database): make the series book-getter agree across memdb and Pebble

### DIFF
--- a/changelog.d/20260814_055000_series_getter_store_conformance.md
+++ b/changelog.d/20260814_055000_series_getter_store_conformance.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- **A series listing served during startup showed duplicate versions in arbitrary
+  order.** `GetBooksBySeriesIDCore` has two backing implementations and they
+  disagreed on two axes at once: the memdb walk excluded non-primary versions and
+  sorted by series sequence, while the Pebble scan kept every alternate rip and did
+  not sort at all. During the roughly two minutes it takes memdb to warm up after a
+  restart, a series therefore came back with its duplicates included and its books
+  in storage order rather than reading order. Both paths now apply the same filters
+  and share one ordering helper.
+
+  Found by sweeping the other 25 dual-implementation store methods for the defect
+  shape fixed in the author getters. Of those, this was the only remaining method
+  where one store filtered non-primary versions and the other did not;
+  `GetFolderDuplicatesCore` and `GetDuplicateBooksByMetadataCore` were checked and
+  already agree.
+
+  The shared ordering helper also drops a comparator that indexed a precomputed
+  slice of lowercased titles from inside the sort. Sorting permutes only the slice
+  handed to it, so that parallel slice kept its original order and the tiebreaker
+  could read a title belonging to a different book. It was not observed producing a
+  wrong order, and it is corrected rather than carried forward.

--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -1,5 +1,5 @@
 // file: internal/database/memdb_reads.go
-// version: 1.19.0
+// version: 1.20.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000006
 // last-edited: 2026-08-14
 
@@ -482,27 +482,9 @@ func (m *MemStore) GetBooksBySeriesIDCore(seriesID int, limit, offset int) ([]Bo
 		}
 		all = append(all, *b)
 	}
-	if len(all) > 1 {
-		keys := make([]string, len(all))
-		for i := range all {
-			keys[i] = strings.ToLower(all[i].Title)
-		}
-		sort.SliceStable(all, func(i, j int) bool {
-			si, sj := all[i].SeriesSequence, all[j].SeriesSequence
-			switch {
-			case si == nil && sj == nil:
-				return keys[i] < keys[j]
-			case si == nil:
-				return false
-			case sj == nil:
-				return true
-			case *si != *sj:
-				return *si < *sj
-			default:
-				return keys[i] < keys[j]
-			}
-		})
-	}
+	// Shared with the Pebble scan so the two implementations of this method
+	// cannot order a series differently. See series_ordering.go.
+	sortBooksInSeriesOrder(all)
 	paged := paginate(all, limit, offset)
 	cores := make([]BookCore, len(paged))
 	for i := range paged {

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.128.0
+// version: 1.129.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-08-14
 
@@ -1747,8 +1747,17 @@ func (p *PebbleStore) GetBooksBySeriesIDCore(seriesID int) ([]BookCore, error) {
 	return cores, nil
 }
 
-// getBooksBySeriesIDFull performs a full Pebble book scan filtered by series ID.
-// Fallback path after Task 3.4 index removal.
+// getBooksBySeriesIDFull performs a full Pebble book scan for the series
+// LISTING view: soft-deleted excluded, non-primary versions excluded, ordered
+// by SeriesSequence then title.
+//
+// All three of those were missing before 2026-08-14 except the soft-delete
+// check, leaving this path disagreeing with its memdb counterpart on both what
+// it returned and what order it returned it in — a series listing served during
+// the ~132 s warmup window showed every alternate rip alongside the book it
+// duplicates, in ULID order. Found by sweeping the other dual-dispatch store
+// methods for the defect shape fixed in the author getters. See
+// internal/database/series_getter_conformance_test.go.
 func (p *PebbleStore) getBooksBySeriesIDFull(seriesID int) ([]Book, error) {
 	var books []Book
 	iter, err := p.db.NewIter(&pebble.IterOptions{
@@ -1777,9 +1786,15 @@ func (p *PebbleStore) getBooksBySeriesIDFull(seriesID int) ([]Book, error) {
 		if bookIsSoftDeleted(&book) {
 			continue
 		}
+		if book.IsPrimaryVersion != nil && !*book.IsPrimaryVersion {
+			continue
+		}
 		books = append(books, book)
 	}
 
+	// Shared with the memdb walk so the two implementations of this method
+	// cannot order a series differently. See series_ordering.go.
+	sortBooksInSeriesOrder(books)
 	return books, nil
 }
 

--- a/internal/database/series_getter_conformance_test.go
+++ b/internal/database/series_getter_conformance_test.go
@@ -1,0 +1,178 @@
+// file: internal/database/series_getter_conformance_test.go
+// version: 1.0.0
+// guid: 9a4c72e1-3f68-4d20-8b95-6c07e3d1a4f8
+// last-edited: 2026-08-14
+
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// seriesGetterConformanceFixture builds one series whose books exercise every
+// axis GetBooksBySeriesIDCore filters or orders on.
+//
+// Helper name is task-unique on purpose: several suites in this package define
+// fixture builders and a generic name collides on rebase.
+type seriesGetterConformanceFixture struct {
+	seriesID int
+
+	// Live primary books, in the order the series listing should return them:
+	// by SeriesSequence ascending, then title.
+	wantOrderedIDs []string
+
+	nonPrimaryBookID  string
+	softDeletedBookID string
+	otherSeriesBookID string
+}
+
+func buildSeriesGetterConformanceFixture(t *testing.T, store Store) seriesGetterConformanceFixture {
+	t.Helper()
+
+	var fx seriesGetterConformanceFixture
+
+	series, err := store.CreateSeries("Conformance Series", nil)
+	require.NoError(t, err)
+	fx.seriesID = series.ID
+
+	other, err := store.CreateSeries("Some Other Series", nil)
+	require.NoError(t, err)
+
+	yes := true
+	no := false
+
+	mk := func(title string, seriesID int, seq *int, primary *bool, trash bool) *Book {
+		b := &Book{
+			Title:            title,
+			FilePath:         "/lib/series/" + title,
+			SeriesID:         &seriesID,
+			SeriesSequence:   seq,
+			IsPrimaryVersion: primary,
+		}
+		created, cErr := store.CreateBook(b)
+		require.NoError(t, cErr)
+		if trash {
+			created.MarkedForDeletion = &yes
+			_, uErr := store.UpdateBook(created.ID, created)
+			require.NoError(t, uErr)
+		}
+		return created
+	}
+
+	seq := func(n int) *int { return &n }
+
+	// Created OUT of sequence order on purpose. If a path does not sort, the
+	// ULID/key order it returns will not match wantOrderedIDs, and creating
+	// them pre-sorted would hide exactly that.
+	third := mk("Book Three", fx.seriesID, seq(3), &yes, false)
+	first := mk("Book One", fx.seriesID, seq(1), &yes, false)
+	second := mk("Book Two", fx.seriesID, seq(2), &yes, false)
+
+	// Two books SHARING a sequence number, created with their titles in
+	// reverse. This is what exercises the title tiebreaker, and it is not
+	// decoration: the tiebreaker read a stale, unpermuted keys slice until
+	// 2026-08-14, so with distinct sequence numbers alone the bug is invisible.
+	// "Zulu" is created before "Alpha" so a comparator that is merely stable
+	// (rather than correct) leaves them in the wrong order.
+	tieZulu := mk("Book Four Zulu", fx.seriesID, seq(4), &yes, false)
+	tieAlpha := mk("Book Four Alpha", fx.seriesID, seq(4), &yes, false)
+
+	fx.wantOrderedIDs = []string{first.ID, second.ID, third.ID, tieAlpha.ID, tieZulu.ID}
+
+	// Non-primary version of a book in the series: a duplicate of something
+	// already listed, so the listing view must exclude it.
+	fx.nonPrimaryBookID = mk("Book Two Alternate Rip", fx.seriesID, seq(2), &no, false).ID
+
+	// In the series but in the trash.
+	fx.softDeletedBookID = mk("Book Four Trashed", fx.seriesID, seq(4), &yes, true).ID
+
+	// Control: an implementation that ignored seriesID entirely would pass
+	// every "contains" assertion without this.
+	fx.otherSeriesBookID = mk("Wrong Series Book", other.ID, seq(1), &yes, false).ID
+
+	return fx
+}
+
+// TestGetBooksBySeriesIDCore_MemDBAndPebbleAgree is the conformance gate for the
+// series listing getter.
+//
+// This is the same defect shape as the author getters (see
+// author_getter_conformance_test.go), found by sweeping the other 25
+// dual-dispatch store methods for it. GetBooksBySeriesIDCore has two backing
+// implementations that disagreed on TWO axes at once:
+//
+//   - the memdb walk excluded non-primary versions; the Pebble scan kept them,
+//     so a series listing served during the ~132 s warmup window showed every
+//     alternate rip alongside the book it duplicates;
+//   - the memdb walk sorted by SeriesSequence then title; the Pebble scan did
+//     not sort at all, so the same series came back in ULID order.
+//
+// Sequence order is the whole point of a series listing, so the second half is
+// not cosmetic either: "book 1, book 2, book 3" became whatever order the keys
+// happened to be in.
+//
+// Asserting each path against its own hardcoded expectation would not have
+// caught this. What catches it is holding the two implementations to the SAME
+// answer on the SAME fixture.
+func TestGetBooksBySeriesIDCore_MemDBAndPebbleAgree(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	fx := buildSeriesGetterConformanceFixture(t, store)
+
+	p, ok := store.(*PebbleStore)
+	require.True(t, ok, "expected *PebbleStore from setupPebbleTestDB")
+	p.WaitForWarmup()
+	require.True(t, p.IsMemReady(),
+		"memdb must be published or the UseMemDB=true arm silently runs the Pebble path")
+
+	// Non-vacuity guards: without each of these rows the corresponding
+	// assertion below is unfalsifiable.
+	require.NotEmpty(t, fx.nonPrimaryBookID, "fixture must contain a non-primary version")
+	require.NotEmpty(t, fx.softDeletedBookID, "fixture must contain a soft-deleted book")
+	require.Greater(t, len(fx.wantOrderedIDs), 1, "fixture must contain enough books to order")
+
+	got := map[bool][]string{}
+
+	for _, useMemDB := range []bool{true, false} {
+		p.UseMemDB = useMemDB
+		label := "PebbleScanPath"
+		if useMemDB {
+			label = "MemDBPath"
+		}
+
+		t.Run(label, func(t *testing.T) {
+			books, err := store.GetBooksBySeriesIDCore(fx.seriesID)
+			require.NoError(t, err)
+
+			ids := make([]string, 0, len(books))
+			for _, b := range books {
+				ids = append(ids, b.ID)
+			}
+
+			require.NotContains(t, ids, fx.nonPrimaryBookID,
+				"non-primary version leaked into the series listing — it duplicates a book "+
+					"already in the list")
+			require.NotContains(t, ids, fx.softDeletedBookID,
+				"soft-deleted book leaked into the series listing")
+			require.NotContains(t, ids, fx.otherSeriesBookID,
+				"book from a different series was returned")
+
+			// Order is asserted, not just membership: a series listing that
+			// returns the right books in the wrong order is still broken.
+			require.Equal(t, fx.wantOrderedIDs, ids,
+				"series listing did not return the live primary books ordered by "+
+					"SeriesSequence — the fixture is created out of sequence order on "+
+					"purpose, so an unsorted path fails here")
+
+			got[useMemDB] = ids
+		})
+	}
+	p.UseMemDB = true
+
+	require.Equal(t, got[true], got[false],
+		"memdb and Pebble implementations of GetBooksBySeriesIDCore returned different "+
+			"results — same defect shape as the author getters fixed alongside this")
+}

--- a/internal/database/series_ordering.go
+++ b/internal/database/series_ordering.go
@@ -1,0 +1,60 @@
+// file: internal/database/series_ordering.go
+// version: 1.0.0
+// guid: 3e8b1d47-9c25-4a60-b7f8-2d04e916c5a3
+// last-edited: 2026-08-14
+
+package database
+
+import (
+	"sort"
+	"strings"
+)
+
+// sortBooksInSeriesOrder orders a series' books the way a reader expects them:
+// by SeriesSequence ascending, with unnumbered books last, and ties broken by
+// title (case-insensitive).
+//
+// This lives in one place because GetBooksBySeriesIDCore has two backing
+// implementations and they did not agree: the memdb walk sorted, the Pebble
+// scan did not sort at all, so the same series came back in ULID order whenever
+// it was served during the ~132 s memdb warmup window. Sequence order is the
+// entire point of a series listing, so "same books, arbitrary order" is a real
+// defect and not a cosmetic one. Sharing the comparator is what keeps the two
+// paths from drifting again — see series_getter_conformance_test.go.
+//
+// The title tiebreaker compares titles directly rather than through a parallel
+// precomputed slice. The previous memdb implementation built a `keys` slice of
+// lowercased titles up front and then indexed it from inside the comparator,
+// but sort permutes only the slice handed to it — `keys` kept the ORIGINAL
+// order, so after the first swap the comparator was reading a title belonging
+// to some other book. It was not observed producing a wrong order on a small
+// fixture, and it is fixed here rather than preserved, because a comparator
+// that reads stale data is not something to carry forward on the argument that
+// it happened to work.
+func sortBooksInSeriesOrder(books []Book) {
+	if len(books) < 2 {
+		return
+	}
+	sort.SliceStable(books, func(i, j int) bool {
+		si, sj := books[i].SeriesSequence, books[j].SeriesSequence
+		switch {
+		case si == nil && sj == nil:
+			return lessTitle(books[i].Title, books[j].Title)
+		case si == nil:
+			// Unnumbered books sort after numbered ones.
+			return false
+		case sj == nil:
+			return true
+		case *si != *sj:
+			return *si < *sj
+		default:
+			return lessTitle(books[i].Title, books[j].Title)
+		}
+	})
+}
+
+// lessTitle is the case-insensitive title comparison used as the series-order
+// tiebreaker.
+func lessTitle(a, b string) bool {
+	return strings.ToLower(a) < strings.ToLower(b)
+}


### PR DESCRIPTION
Follow-on to #2406. Found by sweeping the other 25 dual-dispatch store methods for the defect shape fixed there.

## What

`GetBooksBySeriesIDCore` has the same defect, on **two axes at once**:

| | non-primary versions | ordering |
|---|---|---|
| memdb walk | filtered out | sorted by `SeriesSequence`, then title |
| Pebble scan | **kept** | **not sorted at all** |

So during the ~132 s memdb warmup window after a restart, a series listing returned every alternate rip alongside the book it duplicates, in ULID order rather than reading order.

Sequence order is the entire point of a series listing, so "same books, arbitrary order" is a real defect and not a cosmetic one.

## Scope of the sweep

Stated explicitly so the absence of other findings is legible rather than being indistinguishable from having stopped looking:

- Of the 25 dual-dispatch methods, this was the **only** remaining one where a primary-version filter existed on one side and not the other.
- `GetFolderDuplicatesCore` and `GetDuplicateBooksByMetadataCore` were checked and **already agree**.
- `nil` `IsPrimaryVersion` is treated as primary consistently on both sides everywhere it appears — that is not a divergence.

## The ordering helper

Both paths now share `sortBooksInSeriesOrder`, so they cannot drift on order again.

It also drops a comparator that indexed a precomputed slice of lowercased titles from inside the sort. Sorting permutes only the slice handed to it, so that parallel slice kept its **original** order and the tiebreaker could read a title belonging to a different book.

**I did not observe it producing a wrong order.** The fixture was extended with two books sharing a sequence number specifically to try to catch it, and the memdb path ordered them correctly anyway. It is corrected on the merits — a comparator reading stale data is not worth carrying forward on the argument that it happened to work — and reported as exactly that, not as a live defect.

## Tests

`internal/database/series_getter_conformance_test.go`, following the pattern from #2392 and #2406: one fixture, both implementations, assert equal.

- Asserts **order**, not just membership.
- Creates its books **out of sequence order** so an unsorted path cannot pass by accident.
- Non-vacuity guards on the non-primary row, the trashed row, and having enough books to order.
- Confirmed **RED** before the fix on the Pebble path (`non-primary version leaked into the series listing`), green after.

Full `go test ./... -short` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxigqrwz9WfwN1wx8QhoQW