### PR TITLE
fix(security): remove clean-string fast-paths that bypassed the CodeQL sanitizer barrier (CA12 wave 1.1)

### DIFF
--- a/changelog.d/20260814_130000_ca12_sanitizer_barrier_bypass.md
+++ b/changelog.d/20260814_130000_ca12_sanitizer_barrier_bypass.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Log-injection sanitizers (`logging.Sanitize`, `logger.sanitizeLogLine`) had a
+  clean-string fast-path that returned before the `strings.ReplaceAll` barrier,
+  so CodeQL's path-sensitive analysis saw taint bypassing the sanitizer and
+  321 of 322 go/log-injection alerts survived the CA12 wave-1 conduit fix.
+  Every path now flows through `ReplaceAll` (which is already allocation-free
+  on clean strings); output behavior is unchanged on all inputs.

--- a/internal/logger/sanitize.go
+++ b/internal/logger/sanitize.go
@@ -1,5 +1,5 @@
 // file: internal/logger/sanitize.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 1a7f3c92-5e6b-4d08-9c2a-3b8e0f1d6a47
 // last-edited: 2026-08-14
 
@@ -16,21 +16,23 @@ import "strings"
 //   - other C0 control bytes and DEL -> `\xNN`
 //   - "\t" is preserved (intended, safe in logs)
 //
-// Clean strings (the common case) are returned unchanged with no allocation.
+// Clean strings (the common case) are returned unchanged with no allocation:
+// ReplaceAll returns its input untouched when there is nothing to replace.
 //
 // The explicit `strings.ReplaceAll` of "\r" and "\n" below is what CodeQL
-// recognizes as a log-injection sanitizer barrier. A previous revision of this
-// function claimed that in a comment while the code only had the builder loop —
-// which CodeQL does NOT model — so every call site downstream of this sanitizer
-// stayed flagged (322 open go/log-injection alerts on 2026-08-14, many of them
-// through here). The ReplaceAll calls are semantically redundant with the loop;
-// they exist to be machine-recognizable. Do not "simplify" them away again.
+// recognizes as a log-injection sanitizer barrier, and it must run on EVERY
+// path through this function. Two prior revisions broke that invisibly:
+// one had only the builder loop (which CodeQL does not model), and the next
+// put a clean-string fast-path (`if !ContainsFunc { return s }`) BEFORE the
+// ReplaceAll calls — CodeQL's barrier is path-sensitive, so the early return
+// read as taint bypassing the sanitizer and 321 of 322 go/log-injection
+// alerts stayed open. No guard clause before the ReplaceAll calls, ever.
 func sanitizeLogLine(s string) string {
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
 	if !strings.ContainsFunc(s, isLogControl) {
 		return s
 	}
-	s = strings.ReplaceAll(s, "\r", `\r`)
-	s = strings.ReplaceAll(s, "\n", `\n`)
 	var b strings.Builder
 	b.Grow(len(s) + 8)
 	const hex = "0123456789abcdef"

--- a/internal/logging/sanitize.go
+++ b/internal/logging/sanitize.go
@@ -1,5 +1,5 @@
 // file: internal/logging/sanitize.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6e2a8b40-1d5f-4c93-b7e8-3a09d6c15f82
 // last-edited: 2026-08-14
 
@@ -19,10 +19,13 @@ import "strings"
 // external API payloads — at the point it is passed to slog/fmt logging.
 // Values the program itself computed (op IDs, enum states, counts) need no
 // wrapping.
+// Every path MUST flow through the ReplaceAll calls: CodeQL's barrier is
+// path-sensitive, and a clean-string fast-path (`if !ContainsAny { return s }`)
+// reads to the analyzer as taint bypassing the sanitizer — 321 of 322
+// go/log-injection alerts survived the 2026-08-14 conduit fix for exactly that
+// reason. ReplaceAll already returns the original string allocation-free when
+// there is nothing to replace, so no guard clause is needed.
 func Sanitize(s string) string {
-	if !strings.ContainsAny(s, "\n\r") {
-		return s
-	}
 	s = strings.ReplaceAll(s, "\r", "\\r")
 	s = strings.ReplaceAll(s, "\n", "\\n")
 	return s


### PR DESCRIPTION
## Why

CA12 wave 1 (#2439) put sanitizing barriers at the logging conduits, but the next main CodeQL analysis (commit 48b08378, 16:29Z) closed only **1 of 322** go/log-injection alerts — the top three open alerts are now the conduit's own slog calls in `internal/logging/structured.go:51/58/65`.

Root cause: both sanitizers guard the `strings.ReplaceAll` barrier with a clean-string early return (`if !strings.ContainsAny(s, "\n\r") { return s }`). CodeQL's barrier recognition is **path-sensitive** — the early return is a dataflow path on which taint reaches the sink without passing through the recognized sanitizer, so the barrier never registers. This is the same failure mode the wave-1 comment warned about (rune loop not modeled), reintroduced one line higher.

## What

- `internal/logging/sanitize.go` — drop the `ContainsAny` guard; every path flows through `ReplaceAll`.
- `internal/logger/sanitize.go` — move the `ContainsFunc` guard **after** the `ReplaceAll` calls (it still short-circuits the builder loop for strings with no other control bytes).
- Comments in both files now state the invariant: no guard clause before the `ReplaceAll` calls, ever.

`strings.ReplaceAll` already returns its input unchanged with zero allocation when nothing matches, so the removed guards bought one string scan each. Output is byte-identical on all inputs.

## Verification

- `go test ./internal/logging/ ./internal/logger/` — ok (existing tests cover clean and dirty paths in both packages; behavior unchanged, so no new tests).
- The real gate is the next main CodeQL analysis: expect the conduit-routed alert families to close. Fan-out of per-site wraps (~300 sites: metafetch 99, server+handlers ~80) stays gated on that measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS