### PR TITLE
docs(todo): file the 56 duplicate-name author groups, split by kind

### DIFF
--- a/todo.d/20260814-duplicate-author-rows.md
+++ b/todo.d/20260814-duplicate-author-rows.md
@@ -1,0 +1,64 @@
+## 56 duplicate-name author groups, and most of them are not authors
+
+Found 2026-08-14 while checking whether the stranded-ampersand repair had left
+duplicates behind. It had not — all 16 repaired names resolve to exactly one row
+— but enumerating all 9,320 authors to prove that surfaced a separate problem.
+
+**49 exact-duplicate name groups, 56 once case and whitespace are normalized.**
+
+They fall into three kinds, and they want different fixes:
+
+### 1. Book titles stored as authors
+
+| name | rows |
+|---|---|
+| `Cthulhu Armageddon (Unabridged)` | **25** |
+| `1 Ο Χάρι Πότερ και η Φιλοσοφική Λίθος` | 4 |
+| `05_Rise of the Corinari` | 3 |
+| `Sorcerer Ascendant` | 3 |
+| `"Mind's Eye"` | 3 |
+
+### 2. Disc labels stored as authors
+
+`CD 13` ×10, `CD 06` ×10, `CD 05` ×7, `CD 15` ×5, `CD 18` ×4.
+
+Both of these are the same disease as the `& Name` rows — a metadata parse
+writing a non-author string into the author field — just a different input
+shape. `-Dickens Short Stories` ×3 is the leading-delimiter variant, matching
+the `- 3` / `- Legion` junk seen in the ABS series listing the same day.
+
+### 3. Real authors, genuinely duplicated
+
+| name | rows (id, book_count) |
+|---|---|
+| `Karen Joy Fowler` | 44479(1) 44480(0) 44481(1) 44482(1) 44483(1) 44484(3) |
+| `Valery Starsky` | 46007(1) 46008(1) 46009(1) 46010(27) |
+| `Raymond L. Weil` | 40775(39) 42117(27) **45616(0) spelled `Raymond  L.  Weil`** |
+| `Time Pebbles` | 43574(0) 43575(0) 43576(29) |
+
+`Raymond L. Weil` is the instructive one: two legitimate rows PLUS a third whose
+only difference is doubled internal whitespace. Author matching is not
+normalizing whitespace, so the dedupe that should have caught it never fires.
+
+- [ ] Normalize whitespace (and probably case) in author lookup/creation, so a
+      `Raymond  L.  Weil` can never be minted alongside `Raymond L. Weil`.
+      ⚠️ Check `util.NormalizeAuthor` first — it is already used for the series
+      name index (`pebble_store_series.go`), so the helper may exist and simply
+      not be applied on the author path.
+- [ ] Merge the type-3 real-author duplicates. The existing
+      `maintenance.author-*` ops already know how to relink via the join slice —
+      see `author_conjunction_repair.go`'s `mergeAuthorInto`, which handles the
+      BookAuthor rewrite and the AuthorID hydration correctly.
+- [ ] Decide what to DO with types 1 and 2 rather than merging them. Merging 25
+      `Cthulhu Armageddon (Unabridged)` rows into one still leaves a book title
+      masquerading as an author. These need the books re-parsed, or the rows
+      retired and the books re-attributed — a different operation from dedupe.
+- [ ] 🚨 Do NOT write a single op that treats all three kinds the same. Type 3
+      wants a merge; types 1 and 2 want the author link removed entirely. An op
+      that merges everything would consolidate the junk and make it look
+      intentional — the laundering failure mode recorded in
+      `feedback_stripping_without_corroboration_is_laundering`.
+
+**Counts to re-measure before acting** — these are from the 2026-08-14 07:50
+snapshot of a 9,320-row author table, taken via `/api/v1/authors` paged by
+`limit`/`offset` (note: `page` is not a parameter this endpoint accepts).


### PR DESCRIPTION
Documentation only — one `todo.d/` fragment, no code.

## Why

While answering "we fixed the names, but did we deduplicate them?" I enumerated all 9,320 authors. **The ampersand repair is clean** — all 16 repaired names resolve to exactly one row, and the merge counts moved up correctly as the stranded rows' books came home:

| name | before | after |
|---|---|---|
| Beth Chalmers | 3 | **5** |
| Caroline Morris | 11 | **12** |
| India Fisher | 40 | **41** |

But the enumeration surfaced something separate: **49 exact duplicate-name groups, 56 once case and whitespace are normalized.**

## Filed as three kinds, because they want three different fixes

**1. Book titles stored as authors** — `Cthulhu Armageddon (Unabridged)` ×25, `1 Ο Χάρι Πότερ και η Φιλοσοφική Λίθος` ×4.

**2. Disc labels stored as authors** — `CD 13` ×10, `CD 06` ×10, `CD 05` ×7, `CD 15` ×5.

Kinds 1 and 2 are the same disease as the `& Name` rows — a metadata parse writing a non-author string into the author field, just a different input shape. `-Dickens Short Stories` ×3 is the leading-delimiter variant, matching the `- Legion` / `- 3` junk visible in the ABS series listing the same day.

**3. Real authors, genuinely duplicated** — `Karen Joy Fowler` ×6, `Valery Starsky` ×4, `Time Pebbles` ×3, and:

```
Raymond L. Weil    40775 (39 books)
Raymond L. Weil    42117 (27 books)
Raymond  L.  Weil  45616 ( 0 books)   <-- doubled internal whitespace
```

That third row is the tell: author matching is not normalizing whitespace, so the dedupe that should have prevented it never fires. `util.NormalizeAuthor` already exists and is applied to the series name index — the fragment flags checking whether it is simply missing from the author path before anything new gets written.

## The warning that matters most

The fragment explicitly says **do not write one op for all three kinds.** Kind 3 wants a merge; kinds 1 and 2 want the author link removed entirely. An op that merged everything would consolidate 25 `Cthulhu Armageddon (Unabridged)` rows into one tidy row that is still a book title masquerading as an author — the laundering failure mode, where the data stops *looking* broken without being fixed.

Counts are stamped with their snapshot time and the method used to take them, since they will drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxigqrwz9WfwN1wx8QhoQW