### PR TITLE
feat(make): opt-in RAM-disk TMPDIR test targets (H111)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # file: Makefile
-# version: 2.17.0
+# version: 2.18.0
 # guid: c1d2e3f4-g5h6-7890-ijkl-m1234567890n
-# last-edited: 2026-08-12
+# last-edited: 2026-08-14
 
 BINARY := audiobook-organizer
 ROOT_DIR := $(shell git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -169,6 +169,24 @@ test: vet
 	@echo "🧪 Running backend tests (full suite)..."
 	@go test ./... -v -race -timeout 25m
 	@echo "✅ Backend tests passed"
+
+## test-fast: Full backend suite with TMPDIR on a RAM disk (H111, opt-in).
+## The per-test Pebble+migration setup is write-bound: measured 532s for
+## internal/server on a normal macOS TMPDIR vs 33.7s on a RAM disk (~15.8x).
+## Creates/reuses a 3GB RAM disk at /Volumes/abo-test-ram (macOS) or uses
+## /dev/shm (Linux). Test artifacts on it vanish at detach/reboot — the
+## wrapper only sets TMPDIR for the test run, it never touches data paths.
+## Remove the disk afterwards with: hdiutil detach /Volumes/abo-test-ram
+test-fast: vet
+	@echo "🧪 Running backend tests (full suite, RAM-disk TMPDIR)..."
+	@bash scripts/with-ramdisk-tmpdir.sh go test ./... -v -race -timeout 25m
+	@echo "✅ Backend tests passed (RAM-disk TMPDIR)"
+
+## test-fast-short: -short variant of test-fast.
+test-fast-short: vet
+	@echo "🧪 Running backend tests (-short, RAM-disk TMPDIR)..."
+	@bash scripts/with-ramdisk-tmpdir.sh go test ./... -short -race -timeout 25m
+	@echo "✅ Short backend tests passed (RAM-disk TMPDIR)"
 
 ## test-short: Run Go backend tests in short mode — skips slow property
 ## tests (undo/playlist/dedup/etc.) that create per-iteration PebbleStores.

--- a/changelog.d/20260814_195000_tmpfs_test_target.md
+++ b/changelog.d/20260814_195000_tmpfs_test_target.md
@@ -1,0 +1,7 @@
+### Added
+
+- `make test-fast` / `make test-fast-short`: run the backend suite with TMPDIR
+  on a RAM disk (auto-created at /Volumes/abo-test-ram on macOS, /dev/shm on
+  Linux). The per-test Pebble setup is write-bound — measured 532s → 33.7s for
+  internal/server, and 54.1s → 5.3s for internal/playlist on the day this
+  landed. Opt-in only; default `make test` unchanged.

--- a/scripts/with-ramdisk-tmpdir.sh
+++ b/scripts/with-ramdisk-tmpdir.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# file: scripts/with-ramdisk-tmpdir.sh
+# version: 1.0.0
+# guid: 5b9d2e70-8f41-4c6a-b3d5-1e07a9c48f26
+# last-edited: 2026-08-14
+#
+# Run a command with TMPDIR on a RAM disk (H111 / TODO-SRVTIMEOUT).
+#
+# WHY: the per-test setup in this repo (PebbleStore + migrations) is
+# write-heavy, and on macOS/APFS that write cost dominates test wall-clock:
+# measured 532s for internal/server with a normal TMPDIR vs 33.7s with TMPDIR
+# on a RAM disk — same commit, same machine (~15.8x).
+#
+# macOS: creates (or reuses) an APFS RAM disk mounted at /Volumes/abo-test-ram.
+# Linux: uses /dev/shm, which is already RAM-backed.
+#
+# The disk is deliberately left mounted for reuse across runs. Remove it with:
+#   hdiutil detach /Volumes/abo-test-ram
+#
+# DURABILITY: everything under the RAM disk vanishes at detach/reboot. Only
+# ever point TEST scratch at it — never real data. This wrapper only sets
+# TMPDIR for the child command; it does not touch any configured data path.
+
+set -euo pipefail
+
+[ $# -ge 1 ] || { echo "usage: $0 <command> [args...]" >&2; exit 2; }
+
+RAM_MB="${ABO_RAMDISK_MB:-3072}"
+MOUNT="/Volumes/abo-test-ram"
+
+case "$(uname -s)" in
+  Darwin)
+    if [ ! -d "$MOUNT" ]; then
+      sectors=$((RAM_MB * 2048)) # 512-byte sectors
+      dev=$(hdiutil attach -nomount "ram://$sectors" | tr -d '[:space:]')
+      diskutil erasevolume APFS "abo-test-ram" "$dev" >/dev/null
+      echo "ramdisk: created ${RAM_MB}MB at $MOUNT ($dev)" >&2
+    else
+      echo "ramdisk: reusing $MOUNT" >&2
+    fi
+    export TMPDIR="$MOUNT"
+    ;;
+  Linux)
+    export TMPDIR="/dev/shm"
+    echo "ramdisk: using /dev/shm" >&2
+    ;;
+  *)
+    echo "ramdisk: unsupported OS $(uname -s); running with default TMPDIR" >&2
+    ;;
+esac
+
+exec "$@"


### PR DESCRIPTION
## Summary
Task H111, D-9 approved (opt-in form). Adds `make test-fast` / `make test-fast-short` running the suite with `TMPDIR` on a RAM disk via new `scripts/with-ramdisk-tmpdir.sh` (macOS: auto-created 3GB APFS RAM disk at `/Volumes/abo-test-ram`, reused across runs, `hdiutil detach` to remove; Linux: `/dev/shm`). The wrapper sets TMPDIR for the child command only — no configured data path is touched; the durability caveat is documented in the script header and target comment. Defaults unchanged.

## Verification
- Wrapper smoke-tested: disk created, `internal/playlist` green in **5.3s** vs **54.1s** on normal TMPDIR earlier today (same machine) — consistent with the 532s→33.7s internal/server measurement already cited in the Makefile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS