### PR TITLE
feat(audiobooks): version_group_id becomes a real filter field (C110)

### DIFF
--- a/changelog.d/20260814_193000_version_group_filter.md
+++ b/changelog.d/20260814_193000_version_group_filter.md
@@ -1,0 +1,7 @@
+### Added
+
+- `version_group_id` is now a real filter field on the audiobooks list
+  (`filters=[{"field":"version_group_id","value":"01…"}]`). Previously it was
+  not a filter at all: the bare-param guard 400'd it, and before that guard a
+  `?version_group_id=X` request silently listed the entire library. Unblocks
+  the clickable version-group link in the UI (G111).

--- a/internal/audiobooks/filter_field_conformance_test.go
+++ b/internal/audiobooks/filter_field_conformance_test.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/filter_field_conformance_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2d84f0b6-31ca-4e57-9a1f-6b70c8e2d415
 // last-edited: 2026-08-14
 
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
 
 // searchParserPath is the frontend's field list, read as a fixture. Relative to
@@ -122,11 +124,33 @@ func TestFilterFieldNames_MatchTheMatcher(t *testing.T) {
 
 	// And the reverse direction, spot-checked: a name the matcher accepts but
 	// the list omits would never be suggested to a caller who needs it.
-	for _, implemented := range []string{"title", "year", "duration", "marked_for_deletion", "isbn13"} {
+	for _, implemented := range []string{"title", "year", "duration", "marked_for_deletion", "isbn13", "version_group_id"} {
 		require.Containsf(t, names, implemented,
 			"%q is filterable but missing from KnownFilterFields", implemented)
 	}
 
 	require.False(t, FieldIsKnown("zzz_not_a_real_field"),
 		"an unknown field must be reported unknown, or the boundary rejection never fires")
+}
+
+// TestVersionGroupIDFilter_MatchesMembersOnly pins C110: version_group_id is a
+// real filter field. Before this, the #2417 bare-param guard 400'd it and the
+// filters form rejected it as unknown — production measured ?version_group_id=X
+// listing the ENTIRE library (fragment 20260814-version-group-id-not-a-filter-field).
+func TestVersionGroupIDFilter_MatchesMembersOnly(t *testing.T) {
+	vg := "01KNDC17RY2ATJFRACA8KK301A"
+	other := "01KZZZZZZZZZZZZZZZZZZZZZZZ"
+	member := database.Book{ID: "b1", Title: "Member", VersionGroupID: &vg}
+	otherBook := database.Book{ID: "b2", Title: "Other", VersionGroupID: &other}
+	ungrouped := database.Book{ID: "b3", Title: "Ungrouped"}
+
+	require.True(t, fieldMatchesValue(member, "version_group_id", vg))
+	require.False(t, fieldMatchesValue(otherBook, "version_group_id", vg))
+	require.False(t, fieldMatchesValue(ungrouped, "version_group_id", vg),
+		"a nil VersionGroupID must not match any group filter")
+
+	// The boundary validators must now accept it end to end.
+	if field, unknown := FirstUnknownFilterField([]FieldFilter{{Field: "version_group_id", Value: vg}}); unknown {
+		t.Fatalf("FirstUnknownFilterField still rejects %q", field)
+	}
 }

--- a/internal/audiobooks/service_filtering.go
+++ b/internal/audiobooks/service_filtering.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/service_filtering.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: b4e8c3d2-e5f6-7a80-9b0c-1d2e3f4a5b6c
 // last-edited: 2026-08-14
 
@@ -524,6 +524,8 @@ func bookFieldValue(book database.Book, field string) (string, bool) {
 		bookValue = derefStr(book.ISBN10)
 	case "isbn13":
 		bookValue = derefStr(book.ISBN13)
+	case "version_group_id":
+		bookValue = derefStr(book.VersionGroupID)
 	case "work_id":
 		bookValue = derefStr(book.WorkID)
 
@@ -648,6 +650,7 @@ var allFilterFieldNames = []string{
 	"itunes_sync_status", "duration", "duration_seconds", "bitrate",
 	"bitrate_kbps", "file_size", "file_size_bytes", "sample_rate",
 	"sample_rate_hz", "channels", "bit_depth", "isbn10", "isbn13", "work_id",
+	"version_group_id",
 	"year", "created_at", "updated_at", "marked_for_deletion",
 	"read_status", "progress_pct", "last_played",
 	"user_rating_overall", "user_rating_story", "user_rating_performance",

--- a/internal/server/handlers/audiobooks/unknown_filter_field_test.go
+++ b/internal/server/handlers/audiobooks/unknown_filter_field_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/audiobooks/unknown_filter_field_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 13ea27a2-ccad-49a7-a164-0bc1ca711898
 // last-edited: 2026-08-14
 
@@ -20,7 +20,9 @@ import (
 // 2026-08-14: the nonsense field zzz_not_a_real_field returned count:0, exactly
 // as marked_for_deletion did while 3,953 books qualified.
 func TestListAudiobooks_UnknownFilterField_400(t *testing.T) {
-	for _, field := range []string{"zzz_not_a_real_field", "titel", "version_group_id"} {
+	// version_group_id was in this list until C110 promoted it to a real
+	// filter field (2026-08-14) — it now belongs to the accepted set below.
+	for _, field := range []string{"zzz_not_a_real_field", "titel"} {
 		t.Run(field, func(t *testing.T) {
 			h, _ := newHandler(t)
 			q := url.Values{"filters": {`[{"field":"` + field + `","value":"x"}]`}}
@@ -55,6 +57,7 @@ func TestListAudiobooks_PreviouslyBrokenFields_NotRejected(t *testing.T) {
 		"year", "series_number", "isbn10", "isbn13", "work_id", "channels",
 		"bit_depth", "created_at", "updated_at", "duration", "file_size",
 		"bitrate", "sample_rate", "marked_for_deletion",
+		"version_group_id", // promoted by C110 (2026-08-14)
 	} {
 		t.Run(field, func(t *testing.T) {
 			h, d := newHandler(t)


### PR DESCRIPTION
## Summary
Task C110, D-1 approved. `version_group_id` joins `bookFieldValue` (the single switch behind both `FieldIsKnown` and the matcher) and `allFilterFieldNames`. Substring semantics match the sibling `work_id`; `nil` VersionGroupID matches no filter. Unblocks G111's clickable version-group links (UI `SEARCH_FIELDS` parity is G111's half).

## Verification
- New `TestVersionGroupIDFilter_MatchesMembersOnly`: member matches, other-group and ungrouped (nil) don't, `FirstUnknownFilterField` accepts the name.
- Conformance spot-check list now pins `version_group_id`.
- **Mutation-verified**: removing the matcher case fails both tests — the conformance test names the drifted field explicitly.
- Full `internal/audiobooks` short suite green (20s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS