### PR TITLE
docs(todo): B06 chapters end-to-end verified on prod (feeds E02)

### DIFF
--- a/changelog.d/20260814_173500_b06_chapters_verified.md
+++ b/changelog.d/20260814_173500_b06_chapters_verified.md
@@ -1,0 +1,6 @@
+### Documentation
+
+- Filed the B06 chapters end-to-end verification: multi-file synthesis, stored-
+  chapter serving (21/29 sampled single-file items already have stored chapters),
+  and graceful absence all verified against the live ABS surface on production.
+  The E02 backfill is a residue job, not a whole-library one.

--- a/todo.d/20260814-b06-chapters-endtoend-verified.md
+++ b/todo.d/20260814-b06-chapters-endtoend-verified.md
@@ -1,0 +1,22 @@
+## B06 chapters end-to-end: VERIFIED on prod — E02 backfill only needs the residue
+
+Measured against the LIVE ABS surface on production 2026-08-14 (ABS API is
+enabled and serving at root: `/ping`, `/api/libraries`, `/api/items/:id`;
+library `b5e3a5b2…`, 34,513 items):
+
+- **Multi-file synthesis works.** 28-file book (Mutineer): 28 synthesized
+  chapters, offsets contiguous, `last end == media.duration` exactly
+  (103,747s), titles from embedded track titles.
+- **Stored chapters ARE being served — and they are widespread.** 21 of 29
+  sampled single-file items return >1 chapter (37, 85, 105 …), which for a
+  single file can only come from the chapters store. Timeline sanity-checked
+  on one (37 chapters, contiguous, last end 28,885.1 vs duration 28,885).
+  The "backfill has NOT run library-wide so most books have no stored
+  chapters" premise is stale — scan-time extraction has already covered
+  ~72% of the sampled single-file population.
+- **Graceful absence works.** Single-file item with no stored chapters
+  serves exactly one whole-book chapter (0 → duration).
+
+**E02 implication:** the chapters-backfill run is a RESIDUE job (~28% of
+single-file books in the sample), not a whole-library one. Run it dry-run
+first to size the real target set; the serving path needs no changes.


### PR DESCRIPTION
## Summary
Task B06 (gates E02). Verified all three chapter cases against the LIVE prod ABS surface — measurements in the fragment:
- Multi-file synthesis: 28 files → 28 contiguous chapters, last end == duration exactly.
- Stored chapters serve correctly AND are widespread: 21/29 sampled single-file items have stored chapters — the "backfill hasn't run so most books lack chapters" premise is stale.
- Graceful absence: exactly one whole-book chapter.

**E02 conclusion: residue job (~28% of single-file sample), dry-run first to size it. No serving-path changes needed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS