### PR TITLE
feat(maintenance): normalize-primary-flags job makes nil/incoherent flags explicit (C111)

### DIFF
--- a/changelog.d/20260814_141500_normalize_primary_flags.md
+++ b/changelog.d/20260814_141500_normalize_primary_flags.md
@@ -1,0 +1,7 @@
+### Added
+
+- New `normalize-primary-flags` maintenance job (dry-run default): writes
+  explicit `is_primary_version=true` for ungrouped books whose flag is nil
+  (effective-true by the memdb convention) or incoherently false, so every
+  layer reads the flag the same way. Grouped books are counted but never
+  written — primary-ness inside a version group is elected, not guessed.

--- a/internal/maintenance/jobs/normalize_primary_flags.go
+++ b/internal/maintenance/jobs/normalize_primary_flags.go
@@ -1,0 +1,136 @@
+// file: internal/maintenance/jobs/normalize_primary_flags.go
+// version: 1.0.0
+// guid: 4b8e2d19-7c5a-4f60-9d3b-1e6a8c4f2b07
+// last-edited: 2026-08-14
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sync/atomic"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
+	"golang.org/x/sync/errgroup"
+)
+
+func init() { maintenance.Register(&normalizePrimaryFlagsJob{}) }
+
+// normalizePrimaryFlagsJob makes is_primary_version explicit for books where
+// the effective value is unambiguous, so every layer reads the same answer.
+//
+// The 2026-08-14 census (todo.d / #2438) settled the semantics: a nil flag
+// means "primary" — the memdb index (effectiveBoolFieldIndex{Default: true})
+// and the summary post-filter already agree on that, but any reader that
+// derefs the raw *bool without the nil-means-true convention silently flips
+// the answer (the author-path divergence). Writing the value explicitly
+// removes the convention dependence instead of asking every future reader to
+// know it.
+//
+// Normalization rules — only books OUTSIDE version groups are touched:
+//   - nil flag, no version group   -> explicit true  (census: 5,702 books)
+//   - false flag, no version group -> explicit true  (census: 41 books; a
+//     non-primary version of nothing is incoherent — C314's population)
+//   - nil flag, IN a version group -> COUNTED, never written. Group membership
+//     means primary-ness is elected (reconcile's elect-missing-primaries owns
+//     it); guessing here could mint a second primary. Census says this set is
+//     empty today; the count existing at all is the regression alarm.
+//   - explicit true, or explicit false inside a group -> untouched.
+type normalizePrimaryFlagsJob struct{}
+
+func (j *normalizePrimaryFlagsJob) ID() string       { return "normalize-primary-flags" }
+func (j *normalizePrimaryFlagsJob) Name() string     { return "Normalize is_primary_version flags" }
+func (j *normalizePrimaryFlagsJob) Category() string { return "maintenance" }
+func (j *normalizePrimaryFlagsJob) DefaultParams() any {
+	return struct {
+		DryRun bool `json:"dry_run"`
+	}{DryRun: true}
+}
+func (j *normalizePrimaryFlagsJob) Description() string {
+	return "Write explicit is_primary_version=true for ungrouped books whose flag is nil (effective-true) or incoherently false"
+}
+func (j *normalizePrimaryFlagsJob) CanResume() bool { return false } // idempotent single pass
+
+func (j *normalizePrimaryFlagsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	// One limit-0 call = one consistent snapshot; offset pages over the async
+	// memdb can skip or repeat rows on snapshot swap (see reconcile #2443).
+	books, err := store.GetAllBooksCore(0, 0)
+	if err != nil {
+		return fmt.Errorf("list books: %w", err)
+	}
+
+	var toFix []database.BookCore
+	var nilGrouped, falseUngrouped, nilUngrouped int
+	for i := range books {
+		b := &books[i]
+		grouped := b.VersionGroupID != nil && *b.VersionGroupID != ""
+		switch {
+		case b.IsPrimaryVersion == nil && !grouped:
+			nilUngrouped++
+			toFix = append(toFix, *b)
+		case b.IsPrimaryVersion == nil && grouped:
+			nilGrouped++ // elected, not guessed — see doc comment
+		case !*b.IsPrimaryVersion && !grouped:
+			falseUngrouped++
+			toFix = append(toFix, *b)
+		}
+	}
+
+	slog.Info("normalize-primary-flags: classified",
+		"books", len(books), "nil_ungrouped", nilUngrouped,
+		"false_ungrouped", falseUngrouped, "nil_grouped_left_for_election", nilGrouped,
+		"dry_run", dryRun)
+
+	if dryRun {
+		slog.Info("normalize-primary-flags: DRY RUN complete",
+			"would_write", len(toFix), "dry_run", true)
+		return nil
+	}
+
+	reporter.SetTotal(len(toFix))
+	var written, errCount int64
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(max(runtime.NumCPU(), 1))
+	for i := range toFix {
+		b := toFix[i]
+		g.Go(func() error {
+			if gctx.Err() != nil {
+				return gctx.Err()
+			}
+			// Hydrate the full row before write-back: the Core projection is
+			// slim, and UpdateBook persists the whole struct (same pattern as
+			// reconcile's elect-missing-primaries).
+			full, herr := store.GetBookByID(b.ID)
+			if herr != nil || full == nil {
+				slog.Warn("normalize-primary-flags: hydrate failed", "book", b.ID, "err", herr)
+				atomic.AddInt64(&errCount, 1)
+				return nil
+			}
+			t := true
+			full.IsPrimaryVersion = &t
+			if _, uerr := store.UpdateBook(full.ID, full); uerr != nil {
+				slog.Warn("normalize-primary-flags: write failed", "book", full.ID, "err", uerr)
+				atomic.AddInt64(&errCount, 1)
+				return nil
+			}
+			atomic.AddInt64(&written, 1)
+			reporter.Increment()
+			return nil
+		})
+	}
+	if werr := g.Wait(); werr != nil {
+		return werr
+	}
+
+	slog.Info("normalize-primary-flags: complete",
+		"written", written, "errors", errCount,
+		"nil_ungrouped", nilUngrouped, "false_ungrouped", falseUngrouped,
+		"nil_grouped_left_for_election", nilGrouped)
+	if errCount > 0 {
+		return fmt.Errorf("normalize-primary-flags: %d of %d writes failed", errCount, len(toFix))
+	}
+	return nil
+}

--- a/internal/maintenance/jobs/normalize_primary_flags_test.go
+++ b/internal/maintenance/jobs/normalize_primary_flags_test.go
@@ -1,0 +1,83 @@
+// file: internal/maintenance/jobs/normalize_primary_flags_test.go
+// version: 1.0.0
+// guid: 9f1c4e27-8b6d-4a35-b2e0-7c5d3f8a1e64
+// last-edited: 2026-08-14
+
+package jobs
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// normalizeFixture builds a store holding all five flag/group states. Only the
+// two "unambiguous ungrouped" rows may ever be written; the grouped rows belong
+// to primary ELECTION and a fixture without them cannot catch a job that
+// guesses (the census memory's warning: nil, true, and false must all appear).
+func normalizeFixture() (*database.MockStore, *map[string]bool, *sync.Mutex) {
+	f, tr := false, true
+	vg := "01VGROUP"
+	books := []database.BookCore{
+		{ID: "NIL-UNGROUPED"},
+		{ID: "NIL-GROUPED", VersionGroupID: &vg},
+		{ID: "FALSE-UNGROUPED", IsPrimaryVersion: &f},
+		{ID: "FALSE-GROUPED", IsPrimaryVersion: &f, VersionGroupID: &vg},
+		{ID: "TRUE-UNGROUPED", IsPrimaryVersion: &tr},
+	}
+	written := map[string]bool{}
+	var mu sync.Mutex
+	m := &database.MockStore{}
+	m.GetAllBooksCoreFunc = func(limit, offset int) ([]database.BookCore, error) {
+		if limit != 0 || offset != 0 {
+			// One consistent snapshot, never offset pages (see #2443).
+			panic("normalize-primary-flags must use a single limit-0 read")
+		}
+		return books, nil
+	}
+	m.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		return &database.Book{ID: id}, nil
+	}
+	m.UpdateBookFunc = func(id string, b *database.Book) (*database.Book, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if b.IsPrimaryVersion == nil || !*b.IsPrimaryVersion {
+			panic("job wrote a non-true flag: " + id)
+		}
+		written[id] = true
+		return b, nil
+	}
+	return m, &written, &mu
+}
+
+func TestNormalizePrimaryFlags_DryRunWritesNothing(t *testing.T) {
+	store, written, _ := normalizeFixture()
+	j := &normalizePrimaryFlagsJob{}
+	if err := j.Run(context.Background(), store, &nopReporter{}, true); err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	if len(*written) != 0 {
+		t.Fatalf("dry-run wrote %v, want none", *written)
+	}
+}
+
+func TestNormalizePrimaryFlags_WritesOnlyUnambiguousUngrouped(t *testing.T) {
+	store, written, _ := normalizeFixture()
+	j := &normalizePrimaryFlagsJob{}
+	if err := j.Run(context.Background(), store, &nopReporter{}, false); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	w := *written
+	if !w["NIL-UNGROUPED"] || !w["FALSE-UNGROUPED"] || len(w) != 2 {
+		t.Fatalf("wrote %v, want exactly {NIL-UNGROUPED, FALSE-UNGROUPED}", w)
+	}
+	// The keep cases are the load-bearing half: writing a grouped book's flag
+	// here could mint a second primary in its version group.
+	for _, id := range []string{"NIL-GROUPED", "FALSE-GROUPED", "TRUE-UNGROUPED"} {
+		if w[id] {
+			t.Fatalf("job wrote %s — grouped/explicit-true rows must be untouched", id)
+		}
+	}
+}


### PR DESCRIPTION
## Why

The C111 census (#2438) settled the semantics of `is_primary_version`: nil means primary — the memdb index (`effectiveBoolFieldIndex{Default: true}`) and the summary post-filter already read it that way, but any code that derefs the raw `*bool` without knowing the convention silently flips the answer (the author-path divergence in `todo.d`). The durable fix is to make the value explicit where it's unambiguous, instead of asking every future reader to know the convention.

## What

New `maintenance.normalize-primary-flags` job (dry-run default):

- **nil flag, no version group → explicit true** (census: 5,702 books, all ungrouped)
- **false flag, no version group → explicit true** (census: 41 books — a "non-primary version" of nothing is incoherent; this is exactly C314's population)
- **nil flag inside a version group → counted, never written.** Election (`elect-missing-primaries`) owns grouped primary-ness; writing here could mint a second primary. Census says this set is empty today — the counter existing at all is the regression alarm.
- explicit true, or explicit false inside a group → untouched.

Mechanics follow the established patterns: one limit-0 `GetAllBooksCore` read (single snapshot, no offset paging per #2443), hydrate-then-`UpdateBook` write path from `elect_primaries.go`, errgroup bounded to NumCPU per the concurrency mandate.

## Testing

Fixture holds all five flag/group states (the census memory's warning: a fixture without nil, true, AND false rows can't catch a guesser). Dry-run test pins zero writes; apply test pins exactly the two unambiguous rows written and the grouped/explicit rows untouched. The mock's `UpdateBookFunc` panics on any non-true write, and `GetAllBooksCoreFunc` panics on paged reads.

Mutation-verified against the committed base: (1) grouped nils also fixed, (2) false-ungrouped skipped, (3) dry-run gate removed — each FAILS; restored base passes. `go vet` + full maintenance suite green.

## Prod plan (after merge+deploy)

Dry-run first — expect `nil_ungrouped=5702, false_ungrouped=41, nil_grouped_left_for_election=0` (numbers may drift slightly with today's merges). Any nonzero `nil_grouped` or a wildly different count = STOP and re-census. Then apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS