### PR TITLE
chore(playlist): delete dead file-level M3U playlist path

### DIFF
--- a/changelog.d/20260814_152800_delete_dead_playlist_path.md
+++ b/changelog.d/20260814_152800_delete_dead_playlist_path.md
@@ -1,0 +1,5 @@
+### Removed
+
+- Deleted the dead file-level M3U playlist path (`internal/playlist.generatePlaylistFile`
+  and its package-local `PlaylistItem`) — zero non-test callers since the fable5 T022
+  SQLite removal. The Store-backed playlist API and smart-playlist evaluator are untouched.

--- a/internal/playlist/playlist.go
+++ b/internal/playlist/playlist.go
@@ -1,29 +1,14 @@
 // file: internal/playlist/playlist.go
-// version: 2.0.0
+// version: 3.0.0
 // guid: 2a3b4c5d-6e7f-8a9b-0c1d-2e3f4a5b6c7d
-// last-edited: 2026-06-10
+// last-edited: 2026-08-14
 
 package playlist
 
 import (
 	"fmt"
 	"log/slog"
-	"os"
-	"path/filepath"
-	"sort"
-	"strings"
-
-	"github.com/falkcorp/audiobook-organizer/internal/config"
 )
-
-// PlaylistItem represents a book in a playlist
-type PlaylistItem struct {
-	BookID   int
-	Title    string
-	Author   string
-	FilePath string
-	Position int
-}
 
 // GeneratePlaylistsForSeries generates playlists for all identified series.
 //
@@ -34,44 +19,4 @@ type PlaylistItem struct {
 func GeneratePlaylistsForSeries() error {
 	slog.Warn("GeneratePlaylistsForSeries: legacy SQLite path removed in fable5 T022; use Store-backed playlist API")
 	return fmt.Errorf("GeneratePlaylistsForSeries: the legacy SQLite path was removed in fable5 T022; use the Store-backed playlist API instead")
-}
-
-// generatePlaylistFile writes a M3U playlist for a set of items to the
-// configured playlist directory. This function does not require a database
-// connection and is used by the Store-backed playlist handlers.
-func generatePlaylistFile(playlistName string, items []PlaylistItem) (string, error) {
-	// Sort by position then title
-	sort.Slice(items, func(i, j int) bool {
-		if items[i].Position == items[j].Position {
-			return items[i].Title < items[j].Title
-		}
-		return items[i].Position < items[j].Position
-	})
-
-	safePlaylistName := strings.ReplaceAll(playlistName, "/", "-")
-	safePlaylistName = strings.ReplaceAll(safePlaylistName, "\\", "-")
-	safePlaylistName = strings.ReplaceAll(safePlaylistName, ":", "-")
-
-	playlistPath := filepath.Join(config.AppConfig.PlaylistDir, safePlaylistName+".m3u")
-
-	f, err := os.Create(playlistPath)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	if _, err = f.WriteString("#EXTM3U\n"); err != nil {
-		return "", err
-	}
-
-	for _, item := range items {
-		if _, err = fmt.Fprintf(f, "#EXTINF:-1,%s - %s\n", item.Author, item.Title); err != nil {
-			return "", err
-		}
-		if _, err = f.WriteString(item.FilePath + "\n"); err != nil {
-			return "", err
-		}
-	}
-
-	return playlistPath, nil
 }

--- a/internal/playlist/playlist_test.go
+++ b/internal/playlist/playlist_test.go
@@ -1,148 +1,19 @@
 // file: internal/playlist/playlist_test.go
-// version: 2.0.0
+// version: 3.0.0
 // guid: 3b4c5d6e-7f8a-9b0c-1d2e-3f4a5b6c7d8e
-// last-edited: 2026-06-10
+// last-edited: 2026-08-14
 
 // NOTE(fable5 T022): Tests that relied on database.DB (getBooksInSeries,
 // savePlaylistToDatabase, GeneratePlaylistsForSeries with live data) were
-// removed; those code paths were deleted with the SQLite store.
-// generatePlaylistFile (previously createiTunesPlaylist) is tested below.
+// removed; those code paths were deleted with the SQLite store. The
+// file-level M3U path (generatePlaylistFile + its PlaylistItem) was deleted
+// on 2026-08-14 — it had zero non-test callers.
 
 package playlist
 
 import (
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
-
-	"github.com/falkcorp/audiobook-organizer/internal/config"
 )
-
-func TestGeneratePlaylistFile(t *testing.T) {
-	tempDir := t.TempDir()
-	config.AppConfig.PlaylistDir = tempDir
-
-	items := []PlaylistItem{
-		{BookID: 1, Title: "First Book", Author: "Author One", FilePath: "/path/to/book1.m4b", Position: 1},
-		{BookID: 2, Title: "Second Book", Author: "Author One", FilePath: "/path/to/book2.m4b", Position: 2},
-	}
-
-	playlistPath, err := generatePlaylistFile("Test Series - Author One", items)
-	if err != nil {
-		t.Fatalf("generatePlaylistFile failed: %v", err)
-	}
-
-	// Check file exists
-	if _, err := os.Stat(playlistPath); os.IsNotExist(err) {
-		t.Fatalf("playlist file not created: %s", playlistPath)
-	}
-
-	// Read and verify content
-	content, err := os.ReadFile(playlistPath)
-	if err != nil {
-		t.Fatalf("failed to read playlist file: %v", err)
-	}
-
-	contentStr := string(content)
-
-	// Check header
-	if !strings.Contains(contentStr, "#EXTM3U") {
-		t.Error("playlist missing #EXTM3U header")
-	}
-
-	// Check both books are present
-	if !strings.Contains(contentStr, "Author One - First Book") {
-		t.Error("playlist missing first book info")
-	}
-	if !strings.Contains(contentStr, "/path/to/book1.m4b") {
-		t.Error("playlist missing first book path")
-	}
-	if !strings.Contains(contentStr, "Author One - Second Book") {
-		t.Error("playlist missing second book info")
-	}
-	if !strings.Contains(contentStr, "/path/to/book2.m4b") {
-		t.Error("playlist missing second book path")
-	}
-}
-
-func TestGeneratePlaylistFileSpecialChars(t *testing.T) {
-	tempDir := t.TempDir()
-	config.AppConfig.PlaylistDir = tempDir
-
-	items := []PlaylistItem{
-		{BookID: 1, Title: "Book", Author: "Author", FilePath: "/path/to/book.m4b", Position: 1},
-	}
-
-	// Test with special characters in playlist name
-	playlistPath, err := generatePlaylistFile("Series/With\\Special:Chars", items)
-	if err != nil {
-		t.Fatalf("generatePlaylistFile failed: %v", err)
-	}
-
-	// Verify special characters are replaced
-	expectedFilename := "Series-With-Special-Chars.m3u"
-	if !strings.Contains(playlistPath, expectedFilename) {
-		t.Errorf("expected filename %s, got %s", expectedFilename, filepath.Base(playlistPath))
-	}
-
-	// Check file exists
-	if _, err := os.Stat(playlistPath); os.IsNotExist(err) {
-		t.Fatalf("playlist file not created: %s", playlistPath)
-	}
-}
-
-func TestGeneratePlaylistFileCreateError(t *testing.T) {
-	tempDir := t.TempDir()
-	blocker := filepath.Join(tempDir, "blocker")
-	if err := os.WriteFile(blocker, []byte("not a dir"), 0o644); err != nil {
-		t.Fatalf("failed to create blocker file: %v", err)
-	}
-
-	config.AppConfig.PlaylistDir = blocker
-
-	_, err := generatePlaylistFile("Blocked Playlist", []PlaylistItem{
-		{BookID: 1, Title: "Book", Author: "Author", FilePath: "/path/to/book.m4b", Position: 1},
-	})
-	if err == nil {
-		t.Fatal("expected error when playlist directory is not a folder")
-	}
-}
-
-func TestGeneratePlaylistFileEmpty(t *testing.T) {
-	tempDir := t.TempDir()
-	config.AppConfig.PlaylistDir = tempDir
-
-	items := []PlaylistItem{}
-
-	playlistPath, err := generatePlaylistFile("Empty Series", items)
-	if err != nil {
-		t.Fatalf("generatePlaylistFile failed: %v", err)
-	}
-
-	// Check file exists
-	if _, err := os.Stat(playlistPath); os.IsNotExist(err) {
-		t.Fatalf("playlist file not created: %s", playlistPath)
-	}
-
-	// Read and verify content
-	content, err := os.ReadFile(playlistPath)
-	if err != nil {
-		t.Fatalf("failed to read playlist file: %v", err)
-	}
-
-	contentStr := string(content)
-
-	// Should only have header
-	if !strings.Contains(contentStr, "#EXTM3U") {
-		t.Error("playlist missing #EXTM3U header")
-	}
-
-	// Should not have any EXTINF entries
-	if strings.Contains(contentStr, "#EXTINF") {
-		t.Error("empty playlist should not have EXTINF entries")
-	}
-}
 
 // TestGeneratePlaylistsForSeriesReturnsError verifies that the legacy
 // SQLite-backed GeneratePlaylistsForSeries path now returns an error


### PR DESCRIPTION
## Summary
- Deletes `internal/playlist.generatePlaylistFile` and the package-local `PlaylistItem{BookID, Title, Author, FilePath, Position}` — **zero non-test callers** (verified by repo-wide grep at fix time, per the F115 brief). The only tests in `playlist_test.go` besides the stub-error test were tests of the dead code itself; they go with it.
- Keeps `GeneratePlaylistsForSeries` (still referenced from `cmd/root.go:45`) and the smart-playlist evaluator (`EvaluateSmartPlaylist`, used by `internal/server/handlers/playlists.go`).
- `database.PlaylistItem` (the store row type behind `AddPlaylistItem`/`GetPlaylistItems`) is a **different type** and is untouched.
- `config.PlaylistDir` stays: it still has live users in `cmd/root.go` and config validation/persistence.

## Verification
- `go build ./...` clean in the worktree.
- `go test ./internal/playlist/ ./cmd/` — both `ok`.

Task F115 from the 2026-08-14 breakdown (fragment: `20260811`-era dead-path note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS