### PR TITLE
fix(database): exclude soft-deleted books from series and import-path counts

### DIFF
--- a/changelog.d/20260814_062000_aggregate_count_soft_delete.md
+++ b/changelog.d/20260814_062000_aggregate_count_soft_delete.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **Series and import-path counts included books in the trash during startup.**
+  `GetAllSeriesBookCounts`, `GetAllSeriesFileCounts` and `CountBooksByPathPrefix`
+  each have two backing implementations, and the memdb ones excluded soft-deleted
+  books while the Pebble ones counted them. For the roughly two minutes it takes
+  memdb to warm up after a restart, a series therefore reported more books and
+  files than it has, and an import path reported more books than it holds.
+
+  This is the same defect class as the soft-deleted rows that leaked into
+  `GetAllBooksCore`, but leaking from the other store — which is the argument for
+  testing the two implementations against each other rather than auditing either
+  one: whichever path a reviewer reads, the bug is in the one they did not.
+
+- **`CountBooksByPathPrefix` could never reach its own Pebble path.** It chose an
+  implementation based on whether memdb was published, ignoring the flag that is
+  supposed to select between them. Besides making the fallback dead code whenever
+  memdb was up, this quietly reduces any conformance test to comparing memdb
+  against itself. Repairing the selector is what allowed the count bug above to be
+  observed at all.

--- a/internal/database/aggregate_count_conformance_test.go
+++ b/internal/database/aggregate_count_conformance_test.go
@@ -1,0 +1,179 @@
+// file: internal/database/aggregate_count_conformance_test.go
+// version: 1.0.0
+// guid: 6f2a83d5-14c7-4e91-a06b-5d38e7b2f94c
+// last-edited: 2026-08-14
+
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// aggregateCountConformanceFixture builds a library where the live and trashed
+// halves are deliberately DIFFERENT sizes, so a count that includes the trash
+// cannot coincidentally match a count that excludes it.
+//
+// Helper name is task-unique on purpose: several suites in this package define
+// fixture builders and a generic name collides on rebase.
+type aggregateCountConformanceFixture struct {
+	seriesID int
+
+	liveBooks    int
+	trashedBooks int
+
+	// Every book is created under this path prefix so CountBooksByPathPrefix
+	// sees the same live/trashed split as the series counters.
+	pathPrefix string
+}
+
+func buildAggregateCountConformanceFixture(t *testing.T, store Store) aggregateCountConformanceFixture {
+	t.Helper()
+
+	fx := aggregateCountConformanceFixture{pathPrefix: "/lib/aggcount/"}
+
+	series, err := store.CreateSeries("Aggregate Count Series", nil)
+	require.NoError(t, err)
+	fx.seriesID = series.ID
+
+	yes := true
+
+	mk := func(title string, trash bool) {
+		b := &Book{
+			Title:            title,
+			FilePath:         fx.pathPrefix + title,
+			SeriesID:         &fx.seriesID,
+			IsPrimaryVersion: &yes,
+		}
+		created, cErr := store.CreateBook(b)
+		require.NoError(t, cErr)
+
+		// One file per book, so the *FileCounts variants have something to
+		// count and inherit the same live/trashed split.
+		require.NoError(t, store.CreateBookFile(&BookFile{
+			BookID:   created.ID,
+			FilePath: fx.pathPrefix + title + "/01.m4b",
+		}))
+
+		if trash {
+			// Soft-delete through the real update path so the memdb re-index
+			// runs, matching how a real deletion reaches the store.
+			created.MarkedForDeletion = &yes
+			_, uErr := store.UpdateBook(created.ID, created)
+			require.NoError(t, uErr)
+		}
+	}
+
+	for _, title := range []string{"Live One", "Live Two", "Live Three", "Live Four", "Live Five"} {
+		mk(title, false)
+		fx.liveBooks++
+	}
+	for _, title := range []string{"Trashed One", "Trashed Two"} {
+		mk(title, true)
+		fx.trashedBooks++
+	}
+
+	return fx
+}
+
+// TestAggregateCounts_MemDBAndPebbleAgree is the conformance gate for the
+// per-series and per-path aggregate counters.
+//
+// These are the counts that feed the series list and the import-path screens.
+// Their two implementations disagreed about the trash: the memdb walks excluded
+// soft-deleted books, the Pebble scans counted them. So for the ~132 s it takes
+// memdb to warm up after a restart, a series reported more books than it has and
+// an import path reported more books than it holds.
+//
+// This is the same defect class as #2392 (soft-deleted rows leaking into
+// GetAllBooksCore) but leaking from the OTHER store, which is the argument for
+// testing conformance rather than auditing one implementation: whichever path a
+// reviewer reads, the bug is in the one they did not.
+//
+// The fixture uses 5 live and 2 trashed books on purpose. Equal halves would let
+// an off-by-one-direction implementation pass by coincidence.
+func TestAggregateCounts_MemDBAndPebbleAgree(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	fx := buildAggregateCountConformanceFixture(t, store)
+
+	p, ok := store.(*PebbleStore)
+	require.True(t, ok, "expected *PebbleStore from setupPebbleTestDB")
+	p.WaitForWarmup()
+	require.True(t, p.IsMemReady(),
+		"memdb must be published or the UseMemDB=true arm silently runs the Pebble path")
+
+	// Non-vacuity guards: without trashed rows every assertion below passes
+	// against an implementation that ignores the trash entirely.
+	require.NotZero(t, fx.trashedBooks, "fixture must contain soft-deleted books")
+	require.NotEqual(t, fx.liveBooks, fx.trashedBooks,
+		"live and trashed counts must differ or a wrong answer can coincide with the right one")
+
+	type snapshot struct {
+		seriesBooks int
+		seriesFiles int
+		pathBooks   int
+	}
+	got := map[bool]snapshot{}
+
+	for _, useMemDB := range []bool{true, false} {
+		p.UseMemDB = useMemDB
+		label := "PebbleScanPath"
+		if useMemDB {
+			label = "MemDBPath"
+		}
+
+		t.Run(label, func(t *testing.T) {
+			bookCounts, err := store.GetAllSeriesBookCounts()
+			require.NoError(t, err)
+			fileCounts, err := store.GetAllSeriesFileCounts()
+			require.NoError(t, err)
+			pathCount, err := store.CountBooksByPathPrefix(fx.pathPrefix)
+			require.NoError(t, err)
+
+			// assert, not require: these three are independent counters and a
+			// reader needs to see WHICH of them drifted. require aborts the
+			// subtest at the first failure, which hides the others — and the
+			// path-prefix counter in particular has its own dispatch bug, so
+			// masking it behind the series counter is how it stayed invisible.
+			assert.Equal(t, fx.liveBooks, bookCounts[fx.seriesID],
+				"series book count included soft-deleted books — the series list would "+
+					"report more books than the series has")
+			assert.Equal(t, fx.liveBooks, fileCounts[fx.seriesID],
+				"series file count included files belonging to soft-deleted books")
+			assert.Equal(t, fx.liveBooks, pathCount,
+				"import-path book count included soft-deleted books")
+
+			got[useMemDB] = snapshot{
+				seriesBooks: bookCounts[fx.seriesID],
+				seriesFiles: fileCounts[fx.seriesID],
+				pathBooks:   pathCount,
+			}
+		})
+	}
+	p.UseMemDB = true
+
+	require.Equal(t, got[true], got[false],
+		"memdb and Pebble implementations of the aggregate counters disagree")
+}
+
+// A note on the selector, because it is what makes the loop above mean
+// anything.
+//
+// CountBooksByPathPrefix dispatched on memdb PUBLICATION alone
+// (`p.mem() != nil`) rather than on UseMemDB, so its Pebble branch was
+// unreachable whenever memdb was up. That is worse than a dormant fallback: it
+// silently reduced the UseMemDB=false arm above to a second run of the memdb
+// code, and the pathBooks assertion passed while proving nothing.
+// ListBooksByITunesPID had the same defect, fixed 2026-08-14.
+//
+// A standalone "does it respect the flag?" test cannot detect this once both
+// implementations are correct, because by then they agree by construction — it
+// would pass whichever branch ran, which is the same trap one level up. What
+// actually demonstrated the fix was the sequence: with the selector repaired
+// and the soft-delete filter still missing, the pathBooks assertion above began
+// failing (7 vs 5) where it had previously passed. That transition is the
+// evidence the Pebble branch is now genuinely reached.

--- a/internal/database/pebble_store_importpaths.go
+++ b/internal/database/pebble_store_importpaths.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_importpaths.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: eb97f1d9-af89-4dc7-add9-70ab7c30d137
-// last-edited: 2026-07-03
+// last-edited: 2026-08-14
 
 package database
 
@@ -60,8 +60,15 @@ func (p *PebbleStore) CountBooksByPathPrefix(prefix string) (int, error) {
 		return 0, nil
 	}
 	// Fast path: memdb scan is ~200× faster than Pebble + JSON unmarshal.
-	if mem := p.mem(); mem != nil {
-		return mem.CountBooksByPathPrefix(prefix)
+	//
+	// Gated on UseMemDB as well as publication. Dispatching on `p.mem() != nil`
+	// alone made the Pebble branch below unreachable whenever memdb was up,
+	// which is not merely a dormant fallback: it silently reduces any
+	// conformance test that flips UseMemDB to comparing memdb against itself.
+	// ListBooksByITunesPID had the same defect and was fixed on 2026-08-14 for
+	// the same reason. See aggregate_count_conformance_test.go.
+	if p.UseMemDB && p.mem() != nil {
+		return p.mem().CountBooksByPathPrefix(prefix)
 	}
 	count := 0
 	iter, err := p.db.NewIter(&pebble.IterOptions{
@@ -75,6 +82,11 @@ func (p *PebbleStore) CountBooksByPathPrefix(prefix string) (int, error) {
 	for iter.First(); iter.Valid(); iter.Next() {
 		var b Book
 		if json.Unmarshal(iter.Value(), &b) != nil {
+			continue
+		}
+		// Matches the memdb counterpart, which has always excluded the trash.
+		// See aggregate_count_conformance_test.go.
+		if bookIsSoftDeleted(&b) {
 			continue
 		}
 		if b.SourceImportPath != nil && *b.SourceImportPath != "" {

--- a/internal/database/pebble_store_series.go
+++ b/internal/database/pebble_store_series.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_series.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 29120d16-9add-4efd-81a5-edc1e8951f4d
-// last-edited: 2026-07-03
+// last-edited: 2026-08-14
 
 package database
 
@@ -269,6 +269,12 @@ func (p *PebbleStore) GetAllSeriesBookCounts_Pebble() (map[int]int, error) {
 		if b.SeriesID == nil || (b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion) {
 			continue
 		}
+		// The memdb counterpart has always excluded the trash; this path did
+		// not, so a series reported more books than it has whenever it was
+		// served before memdb published. See aggregate_count_conformance_test.go.
+		if bookIsSoftDeleted(&b) {
+			continue
+		}
 		counts[*b.SeriesID]++
 	}
 	return counts, nil
@@ -300,7 +306,10 @@ func (p *PebbleStore) GetAllSeriesFileCounts() (map[int]int, error) {
 		if err := json.Unmarshal(iter.Value(), &b); err != nil {
 			continue
 		}
-		if b.SeriesID != nil && (b.IsPrimaryVersion == nil || *b.IsPrimaryVersion) {
+		// Soft-deleted books are excluded here rather than when counting files,
+		// so their files never enter the map in the first place — matching the
+		// memdb counterpart. See aggregate_count_conformance_test.go.
+		if b.SeriesID != nil && (b.IsPrimaryVersion == nil || *b.IsPrimaryVersion) && !bookIsSoftDeleted(&b) {
 			bookIDToSeriesID[b.ID] = *b.SeriesID
 		}
 	}


### PR DESCRIPTION
Third find in the dual-implementation sweep started in #2406, on the **soft-delete** axis this time (#2410 was the primary-version axis).

## What

`GetAllSeriesBookCounts`, `GetAllSeriesFileCounts` and `CountBooksByPathPrefix` each have two backing implementations. The memdb ones excluded soft-deleted books; the Pebble ones counted them.

So for the ~132 s memdb warmup window after a restart, a series reported more books and files than it has, and an import path reported more books than it holds.

Same defect class as the soft-deleted rows that leaked into `GetAllBooksCore` in #2392 — but leaking from the **other** store. That is the argument for conformance testing over auditing: whichever implementation a reviewer reads, the bug is in the one they did not.

## A second bug that was hiding the first

`CountBooksByPathPrefix` dispatched on memdb **publication** (`p.mem() != nil`) rather than on `UseMemDB`, making its Pebble branch unreachable whenever memdb was up.

That is worse than dead code: it silently reduces any conformance loop that flips `UseMemDB` to comparing memdb against itself. `ListBooksByITunesPID` had the identical defect, fixed 2026-08-14.

**Fixing the selector is what made the count bug observable.** With the selector repaired and the filter still missing, the `pathBooks` assertion began failing 7-vs-5 where it had previously *passed*. That transition is the evidence the Pebble branch is genuinely reached now.

It is also why there is **no** standalone "does it respect the flag?" test here: once both implementations are correct, such a test passes whichever branch runs — the same vacuity trap one level up. I wrote one, found it passed for the wrong reason, and removed it.

## Test design

`internal/database/aggregate_count_conformance_test.go`

- **5 live / 2 trashed**, deliberately unequal — equal halves would let a wrong answer coincide with the right one.
- Uses `assert` rather than `require` for the three counters, so a reader sees **which** drifted instead of only the first. With `require`, the series-count failure masked the path-prefix failure entirely.
- Soft-deletes through the real update path so the memdb re-index runs.
- Confirmed **RED** before the fix (all three at 7 vs 5), green after.

## Scope note

`GetAllAuthorFileCounts` was initially flagged and is **NOT** affected — my first grep matched its dispatcher rather than its `_Pebble` body, which does filter correctly. Removed after reading the code. Recording it so the negative result is legible rather than looking like it was never checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxigqrwz9WfwN1wx8QhoQW