### PR TITLE
fix(maintenance): resolve dry_run from the advertised default, not Go's zero value

### DIFF
--- a/changelog.d/20260814_090000_maintenance_dry_run_default.md
+++ b/changelog.d/20260814_090000_maintenance_dry_run_default.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- Maintenance jobs no longer run for real when you asked for a preview. Most
+  maintenance jobs (18 of 34) are meant to preview their changes by default, and
+  the settings screen showed them that way — but the server ignored that and
+  applied the changes for real whenever the preview setting wasn't spelled out in
+  the request. The two now agree, and a job you explicitly set to apply still
+  applies.
+- A preview that was interrupted by a server restart no longer comes back as a
+  real change. The server kept no record of whether a running job was a preview,
+  so when it restarted and picked the job back up it treated every one of them as
+  a real change — including the job that deletes empty folders from disk. Your
+  choice is now saved with the job and restored on restart.

--- a/docs/executive-summaries/2026-08-14-the-preview-button-that-was-not-a-preview-executive-summary.md
+++ b/docs/executive-summaries/2026-08-14-the-preview-button-that-was-not-a-preview-executive-summary.md
@@ -1,0 +1,113 @@
+<!-- file: docs/executive-summaries/2026-08-14-the-preview-button-that-was-not-a-preview-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b7e4c210-5f83-4a96-9d1e-3c6208a7b41f -->
+<!-- last-edited: 2026-08-14 -->
+
+# Executive Summary: The Preview That Was Not a Preview
+
+**Date:** 2026-08-14
+**In one line:** Most maintenance jobs advertise themselves as "preview only" by default,
+and the server ignored that and made the changes for real.
+
+---
+
+## What you saw
+
+Nothing. That is the whole problem.
+
+A maintenance job that previews its changes and one that makes them for real look
+identical from the outside. Same button, same spinner, same "started" confirmation, same
+place in the activity list. The only way to tell them apart is to go and check whether
+your library actually changed — and if you believed you had run a preview, you had no
+reason to check.
+
+## What was actually happening
+
+Every maintenance job publishes its own default settings, and the settings screen reads
+them. **18 of the 34 jobs say the same thing: by default, preview only, don't change
+anything.** That is the sensible default for a job that deletes folders or merges records,
+and it is what the screen showed you.
+
+The part of the server that actually *starts* the job never read that. It had its own
+idea of the default, and its idea was the opposite one: make the changes for real.
+
+So the two halves of the same feature disagreed. One half told you "this will only
+preview." The other half applied the changes. Whenever the preview setting wasn't spelled
+out explicitly in the request — which is exactly what happens when something trusts the
+published default — you got a real change while being told it was a preview.
+
+This was not one job. It was every one of those 18, including:
+
+- the job that deletes series with only one book in them,
+- the job that deletes empty folders from disk,
+- the job that merges books it believes are duplicates,
+- the job that rewrites file paths.
+
+## Why the series job is the sharp example
+
+That job's first step deletes every series holding exactly one book. A census taken the
+same day found that of 6,245 single-book series in the library, **2,322 are genuinely
+distinct real series** — not duplicates, not mistakes, just series you happen to own one
+book from.
+
+And a deleted series name does not come back. It is not stored on the book, not in the
+undo history, and not in the file path. Only about 6% could be reconstructed from
+information elsewhere. An accidental non-preview run of that job would have quietly
+deleted thousands of real series names with no way to recover them.
+
+## The second, worse version of the same problem
+
+There is a related case that is harder to spot and worse when it happens.
+
+If the server restarts while a maintenance job is running, it picks the job back up on
+the way up. But it kept **no record of whether that job was a preview or a real run.**
+The information existed only in the original request, and the request was gone.
+
+So it guessed — and it guessed "real."
+
+That means an operator who deliberately chose *preview*, watched it start, and then hit
+an ordinary restart (a deploy, a reboot, a crash) would get a **real change** on the way
+back up, filed under the same operation they had started as a preview. Seven jobs can be
+resumed this way and default to preview, and one of them deletes directories from disk.
+
+Nothing in the interface would have distinguished that from a normal resume.
+
+## What changed
+
+Two things, one for each half:
+
+1. **When the preview setting isn't spelled out, the server now uses the default the job
+   itself publishes** — the same one the settings screen shows you. If a job says it
+   previews by default, it previews. If you explicitly ask it to apply, it still applies:
+   saying so out loud is unchanged.
+
+2. **Your choice is now saved with the job**, so a restart resumes it exactly as you
+   started it — a preview stays a preview, a real run stays a real run. For jobs that
+   were already running when this shipped, and so have nothing saved, the server falls
+   back to the job's published default rather than to "real."
+
+The 16 jobs that legitimately default to applying are unaffected.
+
+## How we know it holds
+
+The risky part of a fix like this is that it quietly stops working later — someone adds
+job #35, forgets a detail, and the two halves drift apart again exactly as before.
+
+So the main test does not check the jobs one at a time against a list someone typed out.
+It reads the *same published settings the screen reads*, for **every** job that exists,
+and requires the server to reach the same answer. A new job that disagrees with what it
+advertises fails the build. It also fails if a job publishes its setting under a slightly
+different name, which is the specific mistake that would have recreated this bug while
+looking completely correct.
+
+Each of the four separate parts of the fix was then individually broken on purpose to
+confirm the tests actually catch it. Each break was caught, by a different test.
+
+## What is still open
+
+- The saved settings accumulate a small record per job run that nothing cleans up yet.
+  It is tiny, but it grows without limit; a cleanup pass is filed.
+- A separate, unrelated duplicate-series routine has **no preview option at all** — every
+  run applies. It has never been run in this library (0 times out of 10,161 recorded
+  operations), so there is nothing to repair; it is filed to be fixed before anything
+  connects it to a button.

--- a/internal/server/maintenance_dispatcher.go
+++ b/internal/server/maintenance_dispatcher.go
@@ -1,19 +1,22 @@
 // file: internal/server/maintenance_dispatcher.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: 55555555-5555-5555-5555-555555555555
-// last-edited: 2026-08-11
+// last-edited: 2026-08-14
 
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
+	"github.com/falkcorp/audiobook-organizer/internal/operations"
 	"github.com/gin-gonic/gin"
 	ulid "github.com/oklog/ulid/v2"
 )
@@ -51,6 +54,31 @@ func (s *Server) listMaintenanceJobs(c *gin.Context) {
 	}{Jobs: out})
 }
 
+// advertisedDryRunDefault reports the dry_run value this job publishes in its
+// DefaultParams(), which is what listMaintenanceJobs serves to clients as
+// `default_params`. Jobs that expose no dry_run key at all report false.
+//
+// It goes through JSON deliberately rather than reflecting over the struct.
+// DefaultParams() returns `any` — in practice an anonymous struct declared
+// inline in each job file — and JSON is the representation the client actually
+// received. Reading it the same way the client did is what keeps the advertised
+// default and the applied default from drifting apart again; a reflection-based
+// reader could disagree with the wire format over tags, embedding or casing,
+// which is the exact class of divergence this function exists to close.
+func advertisedDryRunDefault(job maintenance.MaintenanceJob) bool {
+	raw, err := json.Marshal(job.DefaultParams())
+	if err != nil {
+		return false
+	}
+	var dp struct {
+		DryRun *bool `json:"dry_run"`
+	}
+	if err := json.Unmarshal(raw, &dp); err != nil || dp.DryRun == nil {
+		return false
+	}
+	return *dp.DryRun
+}
+
 // runMaintenanceJob enqueues the named maintenance job as an async operation.
 func (s *Server) runMaintenanceJob(c *gin.Context) {
 	jobID := c.Param("job_id")
@@ -84,15 +112,42 @@ func (s *Server) runMaintenanceJob(c *gin.Context) {
 	// byte-identical either way, so the operator who asked for a preview had no
 	// signal at all that they got a mutation.
 	//
-	// An ABSENT body still means DryRun=false; that is this endpoint's existing
-	// contract and is deliberately unchanged here. Only "you sent something and
-	// we could not read it" becomes an error.
+	// DryRun is a *bool so that "omitted" is representable at all. With a plain
+	// bool, omitted and false are the same value and the handler cannot tell an
+	// operator who asked to apply from one who said nothing.
 	var req struct {
-		DryRun bool `json:"dry_run"`
+		DryRun *bool `json:"dry_run"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
 		httputil.RespondWithBadRequest(c, "invalid request body: "+err.Error())
 		return
+	}
+
+	// When dry_run is omitted, honor the default this job ADVERTISES rather than
+	// Go's zero value.
+	//
+	// listMaintenanceJobs (above) publishes each job's DefaultParams() to clients
+	// as `default_params`, and 18 of the 34 registered jobs advertise
+	// {"dry_run": true} — including cleanup-series, cleanup-organize-mess,
+	// dedup-books, repair-missing-files and fix-library-states. This handler
+	// previously ignored that entirely and fell through to false, so a client
+	// that read the catalogue, saw dry_run:true, and POSTed without a body got
+	// the exact opposite of what the API had just told it — a real mutation,
+	// behind an identical 202.
+	//
+	// cleanup-series is the sharp case: its first phase deletes every series
+	// holding exactly one book, and a census on 2026-08-14 found 2,322 of 6,245
+	// single-book series are genuinely distinct real series. Series names are
+	// not recoverable once deleted — they are not on the book row, not in
+	// operation_changes, and not in file paths.
+	//
+	// This changes behavior only for jobs advertising dry_run:true, and only in
+	// the fail-safe direction (omission now previews instead of applies). The 16
+	// jobs advertising false are unaffected. An explicit "dry_run": false still
+	// applies — callers that mean it say so.
+	dryRun := advertisedDryRunDefault(job)
+	if req.DryRun != nil {
+		dryRun = *req.DryRun
 	}
 
 	opID := ulid.Make().String()
@@ -105,10 +160,36 @@ func (s *Server) runMaintenanceJob(c *gin.Context) {
 		return
 	}
 
+	// Persist the resolved dry_run so a restart mid-run can resume FAITHFULLY
+	// rather than guess.
+	//
+	// database.Operation carries no params field, so before this the resume path
+	// (resumeLegacyOp in server_lifecycle.go) had no record of the operator's
+	// choice at all and fell through to Go's zero value — turning an interrupted
+	// PREVIEW into a real mutation, under the original operation's own ID. Seven
+	// jobs are both CanResume() and advertise dry_run:true, one of which
+	// (cleanup-empty-folders) removes directories from disk.
+	//
+	// This mirrors the bulk_write_back case in the same switch, which already
+	// saves its params and reloads them on resume.
+	//
+	// A save failure does not fail the request: the operator asked for this job
+	// and it is about to run correctly. Only a subsequent restart is affected,
+	// and resumeLegacyOp falls back to the advertised default there. Log it so
+	// the degraded resume is not silent.
+	if err := operations.SaveParams(store, opID, maintenanceJobOpParams{
+		LegacyOpID: opID,
+		JobID:      jobID,
+		DryRun:     dryRun,
+	}); err != nil {
+		slog.Warn("maintenance job params not saved; a resume would fall back to the advertised dry_run default",
+			"opID", opID, "jobID", jobID, "dryRun", dryRun, "err", err)
+	}
+
 	if _, err := s.opRegistry.EnqueueOp(c.Request.Context(), "maintenance.job", maintenanceJobOpParams{
 		LegacyOpID: opID,
 		JobID:      jobID,
-		DryRun:     req.DryRun,
+		DryRun:     dryRun,
 	}); err != nil {
 		httputil.RespondWithConflict(c, err.Error())
 		return

--- a/internal/server/maintenance_dryrun_default_test.go
+++ b/internal/server/maintenance_dryrun_default_test.go
@@ -1,0 +1,494 @@
+// file: internal/server/maintenance_dryrun_default_test.go
+// version: 1.0.0
+// guid: 6c1d84af-97b2-4e30-8f55-2b70e9c14d63
+// last-edited: 2026-08-14
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
+	"github.com/falkcorp/audiobook-organizer/internal/operations"
+	"github.com/gin-gonic/gin"
+	ulid "github.com/oklog/ulid/v2"
+)
+
+// ---------------------------------------------------------------------------
+// Probe jobs
+// ---------------------------------------------------------------------------
+
+// dryRunProbeJob is a maintenance job that does nothing except record the
+// dryRun value it was handed. It exists so the tests below can assert the value
+// that reaches Run — the only place the flag actually decides between a preview
+// and a mutation — rather than asserting on an intermediate the handler happens
+// to compute.
+type dryRunProbeJob struct {
+	id string
+	// params is returned verbatim from DefaultParams(), so each probe can
+	// advertise a different shape (dry_run true, false, or absent entirely).
+	params    any
+	canResume bool
+
+	mu   sync.Mutex
+	runs []bool
+}
+
+func (j *dryRunProbeJob) ID() string          { return j.id }
+func (j *dryRunProbeJob) Name() string        { return "Dry-Run Probe " + j.id }
+func (j *dryRunProbeJob) Description() string { return "Test probe; records the dryRun it receives." }
+func (j *dryRunProbeJob) Category() string    { return "test" }
+func (j *dryRunProbeJob) DefaultParams() any  { return j.params }
+func (j *dryRunProbeJob) CanResume() bool     { return j.canResume }
+
+func (j *dryRunProbeJob) Run(_ context.Context, _ database.Store, _ maintenance.ProgressReporter, dryRun bool) error {
+	j.mu.Lock()
+	j.runs = append(j.runs, dryRun)
+	j.mu.Unlock()
+	return nil
+}
+
+// awaitRun blocks until the job has been run at least once and returns the
+// dryRun value of the first run. Failing here means the request never reached
+// Run at all, which is a different defect from resolving the wrong value — so
+// it is reported separately rather than folded into the value assertion.
+func (j *dryRunProbeJob) awaitRun(t *testing.T) bool {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		j.mu.Lock()
+		n := len(j.runs)
+		var first bool
+		if n > 0 {
+			first = j.runs[0]
+		}
+		j.mu.Unlock()
+		if n > 0 {
+			return first
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("job %q never ran within 20s", j.id)
+	return false
+}
+
+var (
+	// Advertises dry_run:true — the 18-of-34 case the fix is about.
+	probeAdvertisesTrue = &dryRunProbeJob{
+		id: "test-probe-advertises-dry-run-true",
+		params: struct {
+			DryRun bool `json:"dry_run"`
+		}{DryRun: true},
+		canResume: true,
+	}
+	// Advertises dry_run:false — must be untouched by the fix.
+	probeAdvertisesFalse = &dryRunProbeJob{
+		id: "test-probe-advertises-dry-run-false",
+		params: struct {
+			DryRun bool `json:"dry_run"`
+		}{DryRun: false},
+		canResume: true,
+	}
+	// Advertises no dry_run key at all — the reader must not invent one.
+	probeAdvertisesNothing = &dryRunProbeJob{
+		id: "test-probe-advertises-no-dry-run",
+		params: struct {
+			Limit int `json:"limit"`
+		}{Limit: 5},
+		canResume: true,
+	}
+)
+
+func init() {
+	// maintenance.Register panics on a duplicate ID and has no Unregister, so
+	// these are registered exactly once for the package's whole test run.
+	// maintenance.All() has a single production caller (listMaintenanceJobs),
+	// and no test asserts a job count, so the extra entries are inert.
+	maintenance.Register(probeAdvertisesTrue)
+	maintenance.Register(probeAdvertisesFalse)
+	maintenance.Register(probeAdvertisesNothing)
+}
+
+// ---------------------------------------------------------------------------
+// Conformance: the reader must agree with what the catalogue publishes
+// ---------------------------------------------------------------------------
+
+// normalizeParamKey folds a JSON key to a form that collapses `dry_run`,
+// `dryRun` and `DryRun` onto the same string. A struct field declared without a
+// json tag marshals as `DryRun`, which advertisedDryRunDefault (matching the tag
+// `dry_run`) would NOT bind — encoding/json's case-insensitive fallback matches
+// on case, not on punctuation. That job would then advertise dry_run:true to the
+// UI while the handler applied false: the exact advertised-vs-applied
+// divergence this whole change exists to close, reintroduced by a missing tag.
+func normalizeParamKey(k string) string {
+	return strings.ToLower(strings.ReplaceAll(k, "_", ""))
+}
+
+// TestAdvertisedDryRunDefault_AgreesWithEveryRegisteredJob is the conformance
+// test that keeps the fix true for job #35.
+//
+// It does not hardcode per-job expectations — the author of a new job would just
+// write their own expectation and the test would agree with whatever they did.
+// Instead it derives the expectation from the SAME bytes listMaintenanceJobs
+// serves to clients, and requires the reader to reproduce it.
+func TestAdvertisedDryRunDefault_AgreesWithEveryRegisteredJob(t *testing.T) {
+	jobs := maintenance.All()
+	if len(jobs) == 0 {
+		t.Fatal("no maintenance jobs registered; this test would pass vacuously")
+	}
+
+	checkedAdvertisers := 0
+	for _, job := range jobs {
+		t.Run(job.ID(), func(t *testing.T) {
+			raw, err := json.Marshal(job.DefaultParams())
+			if err != nil {
+				// A job whose defaults do not marshal cannot advertise a
+				// dry_run at all, so false is the only answer available.
+				if got := advertisedDryRunDefault(job); got {
+					t.Fatalf("DefaultParams() does not marshal (%v) yet advertisedDryRunDefault returned true", err)
+				}
+				return
+			}
+
+			var asMap map[string]any
+			if err := json.Unmarshal(raw, &asMap); err != nil {
+				// Not a JSON object (nil, scalar, array): no dry_run key.
+				if got := advertisedDryRunDefault(job); got {
+					t.Fatalf("DefaultParams() marshals to non-object %s yet advertisedDryRunDefault returned true", raw)
+				}
+				return
+			}
+
+			var advertised *bool
+			var advertisedKey string
+			for k, v := range asMap {
+				if normalizeParamKey(k) != "dryrun" {
+					continue
+				}
+				b, ok := v.(bool)
+				if !ok {
+					t.Fatalf("job advertises %q as %T (%v); dry_run must be a bool or the UI checkbox cannot bind it", k, v, v)
+				}
+				advertised = &b
+				advertisedKey = k
+			}
+
+			got := advertisedDryRunDefault(job)
+			if advertised == nil {
+				if got {
+					t.Fatalf("job advertises no dry_run key (%s) yet advertisedDryRunDefault returned true", raw)
+				}
+				return
+			}
+
+			checkedAdvertisers++
+			if advertisedKey != "dry_run" {
+				t.Fatalf("job advertises its dry-run default under key %q, not \"dry_run\" — "+
+					"the catalogue would publish %s to the UI while the handler reads \"dry_run\" and applies %v. "+
+					"Add a `json:\"dry_run\"` tag to the DefaultParams field.", advertisedKey, raw, got)
+			}
+			if got != *advertised {
+				t.Fatalf("catalogue advertises dry_run=%v (%s) but advertisedDryRunDefault returned %v", *advertised, raw, got)
+			}
+		})
+	}
+
+	if checkedAdvertisers == 0 {
+		t.Fatal("no registered job advertises a dry_run default; the agreement assertion never ran")
+	}
+}
+
+// TestAdvertisedDryRunDefault_PinnedRealJobs guards against the conformance test
+// above degenerating. If maintenance.All() ever came back empty or the probes
+// were the only entries, the derived-expectation loop would still pass on the
+// probes alone. These two are real production jobs on opposite sides.
+func TestAdvertisedDryRunDefault_PinnedRealJobs(t *testing.T) {
+	for _, tc := range []struct {
+		jobID string
+		want  bool
+	}{
+		// Phase 1 deletes every single-book series; 2,322 of 6,245 such series
+		// on production are genuinely distinct real series, and series names
+		// are not recoverable once deleted.
+		{"cleanup-series", true},
+		{"backfill-file-hashes", false},
+	} {
+		job, err := maintenance.Get(tc.jobID)
+		if err != nil {
+			t.Fatalf("maintenance.Get(%q): %v", tc.jobID, err)
+		}
+		if got := advertisedDryRunDefault(job); got != tc.want {
+			t.Errorf("advertisedDryRunDefault(%q) = %v, want %v", tc.jobID, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The HTTP entry point
+// ---------------------------------------------------------------------------
+
+// postMaintenanceJob drives runMaintenanceJob the way the route does. body==""
+// means no body at all, which is what a client that read default_params and
+// POSTed nothing sends — and the case that used to silently resolve to false.
+func postMaintenanceJob(t *testing.T, s *Server, jobID, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "job_id", Value: jobID}}
+
+	var req *http.Request
+	if body == "" {
+		req = httptest.NewRequest(http.MethodPost, "/maintenance/jobs/"+jobID, http.NoBody)
+	} else {
+		req = httptest.NewRequest(http.MethodPost, "/maintenance/jobs/"+jobID, strings.NewReader(body))
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	s.runMaintenanceJob(c)
+	return w
+}
+
+func TestRunMaintenanceJob_ResolvesDryRunFromTheAdvertisedDefault(t *testing.T) {
+	tests := []struct {
+		name  string
+		job   *dryRunProbeJob
+		body  string
+		want  bool
+		notes string
+	}{
+		{
+			name:  "advertises true, no body at all",
+			job:   probeAdvertisesTrue,
+			body:  "",
+			want:  true,
+			notes: "the regression: this used to resolve to false and mutate",
+		},
+		{
+			name: "advertises true, empty JSON object",
+			job:  probeAdvertisesTrue,
+			body: `{}`,
+			want: true,
+		},
+		{
+			name:  "advertises true, explicit false",
+			job:   probeAdvertisesTrue,
+			body:  `{"dry_run": false}`,
+			want:  false,
+			notes: "an explicit apply still applies — callers that mean it say so",
+		},
+		{
+			name: "advertises true, explicit true",
+			job:  probeAdvertisesTrue,
+			body: `{"dry_run": true}`,
+			want: true,
+		},
+		{
+			name:  "advertises false, no body at all",
+			job:   probeAdvertisesFalse,
+			body:  "",
+			want:  false,
+			notes: "unchanged by the fix",
+		},
+		{
+			name: "advertises false, explicit true",
+			job:  probeAdvertisesFalse,
+			body: `{"dry_run": true}`,
+			want: true,
+		},
+		{
+			name:  "advertises no dry_run key, no body at all",
+			job:   probeAdvertisesNothing,
+			body:  "",
+			want:  false,
+			notes: "the reader must not invent a default the job never published",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server, cleanup := setupTestServer(t)
+			defer cleanup()
+			if server.opRegistry == nil {
+				t.Skip("ops registry not wired in this build")
+			}
+
+			// Each subtest gets a fresh recording window on the shared probe.
+			tc.job.mu.Lock()
+			tc.job.runs = nil
+			tc.job.mu.Unlock()
+
+			w := postMaintenanceJob(t, server, tc.job.ID(), tc.body)
+			if w.Code != http.StatusAccepted {
+				t.Fatalf("status = %d, want 202; body = %s", w.Code, w.Body.String())
+			}
+
+			if got := tc.job.awaitRun(t); got != tc.want {
+				t.Fatalf("job ran with dryRun=%v, want %v (%s)", got, tc.want, tc.notes)
+			}
+		})
+	}
+}
+
+// TestRunMaintenanceJob_MalformedBodyIsRejected locks in the behavior the *bool
+// change had to preserve: a body that fails to parse is a 400, not a silent
+// fall-through to the destructive default.
+func TestRunMaintenanceJob_MalformedBodyIsRejected(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	probeAdvertisesTrue.mu.Lock()
+	probeAdvertisesTrue.runs = nil
+	probeAdvertisesTrue.mu.Unlock()
+
+	w := postMaintenanceJob(t, server, probeAdvertisesTrue.ID(), `{"dry_run":`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", w.Code, w.Body.String())
+	}
+
+	// Nothing should have been enqueued. Give a real (if short) window so this
+	// asserts absence rather than merely racing the worker.
+	time.Sleep(500 * time.Millisecond)
+	probeAdvertisesTrue.mu.Lock()
+	n := len(probeAdvertisesTrue.runs)
+	probeAdvertisesTrue.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("job ran %d time(s) despite a 400 response", n)
+	}
+}
+
+// TestRunMaintenanceJob_PersistsResolvedDryRun asserts the value is written
+// where resumeLegacyOp can find it. Without this the resume path has no record
+// of the operator's choice and falls back to a guess.
+func TestRunMaintenanceJob_PersistsResolvedDryRun(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	probeAdvertisesTrue.mu.Lock()
+	probeAdvertisesTrue.runs = nil
+	probeAdvertisesTrue.mu.Unlock()
+
+	w := postMaintenanceJob(t, server, probeAdvertisesTrue.ID(), "")
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body = %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Data struct {
+			OperationID string `json:"operation_id"`
+		} `json:"data"`
+		OperationID string `json:"operation_id"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response %s: %v", w.Body.String(), err)
+	}
+	opID := resp.Data.OperationID
+	if opID == "" {
+		opID = resp.OperationID
+	}
+	if opID == "" {
+		t.Fatalf("no operation_id in response %s", w.Body.String())
+	}
+
+	saved, err := operations.LoadParams[maintenanceJobOpParams](server.Store(), opID)
+	if err != nil {
+		t.Fatalf("LoadParams: %v", err)
+	}
+	if saved == nil {
+		t.Fatal("no params persisted for the operation; a restart would resume on a guess")
+	}
+	if saved.JobID != probeAdvertisesTrue.ID() {
+		t.Errorf("persisted JobID = %q, want %q", saved.JobID, probeAdvertisesTrue.ID())
+	}
+	if !saved.DryRun {
+		t.Error("persisted DryRun = false, want true (the advertised default that was applied)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The restart entry point
+// ---------------------------------------------------------------------------
+
+// TestResumeLegacyOp_MaintenanceJobHonorsSavedDryRun covers the sharper of the
+// two defects: an operator explicitly asked for a PREVIEW, the server restarted
+// mid-run, and the resume re-enqueued with DryRun at Go's zero value — turning
+// the preview into a real mutation under the original operation's own ID.
+func TestResumeLegacyOp_MaintenanceJobHonorsSavedDryRun(t *testing.T) {
+	tests := []struct {
+		name     string
+		job      *dryRunProbeJob
+		savedDry *bool
+		want     bool
+		notes    string
+	}{
+		{
+			name:     "saved dry-run preview resumes as a preview",
+			job:      probeAdvertisesTrue,
+			savedDry: boolPtr(true),
+			want:     true,
+			notes:    "the regression: this used to resume as a real mutation",
+		},
+		{
+			name:     "saved apply resumes as an apply",
+			job:      probeAdvertisesTrue,
+			savedDry: boolPtr(false),
+			want:     false,
+			notes:    "faithful resume, not a blanket fail-safe",
+		},
+		{
+			name:     "no saved params falls back to the advertised default",
+			job:      probeAdvertisesTrue,
+			savedDry: nil,
+			want:     true,
+			notes:    "covers ops enqueued before this shipped",
+		},
+		{
+			name:     "no saved params on a job advertising false stays false",
+			job:      probeAdvertisesFalse,
+			savedDry: nil,
+			want:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server, cleanup := setupTestServer(t)
+			defer cleanup()
+			if server.opRegistry == nil {
+				t.Skip("ops registry not wired in this build")
+			}
+
+			tc.job.mu.Lock()
+			tc.job.runs = nil
+			tc.job.mu.Unlock()
+
+			opID := ulid.Make().String()
+			opType := "maintenance:" + tc.job.ID()
+			if _, err := server.Store().CreateOperation(opID, opType, nil); err != nil {
+				t.Fatalf("CreateOperation: %v", err)
+			}
+			if tc.savedDry != nil {
+				if err := operations.SaveParams(server.Store(), opID, maintenanceJobOpParams{
+					LegacyOpID: opID,
+					JobID:      tc.job.ID(),
+					DryRun:     *tc.savedDry,
+				}); err != nil {
+					t.Fatalf("SaveParams: %v", err)
+				}
+			}
+
+			server.resumeLegacyOp(opID, opType)
+
+			if got := tc.job.awaitRun(t); got != tc.want {
+				t.Fatalf("resumed with dryRun=%v, want %v (%s)", got, tc.want, tc.notes)
+			}
+		})
+	}
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 3.15.0
+// version: 3.16.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-08-13
+// last-edited: 2026-08-14
 
 package server
 
@@ -236,7 +236,43 @@ func (s *Server) resumeLegacyOp(opID, opType string) {
 		jobID := strings.TrimPrefix(opType, "maintenance:")
 		if j, jobErr := maintenance.Get(jobID); jobErr == nil && j.CanResume() {
 			if s.opRegistry != nil {
-				enqParams := maintenanceJobOpParams{LegacyOpID: opID, JobID: jobID}
+				// Resume with the dry_run the operator actually chose.
+				//
+				// database.Operation carries no params field, so this branch used
+				// to have no record of that choice and left DryRun at Go's zero
+				// value — every resume resolved to false. An operator who asked
+				// for a PREVIEW and then hit a restart got a real mutation on the
+				// way back up, under the original operation's own ID. Seven jobs
+				// are both CanResume() and advertise dry_run:true —
+				// bulk-deluge-import, cleanup-empty-folders,
+				// recompute-book-aggregates, refetch-missing-authors,
+				// repair-missing-files, retention-and-hygiene, scan-composer-tags
+				// — and cleanup-empty-folders removes directories from disk.
+				//
+				// runMaintenanceJob now persists the resolved value via
+				// operations.SaveParams, the same way bulk_write_back above does,
+				// so the usual case is an exact resume.
+				//
+				// The fallback covers ops enqueued before this shipped and any
+				// save failure: use what the job ADVERTISES rather than false.
+				// That trades an unrequested mutation for an incomplete one — if
+				// the interrupted run was a real apply, the resumed run previews
+				// and reports what it would have done, and the operator re-runs
+				// it. That direction is recoverable; the other is not.
+				enqParams := maintenanceJobOpParams{
+					LegacyOpID: opID,
+					JobID:      jobID,
+					DryRun:     advertisedDryRunDefault(j),
+				}
+				if saved, perr := operations.LoadParams[maintenanceJobOpParams](store, opID); perr != nil {
+					slog.Warn("Could not load saved params for interrupted maintenance job; resuming with the advertised dry_run default",
+						"opID", opID, "jobID", jobID, "dryRun", enqParams.DryRun, "err", perr)
+				} else if saved != nil {
+					enqParams.DryRun = saved.DryRun
+				} else {
+					slog.Info("No saved params for interrupted maintenance job; resuming with the advertised dry_run default",
+						"opID", opID, "jobID", jobID, "dryRun", enqParams.DryRun)
+				}
 				if _, enqErr := s.opRegistry.EnqueueOp(context.Background(), "maintenance.job", enqParams); enqErr != nil {
 					slog.Warn("Failed to re-enqueue maintenance job () via v2", "opID", opID, "jobID", jobID, "enqErr", enqErr)
 					_ = store.UpdateOperationError(opID, "failed to resume: "+enqErr.Error())

--- a/todo.d/20260814-maintenance-dryrun-followups.md
+++ b/todo.d/20260814-maintenance-dryrun-followups.md
@@ -1,0 +1,42 @@
+- [ ] **Check GitHub CI on the merge commit.** Merged on an explicit instruction
+      to skip the CI *wait*, so no GitHub result was read. Local verification was
+      complete and green: `go build ./...` exit 0, `go vet ./internal/server/...`
+      exit 0, `gofmt` clean, and `go test ./internal/server/...
+      ./internal/maintenance/... ./internal/operations/... -short -race -count=1`
+      → **exit 0, 19/19 packages ok, zero failures** (`internal/server` 898s).
+      Plus four independent mutations each killing a distinct test. Only the
+      GitHub-side result (lint, frontend, changelog-check) is unread.
+
+- [ ] **`opstate:<id>:params` keys are never swept.** `runMaintenanceJob` now
+      persists a small params blob (~90 bytes) per maintenance run so a restart
+      can resume faithfully. `DeleteOperationState` clears both `opstate:<id>`
+      and `opstate:<id>:params`, but only two of the 34 jobs
+      (`recompute-book-aggregates`, `backfill-file-hashes`) call
+      `operations.ClearState` on clean completion — the other 32 leave the key
+      behind forever. There is no retention sweep for the `opstate:` prefix
+      (grep confirms the only writers/deleters are in
+      `internal/database/pebble_store_operations.go`). Growth is small but
+      unbounded; either add an `opstate:` sweep to `retention-and-hygiene` or
+      have `maintenance.job`'s Run clear params when the job finishes.
+
+- [ ] **Verify the dry-run default on prod after deploy.** `GET
+      /api/v1/maintenance/jobs` publishes `default_params`; POST a job that
+      advertises `dry_run:true` with no body and confirm the run reports a
+      preview rather than applying. Safest probe: `scan-composer-tags` (scan
+      only). Do **not** probe with `cleanup-series` or `cleanup-empty-folders`.
+
+- [ ] **`dedup.series-dedup` still has no dry-run parameter at all.**
+      `internal/dedup/series_dedup.go:266` `DedupSeries` applies on every
+      invocation, and its merge loop reassigns books via the *listing* getter
+      `GetBooksBySeriesIDCore` (which filters trashed and non-primary rows)
+      before calling `DeleteSeries` unconditionally — the mechanism that strands
+      books on a deleted series ID. It has never run in production (0 of 10,161
+      operations), so there is no existing damage; it is a latent hazard only.
+      Give it a dry-run parameter and switch it to the all-versions getter
+      before anything wires it to a trigger.
+
+- [ ] **Consider making the resume path's fallback observable.** When no saved
+      params exist, `resumeLegacyOp` now logs at info and resumes with the
+      advertised default. Once the pre-change operations have aged out, that log
+      line firing at all means something failed to save — worth a metric rather
+      than a log grep.


### PR DESCRIPTION
Two entry points started maintenance jobs with `DryRun` at its zero value — `false`, the destructive branch — while the API told clients the opposite.

## 1. HTTP: absent body applied instead of previewing

`listMaintenanceJobs` publishes each job's `DefaultParams()` as `default_params`, and **18 of the 34 registered jobs advertise `{"dry_run": true}`**. `runMaintenanceJob` bound the body into `struct{ DryRun bool }` and, on an absent body (`io.EOF`), proceeded with `false`. A client that read the catalogue and POSTed without a body got the exact opposite of what it had just been told, behind a byte-identical `202`.

`DryRun` is now `*bool` so omission is representable, and omission resolves to `advertisedDryRunDefault(job)`.

`cleanup-series` is the sharp case: phase 1 deletes every series holding exactly one book, and a census on 2026-08-14 found **2,322 of 6,245 single-book series are genuinely distinct real series**. Series names are not recoverable once deleted — not on the book row, not in `operation_changes`, not in file paths.

## 2. Restart: an interrupted preview resumed as a real mutation

`resumeLegacyOp` re-enqueued interrupted jobs as `maintenanceJobOpParams{LegacyOpID, JobID}` — `DryRun` zero-valued again. `database.Operation` has no params field, so the operator's choice was recorded nowhere: an explicit **preview** came back as a real mutation under the original operation's own ID. **Seven jobs are both `CanResume()` and advertise `dry_run:true`**, and `cleanup-empty-folders` removes directories from disk.

`runMaintenanceJob` now persists the resolved value via `operations.SaveParams` (mirroring the `bulk_write_back` case in the same switch) and `resumeLegacyOp` reads it back, falling back to the advertised default only for ops enqueued before this shipped.

Verified the read can see the write: `maintenance:<jobID>` is not a v2 registry def, so `resumeV2Op`'s `ResumeDrop` → `ClearState` never fires on these rows; the only other `DeleteOperationState` callers are two jobs clearing on clean completion.

## Blast radius

The 16 jobs advertising `dry_run:false` are unaffected. An explicit `"dry_run": false` still applies — callers that mean it say so. The change is fail-safe in one direction only.

## Tests

The primary test is a **conformance test over `maintenance.All()`**: it derives the expectation from the same bytes `listMaintenanceJobs` serves and requires the reader to reproduce it, so job #35 cannot drift. It also fails a job that publishes its default under an untagged `DryRun` key — the casing mistake that would recreate this bug while looking correct.

Four independent mutations, each compiling, each killing a distinct test:

| Mutation | Went red |
|---|---|
| handler → `dryRun := false` | `ResolvesDryRun` (absent-body, `{}`) + `PersistsResolvedDryRun` |
| drop `SaveParams` | `PersistsResolvedDryRun` |
| drop `LoadParams` on resume | `ResumeLegacyOp/saved_apply_resumes_as_an_apply` |
| reader → always false | `AgreesWithEveryRegisteredJob` (18 real jobs + 1 probe) |

The 18-of-34 figure is confirmed twice independently: the production `/api/v1/maintenance/jobs` catalogue, and the m4 mutation's failing subtest list.

Local gate: `go build ./...` exit 0, `go vet` exit 0, `gofmt` clean, and `go test ./internal/server/... ./internal/maintenance/... ./internal/operations/... -short -race -count=1` → **exit 0, 19/19 packages ok, zero failures**.

## Known gap (filed in `todo.d/`)

`opstate:<id>:params` is now written per run, and only two of the 34 jobs call `ClearState` on completion. There is no retention sweep for the `opstate:` prefix, so this grows slowly and without bound (~90 bytes/run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp