### PR TITLE
docs(todo): C111 nil-primary census — 5,702 ungrouped nils, semantics data says nil=true

### DIFF
--- a/changelog.d/20260814_201500_c111_census.md
+++ b/changelog.d/20260814_201500_c111_census.md
@@ -1,0 +1,6 @@
+### Documentation
+
+- Filed the C111 nil-`is_primary_version` census: the nil population is 5,702
+  books (all ungrouped), not the long-quoted 22,552 (which was the explicit-
+  false set). The index path provably counts nil as true; recommended
+  unification is nil=true with an explicit-value backfill.

--- a/todo.d/20260814-c111-nil-primary-census.md
+++ b/todo.d/20260814-c111-nil-primary-census.md
@@ -1,0 +1,38 @@
+## C111 census: the nil `is_primary_version` population is 5,702 (all ungrouped) — "22,552 nils" was a misread
+
+Full-library page-through on production 2026-08-14 (63,839 rows, `omitempty`
+distinguishes nil from false), cross-tabbed against `version_group_id`:
+
+| flag  | has VG | count  |
+|-------|--------|--------|
+| true  | yes    | 35,586 |
+| false | yes    | 22,510 |
+| false | **no** | **41** |
+| nil   | no     | 5,702  |
+| nil   | yes    | 0      |
+| true  | no     | 0      |
+
+- **The structure is clean:** every version-grouped book carries an explicit
+  flag; every nil book is a groupless singleton. The long-quoted "22,552 nil
+  books" was actually the explicit-FALSE population (22,510+41 ≈ today's
+  22,551 `is_primary_version=false` count).
+- **The index path counts nil as TRUE** — proven by arithmetic, not code
+  reading: `is_primary_version=true` answers 41,288 = 35,586 explicit-true
+  + 5,702 nil.
+- **Correction to `20260814-c716-api-store-gap-resolved.md`:** the
+  `show_quarantined=true` bug drops the 22,551 **explicit-false** books
+  (it silently applies primary=true when the filter is unset), NOT the nils.
+- **The 41 false/no-VG books are C314's exact population** — ungrouped books
+  stuck at explicit false, invisible in every primary-only view, electable
+  to primary trivially (they have no group to conflict with).
+
+**D-2 semantic the data recommends: nil = true** (an ungrouped book is its
+own primary). Unify:
+- [ ] Make every raw `*bool` post-filter treat nil as true (matching
+      `effectiveBoolFieldIndex{Default: true}`), or
+- [ ] better: backfill explicit `true` onto the 5,702 nil rows (dry-run
+      gated) so nil ceases to exist, then make nil a validation error at
+      write time.
+- [ ] Fix the 41 ungrouped-false rows to true in the same op (C314).
+- [ ] Re-run this census as the post-fix verification: expected end state is
+      exactly two populations (true, false+VG).


### PR DESCRIPTION
## Summary
C111 measure-half (D-2: user asked for re-verification then measure-first). Re-verified live: the divergence is NOT fixed (no fix commit exists; live probe reproduces). Then the full census, cross-tabbed flag × version-group:

- nil = **5,702 books, all ungrouped** — the "22,552 nils" in prior notes was the explicit-false population.
- Every grouped book has an explicit flag (nil∩grouped = 0; true∩ungrouped = 0).
- Arithmetic proof the index path counts nil as true: filter true answers 41,288 = 35,586 explicit + 5,702 nil.
- Corrects #2430's fragment: `show_quarantined=true` drops the 22,551 **explicit-false** books, not nils.
- The 41 false/ungrouped rows = C314's exact fix population.

Recommended D-2 outcome (filed as follow-ups, not implemented here): nil=true, backfill explicit values (dry-run gated), then reject nil at write time; re-run this census as the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS