### PR TITLE
fix(maintenance): retention job sweeps stale opstate resume blobs (C510)

### DIFF
--- a/changelog.d/20260814_131500_opstate_retention_sweep.md
+++ b/changelog.d/20260814_131500_opstate_retention_sweep.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- `opstate:<id>` / `opstate:<id>:params` keys leaked forever: only 2 of the 34
+  maintenance jobs cleared their persisted resume state on completion. The
+  `retention-and-hygiene` job now sweeps the `opstate:` prefix, deleting state
+  whose owning operation is gone or terminal (completed/failed/canceled) while
+  keeping state for running, queued, interrupted, or unrecognized statuses so
+  restart-resume is never broken.

--- a/internal/maintenance/jobs/retention_and_hygiene.go
+++ b/internal/maintenance/jobs/retention_and_hygiene.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/retention_and_hygiene.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: e7c9d4a2-f1b3-49a8-8c4f-7d2e5a1f3c9e
 // last-edited: 2026-08-14
 
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/config"
@@ -87,8 +88,21 @@ func (j *retentionAndHygieneJob) Run(ctx context.Context, store database.Store, 
 		}
 	}
 
+	// (3) opstate sweep: clear opstate:<id> / opstate:<id>:params blobs whose
+	// owning operation is finished or gone. Only 2 of the 34 maintenance jobs
+	// call operations.ClearState on completion, so these keys otherwise
+	// accumulate forever. Runs AFTER phase (1) so state orphaned by this very
+	// run's operation-retention pass is caught in the same run.
+	stateCut, err := deleteStaleOperationState(ctx, store, dryRun)
+	if err != nil {
+		slog.Error("retention-and-hygiene: opstate sweep failed", "error", err)
+		return fmt.Errorf("opstate sweep: %w", err)
+	}
+	slog.Info("retention-and-hygiene: stale operation state cleared",
+		"count", stateCut, "dry_run", dryRun)
+
 	slog.Info("retention-and-hygiene job complete",
-		"operations_deleted", operationsCut, "dry_run", dryRun)
+		"operations_deleted", operationsCut, "opstate_cleared", stateCut, "dry_run", dryRun)
 	return nil
 }
 
@@ -211,6 +225,80 @@ func deleteDeadPrefixes(ctx context.Context, store database.Store, dryRun bool) 
 	}
 
 	return total, nil
+}
+
+// terminalOpStatuses are the operation statuses from which the resume path can
+// never pick an operation back up: GetInterruptedOperations selects only
+// "running", "queued", and "interrupted", so state for anything here is dead.
+// "canceled" and "cancelled" are both listed because both spellings exist in
+// the codebase's status literals.
+var terminalOpStatuses = map[string]bool{
+	"completed": true,
+	"failed":    true,
+	"canceled":  true,
+	"cancelled": true,
+}
+
+// deleteStaleOperationState removes opstate:<id> and opstate:<id>:params blobs
+// whose owning operation is gone or terminal. runMaintenanceJob persists a
+// params blob per run so a restart can resume faithfully, but only 2 of the 34
+// jobs clear it on completion — the rest leak one pair of keys per run,
+// forever (small but unbounded growth).
+//
+// The decision is per-operation, and it deliberately fails toward KEEPING:
+//   - op record missing            -> state is orphaned (phase (1) may have just
+//     deleted the op)              -> delete
+//   - status in terminalOpStatuses -> resume can never fire -> delete
+//   - anything else — running, queued, interrupted, or a status this map does
+//     not know — -> KEEP. Deleting on "status not recognized" would silently
+//     break resume for any status value added later; an unknown status keeps
+//     its state until the operation itself ages out of retention.
+//
+// Returns the number of operations whose state was (or in dry-run, would be)
+// cleared — counting operations, not raw keys, so the dry-run count matches
+// the subsequent real run.
+func deleteStaleOperationState(ctx context.Context, store database.Store, dryRun bool) (int, error) {
+	pairs, err := store.ScanPrefix("opstate:")
+	if err != nil {
+		return 0, fmt.Errorf("scan opstate prefix: %w", err)
+	}
+
+	// Collapse opstate:<id> and opstate:<id>:params to one entry per op.
+	// Op IDs are ULIDs (no colons), so trimming the suffix is unambiguous.
+	ids := make(map[string]struct{}, len(pairs))
+	for _, pair := range pairs {
+		id := strings.TrimPrefix(pair.Key, "opstate:")
+		id = strings.TrimSuffix(id, ":params")
+		ids[id] = struct{}{}
+	}
+
+	slog.Info("deleteStaleOperationState: scanned opstate prefix",
+		"keys", len(pairs), "operations", len(ids), "dry_run", dryRun)
+
+	count := 0
+	for id := range ids {
+		if ctx.Err() != nil {
+			return count, ctx.Err()
+		}
+		op, err := store.GetOperationByID(id)
+		if err != nil {
+			return count, fmt.Errorf("get operation %s: %w", id, err)
+		}
+		if op != nil && !terminalOpStatuses[op.Status] {
+			continue // live or unknown status — resume may still need this state
+		}
+		if dryRun {
+			count++
+			continue
+		}
+		// DeleteOperationState removes both opstate:<id> and opstate:<id>:params
+		// in one batch.
+		if err := store.DeleteOperationState(id); err != nil {
+			return count, fmt.Errorf("delete operation state %s: %w", id, err)
+		}
+		count++
+	}
+	return count, nil
 }
 
 // isDeadPrefixSweepDone checks if the dead-prefix sweep completion flag is set.

--- a/internal/maintenance/jobs/retention_and_hygiene_test.go
+++ b/internal/maintenance/jobs/retention_and_hygiene_test.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/retention_and_hygiene_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: f8d0e5b9-c2a4-5b1d-9e7f-8c3d2a1b0f5e
 // last-edited: 2026-08-14
 
@@ -440,3 +440,84 @@ type nopReporter struct{}
 func (r *nopReporter) SetTotal(_ int)                     {}
 func (r *nopReporter) Increment()                         {}
 func (r *nopReporter) Log(_ string, _ string, _ *string)  {}
+
+// opstateSweepMock builds a MockStore holding opstate keys for four operations:
+// one running (must be KEPT — the resume path may still load it), one completed
+// (delete), one whose operation record is gone (delete), and one with a status
+// the sweep does not recognize (must be KEPT — fail toward keeping). The
+// completed op has BOTH key forms so the test also pins that the count is
+// per-operation, not per-key.
+func opstateSweepMock() (*database.MockStore, *[]string) {
+	deleted := &[]string{}
+	ops := map[string]*database.Operation{
+		"RUN1":   {ID: "RUN1", Status: "running"},
+		"DONE1":  {ID: "DONE1", Status: "completed"},
+		"WEIRD1": {ID: "WEIRD1", Status: "quarantined"},
+		// "GONE1" has opstate keys but no operation record.
+	}
+	m := &database.MockStore{}
+	m.ScanPrefixFunc = func(prefix string) ([]database.KVPair, error) {
+		if prefix != "opstate:" {
+			return nil, nil
+		}
+		return []database.KVPair{
+			{Key: "opstate:RUN1", Value: []byte("{}")},
+			{Key: "opstate:RUN1:params", Value: []byte("{}")},
+			{Key: "opstate:DONE1", Value: []byte("{}")},
+			{Key: "opstate:DONE1:params", Value: []byte("{}")},
+			{Key: "opstate:GONE1:params", Value: []byte("{}")},
+			{Key: "opstate:WEIRD1:params", Value: []byte("{}")},
+		}, nil
+	}
+	m.GetOperationByIDFunc = func(id string) (*database.Operation, error) {
+		return ops[id], nil // nil for GONE1, matching PebbleStore's not-found contract
+	}
+	m.DeleteOperationStateFunc = func(opID string) error {
+		*deleted = append(*deleted, opID)
+		return nil
+	}
+	return m, deleted
+}
+
+func TestDeleteStaleOperationState_DryRunCountsWithoutDeleting(t *testing.T) {
+	store, deleted := opstateSweepMock()
+	count, err := deleteStaleOperationState(context.Background(), store, true)
+	if err != nil {
+		t.Fatalf("dry-run sweep: %v", err)
+	}
+	// DONE1 (terminal) + GONE1 (orphaned) — counted per OPERATION, so DONE1's
+	// two keys contribute 1, not 2.
+	if count != 2 {
+		t.Fatalf("dry-run count = %d, want 2 (per-operation, not per-key)", count)
+	}
+	if len(*deleted) != 0 {
+		t.Fatalf("dry-run deleted state for %v, want none", *deleted)
+	}
+}
+
+func TestDeleteStaleOperationState_DeletesTerminalAndOrphanedOnly(t *testing.T) {
+	store, deleted := opstateSweepMock()
+	count, err := deleteStaleOperationState(context.Background(), store, false)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("count = %d, want 2", count)
+	}
+	got := map[string]bool{}
+	for _, id := range *deleted {
+		got[id] = true
+	}
+	if !got["DONE1"] || !got["GONE1"] || len(got) != 2 {
+		t.Fatalf("deleted %v, want exactly {DONE1, GONE1}", *deleted)
+	}
+	// The two keep cases are the load-bearing half of this test: a running op's
+	// state feeds the restart-resume path, and an unrecognized status must fail
+	// toward keeping.
+	if got["RUN1"] {
+		t.Fatal("sweep deleted state for a RUNNING op — this breaks restart-resume")
+	}
+	if got["WEIRD1"] {
+		t.Fatal("sweep deleted state for an unrecognized status — must fail toward keeping")
+	}
+}


### PR DESCRIPTION
## Why

`runMaintenanceJob` persists a ~90-byte params blob per run (`opstate:<id>:params`) so a restart can resume faithfully, but only 2 of the 34 maintenance jobs (`recompute-book-aggregates`, `backfill-file-hashes`) call `operations.ClearState` on completion. The other 32 leak both `opstate:` keys per run, forever. No retention path existed for the prefix (fragment `20260814-maintenance-dryrun-followups` item 2).

## What

New phase (3) in `retention-and-hygiene`: scan the `opstate:` prefix, collapse both key forms to one entry per operation, and delete via `DeleteOperationState` (both keys, one batch) only when the owning operation is **missing** or in a **terminal** status (`completed`/`failed`/`canceled`/`cancelled`).

The keep-side is the load-bearing half:
- `running`/`queued`/`interrupted` — exactly the set `GetInterruptedOperations` resumes — are never touched, so a mid-flight resumable op keeps its state.
- **Unrecognized statuses are kept**, not deleted: failing toward keeping means a status value added later can't silently break resume; the state ages out with the op record itself.

Runs after phase (1) so state orphaned by that phase's own op deletions is swept in the same run. Count is per-operation (not per-key) so the dry-run count matches the real run.

## Testing

- `TestDeleteStaleOperationState_DryRunCountsWithoutDeleting` — dry-run counts 2 (terminal + orphan) with zero deletions; pins per-operation counting via a double-keyed op.
- `TestDeleteStaleOperationState_DeletesTerminalAndOrphanedOnly` — real run deletes exactly {terminal, orphan}; running and unknown-status ops kept.
- Mutation-verified against the committed base: (1) inverted keep-guard, (2) orphans-kept, (3) per-key counting — each FAILS the tests; restored base passes.
- `go test ./internal/maintenance/... -count=1` ok, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS