### PR TITLE
fix(web): surface list-endpoint 400 guard messages as a toast (G118)

### DIFF
--- a/changelog.d/20260814_171000_g118_400_toast.md
+++ b/changelog.d/20260814_171000_g118_400_toast.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Library page: a 400 from the list endpoint's filter guards (empty filter
+  value, unknown filter field, bare filter param) now surfaces the server's
+  field-naming message as a toast instead of dying in the console as a silent,
+  non-retrying dead page. Traced all UI paths (G118): none can currently send
+  an empty filter value — dropdowns are truthiness-guarded, the search DSL
+  parser drops empty values, and saved presets flow through the same guards;
+  prod stored state verified clean (0 presets, 1 playlist, no empty criteria).

--- a/web/src/hooks/useLibraryQuery.test.ts
+++ b/web/src/hooks/useLibraryQuery.test.ts
@@ -1,7 +1,7 @@
 // file: web/src/hooks/useLibraryQuery.test.ts
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7c8d9e0f-1a2b-4c5d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-11
+// last-edited: 2026-08-14
 
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { vi, describe, test, expect, beforeEach } from 'vitest';
@@ -218,5 +218,38 @@ describe('useLibraryQuery cancelLoad', () => {
     await waitFor(() => expect(getFirstSignal()?.aborted).toBe(true));
     await waitFor(() => expect(result.current.audiobooks).toHaveLength(1));
     expect(result.current.audiobooks[0].id).toBe('second');
+  });
+});
+
+describe('useLibraryQuery 400 handling (G118)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    useLibraryCache.getState().clear();
+    vi.mocked(api.getImportPaths).mockResolvedValue([]);
+  });
+
+  test('a 400 from the filter guards surfaces the server message as a toast', async () => {
+    const serverMessage =
+      'filter on "title" has an empty value; an empty value matches every book rather than narrowing the results.';
+    // vi.mock('../services/api') automocks ApiError too: its instances pass
+    // the hook's `instanceof api.ApiError` check (same mocked class) but the
+    // mock constructor drops message/status — restore them explicitly.
+    const err = new api.ApiError(serverMessage, 400);
+    Object.assign(err, { message: serverMessage, status: 400 });
+    vi.mocked(api.getBooks).mockRejectedValue(err);
+
+    const toast = vi.fn();
+    const { result } = renderHook(() => useLibraryQuery(makeBaseProps({ toast })));
+
+    await act(async () => {
+      await result.current.loadAudiobooks();
+    });
+
+    // The guard's message names the field and the fix — it must reach the
+    // user, not just the console (before this, a 400 rendered as a silent
+    // non-retrying dead page).
+    await waitFor(() => expect(toast).toHaveBeenCalledWith(serverMessage, 'warning'));
+    // And a 4xx is not transient: no retry may be pending.
+    expect(result.current.isRetrying).toBe(false);
   });
 });

--- a/web/src/hooks/useLibraryQuery.ts
+++ b/web/src/hooks/useLibraryQuery.ts
@@ -1,7 +1,7 @@
 // file: web/src/hooks/useLibraryQuery.ts
-// version: 1.7.0
+// version: 1.8.0
 // guid: d4e5f6a7-b8c9-0123-def0-123456789003
-// last-edited: 2026-08-11
+// last-edited: 2026-08-14
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -329,6 +329,16 @@ export function useLibraryQuery({
       }
       if (error instanceof api.ApiError && error.status >= 500) {
         toast('Server error occurred.', 'error');
+      } else if (error instanceof api.ApiError && error.status === 400) {
+        // The list endpoint rejects narrowing bugs — empty filter values,
+        // unknown filter fields, bare filter params — with a 400 whose message
+        // names the offending field and the fix. Burying that in the console
+        // leaves the user with a silent, non-retrying dead page (G118). No
+        // current UI path can produce these requests (dropdowns are
+        // truthiness-guarded, the search parser drops empty values, presets
+        // flow through the same guards), so this surfaces stale bundles and
+        // future regressions, not routine use.
+        toast(error.message, 'warning');
       }
       const message = error instanceof Error ? error.message : 'Failed to load audiobooks.';
       if (message.toLowerCase().includes('timeout')) {


### PR DESCRIPTION
## Summary
Task G118: trace what UI path sends `value:""` (now rejected 400 by #2417-family guards) and render a sensible message.

**Trace result — no live path exists.** All three producers guard: Library dropdown filters are truthiness-checked (`if (filters.author)`), the search DSL parser drops empty values at parse (`if (trimmedValue)`), and saved filter presets apply through the same dropdown guards. Stored state on prod verified clean: 0 saved filter presets, 1 playlist with no empty-value smart criteria.

**The gap that was real:** when the 400 does fire (stale bundle, hand-built URL, future regression), `useLibraryQuery`'s catch only toasted `>=500` and timeouts — a 400 became a silent, non-retrying dead page while the server's self-explanatory message (it names the field and the fix) died in the console. Now `status === 400` toasts `error.message` as a warning.

## Verification
- New vitest: mocked `getBooks` rejects with ApiError(400 + guard message) → asserts the exact message reaches `toast` with `'warning'`, and no retry is scheduled (4xx is not transient).
- **Mutation-verified:** hook change reverted → test fails (`toast` never called); restored → 5/5 pass.
- Note: `vi.mock` automocks `ApiError`, so the test restores `message`/`status` on the instance explicitly (commented in-code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS