### PR TITLE
fix(series): stop the UI delete paths from deleting a series that still has books

### DIFF
--- a/changelog.d/20260814_064500_series_delete_unfiltered_ref_guard.md
+++ b/changelog.d/20260814_064500_series_delete_unfiltered_ref_guard.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **Deleting a series from the UI could strand its books.** Both series delete
+  endpoints — `DELETE /series/:id` and `POST /series/bulk-delete` — decided
+  whether a series was empty using the counter that fills in the badge next to a
+  series, which deliberately skips books in the trash and non-primary (duplicate)
+  versions. Those books still hold the `series_id`, so a series whose books were
+  all trashed, or all alternate versions, counted as zero and was deleted out
+  from under them, leaving books pointing at a series that no longer exists and a
+  name that cannot be recovered. This is the same defect fixed in the weekly
+  prune; the interactive path still had it. Both endpoints now count references
+  in every book state, and refuse to delete at all if that count is unavailable
+  rather than falling back to the filtered one.

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/mock_store.go
-// version: 1.84.0
+// version: 1.85.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-08-14
 
@@ -123,6 +123,12 @@ type MockStore struct {
 	DeleteSeriesFunc     func(id int) error
 	UpdateSeriesNameFunc func(id int, name string) error
 	GetSeriesByIDsFunc   func(ids []int) (map[int]*Series, error)
+	// GetAllSeriesBookRefCountsFunc backs the SeriesBookRefStore capability.
+	// A nil func yields an empty map, i.e. "no series is referenced by
+	// anything" — the permissive answer, so a mock that does not care about
+	// reference counting still lets deletes through. Tests that assert a
+	// series must survive have to say so explicitly.
+	GetAllSeriesBookRefCountsFunc func() (map[int]int, error)
 
 	// Metadata
 	GetMetadataFieldStatesFunc   func(bookID string) ([]MetadataFieldState, error)
@@ -639,6 +645,18 @@ func (m *MockStore) DeleteSeries(id int) error {
 		return m.DeleteSeriesFunc(id)
 	}
 	return nil
+}
+
+// GetAllSeriesBookRefCounts satisfies SeriesBookRefStore so a MockStore can
+// stand in for a store that answers the UNFILTERED reference question. Without
+// it, AsSeriesBookRefStore returns nil and every caller correctly fails closed,
+// which would make the mock unusable for the delete paths rather than merely
+// permissive.
+func (m *MockStore) GetAllSeriesBookRefCounts() (map[int]int, error) {
+	if m.GetAllSeriesBookRefCountsFunc != nil {
+		return m.GetAllSeriesBookRefCountsFunc()
+	}
+	return map[int]int{}, nil
 }
 
 func (m *MockStore) UpdateSeriesName(id int, name string) error {

--- a/internal/server/handlers/entities/handler.go
+++ b/internal/server/handlers/entities/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/entities/handler.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: b02a07d8-1806-4c86-bb72-f0688d6caff3
-// last-edited: 2026-08-11
+// last-edited: 2026-08-14
 
 // Package entities hosts the entity-domain HTTP handlers extracted from the
 // server package: works, authors, series, and narrators — CRUD plus merges,
@@ -995,12 +995,17 @@ func (h *Handler) DeleteEmptySeries(c *gin.Context) {
 		httputil.RespondWithBadRequest(c, "invalid series ID")
 		return
 	}
-	books, err := h.store.GetBooksBySeriesIDCore(seriesID)
+	// "Is anything still pointing at this series?" is NOT the question
+	// GetBooksBySeriesIDCore answers — it skips trashed and non-primary books,
+	// which still hold the series_id. Deleting on its zero is what stranded
+	// 13,322 books behind 6,893 series that no longer exist; see
+	// internal/database/series_bookref.go and executeSeriesPrune.
+	refCounts, err := seriesRefCounts(h.store)
 	if err != nil {
-		httputil.InternalError(c, "failed to get series books", err)
+		httputil.InternalError(c, "failed to count series references", err)
 		return
 	}
-	if len(books) > 0 {
+	if refCounts[seriesID] > 0 {
 		httputil.RespondWithConflict(c, "cannot delete series with books")
 		return
 	}
@@ -1025,13 +1030,17 @@ func (h *Handler) BulkDeleteSeries(c *gin.Context) {
 	deleted := 0
 	skipped := 0
 	var errors []string
+	// Counted ONCE for the whole library rather than per series. That is both the
+	// only form in which "referenced by nothing" is answerable — the per-series
+	// getter skips trashed and non-primary books that still hold the series_id —
+	// and cheaper than one scan per requested ID.
+	refCounts, err := seriesRefCounts(h.store)
+	if err != nil {
+		httputil.InternalError(c, "failed to count series references", err)
+		return
+	}
 	for _, id := range req.IDs {
-		books, err := h.store.GetBooksBySeriesIDCore(id)
-		if err != nil {
-			errors = append(errors, fmt.Sprintf("series %d: %v", id, err))
-			continue
-		}
-		if len(books) > 0 {
+		if refCounts[id] > 0 {
 			skipped++
 			continue
 		}

--- a/internal/server/handlers/entities/handler_test.go
+++ b/internal/server/handlers/entities/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/entities/handler_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 163bc668-0761-43eb-9d85-f4983e8b014b
-// last-edited: 2026-07-06
+// last-edited: 2026-08-14
 
 package entities_test
 
@@ -36,6 +36,32 @@ type deps struct {
 	seriesCache  *cache.Cache[*audiobooks.SeriesWithCountsResponse]
 	dedupCache   *cache.Cache[gin.H]
 	enrichCalls  int
+	// seriesRefCounts backs the UNFILTERED series reference counter the delete
+	// handlers consult. nil means "no series is referenced by anything", which
+	// is what every test that does not care about deletion wants. Set it to
+	// assert that a referenced series survives.
+	seriesRefCounts map[int]int
+}
+
+// entitiesStoreWithSeriesRefs adds GetAllSeriesBookRefCounts to the generated
+// EntitiesStore mock. SeriesBookRefStore is deliberately kept out of the store
+// interfaces so widening it does not force every implementation and generated
+// mock to grow, and the delete handlers reach it via
+// database.AsSeriesBookRefStore and FAIL CLOSED when it is missing — so a bare
+// generated mock cannot exercise them at all.
+//
+// It reads through to deps so a test can set seriesRefCounts after the handler
+// has already been constructed.
+type entitiesStoreWithSeriesRefs struct {
+	*entitiesmocks.MockEntitiesStore
+	d *deps
+}
+
+func (s entitiesStoreWithSeriesRefs) GetAllSeriesBookRefCounts() (map[int]int, error) {
+	if s.d.seriesRefCounts == nil {
+		return map[int]int{}, nil
+	}
+	return s.d.seriesRefCounts, nil
 }
 
 // newHandler builds a Handler backed by fresh mocks and real (non-nil) caches.
@@ -61,7 +87,7 @@ func newHandler(t *testing.T) (*entities.Handler, *deps) {
 		return out
 	}
 	h := entities.New(
-		d.store,
+		entitiesStoreWithSeriesRefs{MockEntitiesStore: d.store, d: d},
 		d.workSvc,
 		d.authorSeries,
 		d.registry,
@@ -462,7 +488,7 @@ func TestSplitSeries_EmptyBookIDs(t *testing.T) {
 
 func TestDeleteEmptySeries(t *testing.T) {
 	h, d := newHandler(t)
-	d.store.EXPECT().GetBooksBySeriesIDCore(5).Return([]database.BookCore{}, nil)
+	// Referenced by nothing in any state.
 	d.store.EXPECT().DeleteSeries(5).Return(nil)
 	c, w := newCtx(http.MethodDelete, "/series/5", "", idParam("5"))
 	h.DeleteEmptySeries(c)
@@ -471,7 +497,10 @@ func TestDeleteEmptySeries(t *testing.T) {
 
 func TestDeleteEmptySeries_HasBooks(t *testing.T) {
 	h, d := newHandler(t)
-	d.store.EXPECT().GetBooksBySeriesIDCore(5).Return([]database.BookCore{{ID: "b"}}, nil)
+	// One reference refuses the delete. It deliberately does not matter whether
+	// that book is live, trashed or a non-primary version — blindness to the
+	// last two is what stranded 13,322 books behind deleted series.
+	d.seriesRefCounts = map[int]int{5: 1}
 	c, w := newCtx(http.MethodDelete, "/series/5", "", idParam("5"))
 	h.DeleteEmptySeries(c)
 	assert.Equal(t, http.StatusConflict, w.Code)
@@ -479,11 +508,24 @@ func TestDeleteEmptySeries_HasBooks(t *testing.T) {
 
 func TestBulkDeleteSeries(t *testing.T) {
 	h, d := newHandler(t)
-	d.store.EXPECT().GetBooksBySeriesIDCore(1).Return([]database.BookCore{}, nil)
 	d.store.EXPECT().DeleteSeries(1).Return(nil)
 	c, w := newCtx(http.MethodPost, "/series/bulk-delete", `{"ids":[1]}`, nil)
 	h.BulkDeleteSeries(c)
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestBulkDeleteSeries_SkipsReferencedSeries is the regression case: a series
+// the display counter calls empty because its only book is trashed or a
+// non-primary version must NOT be deleted.
+func TestBulkDeleteSeries_SkipsReferencedSeries(t *testing.T) {
+	h, d := newHandler(t)
+	d.seriesRefCounts = map[int]int{1: 1}
+	// No DeleteSeries expectation: calling it at all fails the mock.
+	c, w := newCtx(http.MethodPost, "/series/bulk-delete", `{"ids":[1]}`, nil)
+	h.BulkDeleteSeries(c)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"skipped":1`)
+	assert.Contains(t, w.Body.String(), `"deleted":0`)
 }
 
 func TestUpdateSeriesName(t *testing.T) {

--- a/internal/server/handlers/entities/series_refcount.go
+++ b/internal/server/handlers/entities/series_refcount.go
@@ -1,0 +1,41 @@
+// file: internal/server/handlers/entities/series_refcount.go
+// version: 1.0.0
+// guid: 8e2f5a19-7d64-4c03-b8a1-5f93c0e64b27
+// last-edited: 2026-08-14
+
+package entities
+
+import (
+	"fmt"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// seriesRefCounts returns, per series ID, how many books reference it in ANY
+// state — including books in the trash and non-primary (duplicate) versions.
+// A series ID absent from the map is referenced by nothing and is the only
+// thing safe to delete.
+//
+// This exists because the obvious getter is the wrong question. Both series
+// delete handlers used to guard with GetBooksBySeriesIDCore, which is the
+// counter behind the number shown next to a series in the UI and therefore
+// deliberately skips trashed and non-primary books. Those books still hold the
+// series_id, so a series whose books were all trashed, or all alternate
+// versions, counted as zero and was deleted out from under them. On production
+// 2026-08-14 that had produced 6,893 series IDs referenced by 13,322 live books
+// (+702 trashed), each rendering with no series and unrecoverable — the names
+// live only in the deleted row.
+//
+// It fails CLOSED. If the store cannot answer the unfiltered question, the
+// caller must refuse to delete rather than fall back to the filtered count,
+// because that fallback is precisely the bug: it deletes rows while reporting
+// success. Mirrors the guard executeSeriesPrune adopted in #2400.
+func seriesRefCounts(store any) (map[int]int, error) {
+	refCounter := database.AsSeriesBookRefStore(store)
+	if refCounter == nil {
+		return nil, fmt.Errorf("store cannot count unfiltered series references (got %T); "+
+			"refusing to delete from a filtered count, which silently strands "+
+			"books whose series is trashed or non-primary", store)
+	}
+	return refCounter.GetAllSeriesBookRefCounts()
+}

--- a/internal/server/handlers_unit_test.go
+++ b/internal/server/handlers_unit_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers_unit_test.go
-// version: 1.11.0
+// version: 1.12.0
 // guid: f8a2d1c3-4b5e-6789-abcd-ef0123456789
-// last-edited: 2026-07-16
+// last-edited: 2026-08-14
 //
 // Unit tests for HTTP handlers using MockStore + httptest.
 // Focuses on handlers that directly call s.Store() without
@@ -1272,10 +1272,26 @@ func TestHandler_UpdateSeriesName_InvalidID(t *testing.T) {
 
 // =============== deleteEmptySeries ===============
 
+// seriesRefMockStore adds the unfiltered series reference counter to the
+// generated mock, which cannot carry it on its own: SeriesBookRefStore is
+// deliberately kept OUT of database.Store so that widening the capability does
+// not force every implementation and generated mock to grow with it. The delete
+// handlers reach it through database.AsSeriesBookRefStore and fail closed when
+// it is absent, so a bare generated mock cannot exercise them.
+type seriesRefMockStore struct {
+	*mocks.MockStore
+	refCounts map[int]int
+}
+
+func (s seriesRefMockStore) GetAllSeriesBookRefCounts() (map[int]int, error) {
+	return s.refCounts, nil
+}
+
 func TestHandler_DeleteEmptySeries_Success(t *testing.T) {
 	srv, mockStore, router := setupHandlerTest(t)
 
-	mockStore.EXPECT().GetBooksBySeriesIDCore(10).Return([]database.BookCore{}, nil)
+	// Referenced by nothing in ANY state — the only safe-to-delete condition.
+	srv.store = seriesRefMockStore{MockStore: mockStore, refCounts: map[int]int{}}
 	mockStore.EXPECT().DeleteSeries(10).Return(nil)
 
 	router.DELETE("/series/:id", newEntitiesHandler(srv).DeleteEmptySeries)
@@ -1290,7 +1306,10 @@ func TestHandler_DeleteEmptySeries_Success(t *testing.T) {
 func TestHandler_DeleteEmptySeries_HasBooks(t *testing.T) {
 	srv, mockStore, router := setupHandlerTest(t)
 
-	mockStore.EXPECT().GetBooksBySeriesIDCore(10).Return([]database.BookCore{{ID: "b1"}}, nil)
+	// One reference is enough to refuse, and it deliberately does not matter
+	// whether that book is live, trashed or a non-primary version — the old
+	// guard's blindness to the last two is what stranded 13,322 books.
+	srv.store = seriesRefMockStore{MockStore: mockStore, refCounts: map[int]int{10: 1}}
 
 	router.DELETE("/series/:id", newEntitiesHandler(srv).DeleteEmptySeries)
 

--- a/internal/server/series_delete_refguard_test.go
+++ b/internal/server/series_delete_refguard_test.go
@@ -1,0 +1,141 @@
+// file: internal/server/series_delete_refguard_test.go
+// version: 1.0.0
+// guid: 5b6c1e07-9a34-4d82-bf16-0c72e9a35d84
+// last-edited: 2026-08-14
+
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// The series delete handlers used to guard with GetBooksBySeriesIDCore, the
+// counter behind the badge in the UI, which skips trashed and non-primary
+// books. Those books still hold the series_id, so a series whose only books
+// were in one of those two states counted as zero and was deleted out from
+// under them. On production that produced 6,893 series IDs referenced by 13,322
+// live books, every one rendering with no series and the name unrecoverable.
+//
+// Both tests below FAIL against the old filtered guard, which is the point:
+// each builds a series that the display counter reports as empty and the
+// unfiltered counter reports as referenced.
+
+
+// TestBulkDeleteSeries_KeepsSeriesWhoseOnlyBookIsTrashed is the exact shape of
+// series 160094 on production ("Queen of Fire: A Raven's Shadow Novel"), whose
+// single book sits in the trash.
+func TestBulkDeleteSeries_KeepsSeriesWhoseOnlyBookIsTrashed(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	store := database.GetGlobalStore()
+
+	trashedOnly, err := store.CreateSeries("Only A Trashed Book", nil)
+	require.NoError(t, err)
+	genuinelyEmpty, err := store.CreateSeries("Genuinely Empty", nil)
+	require.NoError(t, err)
+
+	_, err = store.CreateBook(&database.Book{
+		Title:             "Trashed Book",
+		SeriesID:          &trashedOnly.ID,
+		FilePath:          "/tmp/refguard-trashed.m4b",
+		MarkedForDeletion: boolPtr(true),
+	})
+	require.NoError(t, err)
+
+	w := postJSON(server, "/api/v1/series/bulk-delete", map[string]interface{}{
+		"ids": []int{trashedOnly.ID, genuinelyEmpty.ID},
+	})
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var wrapper struct {
+		Data bulkDeleteResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	assert.Equal(t, 1, wrapper.Data.Deleted, "only the genuinely empty series may be deleted")
+	assert.Equal(t, 1, wrapper.Data.Skipped, "the series holding a trashed book must be skipped")
+
+	survivor, err := store.GetSeriesByID(trashedOnly.ID)
+	assert.NoError(t, err)
+	require.NotNil(t, survivor, "deleting this series strands its trashed book on a dead series_id")
+	assert.Equal(t, "Only A Trashed Book", survivor.Name)
+
+	gone, err := store.GetSeriesByID(genuinelyEmpty.ID)
+	assert.NoError(t, err)
+	assert.Nil(t, gone, "a series referenced by nothing should still be deleted")
+}
+
+// TestBulkDeleteSeries_KeepsSeriesWhoseOnlyBookIsNonPrimary covers the other
+// half of the filtered counter: alternate versions of a book are hidden behind
+// the primary one, but they still carry the series_id.
+func TestBulkDeleteSeries_KeepsSeriesWhoseOnlyBookIsNonPrimary(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	store := database.GetGlobalStore()
+
+	nonPrimaryOnly, err := store.CreateSeries("Only A Duplicate Version", nil)
+	require.NoError(t, err)
+
+	_, err = store.CreateBook(&database.Book{
+		Title:            "Alternate Version",
+		SeriesID:         &nonPrimaryOnly.ID,
+		FilePath:         "/tmp/refguard-nonprimary.m4b",
+		IsPrimaryVersion: boolPtr(false),
+	})
+	require.NoError(t, err)
+
+	w := postJSON(server, "/api/v1/series/bulk-delete", map[string]interface{}{
+		"ids": []int{nonPrimaryOnly.ID},
+	})
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var wrapper struct {
+		Data bulkDeleteResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	assert.Equal(t, 0, wrapper.Data.Deleted)
+	assert.Equal(t, 1, wrapper.Data.Skipped)
+
+	survivor, err := store.GetSeriesByID(nonPrimaryOnly.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, survivor, "deleting this series strands its non-primary book")
+}
+
+// TestDeleteEmptySeries_KeepsSeriesWhoseOnlyBookIsTrashed covers the
+// single-series endpoint, which carried the same filtered guard.
+func TestDeleteEmptySeries_KeepsSeriesWhoseOnlyBookIsTrashed(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	store := database.GetGlobalStore()
+
+	series, err := store.CreateSeries("Single Endpoint Trashed", nil)
+	require.NoError(t, err)
+	_, err = store.CreateBook(&database.Book{
+		Title:             "Trashed Book Two",
+		SeriesID:          &series.ID,
+		FilePath:          "/tmp/refguard-single-trashed.m4b",
+		MarkedForDeletion: boolPtr(true),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/series/"+strconv.Itoa(series.ID), nil)
+	w := httptest.NewRecorder()
+	server.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code,
+		"a series still referenced by a trashed book must not be deletable")
+
+	survivor, err := store.GetSeriesByID(series.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, survivor)
+}

--- a/internal/server/server_bulk_delete_test.go
+++ b/internal/server/server_bulk_delete_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_bulk_delete_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-07-06
+// last-edited: 2026-08-14
 
 package server
 
@@ -429,15 +429,26 @@ func TestBulkDeleteSeries_MixedResults(t *testing.T) {
 
 // ---------- Series bulk-delete with mock store ----------
 
+// TestBulkDeleteSeries_StoreError asserts the fail-closed contract.
+//
+// This test previously described the opposite behaviour: a per-series read
+// error produced one soft entry in "errors" while the other IDs deleted
+// anyway. That shape came from asking GetBooksBySeriesIDCore once per ID, and
+// that counter is the display counter — it skips trashed and non-primary books
+// that still hold the series_id, which is what stranded 13,322 books behind
+// deleted series. The handler now asks for UNFILTERED reference counts once for
+// the whole request, so a failure to obtain them is not a per-ID inconvenience:
+// it means the "is anything still pointing at this?" question is unanswerable,
+// and deleting anyway is precisely the bug. Nothing is deleted, and the request
+// fails loudly.
 func TestBulkDeleteSeries_StoreError(t *testing.T) {
+	deleteCalls := 0
 	mock := &database.MockStore{
-		GetBooksBySeriesIDCoreFunc: func(seriesID int) ([]database.BookCore, error) {
-			if seriesID == 1 {
-				return nil, fmt.Errorf("db read error")
-			}
-			return nil, nil
+		GetAllSeriesBookRefCountsFunc: func() (map[int]int, error) {
+			return nil, fmt.Errorf("db read error")
 		},
 		DeleteSeriesFunc: func(id int) error {
+			deleteCalls++
 			return nil
 		},
 	}
@@ -448,18 +459,10 @@ func TestBulkDeleteSeries_StoreError(t *testing.T) {
 		"ids": []int{1, 2},
 	})
 
-	assert.Equal(t, http.StatusOK, w.Code)
-
-	var wrapper struct {
-		Data bulkDeleteResponse `json:"data"`
-	}
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
-	resp := wrapper.Data
-
-	assert.Equal(t, 1, resp.Deleted)
-	assert.Equal(t, 0, resp.Skipped)
-	assert.Len(t, resp.Errors, 1)
-	assert.Equal(t, 2, resp.Total)
+	assert.Equal(t, http.StatusInternalServerError, w.Code,
+		"an unanswerable reference count must fail the request, not delete on a guess")
+	assert.Zero(t, deleteCalls,
+		"no series may be deleted when the reference count could not be read")
 }
 
 func TestBulkDeleteSeries_DeleteError(t *testing.T) {

--- a/todo.d/20260814-author-delete-uses-listing-counter.md
+++ b/todo.d/20260814-author-delete-uses-listing-counter.md
@@ -1,0 +1,29 @@
+### Author delete paths guard with the listing counter, same shape as the series bug
+
+- [ ] **`BulkDeleteAuthors` and `DeleteEmptyAuthor` decide "is this author empty?"
+  with `GetBooksByAuthorIDCore`**, which `internal/database/memdb_reads.go:529`
+  documents as a *listing* view — it applies the primary-version filter and
+  returns only live books. The repo already knows this is the wrong getter for
+  this class of caller; the comment on `GetBooksByAuthorIDAllVersions` says so
+  explicitly:
+
+  > `GetBooksByAuthorIDWithRoleCore` is what merges and deletes consult to find
+  > the links they must rewrite before removing an author. For that caller a
+  > missed link is data loss — the author gets deleted and the junction row is
+  > left pointing at a row that no longer exists.
+
+  The delete handlers are exactly that caller and still use the listing getter,
+  so an author whose only books are trashed or non-primary counts as zero and is
+  deletable, stranding those books and their `book_authors` junction rows.
+
+  This is the author-side twin of the series bug fixed in #2400 (weekly prune)
+  and the UI delete paths. It was NOT fixed alongside them because the series fix
+  could reuse `SeriesBookRefStore`/`GetAllSeriesBookRefCounts`, and no author
+  equivalent exists — the fix needs a `GetAllAuthorBookRefCounts` that counts
+  `Book.AuthorID` **and** `book_authors` junction rows in every book state,
+  across both the memdb and Pebble implementations, with a conformance test
+  (see `internal/database/author_getter_conformance_test.go`, and the
+  memdb-vs-Pebble divergence it already caught: 86 links warm vs 84 cold).
+
+  Until then the risk is live but small — it needs a user to bulk-delete authors
+  from the UI. Not a background job, so nothing is accumulating on its own.


### PR DESCRIPTION
## What

`DELETE /series/:id` and `POST /series/bulk-delete` both decided *"is this series empty?"* with `GetBooksBySeriesIDCore` — the counter behind the badge shown next to a series, which deliberately skips **trashed** and **non-primary** books.

Those books still hold the `series_id`. A series whose books were all in the trash, or all alternate versions, counted as zero and was deleted out from under them — and the name is **unrecoverable**, because it lives only in the deleted row.

This is the same defect #2400 fixed in `executeSeriesPrune`, still live on the interactive path. On production it had already produced **6,893 series IDs referenced by 13,322 live books** (+702 trashed), every one rendering with no series.

## How

Both handlers use the unfiltered counter through a shared `seriesRefCounts` helper, and both **fail closed**: if the store can't answer the unfiltered question they refuse to delete rather than falling back to the filtered count — that fallback deletes rows while reporting success.

Bulk delete computes the counts **once** for the whole request, which is also cheaper than the per-ID scan it replaces.

## Tests

Three new regression tests, each building a series the display counter calls empty and the unfiltered counter calls referenced:

- only book is **trashed** (the exact shape of production series 160094, *Queen of Fire: A Raven's Shadow Novel*)
- only book is **non-primary**
- same, via the **single-delete** endpoint (expects 409)

**Mutation-tested, both mutations compile:**

| mutation | goes red |
|---|---|
| guard never fires (the original bug's exact effect) | all 3 new tests + existing `SkipsSeriesWithBooks` |
| guard always fires | `AllEmpty`, `MixedResults`, `DeleteError` |

Source restored byte-identical, zero leftover markers.

### One existing test was rewritten, not removed

`TestBulkDeleteSeries_StoreError` asserted the **opposite** contract: a per-series read error produced one soft entry in `errors` while the other IDs deleted anyway. That shape only existed because the guard ran per ID. It now asserts the new contract — an unanswerable reference count fails the request and deletes **nothing**.

`MockStore` gains `GetAllSeriesBookRefCounts` so a mock can stand in for a compliant store; a nil func yields an empty map, so mocks that don't care stay permissive.

## Also filed (`todo.d/`)

The **author-side twin**: `BulkDeleteAuthors` / `DeleteEmptyAuthor` guard with `GetBooksByAuthorIDCore`, which `memdb_reads.go` documents as a listing view — and that same file already warns that merges and deletes must not use it because *"a missed link is data loss"*. Not fixed here because it needs a new `GetAllAuthorBookRefCounts` (junction rows, both implementations, conformance test). Risk is live but not accumulating — it takes a user bulk-deleting authors, not a background job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp