### PR TITLE
fix(abs): add the two OpenID routes to absRouteList (N-8)

### DIFF
--- a/changelog.d/20260814_134500_abs_routelist_openid.md
+++ b/changelog.d/20260814_134500_abs_routelist_openid.md
@@ -1,0 +1,9 @@
+### Fixed
+
+#### `absRouteList()` now includes the two OpenID routes
+
+The hand-maintained ABS route list was missing `GET /auth/openid` and
+`GET /auth/openid/callback` from their introduction (the N-8 audit finding,
+made precise by the 2026-08-14 `router.Routes()` dump: 47 listed vs 49 real).
+The list feeds the startup route log and the reserved-path guard tests, so the
+OpenID surface was invisible to both. A membership test now pins the entries.

--- a/internal/server/wire_abs_routes.go
+++ b/internal/server/wire_abs_routes.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_abs_routes.go
-// version: 1.11.0
+// version: 1.12.0
 // guid: 9c6b13f8-40a2-4e57-b18d-72e0a5c4d396
-// last-edited: 2026-08-13
+// last-edited: 2026-08-14
 
 package server
 
@@ -523,6 +523,14 @@ func absRouteList() []string {
 		"GET /status",
 		"POST /login",
 		"POST /auth/refresh",
+		// OpenID web-flow endpoints (Handler.Register :380-381). Absent from this
+		// list from their introduction until 2026-08-14, which made the list's
+		// "every registered route" claim false — the N-8 audit finding, confirmed
+		// against a runtime router.Routes() dump (47 listed vs 49 real; see
+		// docs/reference/abs-implementation-status.md). Root paths, so the /api
+		// reserved-path guard ignores them by design.
+		"GET /auth/openid",
+		"GET /auth/openid/callback",
 		"POST /logout",
 		"POST /api/authorize",
 		"GET /api/me",

--- a/internal/server/wire_abs_routes_test.go
+++ b/internal/server/wire_abs_routes_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_abs_routes_test.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: 3ea1d764-95c8-4b02-8f31-6d70a5be2c49
-// last-edited: 2026-08-13
+// last-edited: 2026-08-14
 
 package server
 
@@ -596,5 +596,27 @@ func TestAbsCollisionDetailReserved_BothNarrowingRules(t *testing.T) {
 			got := absCollisionDetailReserved(tc.method, tc.path)
 			require.Equal(t, tc.want, got, "%s %s — %s", tc.method, tc.path, tc.why)
 		})
+	}
+}
+
+// TestABSRouteListIncludesOpenIDRoutes pins the 2026-08-14 N-8 fix: the two OpenID
+// web-flow routes are registered by Handler.Register but were absent from
+// absRouteList(), making its "every registered route" claim false. A full
+// list-vs-router completeness test needs the abs handler harness (different
+// package); until that exists, membership here at least makes silent removal fail
+// with a name.
+func TestABSRouteListIncludesOpenIDRoutes(t *testing.T) {
+	want := []string{"GET /auth/openid", "GET /auth/openid/callback"}
+	for _, w := range want {
+		found := false
+		for _, entry := range absRouteList() {
+			if entry == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("absRouteList() is missing %q — the registered OpenID surface would again be invisible to the guard tests and the startup route log", w)
+		}
 	}
 }


### PR DESCRIPTION
Closes gap 5 of `docs/reference/abs-implementation-status.md` (PR #2421): the hand-maintained list was missing exactly `GET /auth/openid` + `GET /auth/openid/callback` — confirmed against a runtime `router.Routes()` dump (47 vs 49). The list feeds the startup route log and the guard tests walk it, so the OpenID surface was invisible to both.

Verification: new `TestABSRouteListIncludesOpenIDRoutes` watched RED with an entry removed (fails naming the route), green restored; full `TestABSRouteList*|TestABSReservedPath*` suite green; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS