### PR TITLE
docs(todo): C716 findings — the 3,954 gap was 3,953 instrument + 2 quarantined

### DIFF
--- a/changelog.d/20260814_161000_c716_gap_findings.md
+++ b/changelog.d/20260814_161000_c716_gap_findings.md
@@ -1,0 +1,7 @@
+### Documentation
+
+- Filed the C716 investigation results: the reported 3,954-book API-vs-store gap
+  decomposed into 3,953 (soft-deleted books counted by the pre-#2408 leaky
+  `ListBookIDs`) + 2 quarantined books + 0 unexplained. Two new bugs filed:
+  `show_quarantined=true` silently drops the 22,552 nil-`is_primary_version`
+  books, and the Bleve search index holds ~3,953 docs for soft-deleted books.

--- a/todo.d/20260814-c716-api-store-gap-resolved.md
+++ b/todo.d/20260814-c716-api-store-gap-resolved.md
@@ -1,0 +1,44 @@
+## C716 resolved: the "3,954-book API-vs-store gap" decomposes to 3,953 instrument + 2 quarantined + 0 unexplained
+
+Measured on production 2026-08-14 (~10:30 EDT), every instrument controlled:
+
+- **3,953 of the gap was the measuring instrument.** The 67,824 "live" store
+  count (2026-08-13, search reconciler log) came from the leaky Pebble
+  `ListBookIDs` that still counted soft-deleted books — the drift fixed on
+  main (264585b5, PR #2408). The 10:01 post-fix boot logs now say
+  `books=63871` (search coverage) and `totalBooks=63871` (iTunes PID
+  backfill — a second, independent caller). 63,871 + 3,953 (trash set,
+  re-verified intact via `/audiobooks/soft-deleted` total) = 67,824 exactly.
+- **2 books remain store-visible but list-invisible, and both are
+  QUARANTINED** (`quarantine_reason: "taglib permanently unreadable after
+  transcode attempt"`, quarantined 2026-04-24):
+  `01KNDC17RY2ATJFRACA50N9AMJ`, `01KNDC4VB60GTBQ137A0YJ29KX`.
+  The default list applies `ExcludeQuarantined` unless
+  `?show_quarantined=true` (`audiobooks_helpers.go` /
+  `buildAudiobookListResponse`) — a hidden-but-intentional default filter.
+  Note the **inconsistent visibility**: both books are still served by
+  direct GET `/audiobooks/:id` AND by `/authors/:id/books` (author path does
+  not exclude quarantined). Decide whether that asymmetry is wanted.
+- **The API list is internally consistent**: full page-through returned
+  63,869 rows, 63,869 distinct ids, zero duplicates; `count` stayed 63,869
+  at an off-the-end offset (control); metadata-export (`GetAllBooksCore`,
+  independent store path) returned 63,871 with the two quarantined ids as
+  the exact set difference.
+
+Follow-up bugs found by the controls (route to C1/C3, do NOT fix here):
+
+- [ ] **`show_quarantined=true` SHRINKS the list.** A flag that can only
+      widen the set returned 41,319 books against the default 63,869.
+      41,319 = 41,317 (`is_primary_version=true` count) + the 2 quarantined
+      — i.e. with the quarantine exclusion off and no explicit
+      `is_primary_version` param, the scan path serves only primary-flagged
+      books and silently drops the 22,552-book nil-flag population. Same
+      family as the filed nil/false `is_primary_version` divergence
+      (`effectiveBoolFieldIndex{Default:true}` vs raw `*bool`); this is a
+      second concrete symptom, on the main list path. With an explicit
+      `is_primary_version=false` the flag behaves (22,552 with or without
+      quarantine).
+- [ ] `is_primary_version=false` answers 22,552 — exactly the known
+      nil-flag population size. Establish whether explicit-false books are
+      currently 0 in prod or whether the false-filter is returning nils
+      (memory says the census counted ~765 explicit-false in one path).

--- a/todo.d/20260814-search-index-contains-trash-docs.md
+++ b/todo.d/20260814-search-index-contains-trash-docs.md
@@ -1,0 +1,17 @@
+## Bleve index holds ~3,953 docs for soft-deleted books
+
+The 2026-08-13 search-index repair backfilled 16,738 "missing" books using
+the pre-#2408 leaky `ListBookIDs` enumeration — which included the trash.
+Post-fix boot log (2026-08-14 10:01): `search index coverage OK
+indexed=67824 books=63871`. DocCount − live = 3,953 = the soft-deleted set
+exactly, so trashed books are now indexed and plausibly reachable through
+web search until the index is reconciled.
+
+- [ ] Add/verify a reconcile pass that REMOVES index docs whose book is
+      soft-deleted or gone (the coverage gate only checks
+      `len(ListBookIDs()) <= DocCount()`, which a polluted index passes
+      forever — already noted in 20260813-search-index-repair-prod-findings
+      as the "two slightly different populations" item; this is a live
+      instance, not a hypothetical).
+- [ ] Verify with a bogus-value control: search for a known trashed title
+      before and after the cleanup.


### PR DESCRIPTION
## Summary
Read-only C716 investigation (task brief: establish the excluded population behind store=67,824 vs API=63,870, bogus-value control on every instrument). Production-measured 2026-08-14:

- **3,953 = the instrument.** The 67,824 came from the pre-#2408 leaky Pebble `ListBookIDs` that counted the trash. Post-fix boot logs now read `books=63871` from two independent callers; 63,871 + 3,953 = 67,824 exactly.
- **2 = quarantined books** (hidden `show_quarantined=false` default): `01KNDC17RY2ATJFRACA50N9AMJ`, `01KNDC4VB60GTBQ137A0YJ29KX` — still served by direct GET and the author path (inconsistent visibility, flagged for a decision).
- **0 unexplained.** Full page-through: 63,869 rows, all distinct; off-the-end control sane; metadata-export diff yields exactly the two quarantined ids.

Controls surfaced two NEW bugs, filed as fragments (fixes route to C1/C3):
1. `show_quarantined=true` **shrinks** the list to 41,319 = primary-true (41,317) + 2 — silently dropping the 22,552 nil-`is_primary_version` books. Second concrete symptom of the filed nil/false divergence, now on the main list path.
2. The Bleve index holds ~3,953 docs for soft-deleted books (08-13 backfill used the leaky enumeration; `indexed=67824` vs `books=63871`).

Fragments only — headerless per todo.d rules; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS