### PR TITLE
fix(database): make Pebble listings return the same order as memdb

### DIFF
--- a/changelog.d/20260814_140000_fix_pebble_listing_order.md
+++ b/changelog.d/20260814_140000_fix_pebble_listing_order.md
@@ -1,0 +1,38 @@
+### Fixed
+
+#### Author, series, import-path and trash listings no longer change order during startup
+
+Five listings have two backing implementations, and they disagreed about order.
+`MemStore` sorted; the `PebbleStore` scan did not sort at all. Pebble iterates
+`<kind>:<id>` keys, and because those keys are strings the raw order is neither
+alphabetical nor numeric — `author:10` comes before `author:2` — so what the
+Pebble path returned was not a defensible order in its own right.
+
+The affected listings are all authors, all series, all import paths, all author
+aliases, and the soft-deleted (trash) listing. memdb is the production default,
+so the wrong order appeared during the cold-start window after a restart and
+before the in-memory index publishes, and in any deployment running with
+`UseMemDB=false`. The author and series screens would come up jumbled and then
+silently reshuffle into alphabetical order once warmup finished.
+
+The trash listing was the worst of the five, because it is paginated and the
+Pebble path applied limit/offset *during* iteration — a page was cut before the
+full matching set existed, so it could not have sorted even in principle. A
+caller paging through the trash while warmup completed would see the ordering
+change underneath it and skip or repeat rows. That path now collects the
+matching set, orders it, and paginates, which is affordable because the
+soft-deleted set is tiny relative to the library.
+
+Rather than copy each comparator into the second implementation, the comparators
+now live in one place (`listing_ordering.go`) and both implementations call
+them, following the pattern `series_ordering.go` established. Two copies of a
+sort rule is what produced this bug.
+
+The new conformance tests assert the **sequence** rather than the set. The
+pre-existing conformance test for the trash listing used `ElementsMatch`, which
+is order-insensitive by construction, and so stayed green through the entire
+drift — it could only ever prove the two paths returned the same books, which
+was never in question. Every fixture is built so that insertion order, ID order
+and sorted order all differ, with more than ten rows so the string-key ordering
+actually shows up, and each fix is mutation-verified by removing the sort from
+the Pebble side alone and confirming its test fails on the `useMemDB=false` arm.

--- a/internal/database/listing_order_conformance_test.go
+++ b/internal/database/listing_order_conformance_test.go
@@ -1,0 +1,260 @@
+// file: internal/database/listing_order_conformance_test.go
+// version: 1.0.0
+// guid: 9f4a2c68-3b71-4e05-8a9d-6c0e5b17d234
+// last-edited: 2026-08-14
+
+package database
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The listings below have two backing implementations that disagreed about
+// ORDER: MemStore sorted, the PebbleStore scan did not sort at all.
+//
+// These tests assert the SEQUENCE, not the set. The pre-existing conformance
+// test for ListSoftDeletedBooks used require.ElementsMatch and stayed green
+// through the entire drift, because ElementsMatch is order-insensitive by
+// construction — it can only ever prove the two paths return the same books,
+// which was never in doubt.
+//
+// Each fixture is built so that insertion order, ID order and sorted order are
+// all different, and with enough rows that the raw Pebble key order is visibly
+// wrong: keys are strings, so "author:10" and "author:11" sort before
+// "author:2". A fixture of three rows would let an unsorted implementation pass
+// by coincidence.
+
+// namesOutOfOrder returns 12 names whose alphabetical order differs from both
+// their insertion order and their eventual "<kind>:<id>" key order.
+func namesOutOfOrder(prefix string) []string {
+	return []string{
+		prefix + " Zulu", prefix + " alpha", prefix + " Mike", prefix + " bravo",
+		prefix + " Yankee", prefix + " charlie", prefix + " November", prefix + " delta",
+		prefix + " Xray", prefix + " echo", prefix + " Oscar", prefix + " foxtrot",
+	}
+}
+
+func sortedLower(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Slice(out, func(i, j int) bool { return strings.ToLower(out[i]) < strings.ToLower(out[j]) })
+	return out
+}
+
+// runBothPaths executes fn against the memdb path and the Pebble path and
+// returns the two results keyed by UseMemDB.
+func runBothPaths[T any](t *testing.T, p *PebbleStore, fn func() (T, error)) map[bool]T {
+	t.Helper()
+	original := p.UseMemDB
+	t.Cleanup(func() { p.UseMemDB = original })
+
+	got := map[bool]T{}
+	for _, useMemDB := range []bool{true, false} {
+		p.UseMemDB = useMemDB
+		v, err := fn()
+		require.NoError(t, err)
+		got[useMemDB] = v
+	}
+	return got
+}
+
+func newOrderConformanceStore(t *testing.T) (Store, *PebbleStore) {
+	t.Helper()
+	store, cleanup := setupPebbleTestDB(t)
+	t.Cleanup(cleanup)
+
+	p, ok := store.(*PebbleStore)
+	require.True(t, ok, "expected *PebbleStore from setupPebbleTestDB")
+	p.WaitForWarmup()
+	require.True(t, p.IsMemReady(),
+		"memdb must be published or the UseMemDB=true arm silently runs the Pebble path")
+	return store, p
+}
+
+func TestGetAllAuthors_OrderMatchesOnBothPaths(t *testing.T) {
+	store, p := newOrderConformanceStore(t)
+
+	names := namesOutOfOrder("Author")
+	for _, n := range names {
+		_, err := store.CreateAuthor(n)
+		require.NoError(t, err)
+	}
+	require.Greater(t, len(names), 10,
+		"fixture must exceed 10 rows or the author:10-before-author:2 key ordering never appears")
+
+	got := runBothPaths(t, p, func() ([]Author, error) { return p.GetAllAuthors() })
+
+	want := sortedLower(names)
+	for _, useMemDB := range []bool{true, false} {
+		actual := make([]string, 0, len(got[useMemDB]))
+		for _, a := range got[useMemDB] {
+			actual = append(actual, a.Name)
+		}
+		require.Equal(t, want, actual,
+			"authors must come back name-sorted (useMemDB=%v)", useMemDB)
+	}
+}
+
+func TestGetAllSeries_OrderMatchesOnBothPaths(t *testing.T) {
+	store, p := newOrderConformanceStore(t)
+
+	names := namesOutOfOrder("Series")
+	for _, n := range names {
+		_, err := store.CreateSeries(n, nil)
+		require.NoError(t, err)
+	}
+
+	got := runBothPaths(t, p, func() ([]Series, error) { return p.GetAllSeries() })
+
+	want := sortedLower(names)
+	for _, useMemDB := range []bool{true, false} {
+		actual := make([]string, 0, len(got[useMemDB]))
+		for _, s := range got[useMemDB] {
+			actual = append(actual, s.Name)
+		}
+		require.Equal(t, want, actual,
+			"series must come back name-sorted (useMemDB=%v)", useMemDB)
+	}
+}
+
+func TestGetAllImportPaths_OrderMatchesOnBothPaths(t *testing.T) {
+	store, p := newOrderConformanceStore(t)
+
+	names := namesOutOfOrder("Folder")
+	for i, n := range names {
+		_, err := store.CreateImportPath(fmt.Sprintf("/import/p%02d", i), n)
+		require.NoError(t, err)
+	}
+
+	got := runBothPaths(t, p, func() ([]ImportPath, error) { return p.GetAllImportPaths() })
+
+	want := sortedLower(names)
+	for _, useMemDB := range []bool{true, false} {
+		actual := make([]string, 0, len(got[useMemDB]))
+		for _, ip := range got[useMemDB] {
+			actual = append(actual, ip.Name)
+		}
+		require.Equal(t, want, actual,
+			"import paths must come back name-sorted (useMemDB=%v)", useMemDB)
+	}
+}
+
+func TestListSoftDeletedBooks_OrderMatchesOnBothPaths(t *testing.T) {
+	store, p := newOrderConformanceStore(t)
+
+	// Delete timestamps deliberately NOT in creation order, so "most recently
+	// deleted first" cannot be satisfied by insertion or ID order.
+	base := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	offsets := []int{3, 11, 1, 7, 5, 12, 2, 9, 4, 10, 6, 8}
+	yes := true
+
+	type want struct {
+		id string
+		at time.Time
+	}
+	var expected []want
+
+	for i, off := range offsets {
+		created, err := store.CreateBook(&Book{
+			Title:    fmt.Sprintf("Trashed %02d", i),
+			FilePath: fmt.Sprintf("/lib/trash/%02d.m4b", i),
+		})
+		require.NoError(t, err)
+
+		at := base.Add(time.Duration(off) * time.Hour)
+		created.MarkedForDeletion = &yes
+		created.MarkedForDeletionAt = &at
+		_, err = store.UpdateBook(created.ID, created)
+		require.NoError(t, err)
+
+		expected = append(expected, want{id: created.ID, at: at})
+	}
+	require.Greater(t, len(expected), 10, "fixture must exceed 10 rows")
+
+	// Most recently deleted first.
+	sort.SliceStable(expected, func(i, j int) bool { return expected[i].at.After(expected[j].at) })
+	wantIDs := make([]string, 0, len(expected))
+	for _, e := range expected {
+		wantIDs = append(wantIDs, e.id)
+	}
+
+	got := runBothPaths(t, p, func() ([]Book, error) { return p.ListSoftDeletedBooks(0, 0, nil) })
+	for _, useMemDB := range []bool{true, false} {
+		actual := make([]string, 0, len(got[useMemDB]))
+		for _, b := range got[useMemDB] {
+			actual = append(actual, b.ID)
+		}
+		require.Equal(t, wantIDs, actual,
+			"trash must be ordered most-recently-deleted first (useMemDB=%v)", useMemDB)
+	}
+
+	// The paged form is where unsorted iteration did real damage: the Pebble
+	// path applied limit/offset DURING iteration, so it could not sort at all.
+	// Walking the pages must reconstruct the same total order as one big call.
+	const pageSize = 5
+	for _, useMemDB := range []bool{true, false} {
+		p.UseMemDB = useMemDB
+		var paged []string
+		for offset := 0; offset < len(wantIDs); offset += pageSize {
+			page, err := p.ListSoftDeletedBooks(pageSize, offset, nil)
+			require.NoError(t, err)
+			for _, b := range page {
+				paged = append(paged, b.ID)
+			}
+		}
+		require.Equal(t, wantIDs, paged,
+			"paging must partition the same ordered set (useMemDB=%v)", useMemDB)
+	}
+}
+
+func TestGetAllAuthorAliases_OrderMatchesOnBothPaths(t *testing.T) {
+	store, p := newOrderConformanceStore(t)
+
+	// Two authors, aliases added in an order that is neither grouped by author
+	// nor alphabetical within an author.
+	a1, err := store.CreateAuthor("Alias Owner One")
+	require.NoError(t, err)
+	a2, err := store.CreateAuthor("Alias Owner Two")
+	require.NoError(t, err)
+
+	type seed struct {
+		authorID int
+		alias    string
+	}
+	seeds := []seed{
+		{a2.ID, "zeta"}, {a1.ID, "Yankee"}, {a2.ID, "alpha"}, {a1.ID, "bravo"},
+		{a2.ID, "Mike"}, {a1.ID, "charlie"}, {a2.ID, "delta"}, {a1.ID, "Oscar"},
+		{a1.ID, "echo"}, {a2.ID, "foxtrot"}, {a1.ID, "November"}, {a2.ID, "golf"},
+	}
+	for _, s := range seeds {
+		_, aErr := store.CreateAuthorAlias(s.authorID, s.alias, "manual")
+		require.NoError(t, aErr)
+	}
+
+	want := append([]seed(nil), seeds...)
+	sort.SliceStable(want, func(i, j int) bool {
+		if want[i].authorID != want[j].authorID {
+			return want[i].authorID < want[j].authorID
+		}
+		return strings.ToLower(want[i].alias) < strings.ToLower(want[j].alias)
+	})
+	wantPairs := make([]string, 0, len(want))
+	for _, w := range want {
+		wantPairs = append(wantPairs, fmt.Sprintf("%d/%s", w.authorID, w.alias))
+	}
+
+	got := runBothPaths(t, p, func() ([]AuthorAlias, error) { return p.GetAllAuthorAliases() })
+	for _, useMemDB := range []bool{true, false} {
+		actual := make([]string, 0, len(got[useMemDB]))
+		for _, a := range got[useMemDB] {
+			actual = append(actual, fmt.Sprintf("%d/%s", a.AuthorID, a.AliasName))
+		}
+		require.Equal(t, wantPairs, actual,
+			"aliases must be grouped by author then sorted by name (useMemDB=%v)", useMemDB)
+	}
+}

--- a/internal/database/listing_ordering.go
+++ b/internal/database/listing_ordering.go
@@ -1,0 +1,80 @@
+// file: internal/database/listing_ordering.go
+// version: 1.0.0
+// guid: 5b2e9c14-7a63-4f08-9d5b-8e1c6a30f472
+// last-edited: 2026-08-14
+
+package database
+
+import (
+	"sort"
+	"strings"
+)
+
+// This file holds the comparators for listings that have two backing
+// implementations, for the same reason series_ordering.go does: MemStore sorted
+// and the PebbleStore scan did not sort at all, so each of these listings came
+// back in a different order depending only on whether memdb had finished
+// warming up. Pebble iterates "<kind>:<id>" keys, and because those keys are
+// strings the raw order is neither alphabetical nor numeric — author:10 precedes
+// author:2 — so it is not a defensible order in its own right either.
+//
+// Keeping one comparator per listing, called from both paths, is what stops the
+// two from drifting apart again. Asserting membership (require.ElementsMatch)
+// cannot catch this class; the conformance tests assert the SEQUENCE.
+
+// sortByLowerName orders any listing by a case-insensitive name projection.
+// Used for authors, series and import paths, all three of which MemStore
+// returns sorted by name.
+func sortByLowerName[T any](items []T, name func(T) string) {
+	if len(items) < 2 {
+		return
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return strings.ToLower(name(items[i])) < strings.ToLower(name(items[j]))
+	})
+}
+
+// sortAuthorAliases groups aliases by author, then orders them by alias name
+// (case-insensitive), matching MemStore.GetAllAuthorAliases.
+func sortAuthorAliases(aliases []AuthorAlias) {
+	if len(aliases) < 2 {
+		return
+	}
+	sort.Slice(aliases, func(i, j int) bool {
+		if aliases[i].AuthorID != aliases[j].AuthorID {
+			return aliases[i].AuthorID < aliases[j].AuthorID
+		}
+		return strings.ToLower(aliases[i].AliasName) < strings.ToLower(aliases[j].AliasName)
+	})
+}
+
+// sortBooksByDeletedAtDesc orders the trash the way the UI promises to show it:
+// most recently deleted first, rows carrying no deletion timestamp last, ties
+// broken by ID so the order is total and stable.
+//
+// The Pebble implementation of ListSoftDeletedBooks used to apply limit/offset
+// *during* iteration, which meant it could not sort at all — a page was cut
+// before the full matching set existed. Callers paging through the trash while
+// warmup completed would see the ordering change underneath them, skipping or
+// repeating rows. Sorting forces collect-then-paginate, which is affordable
+// precisely because the soft-deleted set is tiny relative to the library; that
+// is the same assumption the memdb implementation already documents.
+func sortBooksByDeletedAtDesc(books []Book) {
+	if len(books) < 2 {
+		return
+	}
+	sort.SliceStable(books, func(i, j int) bool {
+		ai, aj := books[i].MarkedForDeletionAt, books[j].MarkedForDeletionAt
+		switch {
+		case ai == nil && aj == nil:
+			return books[i].ID < books[j].ID
+		case ai == nil:
+			// Rows with no timestamp sort after rows that have one.
+			return false
+		case aj == nil:
+			return true
+		default:
+			return ai.After(*aj)
+		}
+	})
+}

--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -1,5 +1,5 @@
 // file: internal/database/memdb_reads.go
-// version: 1.20.0
+// version: 1.21.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000006
 // last-edited: 2026-08-14
 
@@ -7,7 +7,6 @@ package database
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -36,9 +35,7 @@ func (m *MemStore) GetAllSeries() ([]Series, error) {
 	for obj := iter.Next(); obj != nil; obj = iter.Next() {
 		out = append(out, *(obj.(*Series)))
 	}
-	sort.Slice(out, func(i, j int) bool {
-		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
-	})
+	sortByLowerName(out, func(v Series) string { return v.Name })
 	return out, nil
 }
 
@@ -55,9 +52,7 @@ func (m *MemStore) GetAllAuthors() ([]Author, error) {
 	for obj := iter.Next(); obj != nil; obj = iter.Next() {
 		out = append(out, *(obj.(*Author)))
 	}
-	sort.Slice(out, func(i, j int) bool {
-		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
-	})
+	sortByLowerName(out, func(v Author) string { return v.Name })
 	return out, nil
 }
 
@@ -74,9 +69,7 @@ func (m *MemStore) GetAllImportPaths() ([]ImportPath, error) {
 	for obj := iter.Next(); obj != nil; obj = iter.Next() {
 		out = append(out, *(obj.(*ImportPath)))
 	}
-	sort.Slice(out, func(i, j int) bool {
-		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
-	})
+	sortByLowerName(out, func(v ImportPath) string { return v.Name })
 	return out, nil
 }
 
@@ -93,12 +86,7 @@ func (m *MemStore) GetAllAuthorAliases() ([]AuthorAlias, error) {
 	for obj := iter.Next(); obj != nil; obj = iter.Next() {
 		out = append(out, *(obj.(*AuthorAlias)))
 	}
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].AuthorID != out[j].AuthorID {
-			return out[i].AuthorID < out[j].AuthorID
-		}
-		return strings.ToLower(out[i].AliasName) < strings.ToLower(out[j].AliasName)
-	})
+	sortAuthorAliases(out)
 	return out, nil
 }
 
@@ -748,21 +736,9 @@ func (m *MemStore) ListSoftDeletedBooks(limit, offset int, olderThan *time.Time)
 		}
 		matched = append(matched, *b)
 	}
-	// Stable sort by MarkedForDeletionAt desc (most recent first), nil last —
-	// matches user expectation in the UI ("most recently deleted on top").
-	sort.SliceStable(matched, func(i, j int) bool {
-		ai, aj := matched[i].MarkedForDeletionAt, matched[j].MarkedForDeletionAt
-		switch {
-		case ai == nil && aj == nil:
-			return matched[i].ID < matched[j].ID
-		case ai == nil:
-			return false
-		case aj == nil:
-			return true
-		default:
-			return ai.After(*aj)
-		}
-	})
+	// Shared with the Pebble scan so the two cannot order the trash
+	// differently. See listing_ordering.go.
+	sortBooksByDeletedAtDesc(matched)
 	return paginate(matched, limit, offset), nil
 }
 

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.130.0
+// version: 1.131.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-08-14
 
@@ -3066,9 +3066,6 @@ func (p *PebbleStore) ListSoftDeletedBooks(limit, offset int, olderThan *time.Ti
 	}
 	defer iter.Close()
 
-	skipped := 0
-	collected := 0
-
 	for iter.First(); iter.Valid(); iter.Next() {
 		key := string(iter.Key())
 		if strings.Contains(key, ":path:") || strings.Contains(key, ":series:") ||
@@ -3086,19 +3083,15 @@ func (p *PebbleStore) ListSoftDeletedBooks(limit, offset int, olderThan *time.Ti
 		if olderThan != nil && book.MarkedForDeletionAt != nil && book.MarkedForDeletionAt.After(*olderThan) {
 			continue
 		}
-
-		if skipped < offset {
-			skipped++
-			continue
-		}
-		if limit > 0 && collected >= limit {
-			break
-		}
 		books = append(books, book)
-		collected++
 	}
 
-	return books, nil
+	// Shared with the memdb walk so the two implementations cannot order the
+	// trash differently. Sorting is why this path now collects the full match
+	// set before paginating instead of applying limit/offset during iteration.
+	// See listing_ordering.go.
+	sortBooksByDeletedAtDesc(books)
+	return paginate(books, limit, offset), nil
 }
 
 // GetBooksByVersionGroup returns all books in a version group

--- a/internal/database/pebble_store_authors.go
+++ b/internal/database/pebble_store_authors.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_authors.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 1f8b9fd2-e424-4a09-9ee4-7b5b64660605
-// last-edited: 2026-08-13
+// last-edited: 2026-08-14
 
 package database
 
@@ -45,6 +45,7 @@ func (p *PebbleStore) GetAllAuthors() ([]Author, error) {
 		authors = append(authors, author)
 	}
 
+	sortByLowerName(authors, func(a Author) string { return a.Name })
 	return authors, nil
 }
 
@@ -305,6 +306,7 @@ func (p *PebbleStore) GetAllAuthorAliases() ([]AuthorAlias, error) {
 		}
 		aliases = append(aliases, a)
 	}
+	sortAuthorAliases(aliases)
 	return aliases, nil
 }
 

--- a/internal/database/pebble_store_importpaths.go
+++ b/internal/database/pebble_store_importpaths.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_importpaths.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: eb97f1d9-af89-4dc7-add9-70ab7c30d137
 // last-edited: 2026-08-14
 
@@ -48,6 +48,7 @@ func (p *PebbleStore) GetAllImportPaths_Pebble() ([]ImportPath, error) {
 		importPaths = append(importPaths, importPath)
 	}
 
+	sortByLowerName(importPaths, func(ip ImportPath) string { return ip.Name })
 	return importPaths, nil
 }
 

--- a/internal/database/pebble_store_series.go
+++ b/internal/database/pebble_store_series.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_series.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 29120d16-9add-4efd-81a5-edc1e8951f4d
 // last-edited: 2026-08-14
 
@@ -48,6 +48,7 @@ func (p *PebbleStore) GetAllSeries_Pebble() ([]Series, error) {
 		series = append(series, s)
 	}
 
+	sortByLowerName(series, func(s Series) string { return s.Name })
 	return series, nil
 }
 


### PR DESCRIPTION
Third finding from the dual-implementation audit, on a **different axis** from the soft-delete drift (#2408, #2411). Same sweep, new predicate: *which listings does MemStore sort that the PebbleStore scan does not?*

## The drift

Five listings sorted in one implementation and not the other:

| listing | memdb order | Pebble |
|---|---|---|
| `GetAllAuthors` | name, case-insensitive | **no sort** |
| `GetAllSeries` | name, case-insensitive | **no sort** |
| `GetAllImportPaths` | name, case-insensitive | **no sort** |
| `GetAllAuthorAliases` | (AuthorID, AliasName) | **no sort** |
| `ListSoftDeletedBooks` | deleted-at desc, nil last | **no sort** |

Pebble iterates `<kind>:<id>` keys. Those keys are **strings**, so the raw order is neither alphabetical nor numeric — `author:10` precedes `author:2`. The Pebble order wasn't a defensible alternative convention; it was arbitrary.

## Blast radius

memdb is the production default, so this appeared during the **cold-start window** after a restart and before warmup publishes, plus any `UseMemDB=false` deployment. The author and series screens came up jumbled and then silently reshuffled into alphabetical order once memdb was ready. **Prod steady-state is unaffected, and I have not validated against prod.**

## `ListSoftDeletedBooks` was the worst of the five

It's **paginated**, and the Pebble path applied limit/offset *during* iteration — a page was cut before the full matching set existed, so it could not have sorted even in principle. A caller paging through the trash while warmup completed would see the ordering change underneath it and skip or repeat rows. It now collects → orders → paginates, affordable because the soft-deleted set is tiny relative to the library (the same assumption the memdb side already documents).

## Shared comparators, not copied ones

The comparators move into `listing_ordering.go` and **both** implementations call them, following the pattern `series_ordering.go` established. Two copies of a sort rule is what produced this bug; a fix that leaves two copies invites its return.

## The tests assert sequence, not membership

The pre-existing conformance test for `ListSoftDeletedBooks` used `require.ElementsMatch` and stayed green through this entire drift — `ElementsMatch` is order-insensitive by construction, so it could only ever prove both paths returned the same *books*, which was never in doubt.

Every fixture is built so insertion order, ID order and sorted order all differ, with **>10 rows** so the `author:10`-before-`author:2` key ordering actually manifests. A 3-row fixture lets an unsorted implementation pass by coincidence.

## Mutation results — 5/5

Each mutation removes the sort from the **Pebble side only**, which is the real drift scenario:

| mutation | expected | result |
|---|---|---|
| Pebble `GetAllAuthors` loses its sort | FAIL | ✅ "authors must come back name-sorted (useMemDB=false)" |
| Pebble `GetAllSeries` loses its sort | FAIL | ✅ "series must come back name-sorted (useMemDB=false)" |
| Pebble `GetAllImportPaths` loses its sort | FAIL | ✅ "import paths must come back name-sorted (useMemDB=false)" |
| Pebble `GetAllAuthorAliases` loses its sort | FAIL | ✅ "aliases must be grouped by author then sorted by name (useMemDB=false)" |
| Pebble `ListSoftDeletedBooks` loses its sort | FAIL | ✅ "trash must be ordered most-recently-deleted first (useMemDB=false)" |
| all restored | PASS | ✅ PASS |

Each failure names `useMemDB=false` specifically — the Pebble arm — so the tests are detecting the drift rather than some collateral effect.

## Note

`GetBooksBySeriesIDCore` was the **sixth** instance of this defect. It was fixed independently while this branch was in progress, and that fix is where the shared-comparator pattern here comes from. Its author also caught a genuine bug in the memdb comparator — a precomputed `keys` slice indexed from inside the comparator, which `sort` never permutes, so after the first swap it read titles belonging to other books.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t