### PR TITLE
fix(search): boot coverage gate compares ID sets, deletes stale docs (C715)

### DIFF
--- a/changelog.d/20260814_180000_coverage_gate_sets.md
+++ b/changelog.d/20260814_180000_coverage_gate_sets.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- The boot-time search-index coverage gate now compares ID SETS instead of
+  counts: live books missing from the index are marked for re-index (as
+  before), and stale documents whose book is gone — hard- or soft-deleted —
+  are removed. The old `len(books) <= DocCount()` gate reported "coverage OK"
+  on a production index padded with 3,953 soft-deleted books, and padding
+  could equally hide genuinely missing live books. Adds
+  `BleveIndex.AllDocIDs()` (one sequential low-level doc-ID pass).

--- a/internal/search/bleve_index.go
+++ b/internal/search/bleve_index.go
@@ -1,7 +1,7 @@
 // file: internal/search/bleve_index.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 3c8e1a2f-4d9b-4f70-a5c6-2f8d0e1b9a47
-// last-edited: 2026-08-13
+// last-edited: 2026-08-14
 //
 // BleveIndex is the single-package wrapper around a Bleve v2 scorch
 // index backing library search (spec DES-1 / backlog §4.7). The
@@ -357,6 +357,51 @@ func facetTermCounts(res *bleve.SearchResult, facetName string) map[string]int {
 		out[t.Term] = t.Count
 	}
 	return out
+}
+
+// AllDocIDs returns the external document ID of every indexed document,
+// via the low-level DocIDReader — one sequential pass, no scoring, no
+// document loading. It exists for the boot coverage gate, which needs the
+// index's ID SET: DocCount alone cannot distinguish "every live book is
+// indexed" from "the count is padded by documents whose books are gone"
+// (measured on production 2026-08-14: 67,824 docs vs 63,871 live books —
+// the surplus was 3,953 soft-deleted books indexed by a backfill that
+// enumerated with a trash-including lister).
+func (b *BleveIndex) AllDocIDs() ([]string, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if b.idx == nil {
+		return nil, fmt.Errorf("bleve index not open")
+	}
+	advanced, err := b.idx.Advanced()
+	if err != nil {
+		return nil, fmt.Errorf("advanced index access: %w", err)
+	}
+	reader, err := advanced.Reader()
+	if err != nil {
+		return nil, fmt.Errorf("index reader: %w", err)
+	}
+	defer func() { _ = reader.Close() }()
+	itr, err := reader.DocIDReaderAll()
+	if err != nil {
+		return nil, fmt.Errorf("doc id reader: %w", err)
+	}
+	defer func() { _ = itr.Close() }()
+	var out []string
+	for {
+		internalID, err := itr.Next()
+		if err != nil {
+			return nil, fmt.Errorf("doc id iterate: %w", err)
+		}
+		if internalID == nil {
+			return out, nil
+		}
+		extID, err := reader.ExternalID(internalID)
+		if err != nil {
+			return nil, fmt.Errorf("external id: %w", err)
+		}
+		out = append(out, extID)
+	}
 }
 
 // DocCount returns the number of documents currently indexed. Useful

--- a/internal/server/search_coverage.go
+++ b/internal/server/search_coverage.go
@@ -1,7 +1,7 @@
 // file: internal/server/search_coverage.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: ee9cc3d9-3925-4f72-af8a-e9f25a943fb9
-// last-edited: 2026-08-13
+// last-edited: 2026-08-14
 //
 // Boot-time repair for a PARTIALLY built Bleve search index.
 //
@@ -56,16 +56,21 @@ type bookIDLister interface {
 	ListBookIDs() ([]string, error)
 }
 
-// reconcileSearchIndexCoverage compares the number of indexed documents
-// against the number of books and, when the index is short, marks every book
-// dirty so runSearchReconciler re-indexes them.
+// reconcileSearchIndexCoverage compares the SET of indexed document IDs
+// against the SET of live book IDs, marks the missing ones dirty so
+// runSearchReconciler re-indexes them, and deletes stale documents whose
+// book is gone (hard-deleted or soft-deleted).
 //
 // It is a no-op on a healthy index, so it is safe to run on every boot.
 //
-// Deliberately compares counts rather than probing each book: a per-book
-// existence check against Bleve would be ~40K point lookups on every start,
-// and the count comparison is enough to decide whether a sweep is warranted.
-// The cost of being wrong is a redundant re-index, not data loss.
+// This replaced a count comparison (len(ids) <= DocCount() → "OK"), which a
+// polluted index passes forever: on production 2026-08-14 the index held
+// 67,824 docs against 63,871 live books — 3,953 soft-deleted books indexed
+// by the 08-13 backfill, whose enumeration used the then-leaky trash-
+// including ListBookIDs — and the count gate reported "coverage OK" over
+// the top. Padding can also mask genuinely missing live books. The set
+// comparison costs one sequential doc-ID pass (AllDocIDs), not per-book
+// point lookups.
 func (s *Server) reconcileSearchIndexCoverage() {
 	if s.searchIndex == nil {
 		return
@@ -88,9 +93,9 @@ func (s *Server) reconcileSearchIndexCoverage() {
 		return
 	}
 
-	docs, err := s.searchIndex.DocCount()
+	docIDs, err := s.searchIndex.AllDocIDs()
 	if err != nil {
-		slog.Warn("search coverage: DocCount failed", "err", err)
+		slog.Warn("search coverage: AllDocIDs failed", "err", err)
 		return
 	}
 	ids, err := lister.ListBookIDs()
@@ -99,30 +104,73 @@ func (s *Server) reconcileSearchIndexCoverage() {
 		return
 	}
 
-	if uint64(len(ids)) <= docs {
-		slog.Info("search index coverage OK", "indexed", docs, "books", len(ids))
+	indexed := make(map[string]struct{}, len(docIDs))
+	for _, id := range docIDs {
+		indexed[id] = struct{}{}
+	}
+	live := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		live[id] = struct{}{}
+	}
+
+	var missing []string
+	for _, id := range ids {
+		if _, ok := indexed[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	var stale []string
+	for _, id := range docIDs {
+		if _, ok := live[id]; !ok {
+			stale = append(stale, id)
+		}
+	}
+
+	if len(missing) == 0 && len(stale) == 0 {
+		slog.Info("search index coverage OK", "indexed", len(docIDs), "books", len(ids))
 		return
 	}
 
-	missing := uint64(len(ids)) - docs
-	slog.Warn("search index is short of the library; marking books for reconciliation",
-		"indexed", docs, "books", len(ids), "shortfall", missing)
+	slog.Warn("search index diverges from the library",
+		"indexed", len(docIDs), "books", len(ids), "missing", len(missing), "stale", len(stale))
 
 	start := time.Now()
 	marked := 0
-	for _, id := range ids {
+	for _, id := range missing {
 		select {
 		case <-s.bgCtx.Done():
 			// Cancellation is safe here in a way it is not in the backfill:
 			// the marks already written are durable, so the next boot's
 			// coverage check resumes from a strictly better position.
-			slog.Info("search coverage: marking canceled (bgCtx)", "marked", marked, "of", len(ids))
+			slog.Info("search coverage: marking canceled (bgCtx)", "marked", marked, "of", len(missing))
 			return
 		default:
 		}
 		s.markIndexDirty(id)
 		marked++
 	}
-	slog.Info("search coverage: books marked for reconciliation",
-		"marked", marked, "shortfall", missing, "took", time.Since(start))
+
+	// Stale documents are removed directly rather than through the dirty set:
+	// the reconciler's unit of work is "re-index book X from the store", and
+	// for these there is no live book to read. DeleteBook on an absent doc is
+	// a no-op, so a doc raced away by a concurrent delete is fine. A book
+	// restored from soft-delete later is re-indexed by the restore path
+	// itself: RestoreAudiobook goes through store.UpdateBook, and the
+	// indexedStore decorator enqueues a reindex on every UpdateBook.
+	deleted := 0
+	for _, id := range stale {
+		select {
+		case <-s.bgCtx.Done():
+			slog.Info("search coverage: stale-doc deletion canceled (bgCtx)", "deleted", deleted, "of", len(stale))
+			return
+		default:
+		}
+		if err := s.searchIndex.DeleteBook(id); err != nil {
+			slog.Warn("search coverage: failed to delete stale doc", "bookID", id, "err", err)
+			continue
+		}
+		deleted++
+	}
+	slog.Info("search coverage: reconciled",
+		"marked_missing", marked, "deleted_stale", deleted, "took", time.Since(start))
 }

--- a/internal/server/search_coverage_test.go
+++ b/internal/server/search_coverage_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/search_coverage_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 000a3aed-48a5-49fd-b36a-d52d7d4de58e
-// last-edited: 2026-08-13
+// last-edited: 2026-08-14
 //
 // Regression tests for a PARTIALLY built search index.
 //
@@ -171,5 +171,68 @@ func TestSearchCoverage_PrecisionAfterRepair(t *testing.T) {
 		if title, isDecoy := decoys[h.BookID]; isDecoy {
 			t.Errorf("unrelated book %s (%q) present in title-scoped results", h.BookID, title)
 		}
+	}
+}
+
+// TestSearchCoverage_StaleDocsAreDeleted pins the C715 upgrade from a count
+// gate to a set gate. Measured on production 2026-08-14: 67,824 indexed docs
+// vs 63,871 live books — 3,953 soft-deleted books indexed by a backfill that
+// enumerated with the then-leaky ListBookIDs — and the old
+// `len(ids) <= DocCount()` gate answered "coverage OK" over the top. A
+// padded index can also hide genuinely missing live books, which is the
+// combined shape this fixture reproduces: 2 live+indexed, 1 live+missing,
+// 2 indexed-but-gone.
+func TestSearchCoverage_StaleDocsAreDeleted(t *testing.T) {
+	srv, store, idx := newDropOnlyServer(t)
+
+	books := coverageBooks()
+	// Live books: first three; index only the first two (one live book missing).
+	seedPartialIndex(t, store, idx, books[:3], 2)
+
+	// Stale docs: index two books that are NOT in the store — the shape a
+	// soft-deleted or hard-deleted book leaves behind.
+	for _, ghost := range []database.Book{
+		{ID: "ghost-01", Title: "Trashed Tome", FilePath: "/tmp/g1", Format: "m4b"},
+		{ID: "ghost-02", Title: "Vanished Volume", FilePath: "/tmp/g2", Format: "m4b"},
+	} {
+		if err := idx.IndexBook(search.BookToDoc(store, &ghost)); err != nil {
+			t.Fatalf("index ghost %s: %v", ghost.ID, err)
+		}
+	}
+
+	// Precondition: the OLD count gate would pass this index — docs (4) >=
+	// books (3) — which is exactly why it could never see either defect.
+	docs, err := idx.DocCount()
+	if err != nil {
+		t.Fatalf("doccount: %v", err)
+	}
+	if docs != 4 {
+		t.Fatalf("precondition: %d docs, want 4 (2 live + 2 stale)", docs)
+	}
+
+	srv.reconcileSearchIndexCoverage()
+	srv.reconcileOnce()
+
+	// The stale docs are gone, the missing live book is indexed: exactly the
+	// live set remains.
+	if d, _ := idx.DocCount(); d != 3 {
+		t.Fatalf("after reconcile: %d docs, want exactly the 3 live books", d)
+	}
+	for _, probe := range []string{"title:trashed", "title:vanished"} {
+		hits, _, err := idx.Search(probe, 0, 5)
+		if err != nil {
+			t.Fatalf("search %q: %v", probe, err)
+		}
+		if len(hits) != 0 {
+			t.Errorf("stale doc still reachable via %q after reconcile", probe)
+		}
+	}
+	// And the previously-missing live book (cov-03, "All in Charisma") serves.
+	hits, _, err := idx.Search("title:charisma", 0, 5)
+	if err != nil {
+		t.Fatalf("search charisma: %v", err)
+	}
+	if len(hits) != 1 || hits[0].BookID != "cov-03" {
+		t.Errorf("missing live book not repaired: hits=%v", hits)
 	}
 }

--- a/todo.d/20260814-softdelete-upserts-into-index.md
+++ b/todo.d/20260814-softdelete-upserts-into-index.md
@@ -1,0 +1,15 @@
+## Soft-deleting a book UPSERTS it into the search index
+
+Found during C715: `DeleteAudiobook(SoftDelete: true)` sets the flags via
+`store.UpdateBook`, and the `indexedStore` decorator enqueues a REINDEX on
+every UpdateBook — so soft-deleting a book refreshes its search doc instead
+of removing it. The trashed book stays searchable until the next boot's
+coverage reconcile (set-based since C715) deletes the stale doc.
+
+- [ ] Make the soft-delete transition enqueue a Bleve DELETE instead: either
+      teach `indexedStore.UpdateBook` to check `MarkedForDeletion` on the
+      updated row, or have the soft-delete path call the index delete
+      explicitly. Mirror-image: RestoreAudiobook's UpdateBook reindex is
+      CORRECT — don't break it.
+- [ ] Regression test: soft-delete an indexed book, assert a title probe
+      returns nothing WITHOUT a boot reconcile.


### PR DESCRIPTION
## Summary
Task C715 — prerequisite for an honest E03. The boot coverage gate compared counts (`len(books) <= DocCount()` → OK), which a polluted index passes forever. Production today: 67,824 docs vs 63,871 live books — the surplus is exactly the 3,953 soft-deleted books the 08-13 backfill indexed through the then-leaky `ListBookIDs` (see #2430's findings) — and the gate logged `search index coverage OK` over the top.

- `BleveIndex.AllDocIDs()` (new): one sequential pass over the low-level doc-ID reader — no scoring, no document loads.
- `reconcileSearchIndexCoverage` now diffs sets both ways: **missing** live books → marked dirty for the reconciler (unchanged mechanism); **stale** docs (book hard- or soft-deleted) → deleted directly, with bgCtx cancellation and per-doc error tolerance.
- Restore-from-trash safety verified in-code: `RestoreAudiobook` → `UpdateBook` → `indexedStore` reindex hook.
- **Filed, not fixed** (fragment): the soft-delete transition itself upserts the trashed book back into the index via that same hook — live re-pollution source between boots.

## Verification
- New `TestSearchCoverage_StaleDocsAreDeleted`: 2 live+indexed, 1 live+missing, 2 indexed-but-gone. Asserts the old count gate would have passed (docs 4 ≥ books 3), then post-reconcile: exactly 3 docs, ghost probes return nothing, the missing live book serves.
- **Mutation-verified**: stale-deletion removed → test FAILs; restored → all 3 coverage tests `ok`.
- Existing partial-backfill repair + precision tests unchanged and green.

## Prod effect on next deploy+boot
The 3,953 trash docs are deleted at boot and the `indexed=67824 books=63871` divergence closes — E03 can then confirm a genuinely clean index instead of a padded "OK".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS