### PR TITLE
fix(dbtest): let the merge-guard invariant actually see the rows it guards

### DIFF
--- a/changelog.d/20260814_071500_dbtest_invariant_sees_trash.md
+++ b/changelog.d/20260814_071500_dbtest_invariant_sees_trash.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **The store-consistency guard that protects merges could never fire in any merge
+  test.** Invariant (a) — no book is both a live primary version and marked for
+  deletion — exists to catch a merge that half-applied. The shared helper enumerated
+  books through a listing that excludes soft-deleted rows, so the contradictory book
+  was never even looked at: the assertion ran, passed, and examined nothing. A
+  white-box version of the check does work, but it is reachable only from tests
+  inside the database package, which perform no merges, while every merge, combine
+  and regroup test in the tree uses the shared helper. The guard was live only where
+  nothing could violate it and blind everywhere the hazard actually is.
+
+  The helper now enumerates the live and soft-deleted listings together. Both are
+  public, so no white-box access was needed — the original reasoning stopped one
+  exported method short of the fix. A new test constructs the contradictory state
+  and asserts the invariant reports it, and was confirmed to fail when the union is
+  removed.

--- a/internal/database/dbtest/invariants.go
+++ b/internal/database/dbtest/invariants.go
@@ -1,7 +1,7 @@
 // file: internal/database/dbtest/invariants.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b1d2f3a4-5c6e-7a8b-9c0d-invariantsdbt1
-// last-edited: 2026-07-13
+// last-edited: 2026-08-14
 
 // Package dbtest holds cross-package TEST-ONLY helpers for asserting
 // data-loss / store-consistency invariants against a real database.Store.
@@ -15,14 +15,23 @@
 // it. Nothing in the production build imports this package.
 //
 // The checks here use ONLY the exported database.Store surface, so they are
-// portable but cannot see raw secondary-index rows. Two limitations follow from
-// the public surface and are covered instead by the database package's own
+// portable but cannot see raw secondary-index rows. One limitation follows from
+// the public surface and is covered instead by the database package's own
 // white-box helper (assertStoreInvariants in store_invariants_test.go):
-//   - ListBookIDs (memdb-backed) omits soft-deleted books, so invariant (a)
-//     ("live primary AND MarkedForDeletion") is effectively vacuous here — a
-//     book in that contradictory state would not be enumerated. The white-box
-//     helper scans raw primary rows and checks it properly.
 //   - The "no dangling index row" check needs the unexported *PebbleStore.db.
+//
+// Invariant (a) used to be a second such limitation, and was NOT actually
+// covered by that fallback in the place it mattered. ListBookIDs omits
+// soft-deleted books, so (a) ("live primary AND MarkedForDeletion") could never
+// fire here — and (a) exists to catch a half-applied MERGE. The white-box
+// helper does check it, but it is only reachable from tests inside the database
+// package, which perform no merges; every merge, combine and regroup test in
+// the tree calls THIS helper. So the guard was live only where nothing could
+// violate it and vacuous everywhere the hazard actually is.
+//
+// Fixed 2026-08-14 by enumerating ListBookIDs ∪ ListSoftDeletedBooks. Both are
+// public, so no white-box access is needed — the original reasoning stopped one
+// exported method short.
 //
 // What this helper DOES robustly verify (via GetBookByID, which returns
 // soft-deleted rows too): index listings never surface a soft-deleted or
@@ -58,8 +67,36 @@ func AssertStoreInvariants(tb testing.TB, store database.Store) {
 		tb.Fatalf("invariant: ListBookIDs: %v", err)
 	}
 
+	// ListBookIDs omits soft-deleted books, so on its own it cannot enumerate a
+	// row that is BOTH marked-for-deletion and a live primary — the exact
+	// contradiction invariant (a) exists to catch. Union in the trashed set so
+	// (a) has something to fire on. ListSoftDeletedBooks is part of the public
+	// Store surface, so this needs no white-box access and no import cycle.
+	//
+	// findOrphanBookFiles unions these same two listings for the same reason: a
+	// soft-deleted book is still physically present and still owns its rows.
+	trashed, err := store.ListSoftDeletedBooks(0, 0, nil)
+	if err != nil {
+		tb.Fatalf("invariant: ListSoftDeletedBooks: %v", err)
+	}
+
 	live := map[string]*database.Book{}
 	all := map[string]*database.Book{}
+
+	// check runs the per-book assertions for a book from either listing.
+	check := func(id string, b *database.Book) {
+		all[id] = b
+		marked := b.MarkedForDeletion != nil && *b.MarkedForDeletion
+
+		// (a) live-primary && marked-for-deletion is contradictory.
+		if marked && b.IsPrimaryVersion != nil && *b.IsPrimaryVersion {
+			tb.Errorf("invariant (a): book %s is a live primary version AND MarkedForDeletion", id)
+		}
+		if !marked {
+			live[id] = b
+		}
+	}
+
 	for _, id := range ids {
 		b, err := store.GetBookByID(id)
 		if err != nil {
@@ -71,16 +108,14 @@ func AssertStoreInvariants(tb testing.TB, store database.Store) {
 			tb.Errorf("invariant (b): ListBookIDs returned %s but GetBookByID is nil (dangling primary)", id)
 			continue
 		}
-		all[id] = b
-		marked := b.MarkedForDeletion != nil && *b.MarkedForDeletion
-
-		// (a) live-primary && marked-for-deletion is contradictory.
-		if marked && b.IsPrimaryVersion != nil && *b.IsPrimaryVersion {
-			tb.Errorf("invariant (a): book %s is a live primary version AND MarkedForDeletion", id)
+		check(id, b)
+	}
+	for i := range trashed {
+		b := trashed[i]
+		if _, already := all[b.ID]; already {
+			continue
 		}
-		if !marked {
-			live[id] = b
-		}
+		check(b.ID, &b)
 	}
 
 	// (b) Nothing an index listing returns may be soft-deleted or non-existent,

--- a/internal/database/dbtest/invariants_fires_test.go
+++ b/internal/database/dbtest/invariants_fires_test.go
@@ -1,0 +1,161 @@
+// file: internal/database/dbtest/invariants_fires_test.go
+// version: 1.0.0
+// guid: 8c50f6a2-7b41-4d39-9e28-3a6f1c04b7de
+// last-edited: 2026-08-14
+
+package dbtest_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/database/dbtest"
+)
+
+// newTestStore opens a throwaway Pebble store. dbtest_test is an external test
+// package, so the database package's own setupPebbleTestDB is out of reach and
+// the exported constructor is used directly.
+func newTestStore(t *testing.T) (database.Store, func()) {
+	t.Helper()
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "invariants.pebble"))
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	store.WaitForWarmup()
+	return store, func() { _ = store.Close() }
+}
+
+// recordingTB captures what AssertStoreInvariants reports instead of failing
+// the real test, so a test can assert that an invariant DID fire.
+//
+// Only the methods AssertStoreInvariants actually calls are implemented with
+// behaviour; the rest satisfy testing.TB. Fatalf must not return, so it panics
+// with a sentinel that the caller recovers — a Fatalf reaching here means the
+// helper hit a store error, which is a different failure than an invariant
+// firing and must not be silently counted as one.
+type recordingTB struct {
+	testing.TB
+	errors []string
+	fatal  string
+}
+
+type recordingTBFatal struct{}
+
+func (r *recordingTB) Helper() {}
+
+func (r *recordingTB) Errorf(format string, args ...any) {
+	r.errors = append(r.errors, fmt.Sprintf(format, args...))
+}
+
+func (r *recordingTB) Fatalf(format string, args ...any) {
+	r.fatal = fmt.Sprintf(format, args...)
+	panic(recordingTBFatal{})
+}
+
+// runInvariants calls the helper against a recording TB and returns what it
+// reported.
+func runInvariants(t *testing.T, store database.Store) *recordingTB {
+	t.Helper()
+	rec := &recordingTB{TB: t}
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				if _, ok := r.(recordingTBFatal); !ok {
+					panic(r)
+				}
+			}
+		}()
+		dbtest.AssertStoreInvariants(rec, store)
+	}()
+	if rec.fatal != "" {
+		t.Fatalf("AssertStoreInvariants hit a store error rather than an invariant: %s", rec.fatal)
+	}
+	return rec
+}
+
+// TestInvariantA_FiresOnLivePrimaryMarkedForDeletion is the instrument check
+// for invariant (a).
+//
+// Invariant (a) — "no book is BOTH a live primary version AND
+// MarkedForDeletion" — exists to catch a merge that half-applied. Until
+// 2026-08-14 it could not fire from this helper at all: the helper enumerated
+// via ListBookIDs, which excludes soft-deleted books, so the contradictory row
+// was never even visited. The assertion ran, passed, and proved nothing, in all
+// ~19 merge/combine/regroup call sites — which are the only places a
+// half-applied merge can occur.
+//
+// A guard that has never been observed going red is not a guard. This test
+// constructs the exact contradictory state and asserts the helper reports it.
+func TestInvariantA_FiresOnLivePrimaryMarkedForDeletion(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	yes := true
+
+	// A normal live book, so the fixture is not degenerate and a helper that
+	// errored unconditionally would be visible.
+	_, err := store.CreateBook(&database.Book{
+		Title:            "Perfectly Fine Book",
+		FilePath:         "/lib/inv/fine",
+		IsPrimaryVersion: &yes,
+	})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	// Baseline: a clean store must report nothing. Without this, an assertion
+	// that "errors is non-empty" below could be satisfied by an unrelated
+	// permanent complaint.
+	if rec := runInvariants(t, store); len(rec.errors) != 0 {
+		t.Fatalf("clean store reported invariant violations: %v", rec.errors)
+	}
+
+	// Now the contradiction: primary version AND marked for deletion. This is
+	// what a merge leaves behind if it flags the source row for deletion but
+	// fails before demoting it from primary.
+	bad, err := store.CreateBook(&database.Book{
+		Title:            "Half Merged Book",
+		FilePath:         "/lib/inv/halfmerged",
+		IsPrimaryVersion: &yes,
+	})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	bad.MarkedForDeletion = &yes
+	bad.IsPrimaryVersion = &yes
+	if _, err := store.UpdateBook(bad.ID, bad); err != nil {
+		t.Fatalf("UpdateBook: %v", err)
+	}
+
+	// Guard the premise: the row must actually be in the contradictory state,
+	// or this test passes for the wrong reason.
+	got, err := store.GetBookByID(bad.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetBookByID(%s): %v", bad.ID, err)
+	}
+	if got.MarkedForDeletion == nil || !*got.MarkedForDeletion {
+		t.Fatalf("premise failed: book is not MarkedForDeletion")
+	}
+	if got.IsPrimaryVersion == nil || !*got.IsPrimaryVersion {
+		t.Fatalf("premise failed: book is not a primary version — the store demoted it, " +
+			"so this fixture no longer represents a half-applied merge")
+	}
+
+	rec := runInvariants(t, store)
+
+	var fired bool
+	for _, e := range rec.errors {
+		if strings.Contains(e, "invariant (a)") && strings.Contains(e, bad.ID) {
+			fired = true
+		}
+	}
+	if !fired {
+		t.Fatalf("invariant (a) did NOT fire for book %s. Reported: %v\n"+
+			"This is the vacuity the 2026-08-14 fix removed: enumerating via ListBookIDs "+
+			"alone skips soft-deleted rows, so the contradictory book is never visited and "+
+			"the assertion passes without examining it.", bad.ID, rec.errors)
+	}
+}


### PR DESCRIPTION
Picks up the item filed in `todo.d/2026-08-14-vacuous-store-invariant-marked-primary.md` (thanks to the ListBookIDs survey in #2408 for flagging it).

## The problem

Invariant (a) — *"no book is BOTH a live primary version AND MarkedForDeletion"* — exists to catch **a merge that half-applied**. It could never fire.

`AssertStoreInvariants` enumerated via `ListBookIDs`, which omits soft-deleted books. So a book in the contradictory state was never visited: the assertion ran, passed, and examined nothing.

## Why the documented fallback did not cover it

The package comment acknowledged the vacuity and pointed at the database package's white-box `assertStoreInvariants` as the real coverage. That helper **does** check it correctly — but look at who can call each one:

| helper | checks (a)? | call sites |
|---|---|---|
| white-box `assertStoreInvariants` | yes (raw row scan) | 5, **all inside `internal/database`** |
| `dbtest.AssertStoreInvariants` | no (vacuous) | ~19, across `internal/merge` + `maintenance/regroup` |

Tests inside `internal/database` perform no merges. Every merge, combine and regroup test in the tree calls the **dbtest** helper. So the working guard ran only where nothing could violate it, and the vacuous one ran everywhere the hazard actually lives.

## The fix

Enumerate `ListBookIDs` ∪ `ListSoftDeletedBooks`. Both are on the **public** Store surface, so this needs no white-box access and creates no import cycle — the original reasoning stopped one exported method short. `findOrphanBookFiles` already unions these same two listings for the same reason, so the precedent was in-tree.

## Verification — by mutation, not by a green test

A guard that has never been watched go red is not a guard. With the union removed:

```
--- FAIL: TestInvariantA_FiresOnLivePrimaryMarkedForDeletion
    invariant (a) did NOT fire for book 01M000GMNC9S9S1NPC934EF2K8. Reported: []
```

`Reported: []` **is** the vacuity — the helper found nothing to say because it never looked at the book. Restored and re-confirmed green.

The new test also guards its own premise: it re-reads the book and fails loudly if the store demoted it from primary on update, since the fixture would then no longer represent a half-applied merge. And it asserts a clean store reports nothing first, so "errors is non-empty" cannot be satisfied by some unrelated standing complaint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxigqrwz9WfwN1wx8QhoQW