### PR TITLE
fix(ops): carry the op ID into run contexts so maintenance ops record undo history

### DIFF
--- a/changelog.d/20260814_073000_op_id_context_audit_trail.md
+++ b/changelog.d/20260814_073000_op_id_context_audit_trail.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **Scheduled maintenance operations recorded no undo history.** Eight operations
+  — including the nightly purge of soft-deleted books, the series prune, temp-file
+  cleanup and metadata write-back — record what they changed so the change can be
+  reviewed later and, where supported, reverted. Each looks up the ID of the
+  operation it is running under, and skips recording when that ID is missing. The
+  code that supplies the ID existed but was never connected to anything, so the
+  ID was always missing and every one of those operations skipped recording, with
+  no error and a successful-looking result. A series prune on 2026-08-14 deleted
+  326 rows and recorded zero changes. The ID is now attached to every operation
+  run, so the history is written again. This also means an empty change list can
+  once more be read as "this operation changed nothing" rather than "the recording
+  was disabled" — during the investigation above, the two were indistinguishable.

--- a/internal/plugins/maintenance/cleanup.go
+++ b/internal/plugins/maintenance/cleanup.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/cleanup.go
-// version: 1.0.2
+// version: 1.1.0
 // guid: c3d4e5f6-a7b8-9012-cdef-234567890123
-// last-edited: 2026-07-12
+// last-edited: 2026-08-14
 
 package maintenance
 
@@ -310,15 +310,29 @@ func (p *Plugin) runArchiveSweep(_ context.Context, _ json.RawMessage, reporter 
 
 // ctxOpID extracts the operation ID stored in context by the UOS worker loop.
 func ctxOpID(ctx context.Context) string {
-	if v, ok := ctx.Value(opIDKey{}).(string); ok {
-		return v
-	}
-	return ""
+	return OpIDFromContext(ctx)
 }
 
 type opIDKey struct{}
 
 // WithOpID returns a context carrying the operation ID for use by run functions.
+//
+// The only production caller is the run-context decorator installed in
+// internal/server (op_run_context.go). If that wiring is ever removed, every
+// `if operationID != ""` guard in this package goes quiet and the ops stop
+// recording undo history — silently, with no error and a successful-looking
+// result. TestOpRunContextDecorator_CarriesOpIDForMaintenanceOps exists to fail
+// if that happens.
 func WithOpID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, opIDKey{}, id)
+}
+
+// OpIDFromContext returns the operation ID carried by ctx, or "" if none is
+// present. Exported so the wiring that supplies it can be tested from the
+// package that installs it; ops inside this package use ctxOpID.
+func OpIDFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(opIDKey{}).(string); ok {
+		return v
+	}
+	return ""
 }

--- a/internal/server/op_run_context.go
+++ b/internal/server/op_run_context.go
@@ -1,0 +1,43 @@
+// file: internal/server/op_run_context.go
+// version: 1.0.0
+// guid: 2a7f4e18-63cb-49d0-9e75-8c31b0d4a6f2
+// last-edited: 2026-08-14
+
+package server
+
+import (
+	"context"
+
+	"github.com/falkcorp/audiobook-organizer/internal/logger"
+	maintenanceplugin "github.com/falkcorp/audiobook-organizer/internal/plugins/maintenance"
+)
+
+// opRunContextDecorator builds the context every operation Run receives. It is
+// installed via Registry.SetRunContextDecorator in registry_wire.go, and it is
+// the ONLY place where an operation's ID and its run context meet — the
+// registry deliberately does not import internal/logger or the plugin packages
+// (SDKGUARD-VIOLATION #1795), so anything that needs the op ID in-band has to
+// be attached here.
+//
+// It carries two things:
+//
+//  1. A context-bound slog.Logger tagged with op_id, so every line a run emits
+//     is attributable. This was already wired.
+//  2. The op ID in the form maintenance.ctxOpID reads. This was NOT. WithOpID
+//     was defined and exported but never called anywhere in production code, so
+//     ctxOpID returned "" for all eight maintenance ops that ask for it, and
+//     every downstream `if operationID != ""` guard silently skipped its
+//     CreateOperationChange.
+//
+// The cost of (2) being missing is not cosmetic. A maintenance.series-prune run
+// on 2026-08-14 deleted 326 series and recorded ZERO operation changes: no
+// record of which rows went, and nothing for the revert path to replay.
+// maintenance.purge-deleted has the same gap while permanently destroying
+// books. It also means "0 changes recorded" cannot be read as evidence that an
+// op did not run — a mistake made during that same investigation.
+//
+// Extracted from an inline closure so it can be tested; see
+// op_run_context_test.go.
+func opRunContextDecorator(ctx context.Context, opID string) context.Context {
+	return maintenanceplugin.WithOpID(logger.WithOperation(ctx, opID), opID)
+}

--- a/internal/server/op_run_context_test.go
+++ b/internal/server/op_run_context_test.go
@@ -1,0 +1,78 @@
+// file: internal/server/op_run_context_test.go
+// version: 1.0.0
+// guid: 8e5b1c93-7a20-4f6e-b1d8-53c9e0a7f412
+// last-edited: 2026-08-14
+
+package server
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/logger"
+	maintenanceplugin "github.com/falkcorp/audiobook-organizer/internal/plugins/maintenance"
+)
+
+// TestOpRunContextDecorator_CarriesOpIDForMaintenanceOps pins the half of the
+// decorator that was missing in production: the op ID in the form the
+// maintenance package reads.
+//
+// maintenance.WithOpID was defined and exported but never called from any
+// production code path, so ctxOpID returned "" inside every op, and each
+// `if operationID != ""` guard skipped its CreateOperationChange without an
+// error or any other visible signal. A series-prune run deleted 326 rows and
+// recorded zero undo history. Nothing failed; the audit trail was simply
+// absent.
+//
+// That is why this asserts through maintenance.OpIDFromContext rather than
+// re-reading the context key locally: the assertion has to travel the same
+// path the ops do, across the package boundary, or it proves nothing about
+// them.
+func TestOpRunContextDecorator_CarriesOpIDForMaintenanceOps(t *testing.T) {
+	const opID = "01KZZRYX6ENB1CGH855N9AVHQJ"
+
+	got := maintenanceplugin.OpIDFromContext(opRunContextDecorator(context.Background(), opID))
+
+	if got != opID {
+		t.Errorf("maintenance.OpIDFromContext = %q, want %q — ops that key their "+
+			"undo history off this value will record nothing", got, opID)
+	}
+}
+
+// TestOpRunContextDecorator_PreservesLoggerDecoration guards the OTHER half.
+//
+// The wiring used to be a bare logger.WithOperation. Composing a second
+// decoration on top of it created a new way to regress: drop the
+// logger.WithOperation call and op-ID log correlation disappears while the
+// audit-trail test above still passes. Both halves need their own assertion.
+//
+// This compares against slog.Default() by identity rather than installing a
+// capturing handler, deliberately. logger.WithOperation reads slog.Default()
+// internally, so a capturing assertion means slog.SetDefault — process-global
+// state mutated inside a large -race package whose siblings log freely. The
+// identity check answers the question that matters (was a logger attached, or
+// is FromContext falling through to the default?) without that hazard.
+func TestOpRunContextDecorator_PreservesLoggerDecoration(t *testing.T) {
+	ctx := opRunContextDecorator(context.Background(), "op-123")
+
+	if logger.FromContext(ctx) == slog.Default() {
+		t.Error("logger.FromContext returned slog.Default() — the op-ID logger " +
+			"decoration was dropped, so run log lines lose their op_id attribute")
+	}
+}
+
+// TestOpRunContextDecorator_UndecoratedContextHasNoOpID is the negative
+// control. Without it the test above cannot distinguish "the decorator
+// attached the ID" from "OpIDFromContext returns something for any context" —
+// the assertion would pass against a stub that ignored its argument.
+func TestOpRunContextDecorator_UndecoratedContextHasNoOpID(t *testing.T) {
+	if got := maintenanceplugin.OpIDFromContext(context.Background()); got != "" {
+		t.Errorf("OpIDFromContext(Background) = %q, want \"\"", got)
+	}
+	if logger.FromContext(context.Background()) != slog.Default() {
+		t.Error("logger.FromContext(Background) did not return slog.Default() — " +
+			"the decoration check in the sibling test cannot distinguish decorated " +
+			"from undecorated contexts")
+	}
+}

--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -1,6 +1,6 @@
 // file: internal/server/registry_wire.go
-// version: 1.20.0
-// last-edited: 2026-07-18
+// version: 1.21.0
+// last-edited: 2026-08-14
 
 package server
 
@@ -20,7 +20,6 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/fileops"
 	"github.com/falkcorp/audiobook-organizer/internal/importer"
 	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
-	"github.com/falkcorp/audiobook-organizer/internal/logger"
 	"github.com/falkcorp/audiobook-organizer/internal/merge"
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
 	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
@@ -351,10 +350,12 @@ func wireServerFromContainer(s *Server, c *serviceregistry.Container) {
 		if s.activityService != nil {
 			s.opRegistry.SetActivityRecorder(s.activityService)
 		}
-		// Wires SLOG op-ID correlation (logger.WithOperation) into every run's
-		// context without the registry package importing internal/logger
-		// directly — see Registry.SetRunContextDecorator (SDKGUARD-VIOLATION #1795).
-		s.opRegistry.SetRunContextDecorator(logger.WithOperation)
+		// Decorates every run's context with the op ID, both as a slog
+		// attribute and in the form maintenance.OpIDFromContext reads. See
+		// opRunContextDecorator in op_run_context.go for why the second one
+		// matters — without it the ops that record undo history recorded
+		// nothing.
+		s.opRegistry.SetRunContextDecorator(opRunContextDecorator)
 	}
 	if hub, ok := serviceregistry.TryGet[*opsregistry.EventHub](c, serviceregistry.KeyOpHub); ok {
 		s.opHub = hub

--- a/todo.d/20260814-op-id-audit-trail-followups.md
+++ b/todo.d/20260814-op-id-audit-trail-followups.md
@@ -1,0 +1,17 @@
+- [ ] **Verify op-ID audit trail on prod after deploying the run-context fix.** Trigger
+  one low-risk maintenance op (`maintenance.temp-file-cleanup` is the safest — it
+  records changes but only touches orphaned `*.tmp.m4b`/`*.tmp.m4a` files) and confirm
+  `operation_changes` now has rows keyed to that op ID. Until this is observed on prod,
+  the fix is verified only by unit test. The prod check is the one that matters: the
+  wiring passes through `wireServerFromContainer`, which no test exercises.
+- [ ] **Historical gap is permanent — do not chase it.** Every maintenance op run before
+  this deploy recorded no `operation_changes` rows. Those runs cannot be reverted and the
+  history cannot be reconstructed; the data to rebuild it was never written. Relevant when
+  investigating anything that happened before 2026-08-14: an empty change list for a
+  pre-fix run means "recording was off", not "nothing changed".
+- [ ] **Audit the eight `ctxOpID` consumers now that the ID actually arrives.** Their
+  `CreateOperationChange` calls have never executed in production, so their payloads have
+  never been exercised against real data — a wrong field or a panic in one of those
+  branches would have been invisible until now. Worth one read-through of each call site
+  (`series.go`, `cleanup.go` x2, `write_back.go`, `reconcile.go`, `dedup_ops.go`,
+  `optimize.go`, `metadata.go`) before or shortly after the deploy.


### PR DESCRIPTION
## The defect

`maintenance.WithOpID` was exported, documented, and **never called from any production code path**. So `ctxOpID` returned `""` inside all eight maintenance ops that read it, and each of those ops guards its `CreateOperationChange` with `if operationID != ""` — every one of them skipped recording, with no error and a successful-looking result.

The run-context decorator installed in `registry_wire.go` was `logger.WithOperation` alone, which attaches an `op_id` slog attribute under `internal/logger`'s own private context key. That key is unrelated to the one `maintenance` reads, so op-ID **log** correlation worked while the **audit trail** did not — the half that was wired made the half that was missing harder to notice.

## Cost, measured

A `maintenance.series-prune` run on 2026-08-14 deleted **326 series rows and recorded zero operation changes**. No record of which rows went, and nothing for the revert path to replay. `maintenance.purge-deleted` has the same gap while permanently destroying books.

It also invalidated a piece of reasoning used during that investigation: *"0 changes recorded, so the op never ran"* was not a valid inference, because recording was disabled for every run.

## Changes

- New `internal/server/op_run_context.go` holds `opRunContextDecorator`, composing both decorations. Extracted from the inline wiring so it can be tested. `internal/server` is the only place the op ID and the run context meet, because the registry package deliberately imports neither `internal/logger` nor the plugin packages (SDKGUARD-VIOLATION #1795).
- New exported `maintenance.OpIDFromContext`, so the wiring can be verified from the package that installs it. `ctxOpID` delegates to it; ops keep using `ctxOpID`.

## Verified before writing the test

Either answer would have made the fix inert:

- `SetRunContextDecorator` has **exactly one** production call site, repo-wide. (An earlier grep was scoped to the registry package and so could not have found a second.)
- The maintenance plugin registers its ops on `server.opRegistry` (`server.go:603`) — the same instance decorated at `registry_wire.go:358`. It is deliberately *not* container-built like the other five plugins, so this needed checking separately.

## Tests

Both halves are asserted separately, because replacing a bare `logger.WithOperation` with a composed function created a new regression path: dropping the logger half would leave the audit-trail assertion green.

Mutation-tested in both directions:

| mutation | result |
|---|---|
| remove `maintenance.WithOpID` | only the op-ID test fails |
| remove `logger.WithOperation` | only the logger test fails |

A negative control asserts an undecorated context yields neither, so the assertions cannot pass against a stub that ignores its argument.

Local CI-equivalent (no `-run` filter): `go test ./internal/server/... ./internal/plugins/maintenance/... ./internal/operations/registry/... -short -race -count=1` → **EXIT=0, 17/17 packages ok**.

## Follow-ups filed (`todo.d/`)

- Verify on prod after deploy that `operation_changes` rows appear (unit tests do not exercise `wireServerFromContainer`).
- The historical gap is permanent — pre-deploy runs cannot be reverted, and an empty change list for a pre-fix run means "recording was off", not "nothing changed".
- Audit the eight `ctxOpID` consumers, whose `CreateOperationChange` payloads have never executed against real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp
