### PR TITLE
fix(fileops): tag write-back preserves the original file mode (+ repair job)

### DIFF
--- a/changelog.d/20260814_150000_writetags_mode_preservation.md
+++ b/changelog.d/20260814_150000_writetags_mode_preservation.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- Tag write-back replaced audio files with mode 0600 copies: `WriteTagsSafe`'s
+  temp file is created 0600 and `OpenFile`'s mode argument applies only at
+  creation, so the "preserve permissions" copy never did. Every rewritten
+  file lost group/other access and its POSIX-ACL mask (found when the E08
+  canary made 100 books' files share-unreadable). The copy now chmods the
+  temp file to the original's mode before the atomic rename.
+
+### Added
+
+- `fix-file-modes` maintenance job (dry-run default): restores 0664 on
+  service-owned book files left at exactly 0600 by the bug above.

--- a/internal/fileops/write_tags_safe.go
+++ b/internal/fileops/write_tags_safe.go
@@ -1,5 +1,5 @@
 // file: internal/fileops/write_tags_safe.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: b4c5d6e7-f8a9-0b1c-2d3e-4f5a6b7c8d9e
 // last-edited: 2026-05-15
 
@@ -105,6 +105,16 @@ func copyFileContents(src, dst string) error {
 		return err
 	}
 	defer out.Close()
+
+	// The mode argument above applies only when OpenFile CREATES dst. Our dst
+	// already exists (os.CreateTemp made it, mode 0600), so an explicit chmod
+	// is required — without it every tag rewrite silently replaced the
+	// original with an 0600 file, zeroing the ACL mask and locking out every
+	// non-owner reader (found via the 2026-08-14 E08 canary: 100 books'
+	// files went share-unreadable).
+	if err := out.Chmod(info.Mode().Perm()); err != nil {
+		return err
+	}
 
 	if _, err := io.Copy(out, in); err != nil {
 		return err

--- a/internal/fileops/write_tags_safe_test.go
+++ b/internal/fileops/write_tags_safe_test.go
@@ -1,7 +1,7 @@
 // file: internal/fileops/write_tags_safe_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c5d6e7f8-a9b0-1c2d-3e4f-5a6b7c8d9e0f
-// last-edited: 2026-05-01
+// last-edited: 2026-08-14
 
 package fileops
 
@@ -170,5 +170,35 @@ func TestWriteTagsSafe_NonExistentFile(t *testing.T) {
 	_, _, err := WriteTagsSafe(path, writeBytes(nil), WriteTagsSafeOptions{})
 	if err == nil {
 		t.Error("expected error for non-existent file")
+	}
+}
+
+// TestWriteTagsSafe_PreservesFileMode pins the permission contract: the
+// rewritten file must carry the ORIGINAL's mode, not os.CreateTemp's 0600.
+// The 0600 leak zeroes the POSIX-ACL mask and locked 100 books' files out of
+// the share on 2026-08-14 (E08 canary) — OpenFile's mode argument applies
+// only at creation, so an existing temp file needs an explicit chmod.
+func TestWriteTagsSafe_PreservesFileMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audio.m4b")
+	if err := os.WriteFile(path, []byte("original audio bytes"), 0o664); err != nil {
+		t.Fatal(err)
+	}
+	// os.WriteFile honors umask; force the exact mode under test.
+	if err := os.Chmod(path, 0o664); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := WriteTagsSafe(path, writeBytes([]byte(" tagged")),
+		WriteTagsSafeOptions{}); err != nil {
+		t.Fatalf("WriteTagsSafe: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o664 {
+		t.Fatalf("rewritten file mode = %o, want 664 (mode must survive the temp-file rename)", got)
 	}
 }

--- a/internal/maintenance/jobs/fix_file_modes.go
+++ b/internal/maintenance/jobs/fix_file_modes.go
@@ -1,0 +1,87 @@
+// file: internal/maintenance/jobs/fix_file_modes.go
+// version: 1.0.0
+// guid: 6d3a9f82-1e47-4b50-8c2d-5f9e7a3b1c48
+// last-edited: 2026-08-14
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&fixFileModesJob{}) }
+
+// fixFileModesJob repairs audio files left mode 0600 by the WriteTagsSafe
+// permission bug (fixed in the same PR): the tag rewrite replaced originals
+// with the temp file's 0600 mode, which also zeroes the POSIX-ACL mask, so
+// every non-owner reader (SMB share, other users' ACL entries) lost access.
+//
+// Scope is deliberately tight: only regular files that are (a) recorded as
+// book_file rows, (b) owned by THIS process's uid (the service can only have
+// broken files it owns, and chmod on anything else would fail anyway), and
+// (c) currently mode exactly 0600. Those are restored to 0664 — the standard
+// mode per the library's group-write convention, which also restores the ACL
+// mask to rw-.
+type fixFileModesJob struct{}
+
+func (j *fixFileModesJob) ID() string       { return "fix-file-modes" }
+func (j *fixFileModesJob) Name() string     { return "Repair 0600 file modes" }
+func (j *fixFileModesJob) Category() string { return "maintenance" }
+func (j *fixFileModesJob) DefaultParams() any {
+	return struct {
+		DryRun bool `json:"dry_run"`
+	}{DryRun: true}
+}
+func (j *fixFileModesJob) Description() string {
+	return "Restore 0664 on service-owned book files left mode 0600 by the tag write-back permission bug"
+}
+func (j *fixFileModesJob) CanResume() bool { return false } // idempotent
+
+func (j *fixFileModesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	files, err := store.GetAllBookFilesCore()
+	if err != nil {
+		return fmt.Errorf("list book files: %w", err)
+	}
+	uid := os.Getuid()
+	var examined, broken, repaired, failed int
+	for i := range files {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		path := files[i].FilePath
+		if path == "" {
+			continue
+		}
+		info, serr := os.Lstat(path)
+		if serr != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		examined++
+		if info.Mode().Perm() != 0o600 || !ownedByUID(info, uid) {
+			continue
+		}
+		broken++
+		if dryRun {
+			continue
+		}
+		if cerr := os.Chmod(path, 0o664); cerr != nil {
+			slog.Warn("fix-file-modes: chmod failed", "path", path, "err", cerr)
+			failed++
+			continue
+		}
+		repaired++
+	}
+	slog.Info("fix-file-modes: complete",
+		"examined", examined, "mode_0600_owned", broken,
+		"repaired", repaired, "failed", failed, "dry_run", dryRun)
+	if failed > 0 {
+		return fmt.Errorf("fix-file-modes: %d chmods failed", failed)
+	}
+	return nil
+}

--- a/internal/maintenance/jobs/fix_file_modes_other.go
+++ b/internal/maintenance/jobs/fix_file_modes_other.go
@@ -1,0 +1,14 @@
+// file: internal/maintenance/jobs/fix_file_modes_other.go
+// version: 1.0.0
+// guid: 8a2d5f17-9c43-4e6b-b0d8-6e1f3a7c2d95
+// last-edited: 2026-08-14
+
+//go:build !unix
+
+package jobs
+
+import "os"
+
+// ownedByUID cannot be determined without unix stat; report false so the
+// repair never chmods on platforms where the ownership check is unavailable.
+func ownedByUID(_ os.FileInfo, _ int) bool { return false }

--- a/internal/maintenance/jobs/fix_file_modes_test.go
+++ b/internal/maintenance/jobs/fix_file_modes_test.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/fix_file_modes_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1f6e3a58-2d94-4c07-b8e5-9a3c7d1f4b62
 // last-edited: 2026-08-14
 
@@ -16,10 +16,12 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
 
-// fixModesFixture: one 0600 file (broken — must be repaired), one 0664 file
-// (healthy — must be untouched), one recorded path that no longer exists
-// (must be skipped without failing). All owned by the test's own uid, which
-// matches the job's owned-by-self gate.
+// fixModesFixture: one 0600 file (broken — must be repaired), one 0644 file
+// (healthy — must be untouched; deliberately NOT 0664, because a job that
+// chmods EVERYTHING to 0664 is indistinguishable from a correctly-gated one
+// when the bystander already wears the target mode — that exact blindness
+// let a gate-inverting mutation survive), and one recorded path that no
+// longer exists (must be skipped without failing).
 func fixModesFixture(t *testing.T) (*database.MockStore, string, string) {
 	t.Helper()
 	dir := t.TempDir()
@@ -30,7 +32,7 @@ func fixModesFixture(t *testing.T) (*database.MockStore, string, string) {
 			t.Fatal(err)
 		}
 	}
-	if err := os.Chmod(healthy, 0o664); err != nil {
+	if err := os.Chmod(healthy, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	m := &database.MockStore{}
@@ -65,7 +67,7 @@ func TestFixFileModes_RepairsOnly0600(t *testing.T) {
 	if info, _ := os.Stat(broken); info.Mode().Perm() != 0o664 {
 		t.Fatalf("broken file mode = %o, want 664", info.Mode().Perm())
 	}
-	if info, _ := os.Stat(healthy); info.Mode().Perm() != 0o664 {
-		t.Fatalf("healthy file mode changed to %o", info.Mode().Perm())
+	if info, _ := os.Stat(healthy); info.Mode().Perm() != 0o644 {
+		t.Fatalf("healthy (0644) file mode changed to %o — the job must touch ONLY exactly-0600 files", info.Mode().Perm())
 	}
 }

--- a/internal/maintenance/jobs/fix_file_modes_test.go
+++ b/internal/maintenance/jobs/fix_file_modes_test.go
@@ -1,0 +1,71 @@
+// file: internal/maintenance/jobs/fix_file_modes_test.go
+// version: 1.0.0
+// guid: 1f6e3a58-2d94-4c07-b8e5-9a3c7d1f4b62
+// last-edited: 2026-08-14
+
+//go:build unix
+
+package jobs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// fixModesFixture: one 0600 file (broken — must be repaired), one 0664 file
+// (healthy — must be untouched), one recorded path that no longer exists
+// (must be skipped without failing). All owned by the test's own uid, which
+// matches the job's owned-by-self gate.
+func fixModesFixture(t *testing.T) (*database.MockStore, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	broken := filepath.Join(dir, "broken.m4b")
+	healthy := filepath.Join(dir, "healthy.m4b")
+	for _, p := range []string{broken, healthy} {
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Chmod(healthy, 0o664); err != nil {
+		t.Fatal(err)
+	}
+	m := &database.MockStore{}
+	m.GetAllBookFilesCoreFunc = func() ([]database.BookFileCore, error) {
+		return []database.BookFileCore{
+			{FilePath: broken},
+			{FilePath: healthy},
+			{FilePath: filepath.Join(dir, "vanished.m4b")},
+		}, nil
+	}
+	return m, broken, healthy
+}
+
+func TestFixFileModes_DryRunTouchesNothing(t *testing.T) {
+	store, broken, _ := fixModesFixture(t)
+	j := &fixFileModesJob{}
+	if err := j.Run(context.Background(), store, &nopReporter{}, true); err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	info, _ := os.Stat(broken)
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("dry-run changed mode to %o", got)
+	}
+}
+
+func TestFixFileModes_RepairsOnly0600(t *testing.T) {
+	store, broken, healthy := fixModesFixture(t)
+	j := &fixFileModesJob{}
+	if err := j.Run(context.Background(), store, &nopReporter{}, false); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if info, _ := os.Stat(broken); info.Mode().Perm() != 0o664 {
+		t.Fatalf("broken file mode = %o, want 664", info.Mode().Perm())
+	}
+	if info, _ := os.Stat(healthy); info.Mode().Perm() != 0o664 {
+		t.Fatalf("healthy file mode changed to %o", info.Mode().Perm())
+	}
+}

--- a/internal/maintenance/jobs/fix_file_modes_unix.go
+++ b/internal/maintenance/jobs/fix_file_modes_unix.go
@@ -1,0 +1,19 @@
+// file: internal/maintenance/jobs/fix_file_modes_unix.go
+// version: 1.0.0
+// guid: 3e7b1c94-6a25-4d08-9f31-2c8d5e0a4b76
+// last-edited: 2026-08-14
+
+//go:build unix
+
+package jobs
+
+import (
+	"os"
+	"syscall"
+)
+
+// ownedByUID reports whether info's underlying file is owned by uid.
+func ownedByUID(info os.FileInfo, uid int) bool {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	return ok && int(st.Uid) == uid
+}


### PR DESCRIPTION
## Why

The E08 canary (100-book bulk-write-back) left every rewritten audio file at mode **0600, service-owned** — which also zeroes the POSIX-ACL mask, so every non-owner reader (the SMB share, the per-user ACL entries) lost access to those files.

Root cause in `WriteTagsSafe`: it copies the original to an `os.CreateTemp` file (created 0600), writes tags into the copy, and atomically renames it over the original. The copy helper passed `info.Mode()` to `OpenFile` — but that argument applies **only when the file is created**, and the temp file already existed. The comment said "preserve permissions"; the code never did. (Second comment-vs-code lie found today — same pattern as the CA12 sanitizer.)

## What

- `copyFileContents` now explicitly `Chmod`s the temp file to the original's mode before the rename, with a comment stating the OpenFile-mode-only-at-creation trap.
- New `fix-file-modes` maintenance job (dry-run default) to repair the damage: restores 0664 on files that are (a) recorded book_file rows, (b) owned by the service's own uid, and (c) at exactly 0600. A 0644 bystander in the test fixture pins that the gate is exact.

## Testing

- `TestWriteTagsSafe_PreservesFileMode` — 0664 original survives the rewrite.
- `TestFixFileModes_DryRunTouchesNothing` / `TestFixFileModes_RepairsOnly0600` — dry-run inert; repair fixes the 0600 file, leaves a 0644 bystander and a vanished path alone.
- Mutation-verified against committed base: chmod removed → FAIL; 0600 gate inverted → FAIL (after hardening the fixture — the first bystander wore the target mode and made the gate unfalsifiable); dry-run gate removed → FAIL. Restored base green.

## Prod plan

Merge → deploy → `fix-file-modes` dry-run (expect ≈ the canary books' file count at `mode_0600_owned`) → apply → re-probe the three E08 sample files as a non-owner user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS