### PR TITLE
fix(api): pid-repair honors dry_run from the JSON body, not just the query

### DIFF
--- a/changelog.d/20260814_134500_pid_repair_dryrun_body.md
+++ b/changelog.d/20260814_134500_pid_repair_dryrun_body.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- `POST /api/v1/itunes/pid-repair` read `dry_run` only from the query string;
+  a JSON body `{"dry_run":true}` was silently ignored and the request took the
+  apply path (fired on prod 2026-08-14 — harmless only because the repair plan
+  had nothing to clear). The endpoint now honors dry_run from either transport,
+  failing toward preview.

--- a/internal/server/itl_pid.go
+++ b/internal/server/itl_pid.go
@@ -1,7 +1,7 @@
 // file: internal/server/itl_pid.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d6b1f048-3e29-4a75-9c81-0f2a7b4c6e93
-// last-edited: 2026-07-23
+// last-edited: 2026-08-14
 //
 // book_file iTunes-PID integrity endpoints. /pid-integrity is a read-only census
 // of duplicate PIDs (a PID must identify exactly one book_file). /pid-repair
@@ -33,6 +33,25 @@ func (s *Server) pidIntegrityHandler(c *gin.Context) {
 	httputil.RespondWithOK(c, gin.H{"report": report})
 }
 
+// pidRepairDryRun reports whether the request asks for a preview. dry_run has
+// historically been a QUERY parameter only, but callers keep sending it as a
+// JSON body ({"dry_run":true}) — which was silently ignored, so a request that
+// asked for a preview took the APPLY path (fired on prod 2026-08-14; harmless
+// only because the plan had files_to_clear=0). Honor both transports and fail
+// toward preview: either source saying true means no writes.
+func pidRepairDryRun(c *gin.Context) bool {
+	if c.Query("dry_run") == "true" {
+		return true
+	}
+	var body struct {
+		DryRun bool `json:"dry_run"`
+	}
+	if err := c.ShouldBindJSON(&body); err == nil && body.DryRun {
+		return true
+	}
+	return false
+}
+
 // pidRepairHandler handles POST /api/v1/itunes/pid-repair. dry_run=true returns the
 // repair plan preview; otherwise it clears the redundant PID copies. Destructive to
 // the itunes_persistent_id FIELD only (no row/file deletion) → guarded by dry_run.
@@ -47,7 +66,7 @@ func (s *Server) pidRepairHandler(c *gin.Context) {
 		return
 	}
 
-	if c.Query("dry_run") == "true" {
+	if pidRepairDryRun(c) {
 		httputil.RespondWithOK(c, gin.H{"dry_run": true, "preview": preview})
 		return
 	}

--- a/internal/server/itl_pid_test.go
+++ b/internal/server/itl_pid_test.go
@@ -1,0 +1,47 @@
+// file: internal/server/itl_pid_test.go
+// version: 1.0.0
+// guid: 7c2e9f14-5a8b-4d36-b0c1-9e4f7a2d8b53
+// last-edited: 2026-08-14
+
+package server
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestPIDRepairDryRun pins that a dry-run request is honored no matter which
+// transport carries it. The body form is the load-bearing case: it used to be
+// silently ignored, so a caller asking for a preview got the APPLY path.
+func TestPIDRepairDryRun(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cases := []struct {
+		name  string
+		query string
+		body  string
+		want  bool
+	}{
+		{"query true", "?dry_run=true", "", true},
+		{"json body true", "", `{"dry_run":true}`, true},
+		{"json body false", "", `{"dry_run":false}`, false},
+		{"no dry_run anywhere", "", "", false},
+		{"malformed body does not force apply-with-preview-intent", "?dry_run=true", `{"dry_run"`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest("POST", "/api/v1/itunes/pid-repair"+tc.query,
+				bytes.NewBufferString(tc.body))
+			if tc.body != "" {
+				c.Request.Header.Set("Content-Type", "application/json")
+			}
+			if got := pidRepairDryRun(c); got != tc.want {
+				t.Fatalf("%s: pidRepairDryRun = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

`POST /api/v1/itunes/pid-repair` read `dry_run` only via `c.Query("dry_run")`. A caller sending `{"dry_run":true}` as a JSON body — the natural shape for a POST — was silently ignored and the request took the **apply** path.

This fired on prod today (2026-08-14, during E07 verification): the request asked for a preview and got an apply. Zero damage, but only by luck — the computed plan had `files_to_clear=0`, so `ApplyPIDRepairPlan` had nothing to write (`groups_repaired=0, files_cleared=0, errors=0`, confirmed in the response).

## What

Extracted `pidRepairDryRun(c)`: dry-run is honored from **either** transport (query `?dry_run=true` or body `{"dry_run":true}`), failing toward preview whenever either source says true. Default with no dry_run anywhere remains apply, unchanged for existing clients.

## Testing

`TestPIDRepairDryRun` — 5 cases: query form, body form (the load-bearing one), explicit body false, absent, and malformed-body-with-query-true. Mutation-verified against the committed base: removing the body path FAILS, inverting the query path FAILS, restored base passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS