### PR TITLE
fix(api): exact soft-deleted total via a real count, error surfaced

### DIFF
--- a/changelog.d/20260814_141500_soft_deleted_count.md
+++ b/changelog.d/20260814_141500_soft_deleted_count.md
@@ -1,0 +1,12 @@
+### Fixed
+
+#### The soft-deleted total is exact, and a failed count is an error
+
+`GET /audiobooks/soft-deleted` computed its `total` by fetching up to 10,000
+rows and taking `len()` — silently wrong above 10,000, a 10,000-row read per
+call, and a discarded error that reported `total: 0`, indistinguishable from
+an empty trash. A new `CountSoftDeletedBooks` store capability (memdb index
+walk / Pebble scan, conformance-tested on both dispatch paths with a
+non-vacuous `olderThan` fixture) feeds the handler, which now surfaces count
+errors as 500s. The service falls back to paging the listing to exhaustion
+for stores without the capability, so no caller can reintroduce a cap.

--- a/internal/audiobooks/service_single.go
+++ b/internal/audiobooks/service_single.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_single.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: d6a0e5f4-a7b8-9c01-bd2e-3f4a5b6c7d8e
-// last-edited: 2026-07-07
+// last-edited: 2026-08-14
 
 package audiobooks
 
@@ -321,6 +321,41 @@ func (svc *AudiobookService) GetSoftDeletedBooks(ctx context.Context, limit int,
 	}
 
 	return books, nil
+}
+
+// CountSoftDeletedBooks reports the EXACT size of the soft-deleted set. It
+// exists because the only prior way to get a total was fetch-with-limit-10000
+// and len(), which silently saturates above the guess and reads 10,000 rows to
+// produce one integer — while a failed fetch reported total 0, which is the
+// alarming direction to be wrong in (an empty trash and a broken count look
+// identical). Callers must propagate the error, never default it to zero.
+func (svc *AudiobookService) CountSoftDeletedBooks(ctx context.Context, olderThanDays *int) (int, error) {
+	if svc.store == nil {
+		return 0, fmt.Errorf("database not initialized")
+	}
+	var cutoff *time.Time
+	if olderThanDays != nil && *olderThanDays > 0 {
+		ts := time.Now().AddDate(0, 0, -*olderThanDays)
+		cutoff = &ts
+	}
+	if cs := database.AsSoftDeletedCountStore(svc.store); cs != nil {
+		return cs.CountSoftDeletedBooks(cutoff)
+	}
+	// Fallback for stores without the counting capability (mocks, mostly):
+	// page the listing to exhaustion rather than guessing a single big limit —
+	// a bounded guess is exactly the saturation bug this method replaces.
+	total := 0
+	const page = 1000
+	for offset := 0; ; offset += page {
+		books, err := svc.store.ListSoftDeletedBooks(page, offset, cutoff)
+		if err != nil {
+			return 0, err
+		}
+		total += len(books)
+		if len(books) < page {
+			return total, nil
+		}
+	}
 }
 
 // PurgeSoftDeletedBooks permanently deletes soft-deleted audiobooks

--- a/internal/database/book_visibility_conformance_test.go
+++ b/internal/database/book_visibility_conformance_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/book_visibility_conformance_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: e398a03c-a0e4-4e64-8da3-3beac8e0ff6b
 // last-edited: 2026-08-14
 
@@ -8,6 +8,7 @@ package database
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -424,4 +425,80 @@ func TestListSoftDeletedBooks_MemDBAndPebbleAgree(t *testing.T) {
 
 	require.ElementsMatch(t, got[true], got[false],
 		"memdb and Pebble implementations of ListSoftDeletedBooks disagree")
+}
+
+// TestCountSoftDeletedBooks_MemDBAndPebbleAgree pins the counting capability
+// added 2026-08-14 to the same fixture and dual-dispatch contract as the
+// listing above: the count must equal the size of the set the listing returns
+// on BOTH paths, or the trash page's "total" disagrees with its own rows.
+func TestCountSoftDeletedBooks_MemDBAndPebbleAgree(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	fx := buildSoftDelConformanceFixture(t, store)
+
+	p, ok := store.(*PebbleStore)
+	require.True(t, ok, "expected *PebbleStore from setupPebbleTestDB")
+	p.WaitForWarmup()
+	require.True(t, p.IsMemReady(), "memdb must be published for the flag flip to select two paths")
+	require.NotEmpty(t, fx.deletedIDs, "fixture must contain soft-deleted books")
+
+	cs := AsSoftDeletedCountStore(store)
+	require.NotNil(t, cs, "PebbleStore must provide the soft-deleted counting capability")
+
+	// The shared fixture's deletions carry NO MarkedForDeletionAt, so an
+	// olderThan assertion against it alone is VACUOUS — the filter would
+	// exclude nothing and a count that ignored the cutoff would still pass
+	// (caught by mutation on 2026-08-14). Add two TIMESTAMPED deletions
+	// straddling a cutoff so the filter provably excludes something.
+	yes := true
+	oldTS := time.Now().AddDate(0, 0, -30)
+	newTS := time.Now()
+	cutoff := time.Now().AddDate(0, 0, -7)
+	for _, d := range []struct {
+		title string
+		ts    time.Time
+	}{{"Trashed Old", oldTS}, {"Trashed Fresh", newTS}} {
+		created, err := store.CreateBook(&Book{Title: d.title, FilePath: "/lib/" + d.title})
+		require.NoError(t, err)
+		created.MarkedForDeletion = &yes
+		ts := d.ts
+		created.MarkedForDeletionAt = &ts
+		_, err = store.UpdateBook(created.ID, created)
+		require.NoError(t, err)
+	}
+	totalDeleted := len(fx.deletedIDs) + 2
+
+	got := map[bool]int{}
+	for _, useMemDB := range []bool{true, false} {
+		p.UseMemDB = useMemDB
+		label := "PebbleScanPath"
+		if useMemDB {
+			label = "MemDBPath"
+		}
+		t.Run(label, func(t *testing.T) {
+			n, err := cs.CountSoftDeletedBooks(nil)
+			require.NoError(t, err)
+			require.Equal(t, totalDeleted, n,
+				"count must equal the size of the soft-deleted set the listing returns")
+			got[useMemDB] = n
+
+			// olderThan semantics must match the listing ON THIS PATH — a
+			// post-loop check would only ever exercise the memdb branch.
+			nFiltered, err := cs.CountSoftDeletedBooks(&cutoff)
+			require.NoError(t, err)
+			listed, err := store.ListSoftDeletedBooks(0, 0, &cutoff)
+			require.NoError(t, err)
+			require.Equal(t, len(listed), nFiltered,
+				"filtered count must equal the filtered listing's size on the same dispatch path")
+			// Non-vacuity guard: the cutoff must exclude the fresh deletion,
+			// or the olderThan assertion above is testing nothing — exactly
+			// the trap the timestamp-less shared fixture posed.
+			require.Less(t, nFiltered, n,
+				"the cutoff must exclude at least one timestamped deletion")
+		})
+	}
+	p.UseMemDB = true
+	require.Equal(t, got[true], got[false],
+		"memdb and Pebble implementations of CountSoftDeletedBooks disagree")
 }

--- a/internal/database/soft_deleted_count.go
+++ b/internal/database/soft_deleted_count.go
@@ -1,0 +1,99 @@
+// file: internal/database/soft_deleted_count.go
+// version: 1.0.0
+// guid: 7e50b3c8-1a92-4d67-8f24-c65e09a1d3b7
+// last-edited: 2026-08-14
+
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// SoftDeletedCountStore is the optional capability of counting the soft-deleted
+// set without materializing it. It exists because the ONLY prior way to answer
+// "how many books are in the trash" was ListSoftDeletedBooks with a large
+// limit and len() on the result — which silently saturates at whatever limit
+// the caller guessed (10,000 in the one production caller) and pays a full
+// materialization for a number. Obtained by assertion rather than widening the
+// Store interface, per the repo convention for new capabilities.
+type SoftDeletedCountStore interface {
+	// CountSoftDeletedBooks reports how many books are soft-deleted, honouring
+	// the same olderThan semantics as ListSoftDeletedBooks: when olderThan is
+	// non-nil, a book is counted unless its MarkedForDeletionAt is set AND
+	// after the cutoff (a nil timestamp is counted — identical to the listing,
+	// so the count can never disagree with the list it paginates).
+	CountSoftDeletedBooks(olderThan *time.Time) (int, error)
+}
+
+// AsSoftDeletedCountStore returns the counting capability, or nil when the
+// store does not have it.
+func AsSoftDeletedCountStore(s any) SoftDeletedCountStore {
+	if cs, ok := s.(SoftDeletedCountStore); ok {
+		return cs
+	}
+	return nil
+}
+
+// CountSoftDeletedBooks counts via the marked_for_deletion index, so cost is
+// O(deleted_count) with no Book copies at all.
+func (m *MemStore) CountSoftDeletedBooks(olderThan *time.Time) (int, error) {
+	txn := m.db.Txn(false)
+	defer txn.Abort()
+
+	iter, err := txn.Get(memTableBooks, memIdxMarkedForDeletion, true)
+	if err != nil {
+		return 0, fmt.Errorf("memdb soft-deleted count: %w", err)
+	}
+	n := 0
+	for obj := iter.Next(); obj != nil; obj = iter.Next() {
+		b := obj.(*Book)
+		if olderThan != nil && b.MarkedForDeletionAt != nil && b.MarkedForDeletionAt.After(*olderThan) {
+			continue
+		}
+		n++
+	}
+	return n, nil
+}
+
+// CountSoftDeletedBooks mirrors ListSoftDeletedBooks' dual dispatch: the memdb
+// index path when available, else a Pebble scan that unmarshals each row only
+// to read its deletion flag — no slice, no sort, no pagination.
+func (p *PebbleStore) CountSoftDeletedBooks(olderThan *time.Time) (int, error) {
+	if p.UseMemDB && p.mem() != nil {
+		return p.mem().CountSoftDeletedBooks(olderThan)
+	}
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book:0"),
+		UpperBound: []byte("book:;"),
+	})
+	if err != nil {
+		return 0, err
+	}
+	defer iter.Close()
+
+	n := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := string(iter.Key())
+		if strings.Contains(key, ":path:") || strings.Contains(key, ":series:") ||
+			strings.Contains(key, ":author:") || strings.Contains(key, ":version:") {
+			continue
+		}
+		var book Book
+		if err := json.Unmarshal(iter.Value(), &book); err != nil {
+			return 0, err
+		}
+		if book.MarkedForDeletion == nil || !*book.MarkedForDeletion {
+			continue
+		}
+		if olderThan != nil && book.MarkedForDeletionAt != nil && book.MarkedForDeletionAt.After(*olderThan) {
+			continue
+		}
+		n++
+	}
+	return n, nil
+}

--- a/internal/server/handlers/audiobooks/handler.go
+++ b/internal/server/handlers/audiobooks/handler.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/audiobooks/handler.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 51fac747-9478-4075-8621-9da4bbdedc37
 // last-edited: 2026-08-14
 
@@ -640,9 +640,14 @@ func (h *Handler) ListSoftDeletedAudiobooks(c *gin.Context) {
 		return
 	}
 
-	// Get total count (unpaginated) for proper pagination support
-	allBooks, _ := h.audiobookService.GetSoftDeletedBooks(c.Request.Context(), 10000, 0, olderThanDays)
-	total := len(allBooks)
+	// Exact total for pagination. This replaced a fetch-of-10,000-and-len()
+	// whose count silently saturated at 10,000 AND whose error was discarded —
+	// a failed count reported total 0, indistinguishable from an empty trash.
+	total, err := h.audiobookService.CountSoftDeletedBooks(c.Request.Context(), olderThanDays)
+	if err != nil {
+		httputil.InternalError(c, "failed to count deleted audiobooks", err)
+		return
+	}
 
 	httputil.RespondWithOK(c, gin.H{
 		"items":  books,

--- a/internal/server/handlers/audiobooks/handler_test.go
+++ b/internal/server/handlers/audiobooks/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler_test.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 5cd764d5-8036-425c-842e-c49d0d44acec
-// last-edited: 2026-07-11
+// last-edited: 2026-08-14
 
 // Tests for the audiobooks-domain handlers (main library list / CRUD). The
 // store / audiobook-service / updater / write-back / metadata-state /
@@ -296,10 +296,46 @@ func TestListSoftDeletedAudiobooks(t *testing.T) {
 	h, d := newHandler(t)
 	d.svc.EXPECT().GetSoftDeletedBooks(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]database.Book{{ID: "b1"}}, nil)
+	// 12,345 is deliberately above the old fetch-and-len path's 10,000 cap AND
+	// unequal to len(items): the assertion below fails if total ever again
+	// derives from the fetched page or a capped refetch.
+	d.svc.EXPECT().CountSoftDeletedBooks(mock.Anything, mock.Anything).Return(12345, nil)
 	c, w := newCtx("GET", "/audiobooks/soft-deleted", nil, nil)
 	h.ListSoftDeletedAudiobooks(c)
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", w.Code)
+	}
+	var body struct {
+		Data struct {
+			Total int `json:"total"`
+			Count int `json:"count"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Data.Total != 12345 {
+		t.Fatalf("total must come from the count capability (want 12345), got %d", body.Data.Total)
+	}
+	if body.Data.Count != 1 {
+		t.Fatalf("count must be the page size, got %d", body.Data.Count)
+	}
+}
+
+// TestListSoftDeletedAudiobooks_CountErrorIs500 pins the error propagation:
+// the pre-2026-08-14 code discarded the count error into `_` and reported
+// total 0 — indistinguishable from an empty trash, the alarming direction to
+// be wrong in. A failed count must be a failed request.
+func TestListSoftDeletedAudiobooks_CountErrorIs500(t *testing.T) {
+	h, d := newHandler(t)
+	d.svc.EXPECT().GetSoftDeletedBooks(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]database.Book{{ID: "b1"}}, nil)
+	d.svc.EXPECT().CountSoftDeletedBooks(mock.Anything, mock.Anything).
+		Return(0, errString("pebble iterator failed"))
+	c, w := newCtx("GET", "/audiobooks/soft-deleted", nil, nil)
+	h.ListSoftDeletedAudiobooks(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("a failed count must 500, not report total 0; got %d", w.Code)
 	}
 }
 

--- a/internal/server/handlers/audiobooks/interfaces.go
+++ b/internal/server/handlers/audiobooks/interfaces.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/interfaces.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 110386de-3e07-4ef3-b0e0-2e717a249e91
-// last-edited: 2026-07-05
+// last-edited: 2026-08-14
 
 // Narrow dependency interfaces for the audiobooks-domain HTTP handlers (the
 // main library list / CRUD domain: list, count, facets, soft-delete /
@@ -90,6 +90,10 @@ type AudiobookService interface {
 	GetAudiobook(ctx context.Context, id string) (*database.Book, error)
 	GetAudiobookTags(ctx context.Context, id, compareID, snapshotTS string) (map[string]any, error)
 	GetSoftDeletedBooks(ctx context.Context, limit, offset int, olderThanDays *int) ([]database.Book, error)
+	// CountSoftDeletedBooks is the exact trash size. It replaced a
+	// fetch-10,000-and-len() whose count saturated and whose error was
+	// swallowed into total:0 — callers must surface the error, never zero it.
+	CountSoftDeletedBooks(ctx context.Context, olderThanDays *int) (int, error)
 	PurgeSoftDeletedBooks(ctx context.Context, deleteFiles bool, olderThanDays *int) (*audiobookspkg.PurgeResult, error)
 	RestoreAudiobook(ctx context.Context, id string) (*database.Book, error)
 	CountAudiobooks(ctx context.Context) (int, error)

--- a/internal/server/handlers/audiobooks/mocks/mock_audiobook_service.go
+++ b/internal/server/handlers/audiobooks/mocks/mock_audiobook_service.go
@@ -171,6 +171,72 @@ func (_c *MockAudiobookService_CountAudiobooks_Call) RunAndReturn(run func(ctx c
 	return _c
 }
 
+// CountSoftDeletedBooks provides a mock function for the type MockAudiobookService
+func (_mock *MockAudiobookService) CountSoftDeletedBooks(ctx context.Context, olderThanDays *int) (int, error) {
+	ret := _mock.Called(ctx, olderThanDays)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountSoftDeletedBooks")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *int) (int, error)); ok {
+		return returnFunc(ctx, olderThanDays)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *int) int); ok {
+		r0 = returnFunc(ctx, olderThanDays)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *int) error); ok {
+		r1 = returnFunc(ctx, olderThanDays)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockAudiobookService_CountSoftDeletedBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountSoftDeletedBooks'
+type MockAudiobookService_CountSoftDeletedBooks_Call struct {
+	*mock.Call
+}
+
+// CountSoftDeletedBooks is a helper method to define mock.On call
+//   - ctx context.Context
+//   - olderThanDays *int
+func (_e *MockAudiobookService_Expecter) CountSoftDeletedBooks(ctx any, olderThanDays any) *MockAudiobookService_CountSoftDeletedBooks_Call {
+	return &MockAudiobookService_CountSoftDeletedBooks_Call{Call: _e.mock.On("CountSoftDeletedBooks", ctx, olderThanDays)}
+}
+
+func (_c *MockAudiobookService_CountSoftDeletedBooks_Call) Run(run func(ctx context.Context, olderThanDays *int)) *MockAudiobookService_CountSoftDeletedBooks_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *int
+		if args[1] != nil {
+			arg1 = args[1].(*int)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockAudiobookService_CountSoftDeletedBooks_Call) Return(n int, err error) *MockAudiobookService_CountSoftDeletedBooks_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockAudiobookService_CountSoftDeletedBooks_Call) RunAndReturn(run func(ctx context.Context, olderThanDays *int) (int, error)) *MockAudiobookService_CountSoftDeletedBooks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteAudiobook provides a mock function for the type MockAudiobookService
 func (_mock *MockAudiobookService) DeleteAudiobook(ctx context.Context, id string, opts *audiobooks.DeleteAudiobookOptions) (map[string]any, error) {
 	ret := _mock.Called(ctx, id, opts)


### PR DESCRIPTION
C814 from the 2026-08-14 task breakdown (fragment `20260811-soft-deleted-total-capped-at-10000.md`).

**Before:** `GET /audiobooks/soft-deleted` fetched up to 10,000 rows and took `len()` — total silently wrong above 10,000, a 10,000-row read on every call, and the second fetch's error discarded into `total: 0` (indistinguishable from an empty trash — the alarming direction).

**After:** `CountSoftDeletedBooks` store capability (capability-assertion pattern, no Store-interface widening): memdb `marked_for_deletion` index walk / Pebble scan mirroring the listing's dual dispatch + `olderThan` semantics exactly. Handler surfaces count errors as 500; service falls back to paging the listing to exhaustion for stores without the capability (no cap can return).

**Verification** — every check watched red:
- Dual-path conformance test in the existing `book_visibility_conformance_test.go` harness, with **timestamped deletions added** because the shared fixture's are timestamp-less and made the `olderThan` assertion vacuous (caught live by mutation: the first Pebble olderThan-drop mutant PASSED until the fixture gained a straddling cutoff + a non-vacuity `require.Less`).
- Mutations: Pebble olderThan-drop → `PebbleScanPath` fails; memdb filter-neutralized → `MemDBPath` fails; a compile-failing mutant was rejected as evidence and redone.
- Handler tests: total must equal the mocked 12,345 (> the old cap, ≠ len(items)); count error → 500 (the old code answered 200/total:0).
- `make`-level: build/vet/gofmt clean on touched files; full `handlers/audiobooks`, `internal/audiobooks`, count+list conformance green. Mocks regenerated via `make mocks` (mockery v3.7.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS