### PR TITLE
docs: session-close handoff, August roundup, follow-up fragments (2026-08-14)

### DIFF
--- a/changelog.d/20260814_142000_session_close_docs.md
+++ b/changelog.d/20260814_142000_session_close_docs.md
@@ -1,0 +1,6 @@
+### Changed
+
+- Session-close handoff for 2026-08-14 (30 merged PRs, verified redeploy,
+  E-wave outcomes, in-flight canary state) and August roundup update; filed
+  fragments for the bulk-write-back speed prerequisites, the 2 remaining
+  ambiguous PID groups, and the prometheus-script indentation bug.

--- a/docs/executive-summaries/2026-08-31-august-monthly-roundup-executive-summary.md
+++ b/docs/executive-summaries/2026-08-31-august-monthly-roundup-executive-summary.md
@@ -1,11 +1,11 @@
 <!-- file: docs/executive-summaries/2026-08-31-august-monthly-roundup-executive-summary.md -->
-<!-- version: 1.2.0 -->
+<!-- version: 1.3.0 -->
 <!-- guid: e7a3f109-52d8-4c6b-91f4-08b7c2d64e35 -->
-<!-- last-edited: 2026-08-09 -->
+<!-- last-edited: 2026-08-14 -->
 
 # Executive Summary: August 2026 Monthly Roundup
 
-**Period covered:** 2026-08-01 through 2026-08-09 (**month in progress** — this is
+**Period covered:** 2026-08-01 through 2026-08-14 (**month in progress** — this is
 updated as work lands, not a closed record).
 **Individual write-ups this consolidates:** the seven dated summaries in this directory
 from 2026-08-04 to 2026-08-09, linked inline below.
@@ -27,6 +27,42 @@ while half of it was broken. The work has largely been finding out which reading
 be trusted, and fixing the ones that could not.
 
 ---
+
+## August 14: a thirty-fix day, and the search index finally tells the truth
+
+One day produced thirty merged fixes and a fully verified redeploy. The thread
+connecting most of them: **finishing off measurements that had been quietly
+wrong.**
+
+The biggest visible one: for weeks, the search index contained 3,983 entries
+for books that had been deleted — searches could surface books that no longer
+existed. A repair shipped earlier in the week ran at startup today and removed
+every one of them, and the index now matches the library exactly, verified on
+two consecutive restarts.
+
+A safety check on a repair tool paid for itself twice. Before running a
+planned iTunes identifier cleanup, a fresh count showed the recorded backlog
+of ~9,000 items was long stale — the real number was two, both needing a
+human decision rather than automation. And the check itself uncovered that
+the tool's "preview only" switch silently did nothing when sent the way most
+tools accept it — the request went straight to "apply." Nothing was damaged
+(there was nothing left to apply), and the switch now works in both forms.
+
+Monitoring is back. The metrics system had been unable to read the
+application's health feed since that feed was put behind a password earlier
+this month. The missing piece turned out to be one credential file; it's in
+place, and the health dashboard has been live again since mid-afternoon.
+
+Two library-wide repairs were measured before being run, and both
+measurements changed the plan. A migration that moves book signatures out of
+hot storage was previewed at 26,159 books — squarely in the predicted range,
+so it proceeds next session with a small first batch. A repair that rewrites
+correct metadata into the audio files themselves (fixing books whose files
+still carry pre-correction tags) was trialed on 100 books and found to be far
+too slow to run across the whole library overnight as hoped — so it was
+deferred for a speed fix rather than left to run for weeks. The trial also
+caught a real specimen: a file from one book still labeled inside as a
+different book entirely.
 
 ## 1. Numbers that were wrong
 

--- a/docs/handoffs/2026-08-14-session-close-handoff.md
+++ b/docs/handoffs/2026-08-14-session-close-handoff.md
@@ -1,0 +1,107 @@
+<!-- file: docs/handoffs/2026-08-14-session-close-handoff.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2e9c7b53-4f18-4d0a-b6e2-8a51d3c97f26 -->
+<!-- last-edited: 2026-08-14 -->
+
+# Session-close handoff — 2026-08-14 (~14:15 EDT)
+
+State dump for the next session. The companion status snapshot is
+[`2026-08-14-task-board.md`](2026-08-14-task-board.md) (v1.1.0); this file is
+the *delta* since that board plus everything in flight at close.
+
+## Where things stand
+
+- **30 PRs merged today (#2421–#2448), #2449 (C111 normalize-primary-flags)
+  auto-merging at close** — a background waiter merges it when the three fast
+  required checks pass. If it's still open at restart: `gh pr checks 2449`,
+  then `gh pr merge 2449 --rebase`, remove worktree
+  `../audiobook-organizer-c111`, delete branch `feat/normalize-primary-flags`.
+- **Production runs the 13:40 EDT build** (all of today's merges through
+  #2447). Boot verified: search index reconciled (3,983 stale docs deleted,
+  index == library, no divergence warning on the next boot), dedup-refresh
+  6h ticker live, config snapshot survived (review_apply on, intervals
+  restored). **#2449's job is NOT deployed yet** — next deploy picks it up.
+- **E09 Prometheus: DONE.** Scrape is `health=up` since 14:02. The yml block
+  pre-existed; the whole fix was a valid key in `/etc/prometheus/abo.token`
+  (minted via the API straight into a server-side file, never in any
+  transcript). Rotation = overwrite that file, no reload. The staged helper
+  script on the server was patched in place to v1.0.1 (its yml-edit step had
+  a guaranteed `ValueError` on list-style job entries — a dead indentation
+  block calling `.index('-')` on pure whitespace; the block was removed).
+  The repo's `scripts/setup-prometheus-auth.py` should be checked for the
+  same pattern before anyone reuses it (fragment filed).
+
+## In flight at close
+
+- **E08 canary (bulk-write-back, 100 books)** — op `01M00PGZKA0KBMPTZMAJTEKPD5`,
+  ~23/100 at ~14:07, 0 failures, ~35 s/book. A waiter task watches it.
+  **Verification procedure** (do this at restart if the session died first):
+  the three before-state samples are in `/tmp/e08_before.txt` locally; re-run
+  the same ffprobe over the three FILE paths and diff — the second sample
+  (an *Abaddon's Gate* file whose embedded album tag said *Nemesis Games*)
+  is the live specimen: its album tag flipping to Abaddon's Gate proves the
+  repair works.
+- **E08 FULL RUN: the nightly plan as approved is NOT executable.** Two
+  findings from the canary, filed as a fragment:
+  1. ~35 s/book, strictly serial (op logs process one book at a time) —
+     library-wide (~40K organizer-tree books after excluding the hands-off
+     iTunes tree; a large share of list rows live IN that tree) is **weeks**,
+     not a night.
+  2. 23/23 processed→written suggests the op rewrites tags unconditionally
+     rather than skipping files whose tags already match the DB.
+  Required before the full run: a tag-diff skip (probe ≈1 s vs rewrite
+  ≈35 s; only mismatched files get rewritten) and a bounded worker pool per
+  the concurrency mandate. `RunBulkWriteBack` lives in
+  `internal/server/server_maintenance_deps.go:44`. The op's ConcurrencyKey
+  serializes concurrent runs, so parallelism must go INSIDE the op.
+  **Owner approved canary + nightly full run — the full run is deferred on
+  these grounds, not on approval.**
+
+## Next queue (post-restart order)
+
+1. Confirm #2449 merged; clean its worktree; redeploy (`make deploy-debug`
+   after `git pull`) so normalize-primary-flags is available.
+2. **C111 prod run**: dry-run `maintenance.normalize-primary-flags` — expect
+   `nil_ungrouped≈5702, false_ungrouped≈41, nil_grouped_left_for_election=0`.
+   Nonzero nil_grouped or wildly different counts = STOP, re-census. Then
+   apply. This also unblocks re-verifying the author-46627 merge (the
+   instrument was blind on nil flags).
+3. **E01 BookSig canary apply**: `maintenance.booksig-sidecar-migrate` with
+   `{"dryRun":false,"limit":100}`; verify pair (GetBookByID non-nil BookSigV1
+   AND stripped `book:` row), then full apply, then re-dry-run ≈0. Dry-run
+   already measured: would migrate 26,159 of 63,841 (gate passed).
+4. **E02 whole-library chapters**: cohort is complete (47/77 already had
+   chapters). Whole-library = dry-run first (`apply:false`, no bookIds),
+   expect ≈14.6K candidates, then apply. Do NOT schedule recurring until the
+   "probed, found none" freshness marker exists.
+5. **A04 tonight-class check**: run a mutating op (series-prune is the
+   designated probe) and confirm `operation_changes` rows appear.
+6. **CA12 fan-out gate**: after the next CodeQL analysis on main lands
+   (baseline 321 open go/log-injection), count closures. If the #2445 barrier
+   fix registered, shard the remaining per-site wraps (metafetch 99,
+   server+handlers ~80). If it did NOT register, stop and re-diagnose — do
+   not fan out blind.
+7. **E08 full-run prerequisites**: tag-diff skip + bounded parallelism in
+   the write-back path (see fragment), then schedule the real nightly run.
+8. Backlog next picks: C514, C212, C413, C414, G110, F114, H115, C610
+   repair-op follow-up (~12K dangling refs), 5 remaining offset-walkers
+   (fragment `20260814-offset-walker-followups`). F-wave stays parked.
+
+## Owner-side / decisions outstanding
+
+- E07 residue: **2 ambiguous duplicate-PID groups** (same Alcatraz content
+  in both trees) need a human pick of canonical file; everything else in
+  that census resolved itself (the 8,984 record was stale).
+- `.api-token` rotation still advised (old value echoed into a local
+  transcript twice earlier today; LAN-only exposure, owner deprioritized).
+- E04 title-match false-series repair: build + dry-run remain unstarted.
+
+## Standing cautions (unchanged but load-bearing)
+
+- Fragments in `todo.d`/`changelog.d` are HEADERLESS.
+- Never `git checkout --` files in a worktree whose base isn't committed —
+  it cost one re-implementation today (C510). Commit BEFORE mutation-testing.
+- `POST /api/v1/itunes/pid-repair`: dry_run was query-only until #2447;
+  older curl habits with a JSON body silently took the APPLY path.
+- Prod stays on the debug build (`make deploy-debug`); `make deploy` pulls
+  the LOCAL tree — always `git pull` first.

--- a/todo.d/20260814-bulk-writeback-needs-diff-skip-and-parallelism.md
+++ b/todo.d/20260814-bulk-writeback-needs-diff-skip-and-parallelism.md
@@ -1,0 +1,14 @@
+- [ ] **`bulk-write-back` cannot do the approved E08 library-wide run as-is.**
+      Canary (100 books, op `01M00PGZKA0KBMPTZMAJTEKPD5`, 2026-08-14) measured
+      ~35 s/book, strictly serial, and 23/23 processed→written — it rewrites
+      tags unconditionally instead of skipping files whose tags already match
+      the DB. Library-wide (~40K organizer-tree books) is weeks, not the
+      approved nightly window. Before the full run: (1) add a tag-diff skip
+      (probe ≈1 s vs rewrite ≈35 s; only mismatched files rewritten — also
+      turns the op into a usable "how many books actually have stale tags"
+      census); (2) bounded worker pool inside the op per the concurrency
+      mandate (`RunBulkWriteBack`,
+      `internal/server/server_maintenance_deps.go:44`) — the ConcurrencyKey
+      serializes whole ops, so chunk-parallelism across ops is not available.
+      Owner approval for the full run already given (2026-08-14); only these
+      prerequisites block it.

--- a/todo.d/20260814-pid-repair-two-ambiguous-groups.md
+++ b/todo.d/20260814-pid-repair-two-ambiguous-groups.md
@@ -1,0 +1,10 @@
+- [ ] **E07 residue: 2 ambiguous duplicate-PID groups need a human pick.**
+      The 2026-08-14 live census (`GET /api/v1/itunes/pid-integrity`) shows
+      the duplicate-PID population is down to 2 groups — the same Alcatraz
+      content present in both the organizer tree and the iTunes tree
+      (sample PID `31A790B4DEF5981C`). The recorded "8,984 auto-resolvable"
+      was stale pre-repair state. `files_to_clear=0`, so the repair op has
+      nothing safe to do automatically; an operator must pick the canonical
+      file per group. The iTunes-tree copies are HANDS-OFF — resolution must
+      clear the organizer-side copy or be deferred, never touch the iTunes
+      tree.

--- a/todo.d/20260814-setup-prometheus-auth-py-dead-block.md
+++ b/todo.d/20260814-setup-prometheus-auth-py-dead-block.md
@@ -1,0 +1,8 @@
+- [ ] **Check `scripts/setup-prometheus-auth.py` for the dead-indentation
+      bug found in its server-side shell sibling.** The staged
+      `abo-prometheus-auth.sh` (server home dir, patched in place to v1.0.1
+      on 2026-08-14) computed a YAML body indent from a whitespace-only
+      regex capture and then called `.index('-')` on it — a guaranteed
+      `ValueError` for any list-style `- job_name:` entry, i.e. every real
+      prometheus.yml. If the repo script shares the pattern, fix it there
+      too; if not, note that the shell script diverged.


### PR DESCRIPTION
Wind-down package: restart handoff (delta since the v1.1.0 board + in-flight canary state + post-restart queue), August roundup section for today's 30-PR arc, and fragments for the bulk-write-back speed prerequisites (E08 full run deferred on measurement, not approval), the 2 remaining ambiguous PID groups, and the prometheus-script indentation bug. Scrub-checked: 0 IPs/keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS