### PR TITLE
fix(database): DeleteBookFilesForBook syncs memdb (stale-row divergence)

### DIFF
--- a/changelog.d/20260814_150000_deletebookfilesforbook_memdb.md
+++ b/changelog.d/20260814_150000_deletebookfilesforbook_memdb.md
@@ -1,0 +1,14 @@
+### Fixed
+
+#### `DeleteBookFilesForBook` no longer leaves stale memdb rows
+
+The method deleted the Pebble rows and their indexes but never told memdb, so
+memdb-backed reads (`total_file_count` among them) kept serving the deleted
+files until a restart — invisible whenever the aggregate recompute happened to
+resync the book as a side effect, and biting exactly when aggregates were
+unchanged (the early-return path the 2026-08-03 canary hit). It now mirrors
+`DeleteBookFilesByIDs`' derived-state pass: memdb delete + quick-query dirty
+mark. The regression test reads through the memdb-dispatched getter with a
+zero-aggregate fixture — both choices mutation-forced: the obvious
+instrument (`GetBookFiles`) and a non-zero fixture each let the unfixed code
+pass.

--- a/internal/database/delete_book_files_for_book_memdb_test.go
+++ b/internal/database/delete_book_files_for_book_memdb_test.go
@@ -1,0 +1,73 @@
+// file: internal/database/delete_book_files_for_book_memdb_test.go
+// version: 1.0.0
+// guid: 2b81f6d4-9e07-4a53-b2c9-e15a08d47f36
+// last-edited: 2026-08-14
+
+package database
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeleteBookFilesForBook_RemovesMemdbRows pins the 2026-08-14 fix: the
+// method deleted the Pebble rows and their indexes but never told memdb, so
+// every memdb-backed read kept serving the deleted files until a restart.
+// The assertion reads back through the MEMDB dispatch path specifically —
+// a Pebble-path read passes with or without the fix and proves nothing.
+func TestDeleteBookFilesForBook_RemovesMemdbRows(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	p, ok := store.(*PebbleStore)
+	require.True(t, ok, "expected *PebbleStore from setupPebbleTestDB")
+	// Writes during warmup are buffered; wait so the create/delete below are
+	// applied live and the memdb read path is actually selectable.
+	p.WaitForWarmup()
+	require.True(t, p.IsMemReady(), "memdb must be published so the read below takes the memdb path")
+	p.UseMemDB = true
+
+	book, err := store.CreateBook(&Book{Title: "Doomed Files", FilePath: "/lib/doomed"})
+	require.NoError(t, err)
+	// ZERO duration/size on purpose. With non-zero aggregates the delete's
+	// notifyBookFileChange -> RecomputeBookAggregates -> UpdateBook chain
+	// resyncs the book's memdb file set from Pebble as a SIDE EFFECT, healing
+	// the divergence and letting a missing memdb delete pass (verified by
+	// mutation: with Duration:100 the unfixed code was green). When the
+	// aggregates do not change, RecomputeBookAggregates early-returns without
+	// UpdateBook (pebble_store_book_aggregates.go:131), no resync happens, and
+	// the missing memdb delete is observable — the only path where it bites,
+	// and exactly the shape the 2026-08-04 canary hit in production.
+	for i := 0; i < 3; i++ {
+		require.NoError(t, store.CreateBookFile(&BookFile{
+			BookID:   book.ID,
+			FilePath: fmt.Sprintf("/lib/doomed/part-%d.mp3", i),
+			Duration: 0,
+		}))
+	}
+
+	// GetBookFilesForIDsCore is the instrument, NOT GetBookFiles:
+	// GetBookFiles reads Pebble unconditionally, so it passes with or without
+	// the memdb delete and can prove nothing (verified — the first version of
+	// this test used it and the mutant survived). GetBookFilesForIDsCore
+	// dispatches to memdb when warm, and it is what feeds total_file_count —
+	// the exact read the 2026-08-03 production canary saw stay stale.
+	before, err := p.GetBookFilesForIDsCore([]string{book.ID})
+	require.NoError(t, err)
+	require.Len(t, before[book.ID], 3, "fixture: three files must be visible on the memdb path before the delete")
+
+	require.NoError(t, store.DeleteBookFilesForBook(book.ID))
+
+	// Memdb path — the one that stayed stale before the fix.
+	after, err := p.GetBookFilesForIDsCore([]string{book.ID})
+	require.NoError(t, err)
+	require.Empty(t, after[book.ID],
+		"memdb still serves book_file rows that DeleteBookFilesForBook removed from Pebble — the memdb delete is missing")
+
+	// And the Pebble rows are genuinely gone, so the two reads agree.
+	afterPebble, err := store.GetBookFiles(book.ID)
+	require.NoError(t, err)
+	require.Empty(t, afterPebble, "pebble rows must be gone after the delete")
+}

--- a/internal/database/pebble_store_bookfiles.go
+++ b/internal/database/pebble_store_bookfiles.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_bookfiles.go
-// version: 1.12.0
+// version: 1.13.0
 // guid: bee03868-fbc4-48b0-9c9a-11180e19779e
-// last-edited: 2026-08-13
+// last-edited: 2026-08-14
 
 package database
 
@@ -900,7 +900,20 @@ func (s *PebbleStore) DeleteBookFilesForBook(bookID string) error {
 	if err := batch.Commit(pebble.Sync); err != nil {
 		return err
 	}
+	// Derived state, mirroring DeleteBookFilesByIDs' pass 3 exactly. Until
+	// 2026-08-14 this method skipped the memdb delete and the quick-query
+	// dirty mark, so Pebble and memdb diverged after every call: the rows were
+	// gone from disk while every memdb-backed read kept serving them until a
+	// restart — a divergence that looks identical to the known
+	// "corrected aggregates invisible until memdb refreshes" staleness and
+	// would have been mis-diagnosed as it.
 	s.InvalidateLibraryStats()
+	s.MarkQuickQueryDirty("no_fingerprints", "delete_book_files_for_book")
+	fileIDs := make([]string, 0, len(files))
+	for i := range files {
+		fileIDs = append(fileIDs, files[i].ID)
+	}
+	s.DeleteBookFilesFromMemDB(fileIDs)
 	// Recompute book-level aggregates after bulk-deleting all files for this book.
 	// The book likely has Duration=0 after deletion, which is correct — nothing to sum.
 	s.notifyBookFileChange(bookID)


### PR DESCRIPTION
C817 from the 2026-08-14 task breakdown (TODO.md ~line 2744).

**Fix:** one derived-state pass mirroring `DeleteBookFilesByIDs`: `MarkQuickQueryDirty` + `DeleteBookFilesFromMemDB(fileIDs)` after the batch commit.

**The verification is the story here — two mutants survived before the test earned its keep:**
1. First test read via `GetBookFiles` → mutant survived → that getter is Pebble-unconditional (wrong instrument).
2. Second test used Duration:100 files → mutant survived → the aggregate recompute's `UpdateBook` resyncs the book's memdb file set as a side effect, healing the divergence. The bug is only observable on the early-return path (aggregates unchanged) — exactly the 2026-08-03 prod canary shape.
Final test: memdb-dispatched `GetBookFilesForIDsCore` + zero-aggregate fixture → fix green, mutant red (naming the missing memdb delete), restored green. Both traps documented in-code.

vet/gofmt clean; targeted + neighbor tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS