### PR TITLE
fix(api): derive the bare-filter-param guard from the canonical field list

### DIFF
--- a/changelog.d/20260814_082000_bare_filter_param_derived.md
+++ b/changelog.d/20260814_082000_bare_filter_param_derived.md
@@ -1,0 +1,35 @@
+### Fixed
+
+- **`?year=2001` and 16 other filters silently returned the entire library.**
+  Field filters travel inside the `filters` JSON parameter; passed bare, gin
+  ignores them and the request lists every book while looking exactly like a
+  narrowed query — matching count and all. Measured on production 2026-08-14,
+  against an unfiltered baseline so the reading is not merely plausible:
+
+      ?year=2001                 -> count=63869
+      ?work_id=abc               -> count=63869
+      ?marked_for_deletion=true  -> count=63869
+      (no filter, baseline)      -> count=63869
+
+  A guard added the previous day
+  rejected 26 such names, but it was a hand-written third copy of a field list
+  that already had a single source of truth, and it had drifted: `year`,
+  `work_id`, `isbn10`, `isbn13`, `series_number`, `created_at`, `updated_at`,
+  `marked_for_deletion`, `duration`, `bitrate`, `bitrate_kbps`, `file_size`,
+  `file_size_bytes`, `sample_rate`, `sample_rate_hz`, `channels` and `bit_depth`
+  were all missing.
+
+  The guard is now derived from `audiobooks.KnownFilterFields()` — the list
+  already pinned to the matcher — minus an explicit two-name allow-list, so the
+  third copy no longer exists and a field added to the canonical list is
+  guarded the same day.
+
+  `library_state` stays allow-listed: it is genuinely both a filter field and a
+  bare parameter of this endpoint. A global collision survey turns up five
+  such names, but four (`title`, `author`, `duration`, `format`) have their
+  accessors on *other* endpoints — metadata search, audio sample, dedup export —
+  and the guard reads only its own request's query string.
+
+  Not fixed here: `?version_group_id=X` still lists the whole library. It is not
+  a filter field at all, so the derivation cannot reach it; making it one needs
+  new matcher work.

--- a/docs/handoffs/2026-08-14-filter-and-author-link-session.md
+++ b/docs/handoffs/2026-08-14-filter-and-author-link-session.md
@@ -1,0 +1,280 @@
+<!-- file: docs/handoffs/2026-08-14-filter-and-author-link-session.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4f7c2b91-8d35-4e60-a1f9-6b208c53d7ea -->
+<!-- last-edited: 2026-08-14 -->
+
+# Handoff — 2026-08-14 — filter guards, author links, and what is still open
+
+Written for a follow-on session picking up every outstanding thread. Everything
+below is either **verified** (measured, with the measurement shown) or
+explicitly marked **UNVERIFIED**. Please keep that distinction — several items
+here look settled and are not.
+
+---
+
+## 1. Shipped and deployed
+
+Three dual-implementation (memdb vs Pebble) divergences, merged **and** live in
+production. The deployed binary is from **07:51:49**, restarted 07:52:57, memdb
+warm at 07:55:07 (129s warmup).
+
+| PR | what diverged |
+|---|---|
+| #2406 | `GetBooksByAuthorIDCore` — Pebble scanned only the legacy `AuthorID` column and was blind to co-authors; memdb did junction+legacy minus non-primary |
+| #2410 | `GetBooksByAuthorIDWithRoleCore` — Pebble included non-primary versions, memdb excluded them (opposite sign to the above, which is why aggregate counts looked plausible) |
+| #2411 | `GetBooksBySeriesIDCore` primary-version filter + ordering; `GetAllSeriesBookCounts` / `GetAllSeriesFileCounts` / `CountBooksByPathPrefix` soft-delete filtering |
+| #2413 | `dbtest.AssertStoreInvariants` — invariant (a) could never fire because `ListBookIDs` omits soft-deleted books; now unions `ListSoftDeletedBooks` |
+| #2416 | docs: 56 duplicate-name author groups, split by kind |
+
+**Semantics chosen** (documented so it is not re-litigated): `...WithRoleCore`
+returns the COMPLETE set — merges and deletes use it, and a missed link there is
+data loss. `...Core` is the LISTING view (primary-only) — it matches what memdb
+already served warm, so only the cold path changed, and it changed to match warm.
+
+**Production confirmation of the fix:** the same dry run that reported `books=0`
+on the warm path in the morning reported `books=2, books_relinked=2` after
+deploy. That is the real evidence the divergence closed — not the test suite.
+
+---
+
+## 2. PR #2417 — OPEN, needs merge
+
+Branch `fix/bare-filter-param-set-derived`, worktree
+`../audiobook-organizer-bareparam`. **CI was 13 pass / 6 pending / 3 skipping
+when last checked — verify and merge.**
+
+### What it fixes
+
+`ab04824e` (2026-08-13) started rejecting filter-field names passed as bare
+query parameters, because gin ignores them and the request then lists the whole
+library while looking exactly like a narrowed query. That guard was correct but
+consulted a **hand-written map in the handler package — a third copy** of a list
+that already had a single source of truth (`audiobooks.KnownFilterFields()`,
+pinned to the matcher by `TestFilterFieldNames_MatchTheMatcher`). It had drifted
+by 17 names.
+
+Measured on production 2026-08-14 **with an unfiltered baseline**, which is what
+makes it a comparison rather than an impression:
+
+    ?year=2001                 -> count=63869
+    ?work_id=abc               -> count=63869
+    ?marked_for_deletion=true  -> count=63869
+    (no filter, baseline)      -> count=63869
+
+Drifted names: `year`, `work_id`, `isbn10`, `isbn13`, `series_number`,
+`created_at`, `updated_at`, `marked_for_deletion`, `duration`, `bitrate`,
+`bitrate_kbps`, `file_size`, `file_size_bytes`, `sample_rate`, `sample_rate_hz`,
+`channels`, `bit_depth`.
+
+The guard is now **derived** from `KnownFilterFields()` minus a two-name
+allow-list, so the third copy no longer exists.
+
+### The collision survey — read this before touching the allow-list
+
+The governing asymmetry: omitting a name is harmless (the guard does not fire,
+which is pre-guard behavior); **including one wrongly rejects a request that
+used to work.**
+
+My first survey repeated the exact mistake `ab04824e` warns about — it matched
+`ParseQueryString("` and so could not see `ParseQueryString(c, "library_state")`.
+The corrected pass returned `limit` but neither `offset` nor `page`, which is
+what revealed it was *still* scoped too narrowly. Widened to all of
+`internal/server` + `internal/httputil`: **95 param names, 44 canonical fields,
+5 collisions.**
+
+| name | accessor | same endpoint as the guard? |
+|---|---|---|
+| `library_state` | `handlers/audiobooks/handler.go:516` | **YES — the only real one** |
+| `title` | `handlers/metadata/handler.go:389` | no |
+| `author` | `handlers/metadata/handler.go:390` | no |
+| `duration` | `server/audio_sample.go:39` | no |
+| `format` | `handlers/dedup/handler.go:492` | no |
+
+The guard has one call site and reads that request's own query string, so only
+same-endpoint collisions matter. `title`/`author` have been guarded since
+`ab04824e` with metadata search unaffected — empirical confirmation.
+
+`fingerprint_status` is allow-listed although the derivation already excludes it
+(it is not a canonical field), so the protection does not depend on that staying
+true.
+
+### Verification done
+
+- 7 top-level tests, **81 subtests, 0 FAIL**, exit 0
+- guard table exercises **43** names, up from 26 — counted explicitly, because a
+  table that iterates nothing also reports success
+- **negative control:** dropping one field from the derivation fails three
+  separate tests and names it:
+  `canonical filter field "year" is not guarded — a bare ?year= would list the entire library while looking like a narrowed query`
+- `./internal/server/handlers/...` and `./internal/audiobooks/...` — green
+
+### ⚠️ UNCOMMITTED work in that worktree
+
+`todo.d/20260814-is-primary-version-nil-vs-false-divergence.md` was written but
+**not committed** (the session was interrupted). Commit it before or with the
+merge — it documents item 4 below.
+
+---
+
+## 3. `?version_group_id=` lists the whole library — filed, not fixed
+
+    version_group_id='vg-08c1a396b'         -> count=63869  first=01KNDB8NWHXV2DKRQESBA9SDRA
+    version_group_id='vg-TOTALLY-BOGUS-XYZ' -> count=63869  first=01KNDB8NWHXV2DKRQESBA9SDRA
+    version_group_id=''                     -> count=63869  first=01KNDB8NWHXV2DKRQESBA9SDRA
+
+A bogus ID and a real one are indistinguishable, so the parameter is not read.
+
+**This is NOT the same bug as #2417 and #2417 does not fix it.** `?year=` was a
+*known* field passed the wrong way. `version_group_id` is not a filter field at
+all — it is absent from `allFilterFieldNames`, `bookFieldValue` has no case for
+it, so the derived guard has nothing to match on.
+
+Filed at `todo.d/20260814-version-group-id-not-a-filter-field.md` with both
+options. The storage layer *does* index it (`memIdxVersionGroupID`,
+`GetAllBooksFrom` accepts it as a filter key), so there is a real case for
+promoting it to a filter field — that is matcher work plus a Pebble-path check.
+
+---
+
+## 4. `is_primary_version` means different things on two paths — NEW, filed
+
+Found while trying to verify the author merge in item 5. Both paths accept the
+parameter and answer confidently; they disagree about what a **nil** flag means.
+
+Library-wide it partitions exactly, returning rows with an explicit `false`:
+
+    is_primary_version=false -> total=22552
+    is_primary_version=true  -> total=41317
+    (no filter)              -> total=63869   = 22552 + 41317 ✓
+
+On the author path it returns rows whose flag is **null**:
+
+    author_id=38542&is_primary_version=false -> 1 row, is_primary_version: null
+    author_id=38543&is_primary_version=false -> 1 row, is_primary_version: null
+
+And it cannot return an explicitly-`false` book at all. Book
+`01KNDB8NWHXV2DKRQESBA9SDRA` records `author_id: 42623`, `is_primary_version:
+false`, yet:
+
+    author_id=42623                          -> 1 row, NOT that book
+    author_id=42623&is_primary_version=false -> 0 rows
+    author_id=42623&is_primary_version=true  -> 1 row (a different book)
+
+**Likely cause:** `memdb_schema.go` indexes with
+`effectiveBoolFieldIndex{Default: true}`, so a nil `IsPrimaryVersion` indexes as
+**true**; a post-filter comparing the raw `*bool` sees nil as "not true" and
+calls it **false**. Same nil, opposite readings by layer.
+
+Fragment: `todo.d/20260814-is-primary-version-nil-vs-false-divergence.md`
+(**uncommitted — see item 2**).
+
+---
+
+## 5. Author 46627 merge — APPLIED, verification IMPOSSIBLE with current tools
+
+The `& Author` conjunction repair. User approved applying it to author 46627.
+
+**Verified:** author count 9,320 → 9,319; row 46627 gone; only **2** `&` names
+remain and both are HTML-entity junk (`&#169`, `&#169;2013 by HarperCollins…`)
+— no person-name rows left. Op reported `merged_into_existing:1`,
+`books_relinked=2`, `rows_written=1`, no errors.
+
+**UNVERIFIED:** that the two `BookAuthor` rows actually landed on 43791.
+
+Do not treat the following as evidence of failure — I nearly did:
+
+- `Nicholas Courtney` (43791) still shows **7** books, and
+  `author_id=43791&is_primary_version=false` returns **0**.
+- That is expected-looking, because the author listing is primary-only by
+  design (#2410) AND, per item 4, cannot return explicitly-non-primary rows for
+  *any* author. Author 42623 is the counterexample that proves the instrument is
+  blind, not that 43791 is empty.
+- The other instrument I reached for (`version_group_id`) is entirely ignored —
+  item 3.
+
+**To actually verify:** read the `book_authors:` rows directly from Pebble for
+author 43791 and confirm the two book IDs are present. Note
+`diagnostics query --raw` failed with "permission denied" on LOCK while the
+service was running, so this needs either a service-aware path or a read against
+a snapshot.
+
+---
+
+## 6. Other open findings, not yet filed as fragments
+
+- **ABS series listing returns `numBooks > 0` with `books: []`** — 23 of 50 on
+  page 0, one with `numBooks=110`. This is the surface behind the user's "shows
+  zero series" complaint in AudioBooth. The native API is healthy
+  (14,286/14,629 series, 14,300 with `book_count>0`), so the defect is in the
+  ABS compatibility layer, not storage.
+- **`/series/count` = 14,286 vs series list = 14,629** — a 343-row discrepancy,
+  unexplained.
+- **Junk series names** — `- 3`, `- Legion`, `- Freedom's Dawn`, and
+  `-Dickens Short Stories` author rows. Same disease as the `& Name` rows: a
+  metadata parse writing a delimiter-prefixed non-name into a name field.
+- **56 duplicate-name author groups** — filed in #2416 (merged), split into three
+  kinds. 🚨 The fragment carries an explicit warning: do NOT write one op that
+  treats all three the same. Type 3 (real duplicates) wants a merge; types 1 and
+  2 (book titles and `CD 13`-style disc labels stored as authors) want the author
+  link removed. Merging everything would consolidate junk and make it look
+  intentional.
+
+---
+
+## 7. Test-suite hazard — unresolved
+
+`go test ./internal/server` (the ROOT package, not the handler subpackages)
+**hangs and dies at exactly the timeout**, in both forms:
+
+    full:  FAIL github.com/falkcorp/audiobook-organizer/internal/server  600.939s
+    short: FAIL github.com/falkcorp/audiobook-organizer/internal/server  300.790s
+
+The goroutine dump shows Pebble `vfs.(*diskHealthCheckingFile).startTicker`
+(`disk_health.go:249/254`). Failing at *exactly* the timeout is the known
+intermittent-stall signature recorded for this repo (usually `internal/database`
+is the victim; here it is `internal/server`). 14 other packages pass.
+
+**I did NOT establish whether this is pre-existing.** I launched a control run on
+unmodified main and the session was interrupted before it finished, so treat
+this as an open question, not as "known environmental." My change is confined to
+`internal/server/handlers/audiobooks`, and both that package and
+`internal/audiobooks` pass — but that is an argument, not the control.
+
+**Next step:** run `go test -short -timeout 300s ./internal/server` on clean
+main. If it hangs there too, it is pre-existing and CI's `Minimal CI / Go Tests
+(short, race)` is the gate to trust.
+
+---
+
+## 8. Worktree / housekeeping state
+
+- `../audiobook-organizer-bareparam` [`fix/bare-filter-param-set-derived`] —
+  **live, has uncommitted work**, PR #2417 open.
+- `../audiobook-organizer-invariant` and `../audiobook-organizer-dupauth` —
+  already removed after their PRs merged.
+- Two orphaned worktree dirs not registered with git, safe to delete:
+  `.claude/worktrees/agent-a65e96827e3098a00`,
+  `.claude/worktrees/agent-aa7e5c1c9192b7beb`.
+- Two peer sessions were live in this repo (`ao-fixes-2`, `ao-fixes-3`).
+  `ao-fixes-2` merged my #2416. **Run `gh pr list` before starting work** — I
+  duplicated #2407/#2408 against a peer's #2411 earlier by checking only
+  `git worktree list`, which shows branch names but not open PRs.
+
+---
+
+## 9. Method notes that earned their place today
+
+- **Verify the instrument before believing the result.** Three separate
+  instruments were broken today (`version_group_id` ignored, `is_primary_version`
+  path-divergent, author listing primary-only). Each looked like a fact about the
+  data. A negative control — a deliberately bogus value that should return
+  nothing — caught all three.
+- **A green test proves nothing until you have watched it go red.** The #2417
+  conformance test was mutation-checked by dropping one field.
+- **Count the subtests.** A table that silently iterates nothing reports success.
+- **`cmd | tail` reports `tail`'s status.** I recorded `BUILD_EXIT=0` from a
+  pipeline once today; the build had not been checked at all.
+- **Grep every accessor spelling, not one.** `ParseQueryString(c, "x")` does not
+  match `ParseQueryString\("`. This bit both `ab04824e` and me.
+- **A global collision count over-reports.** 5 collisions across the server tree,
+  1 on the endpoint that matters — scope the question to the route.

--- a/internal/server/handlers/audiobooks/bare_filter_param_test.go
+++ b/internal/server/handlers/audiobooks/bare_filter_param_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/bare_filter_param_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5a9e2c68-4b71-4d03-9e85-1c6f0a37b2d9
-// last-edited: 2026-08-13
+// last-edited: 2026-08-14
 
 package audiobookshandler
 
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"testing"
 
+	audiobookspkg "github.com/falkcorp/audiobook-organizer/internal/audiobooks"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
@@ -36,7 +37,13 @@ func queryCtx(t *testing.T, rawQuery string) *gin.Context {
 func TestFirstBareFilterFieldParam_RejectsFilterFieldsPassedBare(t *testing.T) {
 	// Every name the guard knows must be caught on its own — a set that is
 	// only spot-checked drifts into holes.
+	//
+	// Counted explicitly: a table that silently iterates nothing also reports
+	// success, so assert the set is the size the derivation should produce
+	// before trusting a green run.
+	ran := 0
 	for field := range filterFieldQueryParams {
+		ran++
 		t.Run(field, func(t *testing.T) {
 			got, bare := firstBareFilterFieldParam(
 				queryCtx(t, url.Values{field: {"anything"}}.Encode()))
@@ -44,6 +51,94 @@ func TestFirstBareFilterFieldParam_RejectsFilterFieldsPassedBare(t *testing.T) {
 			require.Equal(t, field, got)
 		})
 	}
+	require.Equal(t, len(audiobookspkg.KnownFilterFields())-len(bareParamAllowListPresentInCanonical()),
+		ran, "guard table must exercise every derived name")
+}
+
+// bareParamAllowListPresentInCanonical returns the allow-list entries that are
+// actually in the canonical field list. The allow-list may name a field
+// defensively before it exists there (fingerprint_status does), and those
+// entries subtract nothing from the derived set.
+func bareParamAllowListPresentInCanonical() []string {
+	canonical := make(map[string]struct{})
+	for _, n := range audiobookspkg.KnownFilterFields() {
+		canonical[n] = struct{}{}
+	}
+	out := []string{}
+	for name := range bareParamAllowList {
+		if _, ok := canonical[name]; ok {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// TestFilterFieldQueryParams_DerivedFromCanonicalList is the assertion that
+// replaces the hand-maintained mirror this set used to be.
+//
+// audiobooks.KnownFilterFields() is the single source of truth for what the
+// list can filter on, already pinned to the matcher by
+// TestFilterFieldNames_MatchTheMatcher. The guard used to be a THIRD copy of
+// that set, held against nothing — and it drifted: 17 real filter fields were
+// missing, so ?year=2001 answered with the entire 63,870-book library while
+// looking exactly like a narrowed query.
+//
+// With the set derived, this test is what keeps the derivation honest: every
+// canonical field is either guarded or explicitly allow-listed, and nothing is
+// guarded that is not a canonical field.
+func TestFilterFieldQueryParams_DerivedFromCanonicalList(t *testing.T) {
+	canonical := audiobookspkg.KnownFilterFields()
+	require.NotEmpty(t, canonical, "canonical field list must not be empty")
+
+	for _, name := range canonical {
+		_, guarded := filterFieldQueryParams[name]
+		_, allowed := bareParamAllowList[name]
+		if allowed {
+			require.False(t, guarded,
+				"%q is allow-listed and must NOT be guarded", name)
+			continue
+		}
+		require.True(t, guarded,
+			"canonical filter field %q is not guarded — a bare ?%s= would list "+
+				"the entire library while looking like a narrowed query", name, name)
+	}
+
+	// Nothing may be guarded that is not a canonical filter field: the error
+	// message tells the caller to move the name into `filters`, which would be
+	// a lie for a name the matcher does not accept.
+	canonicalSet := make(map[string]struct{}, len(canonical))
+	for _, n := range canonical {
+		canonicalSet[n] = struct{}{}
+	}
+	for name := range filterFieldQueryParams {
+		require.Contains(t, canonicalSet, name,
+			"%q is guarded but is not a canonical filter field", name)
+	}
+}
+
+// TestFilterFieldQueryParams_CoversTheFieldsThatDrifted pins the specific names
+// the hand-written set was missing. Named individually rather than counted, so
+// the test says WHICH field regressed if the derivation is ever unwound.
+//
+// Each of these answered count=63870 when passed bare, on a production library
+// of that exact size.
+func TestFilterFieldQueryParams_CoversTheFieldsThatDrifted(t *testing.T) {
+	drifted := []string{
+		"series_number", "duration", "bitrate", "bitrate_kbps",
+		"file_size", "file_size_bytes", "sample_rate", "sample_rate_hz",
+		"channels", "bit_depth", "isbn10", "isbn13", "work_id", "year",
+		"created_at", "updated_at", "marked_for_deletion",
+	}
+	for _, field := range drifted {
+		t.Run(field, func(t *testing.T) {
+			got, bare := firstBareFilterFieldParam(
+				queryCtx(t, url.Values{field: {"1"}}.Encode()))
+			require.True(t, bare,
+				"bare ?%s= must be rejected, not answered with the whole library", field)
+			require.Equal(t, field, got)
+		})
+	}
+	require.Len(t, drifted, 17)
 }
 
 func TestFirstBareFilterFieldParam_AllowsRealParameters(t *testing.T) {

--- a/internal/server/handlers/audiobooks/handler.go
+++ b/internal/server/handlers/audiobooks/handler.go
@@ -233,39 +233,60 @@ func ptrStr(p *string) string {
 	return *p
 }
 
-// ListAudiobooks handles GET /audiobooks. Mirrors the original listAudiobooks:
-// has_file_errors fast-path, quick-query (missing_covers / in_import_path /
-// no_isbn / duplicates_flagged) fast-path, then the filtered list pipeline with
-// the list cache (skipped when per-user filters are active).
+// bareParamAllowList names fields that are BOTH a filter field and a genuine
+// bare query parameter of the library list, and so must never be rejected.
+//
+// The asymmetry that governs this file: omitting a name from the guard is
+// harmless (the guard just does not fire, which is the pre-guard behavior).
+// INCLUDING one wrongly rejects a request that used to work. So the allow-list
+// is the safety valve, and a name belongs here the moment it has a real
+// accessor on THIS endpoint.
+//
+// "library_state" is the known case: read at ParseQueryString(c,
+// "library_state") in ListAudiobooks, and TestListBooksWithTagFilter asserts
+// ?tag=…&library_state=organized narrows to one book. An earlier revision of
+// the old hand-written set included it and broke that test. The near-miss is
+// worth keeping on the record: the collision survey that produced that set
+// grepped only c.Query("…") and so could not see the ParseQueryString form.
+// Check every accessor spelling, not one, before removing a name from here.
+//
+// "fingerprint_status" is not in KnownFilterFields today, so the derivation
+// below already excludes it. It is named anyway so the protection does not
+// depend on that staying true — if it is ever added to the canonical field
+// list, this endpoint would otherwise start rejecting a parameter it reads.
+var bareParamAllowList = map[string]struct{}{
+	"library_state":      {},
+	"fingerprint_status": {},
+}
+
 // filterFieldQueryParams are names that mean something only INSIDE the
-// `filters` JSON parameter of the library list. Mirrors the field switch in
-// audiobooks.matchesFieldFilters.
+// `filters` JSON parameter of the library list.
 //
-// Omitting a name is harmless — the guard simply does not fire for it, which
-// is today's behavior. INCLUDING a name wrongly is NOT harmless: it rejects a
-// request that used to work. Some names are BOTH a filter field and a genuine
-// bare parameter, and those must stay out.
+// DERIVED, not hand-maintained. audiobooks.KnownFilterFields() is the single
+// source of truth for what the list can filter on, and it is already pinned to
+// the matcher by TestFilterFieldNames_MatchTheMatcher. A literal map here was a
+// THIRD copy of that set — nothing held it against the first, so it drifted:
+// 17 real filter fields (year, work_id, isbn13, marked_for_deletion, …) were
+// missing, and ?year=2001 answered with all 63,870 books while looking exactly
+// like a narrowed query.
 //
-// "library_state" is exactly that case and is deliberately absent: it is a
-// real bare parameter, read at ParseQueryString(c, "library_state") below, and
-// TestListBooksWithTagFilter asserts ?tag=…&library_state=organized narrows to
-// one book. An earlier revision of this set included it and broke that test.
-// The near-miss is worth recording: the collision survey that produced this
-// set grepped only c.Query("…") and so could not see the ParseQueryString
-// form. Check every accessor helper, not one spelling, before adding a name.
+// Deriving it means a field added to the canonical list is guarded here the
+// same day, and the only judgment left is the allow-list above.
 //
-// "author" belongs here while "author_id" does not — adjacent names, different
-// things, and only exact-name lookup keeps them apart.
-var filterFieldQueryParams = map[string]struct{}{
-	"title": {}, "author": {}, "narrator": {}, "series": {}, "genre": {},
-	"language": {}, "publisher": {}, "edition": {}, "format": {}, "codec": {},
-	"quality": {}, "description": {},
-	"metadata_review_status": {}, "review": {}, "has_cover": {},
-	"has_written": {}, "needs_writeback": {}, "has_organized": {},
-	"itunes_sync_status": {}, "duration_seconds": {},
-	"read_status": {}, "progress_pct": {}, "last_played": {},
-	"user_rating_overall": {}, "user_rating_story": {},
-	"user_rating_performance": {},
+// Note "author" is a filter field while "author_id" is a genuine bare
+// parameter — adjacent names, different things, and only exact-name lookup
+// keeps them apart. That is why this is a set lookup and not a prefix match.
+var filterFieldQueryParams = buildFilterFieldQueryParams()
+
+func buildFilterFieldQueryParams() map[string]struct{} {
+	out := make(map[string]struct{})
+	for _, name := range audiobookspkg.KnownFilterFields() {
+		if _, allowed := bareParamAllowList[name]; allowed {
+			continue
+		}
+		out[name] = struct{}{}
+	}
+	return out
 }
 
 // firstBareFilterFieldParam reports the first filter-field name the request
@@ -286,6 +307,10 @@ func firstBareFilterFieldParam(c *gin.Context) (string, bool) {
 	return found[0], true
 }
 
+// ListAudiobooks handles GET /audiobooks. Mirrors the original listAudiobooks:
+// has_file_errors fast-path, quick-query (missing_covers / in_import_path /
+// no_isbn / duplicates_flagged) fast-path, then the filtered list pipeline with
+// the list cache (skipped when per-user filters are active).
 func (h *Handler) ListAudiobooks(c *gin.Context) {
 	store := h.store
 

--- a/todo.d/20260814-is-primary-version-nil-vs-false-divergence.md
+++ b/todo.d/20260814-is-primary-version-nil-vs-false-divergence.md
@@ -1,0 +1,61 @@
+## `is_primary_version` means different things on the library path and the author path
+
+Found 2026-08-14 while trying to verify an author merge. Both paths accept the
+same parameter and answer confidently; they disagree about what a NIL flag
+means, so the same book is primary on one path and non-primary on the other.
+
+### Measured on production 2026-08-14
+
+Library-wide the filter partitions the library exactly, and the rows it returns
+carry an explicit `false`:
+
+    is_primary_version=false  -> total=22552   rows have is_primary_version: false
+    is_primary_version=true   -> total=41317
+    (no filter)               -> total=63869   = 22552 + 41317 ✓
+
+On the author path it returns rows whose flag is **null**, not false:
+
+    author_id=38542&is_primary_version=false -> 1 row, is_primary_version: null
+    author_id=38543&is_primary_version=false -> 1 row, is_primary_version: null
+
+And it cannot return a book whose flag is explicitly `false`. Book
+`01KNDB8NWHXV2DKRQESBA9SDRA` records `author_id: 42623`, `is_primary_version:
+false`. Yet:
+
+    author_id=42623                          -> 1 row, and it is NOT that book
+    author_id=42623&is_primary_version=false -> 0 rows
+    author_id=42623&is_primary_version=true  -> 1 row (a different book)
+
+So a book that exists, names that author, and is explicitly non-primary is
+unreachable through its own author's listing under every value of the filter.
+
+### Likely cause
+
+`memdb_schema.go` builds the index with `effectiveBoolFieldIndex{Default:
+true}` — a nil `IsPrimaryVersion` indexes as **true**. A post-filter comparing
+the raw `*bool` instead sees nil as "not true" and treats it as **false**. Same
+nil, opposite readings, depending on which layer answers.
+
+That also explains the shape of the disagreement: the author path is
+primary-only by design (`GetBooksByAuthorIDCore` is the LISTING view — see
+#2410), so an explicitly-`false` book is dropped before the parameter is ever
+consulted, while a nil-flag book survives the index (nil→true) and is then
+handed to a post-filter that calls it false.
+
+- [ ] Decide the single meaning of a nil `IsPrimaryVersion` and apply it in both
+      places. `Default: true` is already the storage answer, so the post-filter
+      is the side that should change — but confirm before flipping, because
+      22,552 books currently answer to `false` library-wide and some of those
+      may be nil-flagged.
+- [ ] Add a conformance test in the shape used by #2406/#2410/#2411: one
+      fixture containing a nil-flag book, an explicit-true book and an
+      explicit-false book; assert the library path and the author path classify
+      all three identically. A fixture without a nil-flag row cannot catch this.
+- [ ] Decide whether the author listing SHOULD expose non-primary books at all.
+      Today it cannot, which is defensible for a listing, but it means the UI
+      has no way to show a book on the author page it is genuinely attached to.
+
+⚠️ **This is why the 46627 merge could not be verified** — see the handoff. Every
+available instrument for "which books does author X have" is either
+primary-only or disagrees about nil, so `0 non-primary books for 43791` is not
+evidence the merge failed. Do not read it as such.

--- a/todo.d/20260814-version-group-id-not-a-filter-field.md
+++ b/todo.d/20260814-version-group-id-not-a-filter-field.md
@@ -1,0 +1,37 @@
+## `?version_group_id=` lists the whole library, and cannot be guarded
+
+Found 2026-08-14 while trying to verify that an author merge had relinked two
+books. Every form of the query returned the same answer:
+
+    version_group_id='vg-08c1a396b'          -> count=63869  first=01KNDB8NWHXV2DKRQESBA9SDRA
+    version_group_id='vg-TOTALLY-BOGUS-XYZ'  -> count=63869  first=01KNDB8NWHXV2DKRQESBA9SDRA
+    version_group_id=''                      -> count=63869  first=01KNDB8NWHXV2DKRQESBA9SDRA
+
+The negative control is the point: a bogus group ID and a real one are
+indistinguishable, so the parameter is not read at all. The instrument was
+unusable for the verification it was reached for, which is how it was noticed.
+
+**Why the bare-param guard does not cover this.** That guard rejects names in
+`audiobooks.KnownFilterFields()`. `version_group_id` is not in it — it is not a
+filter field, so `bookFieldValue` has no case for it and the guard has nothing
+to match. This is a genuine gap, not the same bug: `?year=` was a *known* field
+passed the wrong way; `?version_group_id=` is a field the list never supported.
+
+- [ ] Decide whether the list should filter on `version_group_id` at all. There
+      is a real case: the memdb store already indexes it (`memIdxVersionGroupID`
+      in `memdb_schema.go`) and `GetAllBooksFrom` accepts it as a filter key, so
+      the storage layer supports the lookup the API does not expose.
+- [ ] If yes: add a `case "version_group_id"` to `bookFieldValue` and the name
+      to `allFilterFieldNames`. `TestFilterFieldNames_MatchTheMatcher` will hold
+      the two together, and the bare-param guard then covers it automatically —
+      no third list to update. Check the Pebble path too; a memdb-only index
+      would be exactly the dual-implementation divergence fixed in #2406/#2410/#2411.
+- [ ] If no: it still must not answer with the whole library. Extend the guard
+      with a small set of *storage* filter keys that are not list filter fields,
+      so the request is rejected rather than silently widened.
+
+⚠️ Whichever way this goes, the rule from `FirstUnknownFilterField` applies: the
+two failure modes here are inverted and both misleading — an unknown field
+*inside* `filters` matches nothing and answers `count:0`, while a filter field
+passed *bare* matches everything and answers with the library. Neither should be
+reachable by a typo.


### PR DESCRIPTION
## The bug

`ab04824e` (yesterday) started rejecting filter field names passed as bare query
parameters — gin ignores them, so the request lists the **entire library** while
looking exactly like a narrowed query, matching count and all.

The guard works. The set it consulted did not stay correct. It was a hand-written
map in the handler package — a **third** copy of a field list that already has a
single source of truth — and nothing held it against the original. It drifted by
17 names.

Measured on production 2026-08-14, against an unfiltered baseline so this is a
comparison and not an impression:

| query | count |
|---|---|
| `?year=2001` | 63,869 |
| `?work_id=abc` | 63,869 |
| `?marked_for_deletion=true` | 63,869 |
| *(no filter, baseline)* | **63,869** |

## The fix

Stop maintaining the copy. `audiobooks.KnownFilterFields()` is canonical and is
already pinned to the matcher by `TestFilterFieldNames_MatchTheMatcher`; the
guard now derives from it minus an explicit allow-list. A field added to the
canonical list is guarded the same day.

Purely additive — every name in the old literal is in the canonical list. Adds:
`year`, `work_id`, `isbn10`, `isbn13`, `series_number`, `created_at`,
`updated_at`, `marked_for_deletion`, `duration`, `bitrate`, `bitrate_kbps`,
`file_size`, `file_size_bytes`, `sample_rate`, `sample_rate_hz`, `channels`,
`bit_depth`.

## The collision survey, which is where a regression would come from

The asymmetry from `ab04824e`: omitting a name is harmless, **including one
wrongly rejects a request that used to work**. So the survey got redone.

My first pass repeated the exact mistake that commit warns about — it matched
`ParseQueryString("` and so could not see `ParseQueryString(c, "library_state")`.
The corrected pass returned `limit` but neither `offset` nor `page`, which is
what revealed it was *still* scoped too narrowly. Widened to all of
`internal/server` + `internal/httputil`: 95 parameter names, 44 canonical
fields, 5 collisions.

| name | accessor | same endpoint? |
|---|---|---|
| `library_state` | `handlers/audiobooks/handler.go:516` | **yes** |
| `title` | `handlers/metadata/handler.go:389` | no |
| `author` | `handlers/metadata/handler.go:390` | no |
| `duration` | `server/audio_sample.go:39` | no |
| `format` | `handlers/dedup/handler.go:492` | no |

The guard has one call site and reads that request's own query string, so only
same-endpoint collisions matter. `title`/`author` have been guarded since
`ab04824e` shipped with metadata search unaffected — empirical confirmation
rather than argument. **`library_state` is the only real one.**

`fingerprint_status` is allow-listed even though the derivation already excludes
it, so the protection does not depend on it staying out of the canonical list.

## Verification

- 7 top-level tests, **81 subtests, 0 FAIL**, exit 0
- guard table exercises **43** names, up from 26 — counted, since a table that
  iterates nothing also reports success
- **Negative control:** dropping one field from the derivation fails three
  separate tests and names it:
  `canonical filter field "year" is not guarded — a bare ?year= would list the entire library while looking like a narrowed query`

## Not fixed here

`?version_group_id=` still lists everything. It is **not a filter field at all**,
so the derivation cannot reach it — a different gap, not this one. Filed in
`todo.d/` with both options; the memdb store does index it, so there is a real
case for adding it, but that is matcher work for its own PR.

Also reattaches the `ListAudiobooks` doc comment, orphaned onto the `var` below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxigqrwz9WfwN1wx8QhoQW