### PR TITLE
fix(search): fuzzy queries are case-insensitive (both call sites)

### DIFF
--- a/changelog.d/20260814_135500_search_fuzzy_case.md
+++ b/changelog.d/20260814_135500_search_fuzzy_case.md
@@ -1,0 +1,10 @@
+### Fixed
+
+#### Fuzzy search (`~`) is case-insensitive again
+
+`FuzzyQuery` bypasses the field analyser exactly as the wildcard/prefix
+queries fixed on 2026-08-13 do, so a capitalised fuzzy term could never come
+within edit distance of the lowercased index terms — `HYPERION~` found
+nothing while `hyperion~` matched. Both construction sites (fielded and
+free-text; the fragment named only one) now route through `patternTerm`.
+Each site is pinned by its own mutation-verified subtest.

--- a/internal/search/bleve_translator.go
+++ b/internal/search/bleve_translator.go
@@ -1,7 +1,7 @@
 // file: internal/search/bleve_translator.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 9c2a4f1d-5b3e-4f70-a7d6-2e8c0f1b9a47
-// last-edited: 2026-08-13
+// last-edited: 2026-08-14
 //
 // AST → Bleve query translator (spec DES-1 v1.1). Walks the AST
 // produced by ParseQuery and emits a bleve/v2 query.Query suitable
@@ -247,7 +247,10 @@ func translateField(n *FieldNode, perUser *[]PerUserFilter, negated bool) (query
 
 	// Fuzzy / prefix / wildcard — take precedence over default match.
 	if n.Fuzzy {
-		fq := bleve.NewFuzzyQuery(n.Value)
+		// FuzzyQuery bypasses the field analyser exactly as PrefixQuery and
+		// WildcardQuery do (see patternTerm), so an uppercase term could never
+		// come within edit distance of the lowercased stored terms.
+		fq := bleve.NewFuzzyQuery(patternTerm(n.Value))
 		fq.SetField(n.Field)
 		if n.Boost > 0 {
 			fq.SetBoost(n.Boost)
@@ -343,7 +346,9 @@ func translateFreeText(n *FreeTextNode) query.Query {
 		return bleve.NewPrefixQuery(patternTerm(n.Value))
 	}
 	if n.Fuzzy {
-		return bleve.NewFuzzyQuery(n.Value)
+		// Same analyser bypass as the fielded branch above; the 2026-08-13
+		// fragment named one call site — there are two.
+		return bleve.NewFuzzyQuery(patternTerm(n.Value))
 	}
 	if n.Quoted {
 		return bleve.NewMatchPhraseQuery(n.Value)

--- a/internal/search/zz_repro_wildcard_phrase_test.go
+++ b/internal/search/zz_repro_wildcard_phrase_test.go
@@ -1,7 +1,7 @@
 // file: internal/search/zz_repro_wildcard_phrase_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 8c4d1f06-2b93-4a57-91e8-73f5a0c6d284
-// last-edited: 2026-08-13
+// last-edited: 2026-08-14
 
 package search
 
@@ -253,4 +253,34 @@ func contains(hay []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+// TestFuzzyIsCaseInsensitive pins the fuzzy sibling of defect 1, filed
+// 2026-08-13 and fixed 2026-08-14: FuzzyQuery bypasses the field analyser
+// exactly as PrefixQuery/WildcardQuery do, so a capitalised term could never
+// come within edit distance of the lowercased stored terms. There are TWO
+// construction sites (fielded and free-text); both are covered because the
+// parser routes a bare `term~` through the free-text branch and
+// `title:term~` through the fielded one.
+func TestFuzzyIsCaseInsensitive(t *testing.T) {
+	idx := wildcardPhraseCorpus(t)
+
+	for _, q := range []string{
+		"hyperion~", "Hyperion~", "HYPERION~", // free-text branch
+		"title:Hyperion~", "title:HYPERION~", // fielded branch
+		"Hyperio~", // one edit away AND mis-cased: needs the lowercase to even enter the automaton
+	} {
+		t.Run(q, func(t *testing.T) {
+			got := runQuery(t, idx, q)
+			if !contains(got, "hyperion") {
+				t.Errorf("%q did not find hyperion: got %v — a fuzzy term must be "+
+					"lowercased before matching the analysed index terms", q, got)
+			}
+			for _, bad := range []string{"sidejobs", "icarus"} {
+				if contains(got, bad) {
+					t.Errorf("IMPRECISE: %q matched unrelated %q: got %v", q, bad, got)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
C710 from the 2026-08-14 task breakdown (fragment `20260813-search-stopwords-and-fuzzy-case.md`). The fragment said "the fix is the same one-line patternTerm() call" — there are TWO NewFuzzyQuery sites (fielded `:250`, free-text `:346`); both fixed.

Verification: new `TestFuzzyIsCaseInsensitive` (6 subtests incl. a distance-1 typo and both parser branches); mutation 1 (revert fielded) kills `title:HYPERION~`, mutation 2 (revert free-text) kills `HYPERION~`+`Hyperio~`; restored → full `internal/search` green. gofmt clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS