### PR TITLE
docs(todo): F110 playlist-PID coverage measured (F111 GO)

### DIFF
--- a/changelog.d/20260814_183000_f110_pid_coverage.md
+++ b/changelog.d/20260814_183000_f110_pid_coverage.md
@@ -1,0 +1,5 @@
+### Documentation
+
+- Filed the F110 playlist-PID coverage measurement: 88.5% of XML tracks resolve
+  via the ExternalIDMapping backfill (post-#2367); the album-level PID field
+  resolves only 14% and must not be used for playlist import. F111 is GO.

--- a/todo.d/20260814-f110-pid-coverage-measured.md
+++ b/todo.d/20260814-f110-pid-coverage-measured.md
@@ -1,0 +1,26 @@
+## F110 measured: playlist-item PID coverage is 88.5% via ExternalIDMapping — F111 is GO
+
+Measured on production 2026-08-14. Two instruments, very different answers —
+the brief named the wrong one:
+
+- **The RIGHT instrument — `ExternalIDMapping` (track-PID → book), i.e.
+  `GetBookByExternalID("itunes", pid)`:** this morning's post-#2367 boot
+  backfill completed `tracks_processed=97981 registered=86732` — **88.5% of
+  all XML tracks** now resolve to a book at track level. This is the lookup
+  F111's importer must use.
+- **The instrument the F110 brief named — `GetBookByITunesPersistentID`
+  (album-level `Book.ITunesPersistentID`):** only 13,128 books carry the
+  field (API `/api/v1/itunes/books` page-through = boot log exactly), and
+  only 14.0% of the 84,296 distinct user-playlist PIDs resolve through it.
+  **Do not use it for playlist import** — it answers a different question.
+- Current XML (`iTunes Library.xml`, 160MB, 2026-07-19): 269 user playlists
+  carry materialized `Playlist Items`, 98,184 refs. Under even the weak
+  album-PID instrument the distribution is bimodal: **124 playlists at 100%
+  coverage**, 96 at 1–49%, 13 at 0% — the mapping instrument strictly
+  improves on this.
+
+**Verdict: coverage does NOT moot the recovery paths (the F110 gate
+question). F111 (static-snapshot import by PID) is GO** once the owner
+green-lights the run — resolve via `GetBookByExternalID("itunes", pid)`,
+import as idempotent one-shot maintenance op, verify by re-reading the DB.
+Exact per-playlist import counts come from that run's report.


### PR DESCRIPTION
## Summary
Task F110 (gates F111/F112). Production-measured with two instruments:
- **`ExternalIDMapping` track-PID lookup (the right one): 86,732/97,981 tracks = 88.5%** resolve, after this morning's post-#2367 boot backfill completed.
- The brief's named instrument (`GetBookByITunesPersistentID`, album-level field): 13,128 books, 14.0% of distinct playlist PIDs — wrong tool for track-level import, documented so F111 doesn't use it.
- 269 user playlists with items (98,184 refs); bimodal per-playlist distribution (124 at 100% even under the weak instrument).

**Verdict: F111 static-snapshot import is GO** (owner run go-ahead still required); importer must resolve via `GetBookByExternalID("itunes", pid)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS