### PR TITLE
feat(metrics): counter for maintenance resumes falling back to the advertised dry_run

### DIFF
--- a/changelog.d/20260814_154500_resume_fallback_metric.md
+++ b/changelog.d/20260814_154500_resume_fallback_metric.md
@@ -1,0 +1,9 @@
+### Added
+
+- New Prometheus counter `audiobook_organizer_maintenance_resume_params_fallback_total{job_id, reason}`:
+  fires when an interrupted maintenance job resumes WITHOUT the operator's saved
+  params, falling back to the job's advertised `dry_run` default
+  (`reason=no_saved_params` or `load_error`). Since #2419 persists resolved params
+  on every enqueue, any fire after pre-#2419 rows age out means a params save
+  silently failed — an alertable condition instead of a log line that ages out of
+  journald. (C511)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,7 +1,7 @@
 // file: internal/metrics/metrics.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 9f8e7d6c-5b4a-3210-9fed-cba876543210
-// last-edited: 2026-07-18
+// last-edited: 2026-08-14
 
 package metrics
 
@@ -149,6 +149,19 @@ var (
 		Name:      "op_items_total",
 		Help:      "Total items expected for an in-flight operation (0 if not yet known), by op_id and op_type. Deleted once the op reaches a terminal state.",
 	}, []string{"op_id", "op_type"})
+
+	// maintenanceResumeParamsFallback counts interrupted maintenance jobs that
+	// resumed WITHOUT the operator's saved params — falling back to the job's
+	// advertised dry_run default (see resumeLegacyOp in internal/server).
+	// runMaintenanceJob persists resolved params on every enqueue since #2419,
+	// so once pre-#2419 rows age out, ANY fire means a SaveParams silently
+	// failed — that is the alert condition (C511). {job_id} is bounded by the
+	// maintenance job registry; {reason} is load_error|no_saved_params.
+	maintenanceResumeParamsFallback = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "audiobook_organizer",
+		Name:      "maintenance_resume_params_fallback_total",
+		Help:      "Interrupted maintenance jobs resumed on the advertised dry_run default because saved params were missing (no_saved_params) or unreadable (load_error). Any fire post-#2419-aging means a params save failed.",
+	}, []string{"job_id", "reason"})
 )
 
 // Register initializes metrics with the global Prometheus registry (idempotent)
@@ -158,7 +171,8 @@ func Register() {
 			booksGauge, foldersGauge, memoryAllocGauge, goroutinesGauge,
 			cacheHits, cacheMisses, cacheSets, cacheInvalidations, cacheEvictions, cacheSize, cacheGetDuration,
 			itunesLocationUnmappable, aiBackendAvailable,
-			opItemsProcessed, opItemsTotal)
+			opItemsProcessed, opItemsTotal,
+			maintenanceResumeParamsFallback)
 	})
 }
 
@@ -213,6 +227,14 @@ func SetOpProgress(opID, opType string, current, total int) {
 func ClearOpProgress(opID, opType string) {
 	opItemsProcessed.DeleteLabelValues(opID, opType)
 	opItemsTotal.DeleteLabelValues(opID, opType)
+}
+
+// RecordMaintenanceResumeParamsFallback counts an interrupted maintenance job
+// that resumed without the operator's saved params, on the advertised dry_run
+// default instead (C511). reason is a small enum: "no_saved_params" (LoadParams
+// found nothing) or "load_error" (LoadParams failed).
+func RecordMaintenanceResumeParamsFallback(jobID, reason string) {
+	maintenanceResumeParamsFallback.WithLabelValues(jobID, reason).Inc()
 }
 
 // Cache helpers

--- a/internal/server/maintenance_resume_fallback_metric_test.go
+++ b/internal/server/maintenance_resume_fallback_metric_test.go
@@ -1,0 +1,114 @@
+// file: internal/server/maintenance_resume_fallback_metric_test.go
+// version: 1.0.0
+// guid: 7c2e9a41-3f58-4b6d-9e0a-8d1c5b2f7a93
+// last-edited: 2026-08-14
+
+package server
+
+import (
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/falkcorp/audiobook-organizer/internal/metrics"
+	"github.com/falkcorp/audiobook-organizer/internal/operations"
+)
+
+// gatherResumeFallbackCount reads the C511 counter for one (job_id, reason)
+// pair from the DEFAULT registry — the same registry /metrics serves — so a
+// nonzero value here proves both registration and the increment. A counter vec
+// with no children is absent from the gather entirely; that reads as 0.
+func gatherResumeFallbackCount(t *testing.T, jobID, reason string) float64 {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, mf := range families {
+		if mf.GetName() != "audiobook_organizer_maintenance_resume_params_fallback_total" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labels["job_id"] == jobID && labels["reason"] == reason {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+// metricFamilyPresent reports whether the named family appears in the default
+// registry's gather output at all.
+func metricFamilyPresent(t *testing.T, name string) bool {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, mf := range families {
+		if mf.GetName() == name {
+			return true
+		}
+	}
+	return false
+}
+
+// TestResumeLegacyOp_NoSavedParamsIncrementsFallbackCounter pins C511: the
+// resume fallback (interrupted maintenance job with no saved params) must be
+// countable from Prometheus, not just visible in a log line that ages out of
+// journald. Post-#2419 every enqueue persists params, so a production fire of
+// this counter means a SaveParams silently failed.
+func TestResumeLegacyOp_NoSavedParamsIncrementsFallbackCounter(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+	if server.opRegistry == nil {
+		t.Skip("ops registry not wired in this build")
+	}
+	metrics.Register()
+
+	jobID := probeAdvertisesTrue.ID()
+
+	// No saved params → the fallback branch must fire and count.
+	opID := ulid.Make().String()
+	opType := "maintenance:" + jobID
+	if _, err := server.Store().CreateOperation(opID, opType, nil); err != nil {
+		t.Fatalf("CreateOperation: %v", err)
+	}
+
+	before := gatherResumeFallbackCount(t, jobID, "no_saved_params")
+	server.resumeLegacyOp(opID, opType)
+	after := gatherResumeFallbackCount(t, jobID, "no_saved_params")
+
+	if after != before+1 {
+		t.Fatalf("no_saved_params fallback counter went %v -> %v, want +1: the C511 metric is not wired to the fallback branch", before, after)
+	}
+	if !metricFamilyPresent(t, "audiobook_organizer_maintenance_resume_params_fallback_total") {
+		t.Fatal("metric family absent from the default registry — Register() does not include the C511 counter")
+	}
+
+	// Control: a resume WITH saved params must NOT count — the metric measures
+	// fallbacks, not resumes. Without this, an increment misplaced onto the
+	// happy path would still pass the assertion above.
+	opID2 := ulid.Make().String()
+	if _, err := server.Store().CreateOperation(opID2, opType, nil); err != nil {
+		t.Fatalf("CreateOperation: %v", err)
+	}
+	if err := operations.SaveParams(server.Store(), opID2, maintenanceJobOpParams{
+		LegacyOpID: opID2,
+		JobID:      jobID,
+		DryRun:     true,
+	}); err != nil {
+		t.Fatalf("SaveParams: %v", err)
+	}
+	mid := gatherResumeFallbackCount(t, jobID, "no_saved_params")
+	server.resumeLegacyOp(opID2, opType)
+	end := gatherResumeFallbackCount(t, jobID, "no_saved_params")
+	if end != mid {
+		t.Fatalf("fallback counter moved (%v -> %v) on a resume that HAD saved params — it must only count fallbacks", mid, end)
+	}
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 3.16.0
+// version: 3.17.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-08-14
 
@@ -265,11 +265,16 @@ func (s *Server) resumeLegacyOp(opID, opType string) {
 					DryRun:     advertisedDryRunDefault(j),
 				}
 				if saved, perr := operations.LoadParams[maintenanceJobOpParams](store, opID); perr != nil {
+					metrics.RecordMaintenanceResumeParamsFallback(jobID, "load_error")
 					slog.Warn("Could not load saved params for interrupted maintenance job; resuming with the advertised dry_run default",
 						"opID", opID, "jobID", jobID, "dryRun", enqParams.DryRun, "err", perr)
 				} else if saved != nil {
 					enqParams.DryRun = saved.DryRun
 				} else {
+					// runMaintenanceJob has persisted resolved params on every
+					// enqueue since #2419, so once pre-#2419 rows age out of the
+					// interrupted set, any fire here means a save failed (C511).
+					metrics.RecordMaintenanceResumeParamsFallback(jobID, "no_saved_params")
 					slog.Info("No saved params for interrupted maintenance job; resuming with the advertised dry_run default",
 						"opID", opID, "jobID", jobID, "dryRun", enqParams.DryRun)
 				}


### PR DESCRIPTION
## Summary
Task C511. `resumeLegacyOp`'s maintenance branch falls back to the job's **advertised** `dry_run` default when the operator's saved params are missing (`LoadParams` nil) or unreadable (`LoadParams` error). Both branches were log-only. Since #2419 persists resolved params on every enqueue, any fire of either branch — once pre-#2419 interrupted rows age out — means a params save **silently failed**. This PR makes that a standing Prometheus signal instead of a journald line:

- `audiobook_organizer_maintenance_resume_params_fallback_total{job_id, reason}` with `reason ∈ {no_saved_params, load_error}` — added to `internal/metrics`, registered in the same `Register()` list `/metrics` serves. `job_id` cardinality is bounded by the maintenance job registry.
- Both fallback branches in `internal/server/server_lifecycle.go` now call `metrics.RecordMaintenanceResumeParamsFallback`.

## Test
`TestResumeLegacyOp_NoSavedParamsIncrementsFallbackCounter` drives the **real** `resumeLegacyOp` path via the existing dry-run probe-job harness and reads the counter from `prometheus.DefaultGatherer` (the exact registry `/metrics` serves — proving registration and increment with one instrument). It asserts:
1. +1 on a no-saved-params resume,
2. the metric family is present in the default registry,
3. **no movement** on a resume that HAD saved params (control against a misplaced increment on the happy path).

**Mutation-verified:** removing the `Record` call fails the test with `counter went 0 -> 0, want +1`; restored code is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS