### PR TITLE
fix(e2e): per-worktree port, bundle identity check, bind-failure exit (H113)

### DIFF
--- a/changelog.d/20260814_223000_e2e_port_isolation.md
+++ b/changelog.d/20260814_223000_e2e_port_isolation.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- E2E runs are now isolated per worktree (H113): the port and /tmp scratch
+  dirs derive from the worktree path (E2E_PORT overrides), global-setup
+  asserts the reused server serves THIS worktree's bundle (hashed asset
+  identity, not just freshness), and a server whose main listener fails to
+  bind now exits non-zero instead of idling as a healthy-looking zombie.
+  Together these close the 2026-08-11 false-green generator where one
+  worktree's suite silently tested a sibling worktree's build.

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 3.17.0
+// version: 3.18.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-08-14
 
@@ -932,7 +932,13 @@ func (s *Server) configureAndStartHTTP(cfg ServerConfig) error {
 			}
 			slog.Info("Starting server on", "protocols", protocols, "addr", s.httpServer.Addr)
 			if err := s.httpServer.ListenAndServeTLS(cfg.TLSCertFile, cfg.TLSKeyFile); err != nil && err != http.ErrServerClosed {
-				slog.Error("Failed to start HTTPS server", "err", err)
+				// A process whose MAIN listener failed to bind is useless but
+				// looks alive: on 2026-08-11 an e2e run probed the port, got a
+				// 200 from the SIBLING that owned it, and gated a change
+				// against the wrong build while this process idled. Exit so
+				// supervisors and scripts see the failure (H113).
+				slog.Error("Failed to start HTTPS server; exiting", "err", err)
+				os.Exit(1)
 			}
 		}()
 
@@ -987,7 +993,10 @@ func (s *Server) configureAndStartHTTP(cfg ServerConfig) error {
 		go func() {
 			slog.Info("Starting HTTP/1.1 server on (use --tls-cert and --tls-key for HTTP/2, add --http3-port for HTTP/3)", "addr", s.httpServer.Addr)
 			if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				slog.Error("Failed to start server", "err", err)
+				// See the TLS twin above: a bind failure must not leave a
+				// healthy-looking zombie process (H113).
+				slog.Error("Failed to start server; exiting", "err", err)
+				os.Exit(1)
 			}
 		}()
 	}

--- a/web/tests/e2e/e2e-env.ts
+++ b/web/tests/e2e/e2e-env.ts
@@ -1,0 +1,45 @@
+// file: tests/e2e/e2e-env.ts
+// version: 1.0.0
+// guid: 4d9e2b71-6c05-483a-9f1e-7b28d0c64a53
+// last-edited: 2026-08-14
+
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Absolute repo root of THIS worktree (…/tests/e2e -> repo root). */
+export const REPO_ROOT = join(__dirname, '../../..');
+
+/**
+ * Per-worktree e2e port (H113).
+ *
+ * The port used to be a hardcoded 8484 with `reuseExistingServer` on, so two
+ * worktrees' agents contended for one port — and on 2026-08-11 a suite ran its
+ * assertions against a SIBLING worktree's server whose bind had succeeded
+ * first (the loser logged the bind error and idled, curl said 200, everything
+ * looked healthy). Deriving the port from the worktree path makes contention
+ * structurally impossible: same worktree → same port every run, different
+ * worktree → different port.
+ *
+ * Range 8500–8899: clear of the dev server's 8484 and of prod's convention.
+ * E2E_PORT overrides for the rare case two paths hash together or a port is
+ * occupied by something unrelated.
+ */
+function hashPath(p: string): number {
+  let h = 5381;
+  for (let i = 0; i < p.length; i++) {
+    h = ((h << 5) + h + p.charCodeAt(i)) >>> 0; // djb2
+  }
+  return h;
+}
+
+export const E2E_PORT: number = process.env.E2E_PORT
+  ? Number.parseInt(process.env.E2E_PORT, 10)
+  : 8500 + (hashPath(REPO_ROOT) % 400);
+
+/**
+ * Per-worktree scratch prefix. The old fixed /tmp/ao-e2e-db meant two
+ * concurrent worktrees clobbered each other's Pebble even on different ports.
+ */
+export const E2E_TMP_PREFIX = `/tmp/ao-e2e-${(hashPath(REPO_ROOT) % 0xffff).toString(16).padStart(4, '0')}`;

--- a/web/tests/e2e/global-setup.ts
+++ b/web/tests/e2e/global-setup.ts
@@ -1,18 +1,21 @@
 // file: tests/e2e/global-setup.ts
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2f7b4e91-8c05-4d63-a1f2-6b98e0c473da
-// last-edited: 2026-08-10
+// last-edited: 2026-08-14
 
 import { execFileSync } from 'child_process';
-import { statSync } from 'fs';
+import { readFileSync, statSync } from 'fs';
 import { createRequire } from 'module';
 import { dirname, join, sep } from 'path';
 import { fileURLToPath } from 'url';
+import { E2E_PORT } from './e2e-env';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '../../..');
 const WEB_DIR = join(__dirname, '../..');
-const PORT = 8484;
+// Derived per worktree (H113) — two agents in different worktrees can no
+// longer contend for one port. E2E_PORT env var overrides.
+const PORT = E2E_PORT;
 
 /**
  * Fail loudly when the suite is about to test a STALE server.
@@ -48,7 +51,7 @@ const PORT = 8484;
  * No-ops under CI (nothing to reuse — the config always builds its own) and
  * no-ops when nothing is listening.
  */
-export default function globalSetup(): void {
+export default async function globalSetup(): Promise<void> {
   assertProjectLocalPlaywright();
 
   if (process.env.CI) return;
@@ -104,7 +107,15 @@ export default function globalSetup(): void {
     }
   }
 
-  if (staler.length === 0) return;
+  if (staler.length === 0) {
+    // Freshness passed — now IDENTITY (H113). A sibling worktree's server that
+    // just rebuilt passes every timestamp check while serving a bundle with
+    // none of this worktree's changes; on 2026-08-11 a gate ran green-path
+    // assertions against exactly that. Hashed asset filenames are
+    // content-addressed, so "same names as my web/dist" is "same bundle".
+    await assertServedBundleIsOurs(pid);
+    return;
+  }
 
   throw new Error(
     [
@@ -181,6 +192,57 @@ function assertProjectLocalPlaywright(): void {
       ].join('\n'),
     );
   }
+}
+
+/**
+ * Assert the REUSED server serves THIS worktree's bundle (identity, not
+ * freshness). Compares the hashed asset filenames in the served index.html
+ * against the local web/dist/index.html. Only called for reused servers —
+ * a server this run started is trivially ours.
+ */
+async function assertServedBundleIsOurs(pid: number): Promise<void> {
+  let local: string;
+  try {
+    local = readFileSync(join(REPO_ROOT, 'web/dist/index.html'), 'utf8');
+  } catch {
+    return; // nothing built locally yet; the freshness check already ran
+  }
+  let served: string;
+  try {
+    const res = await fetch(`http://127.0.0.1:${PORT}/index.html`);
+    if (!res.ok) return; // not serving HTML — webServer will handle it
+    served = await res.text();
+  } catch {
+    return; // unreachable — webServer will start its own
+  }
+  const assetNames = (html: string): string[] =>
+    [...html.matchAll(/assets\/[A-Za-z0-9._-]+-[A-Za-z0-9_-]{8,}\.(?:js|css)/g)]
+      .map((m) => m[0])
+      .sort();
+  const localAssets = assetNames(local);
+  const servedAssets = assetNames(served);
+  if (localAssets.length === 0) return; // unhashed build; nothing to compare
+  if (JSON.stringify(localAssets) === JSON.stringify(servedAssets)) return;
+  throw new Error(
+    [
+      '',
+      `FOREIGN BUNDLE on 127.0.0.1:${PORT} (pid ${pid}).`,
+      '',
+      'The server passes the freshness check but is serving a DIFFERENT build',
+      'than this worktree\'s web/dist — almost certainly a sibling worktree\'s',
+      'server. Assertions against it say nothing about this worktree\'s code',
+      '(this exact false-green shipped-almost on 2026-08-11).',
+      '',
+      `  local  assets: ${localAssets.join(', ') || '(none)'}`,
+      `  served assets: ${servedAssets.join(', ') || '(none)'}`,
+      '',
+      'Fix:',
+      `  kill -9 ${pid}`,
+      '',
+      'Then re-run; Playwright will build and start this worktree\'s own server.',
+      '',
+    ].join('\n'),
+  );
 }
 
 /** PID listening on the e2e port, or null if nothing is. */

--- a/web/tests/e2e/playwright.config.ts
+++ b/web/tests/e2e/playwright.config.ts
@@ -1,9 +1,10 @@
 // file: tests/e2e/playwright.config.ts
-// version: 1.13.0
+// version: 1.14.0
 // guid: 7c8d9e0f-1a2b-3c4d-5e6f-7a8b9c0d1e2f
-// last-edited: 2026-08-11
+// last-edited: 2026-08-14
 
 import { defineConfig, devices } from '@playwright/test';
+import { E2E_PORT, E2E_TMP_PREFIX } from './e2e-env';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
@@ -14,7 +15,7 @@ const DEMO_ARTIFACTS_DIR = join(__dirname, '../../..', 'demo_artifacts');
 
 export default defineConfig({
   testDir: '.',
-  // Fails the run if :8484 is already serving a bundle older than the code
+  // Fails the run if the derived e2e port is already serving a bundle older than the code
   // under test. `reuseExistingServer` below is what makes that possible, and a
   // silently-reused stale server is what produced a false green on 2026-08-08
   // while the suite was ~50% red. See global-setup.ts.
@@ -59,7 +60,7 @@ export default defineConfig({
     ['html', { outputFolder: 'playwright-report', open: 'never' }],
   ],
   use: {
-    baseURL: 'http://127.0.0.1:8484',
+    baseURL: `http://127.0.0.1:${E2E_PORT}`,
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
@@ -138,8 +139,11 @@ export default defineConfig({
     // Build full app (frontend + embedded backend) and run single Go binary
     // Disable TLS for testing by passing empty cert/key flags
     // GOEXPERIMENT=jsonv2 is required for the Go backend (encoding/json/v2)
-    command: `bash -c 'export GOEXPERIMENT=jsonv2 && cd ${__dirname}/../../.. && cd web && npm run build && cd .. && go build -tags embed_frontend -o audiobook-organizer . && rm -rf /tmp/ao-e2e-db && mkdir -p /tmp/ao-e2e-db /tmp/ao-e2e-books && ./audiobook-organizer serve --tls-cert "" --tls-key "" --host 127.0.0.1 --db /tmp/ao-e2e-db/e2e.pebble --dir /tmp/ao-e2e-books'`,
-    url: 'http://127.0.0.1:8484',
+    // Port and scratch dirs derive from the worktree path (H113): two
+    // worktrees can run concurrently without contending for one port or
+    // clobbering one shared /tmp Pebble.
+    command: `bash -c 'export GOEXPERIMENT=jsonv2 && cd ${__dirname}/../../.. && cd web && npm run build && cd .. && go build -tags embed_frontend -o audiobook-organizer . && rm -rf ${E2E_TMP_PREFIX}-db && mkdir -p ${E2E_TMP_PREFIX}-db ${E2E_TMP_PREFIX}-books && ./audiobook-organizer serve --tls-cert "" --tls-key "" --host 127.0.0.1 --port ${E2E_PORT} --http3-port ${E2E_PORT} --db ${E2E_TMP_PREFIX}-db/e2e.pebble --dir ${E2E_TMP_PREFIX}-books'`,
+    url: `http://127.0.0.1:${E2E_PORT}`,
     // The command above builds the frontend AND compiles the Go binary before
     // it can serve anything. 120s was enough on a warm developer machine and
     // nowhere near enough on a cold CI runner with an empty Go build cache —


### PR DESCRIPTION
## Summary
Task H113 / fragment `20260811-e2e-port-collision-across-worktrees.md` — implements BOTH fix shapes plus the bind-failure hazard:

1. **Per-worktree port + scratch** (`tests/e2e/e2e-env.ts`): djb2 hash of the worktree path → port 8500–8899 and `/tmp/ao-e2e-<hash>` dirs; `E2E_PORT` overrides. Contention between worktrees becomes structurally impossible, and concurrent runs stop clobbering one shared Pebble dir.
2. **Identity, not freshness** (`global-setup.ts`): a reused server must serve index.html whose hashed asset filenames match the local `web/dist` — a sibling's fresh build passes every timestamp check and fails this loudly (error names both asset sets and the pid to kill).
3. **Bind failure exits non-zero** (`server_lifecycle.go`, both TLS and plain listeners): no more healthy-looking zombie that made `lsof`/`curl` reassuring while the port belonged to someone else.

## Verification
- `playwright --list`: config + globalSetup compile, 599 tests discovered.
- Full chain on the derived port (8715 for this worktree): webServer built and served with per-worktree tmp dirs; **`library-browser.spec.ts` 21/21 passed (33.4s)**.
- `go build ./internal/server/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS