### PR TITLE
fix(security): log-injection barriers at the logging conduits (CA12 wave 1)

### DIFF
--- a/changelog.d/20260814_210000_log_sanitizer_conduits.md
+++ b/changelog.d/20260814_210000_log_sanitizer_conduits.md
@@ -1,0 +1,10 @@
+### Security
+
+- Log-injection sweep wave 1 (CA12): new `logging.Sanitize`/`SanitizeErr`
+  escape CR/LF in user-controlled strings; the shared logging conduits
+  (`logging.Info/Warn/Error/Debug`, `httputil.InternalError`, the http-request
+  error logger) now sanitize messages and string attribute values for every
+  caller at once. Also restored the machine-recognizable `strings.ReplaceAll`
+  barrier in `internal/logger`'s sanitizer — a comment claimed it existed but
+  a refactor had replaced it with a builder loop CodeQL cannot model, leaving
+  322 downstream alerts open.

--- a/internal/httputil/respond.go
+++ b/internal/httputil/respond.go
@@ -1,7 +1,7 @@
 // file: internal/httputil/respond.go
-// version: 1.0.2
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-06-01
+// last-edited: 2026-08-14
 
 // Package httputil provides shared HTTP response helpers for all packages
 // that handle gin HTTP requests (server, middleware, itunes/service, etc).
@@ -12,6 +12,8 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/falkcorp/audiobook-organizer/internal/logging"
 )
 
 // RespondWithError sends a standardized error response and logs it.
@@ -76,7 +78,9 @@ func RespondWithServiceUnavailable(c *gin.Context, message string) {
 // Use this when you have a concrete error value to log but only want to expose
 // a generic message to the client.
 func InternalError(c *gin.Context, msg string, err error) {
-	slog.Error(msg, "err", err)
+	// Error text routinely wraps user-controlled strings (file names, tag
+	// values) — escape CR/LF so it cannot forge log records (CA12).
+	slog.Error(msg, "err", logging.SanitizeErr(err))
 	RespondWithInternalError(c, msg)
 }
 
@@ -114,7 +118,10 @@ func RespondWithList(c *gin.Context, items any, count int, limit int, offset int
 
 func logErrorWithContext(c *gin.Context, statusCode int, message string) {
 	method := c.Request.Method
-	path := c.Request.URL.Path
+	// Path and message derive from the request; escape CR/LF so a crafted
+	// URL cannot forge log records (CA12).
+	path := logging.Sanitize(c.Request.URL.Path)
+	message = logging.Sanitize(message)
 	clientIP := c.ClientIP()
 	if statusCode >= 500 {
 		slog.Error("http request", "method", method, "path", path, "status", statusCode, "message", message, "clientIP", clientIP)

--- a/internal/logger/sanitize.go
+++ b/internal/logger/sanitize.go
@@ -1,7 +1,7 @@
 // file: internal/logger/sanitize.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1a7f3c92-5e6b-4d08-9c2a-3b8e0f1d6a47
-// last-edited: 2026-06-17
+// last-edited: 2026-08-14
 
 package logger
 
@@ -18,13 +18,19 @@ import "strings"
 //
 // Clean strings (the common case) are returned unchanged with no allocation.
 //
-// The explicit `strings.ReplaceAll` of "\r" and "\n" below is also what CodeQL
-// recognizes as a log-injection sanitizer barrier; keep it even though the
-// builder loop would otherwise handle them.
+// The explicit `strings.ReplaceAll` of "\r" and "\n" below is what CodeQL
+// recognizes as a log-injection sanitizer barrier. A previous revision of this
+// function claimed that in a comment while the code only had the builder loop —
+// which CodeQL does NOT model — so every call site downstream of this sanitizer
+// stayed flagged (322 open go/log-injection alerts on 2026-08-14, many of them
+// through here). The ReplaceAll calls are semantically redundant with the loop;
+// they exist to be machine-recognizable. Do not "simplify" them away again.
 func sanitizeLogLine(s string) string {
 	if !strings.ContainsFunc(s, isLogControl) {
 		return s
 	}
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
 	var b strings.Builder
 	b.Grow(len(s) + 8)
 	const hex = "0123456789abcdef"

--- a/internal/logging/sanitize.go
+++ b/internal/logging/sanitize.go
@@ -1,0 +1,40 @@
+// file: internal/logging/sanitize.go
+// version: 1.0.0
+// guid: 6e2a8b40-1d5f-4c93-b7e8-3a09d6c15f82
+// last-edited: 2026-08-14
+
+package logging
+
+import "strings"
+
+// Sanitize neutralizes log injection (CodeQL go/log-injection, CA12): a
+// user-controlled string containing "\n" or "\r" can otherwise forge entire
+// fake log lines — an attacker-supplied title of
+// "x\nlevel=INFO msg=\"admin login ok\"" prints as two records. Newlines and
+// carriage returns are ESCAPED (\n -> \\n), not dropped, so the logged value
+// remains a faithful, greppable representation of what the user actually sent.
+//
+// Use it on any string that originates outside the process — request params,
+// file paths from disk scans, tag values read from media files, titles,
+// external API payloads — at the point it is passed to slog/fmt logging.
+// Values the program itself computed (op IDs, enum states, counts) need no
+// wrapping.
+func Sanitize(s string) string {
+	if !strings.ContainsAny(s, "\n\r") {
+		return s
+	}
+	s = strings.ReplaceAll(s, "\r", "\\r")
+	s = strings.ReplaceAll(s, "\n", "\\n")
+	return s
+}
+
+// SanitizeErr renders an error for logging with the same newline escaping as
+// Sanitize. Errors routinely wrap user-controlled strings (file names, tag
+// values), which makes err.Error() exactly as forgeable as the raw input.
+// Returns "" for a nil error.
+func SanitizeErr(err error) string {
+	if err == nil {
+		return ""
+	}
+	return Sanitize(err.Error())
+}

--- a/internal/logging/sanitize_test.go
+++ b/internal/logging/sanitize_test.go
@@ -1,0 +1,71 @@
+// file: internal/logging/sanitize_test.go
+// version: 1.0.0
+// guid: 9c4f7d21-6b83-4e05-a1d9-2f68b0c37e54
+// last-edited: 2026-08-14
+
+package logging
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestSanitize_EscapesInjectionVectors(t *testing.T) {
+	// The attack shape: a newline that forges a second log record.
+	forged := "The Hobbit\nlevel=INFO msg=\"admin login ok\""
+	got := Sanitize(forged)
+	if strings.ContainsAny(got, "\n\r") {
+		t.Fatalf("sanitized value still contains raw newline/CR: %q", got)
+	}
+	if got != "The Hobbit\\nlevel=INFO msg=\"admin login ok\"" {
+		t.Fatalf("newline must be ESCAPED, not dropped (the value stays greppable): %q", got)
+	}
+
+	if got := Sanitize("a\r\nb"); got != "a\\r\\nb" {
+		t.Fatalf("CRLF: got %q", got)
+	}
+
+	// The common case allocates nothing and passes through unchanged.
+	clean := "A Perfectly Normal Title (Unabridged)"
+	if got := Sanitize(clean); got != clean {
+		t.Fatalf("clean string must pass through unchanged: %q", got)
+	}
+}
+
+func TestSanitizeErr(t *testing.T) {
+	if got := SanitizeErr(nil); got != "" {
+		t.Fatalf("nil error: got %q", got)
+	}
+	err := errors.New("open /lib/x\ny: no such file")
+	if got := SanitizeErr(err); strings.Contains(got, "\n") {
+		t.Fatalf("error text still contains raw newline: %q", got)
+	}
+}
+
+// TestConduits_SanitizeAttrValues proves the Info/Warn/Error/Debug wrappers
+// are a sanitizing BARRIER: a tainted attr value passed by any caller comes
+// out of the handler as one record with the newline escaped. Captured through
+// a real slog handler, not by calling Sanitize directly — the wiring is the
+// thing under test.
+func TestConduits_SanitizeAttrValues(t *testing.T) {
+	var buf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	Info(context.Background(), "scan result",
+		"title", "Evil Book\nlevel=ERROR msg=forged", "count", 3)
+
+	out := buf.String()
+	if strings.Count(out, "\n") != 1 {
+		t.Fatalf("tainted attr forged extra log lines:\n%s", out)
+	}
+	// slog's TextHandler quotes the value, escaping our backslash again —
+	// the raw output carries \\n for the \n we injected.
+	if !strings.Contains(out, `Evil Book\\nlevel=ERROR`) {
+		t.Fatalf("escaped newline missing — value was dropped instead of escaped:\n%s", out)
+	}
+}

--- a/internal/logging/structured.go
+++ b/internal/logging/structured.go
@@ -1,5 +1,5 @@
 // file: internal/logging/structured.go
-// version: 1.0.0
+// version: 1.1.0
 
 package logging
 
@@ -27,31 +27,47 @@ func opAttrs(op *OpContext) []any {
 	return attrs
 }
 
+
+// sanitizeArgs escapes CR/LF in string-typed attribute VALUES (odd positions
+// in slog's alternating key,value convention). Keys are program constants and
+// are left alone; non-string values (ints, errors passed as any, slog.Attr)
+// are left alone — callers logging tainted error text should pass
+// SanitizeErr(err) explicitly. This makes Info/Warn/Error/Debug below a
+// sanitizing barrier for every caller in one place (CA12).
+func sanitizeArgs(args []any) []any {
+	for i := 1; i < len(args); i += 2 {
+		if s, ok := args[i].(string); ok {
+			args[i] = Sanitize(s)
+		}
+	}
+	return args
+}
+
 // Info logs a message with operation context from ctx automatically included.
 // Additional attrs are appended after operation attributes.
 func Info(ctx context.Context, msg string, attrs ...any) {
 	op := OpFromContext(ctx)
-	args := append(opAttrs(op), attrs...)
-	slog.Info(msg, args...)
+	args := sanitizeArgs(append(opAttrs(op), attrs...))
+	slog.Info(Sanitize(msg), args...)
 }
 
 // Warn logs a warning with operation context from ctx automatically included.
 func Warn(ctx context.Context, msg string, attrs ...any) {
 	op := OpFromContext(ctx)
-	args := append(opAttrs(op), attrs...)
-	slog.Warn(msg, args...)
+	args := sanitizeArgs(append(opAttrs(op), attrs...))
+	slog.Warn(Sanitize(msg), args...)
 }
 
 // Error logs an error with operation context from ctx automatically included.
 func Error(ctx context.Context, msg string, attrs ...any) {
 	op := OpFromContext(ctx)
-	args := append(opAttrs(op), attrs...)
-	slog.Error(msg, args...)
+	args := sanitizeArgs(append(opAttrs(op), attrs...))
+	slog.Error(Sanitize(msg), args...)
 }
 
 // Debug logs a debug message with operation context from ctx automatically included.
 func Debug(ctx context.Context, msg string, attrs ...any) {
 	op := OpFromContext(ctx)
-	args := append(opAttrs(op), attrs...)
-	slog.Debug(msg, args...)
+	args := sanitizeArgs(append(opAttrs(op), attrs...))
+	slog.Debug(Sanitize(msg), args...)
 }


### PR DESCRIPTION
## Summary
CA12 approved (D-7). Today's main CodeQL analysis carries **322 open `go/log-injection` alerts**. Rather than immediately wrapping 322 sites, wave 1 places CodeQL-recognizable barriers at the conduits everything flows through — and doubles as a recognition experiment before the fan-out:

- **New `logging.Sanitize` / `SanitizeErr`** — escape `\r`/`\n` (kept greppable, not dropped) via `strings.ReplaceAll`, the exact form CodeQL models as a log-injection barrier.
- **`logging.Info/Warn/Error/Debug`** sanitize the message + every string attr value → every caller of the structured conduit is covered at once. Proven through a real slog TextHandler capture; **mutation-verified** (removing `sanitizeArgs` → 4 failures).
- **`httputil`**: `InternalError` sanitizes error text; the request logger sanitizes path + message.
- **Root-cause find:** `internal/logger/sanitize.go`'s comment claims "the explicit strings.ReplaceAll below is what CodeQL recognizes" — but a refactor had replaced it with a rune-loop CodeQL cannot model, which is why every downstream line stayed flagged. The real ReplaceAll calls are restored, comment corrected.

## Next (separate PRs)
After the next main analysis: count which alert families closed; remaining direct-`slog` sites get per-site `logging.Sanitize` wraps in package shards (metafetch 99, server+handlers ~80, …).

## Verification
`go build ./...` clean; logger/httputil/logging suites green; barrier test mutation-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS