### PR TITLE
perf(database): hoist Pebble reads out of the memdb writer mutex (C816)

### DIFF
--- a/changelog.d/20260814_235000_memdb_writer_mutex.md
+++ b/changelog.d/20260814_235000_memdb_writer_mutex.md
@@ -1,0 +1,9 @@
+### Performance
+
+- `UpsertBookToMemDB` no longer holds go-memdb's single global writer mutex
+  across three Pebble reads (authors, narrators, and the full book-file prefix
+  scan). The reads are hoisted to enqueue time — same snapshot contract as the
+  existing struct copy. Benchmarked with realistic 30KB fingerprints: parallel
+  UpdateBook 1.35–1.83 ms/op before → 1.21–1.25 ms/op after, with far lower
+  variance. This was the system-wide ceiling that made worker pools on
+  book-level ops buy less than NumCPU×.

--- a/internal/database/memdb_sync.go
+++ b/internal/database/memdb_sync.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_sync.go
-// version: 1.2.1
+// version: 1.3.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000005
-// last-edited: 2026-08-07
+// last-edited: 2026-08-14
 
 package database
 
@@ -126,6 +126,20 @@ func (p *PebbleStore) UpsertBookToMemDB(ctx context.Context, book *Book) {
 	}
 	// Snapshot NOW — the closure may run much later, on another goroutine.
 	snapshot := *book
+
+	// Fetch the relationship rows BEFORE entering memSync (C816). The closure
+	// runs inside go-memdb's single global writer mutex (Txn(true) takes
+	// db.writer.Lock()), and these three reads — two point lookups plus a
+	// full book-file prefix scan that unmarshals every fingerprint-bearing
+	// row — used to run inside it. Every other writer in the process
+	// serialized behind that I/O, which is why worker pools on book-level
+	// ops bought far less than NumCPU×. Enqueue-time capture is the same
+	// contract as the struct snapshot above: any later change to these rows
+	// emits its own sync op, so replay order keeps last-write-wins intact.
+	bas, baErr := p.GetBookAuthors(snapshot.ID)
+	bns, bnErr := p.GetBookNarrators(snapshot.ID)
+	files, fileErr := p.loadBookFilesForBookID(snapshot.ID)
+
 	p.memSync("UpsertBook", func(txn memTxn) error {
 		// Strip heavy fields (Description, BookSigV1, etc.) — memdb
 		// only needs lightweight projections for indexed iteration.
@@ -139,7 +153,7 @@ func (p *PebbleStore) UpsertBookToMemDB(ctx context.Context, book *Book) {
 		if _, err := txn.DeleteAll(memTableBookAuthors, memIdxBookID, snapshot.ID); err != nil {
 			return fmt.Errorf("clear book_authors: %w", err)
 		}
-		if bas, baErr := p.GetBookAuthors(snapshot.ID); baErr == nil {
+		if baErr == nil {
 			for i := range bas {
 				ba := bas[i]
 				if err := txn.Insert(memTableBookAuthors, &ba); err != nil {
@@ -152,7 +166,7 @@ func (p *PebbleStore) UpsertBookToMemDB(ctx context.Context, book *Book) {
 		if _, err := txn.DeleteAll(memTableBookNarrators, memIdxBookID, snapshot.ID); err != nil {
 			return fmt.Errorf("clear book_narrators: %w", err)
 		}
-		if bns, bnErr := p.GetBookNarrators(snapshot.ID); bnErr == nil {
+		if bnErr == nil {
 			for i := range bns {
 				bn := bns[i]
 				if err := txn.Insert(memTableBookNarrators, &bn); err != nil {
@@ -165,7 +179,6 @@ func (p *PebbleStore) UpsertBookToMemDB(ctx context.Context, book *Book) {
 		if _, err := txn.DeleteAll(memTableBookFiles, memIdxBookID, snapshot.ID); err != nil {
 			return fmt.Errorf("clear book_files: %w", err)
 		}
-		files, fileErr := p.loadBookFilesForBookID(snapshot.ID)
 		if fileErr == nil {
 			for i := range files {
 				bf := files[i]

--- a/internal/database/memdb_sync_bench_test.go
+++ b/internal/database/memdb_sync_bench_test.go
@@ -1,0 +1,61 @@
+// file: internal/database/memdb_sync_bench_test.go
+// version: 1.0.0
+// guid: 0e7c4a92-6d15-4b83-a9f0-2c58e1d76b34
+// last-edited: 2026-08-14
+
+package database
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// BenchmarkParallelUpdateBook measures UpdateBook throughput under concurrent
+// writers — the C816 shape. Before the fix, every UpsertBookToMemDB performed
+// three Pebble reads INSIDE go-memdb's single global writer mutex, so parallel
+// writers serialized behind each other's I/O.
+func BenchmarkParallelUpdateBook(b *testing.B) {
+	tmpdir := b.TempDir()
+	store, err := NewPebbleStore(tmpdir)
+	if err != nil {
+		b.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer store.Close()
+	store.WaitForWarmup()
+	store.UseMemDB = true
+
+	const nBooks = 32
+	books := make([]*Book, nBooks)
+	for i := 0; i < nBooks; i++ {
+		bk, err := store.CreateBook(&Book{Title: fmt.Sprintf("bench-%02d", i), FilePath: fmt.Sprintf("/b/%02d", i)})
+		if err != nil {
+			b.Fatalf("CreateBook: %v", err)
+		}
+		// Realistic fingerprint payloads: loadBookFilesForBookID prefix-scans
+		// and unmarshals every fingerprint-bearing row, and that unmarshal cost
+		// is exactly what C816 moved out of the global writer lock. Production
+		// AcoustID fingerprints run tens of KB per file.
+		fp := []byte(strings.Repeat("AQADtEmSJEmSJEcOHzh8", 1500)) // ~30KB
+		for j := 0; j < 8; j++ {
+			if err := store.CreateBookFile(&BookFile{BookID: bk.ID, FilePath: fmt.Sprintf("/b/%02d/f%d.mp3", i, j), Duration: 60, AcoustIDFingerprint: fp}); err != nil {
+				b.Fatalf("CreateBookFile: %v", err)
+			}
+		}
+		books[i] = bk
+	}
+
+	b.ResetTimer()
+	var idx int64
+	var mu sync.Mutex
+	next := func() *Book { mu.Lock(); defer mu.Unlock(); idx++; return books[idx%nBooks] }
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			bk := next()
+			if _, err := store.UpdateBook(bk.ID, bk); err != nil {
+				b.Fatalf("UpdateBook: %v", err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Task C816 (TODO ~2743). The three Pebble reads inside `UpsertBookToMemDB`'s `memSync` closure ran under go-memdb's **single global writer mutex** — the documented system-wide UpdateBook ceiling. They're hoisted to enqueue time; the closure now only does memdb inserts. Same consistency contract as the existing "Snapshot NOW" struct copy (any later relationship change emits its own ordered sync op).

## Benchmark (committed)
Parallel `UpdateBook`, 32 books × 8 files with realistic ~30KB fingerprints (the prefix-scan unmarshal cost is the point), 3 runs per side:
- **before:** 1.83 / 1.44 / 1.35 ms/op (high variance — writers serializing behind each other's I/O)
- **after:** 1.22 / 1.25 / 1.21 ms/op (tight)

With trivial payloads the two sides are indistinguishable (~1.0–1.1 ms both) — measured and stated rather than extrapolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS