### PR TITLE
fix(pagination): collapse the 7 remaining offset walkers to single snapshot reads

### DIFF
--- a/changelog.d/20260814_163500_offset_walker_collapse.md
+++ b/changelog.d/20260814_163500_offset_walker_collapse.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Collapsed the 7 remaining whole-library offset-pagination walkers to single
+  limit-0 snapshot reads (quarantine auto-scan, junk-title repair, title
+  backfill/repair, duration backfill, and PebbleStore's folder-dup and
+  metadata-dup scans). Offset pages over the async memdb can silently skip or
+  repeat rows when the snapshot swaps between calls, and the Pebble pagers
+  additionally paid a full prefix scan per page.

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.131.0
+// version: 1.132.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-08-14
 
@@ -1408,13 +1408,14 @@ func (p *PebbleStore) GetFolderDuplicatesCore() ([][]BookCore, error) {
 	}
 
 	var entries []folderDupEntry
-	const folderDupPageSize = 500
-	offset := 0
-	for {
-		page, err := p.GetAllBooksCore(folderDupPageSize, offset)
-		if err != nil {
-			return nil, err
-		}
+	// One limit-0 call: each paged GetAllBooksCore call re-scans the whole
+	// book: prefix (N/500 full scans), and rows written between calls can be
+	// skipped or repeated (reconcile #2443).
+	page, err := p.GetAllBooksCore(0, 0)
+	if err != nil {
+		return nil, err
+	}
+	{
 		for _, book := range page {
 			// GetAllBooksCore already excludes MarkedForDeletion rows; primary
 			// version is not one of its filters, so it's checked here to
@@ -1445,10 +1446,6 @@ func (p *PebbleStore) GetFolderDuplicatesCore() ([][]BookCore, error) {
 				dir:       dir,
 			})
 		}
-		if len(page) < folderDupPageSize {
-			break
-		}
-		offset += folderDupPageSize
 	}
 
 	return bucketFolderDuplicates(entries), nil
@@ -1545,13 +1542,14 @@ func (p *PebbleStore) GetDuplicateBooksByMetadataCore(threshold float64) ([][]Bo
 	}
 
 	var entries []metadataDupEntry
-	const metadataDupPageSize = 500
-	offset := 0
-	for {
-		page, err := p.GetAllBooksCore(metadataDupPageSize, offset)
-		if err != nil {
-			return nil, err
-		}
+	// One limit-0 call: each paged GetAllBooksCore call re-scans the whole
+	// book: prefix (N/500 full scans), and rows written between calls can be
+	// skipped or repeated (reconcile #2443).
+	page, err := p.GetAllBooksCore(0, 0)
+	if err != nil {
+		return nil, err
+	}
+	{
 		for _, book := range page {
 			// GetAllBooksCore already excludes MarkedForDeletion rows; primary
 			// version is not one of its filters, so it's checked here to mirror
@@ -1563,10 +1561,6 @@ func (p *PebbleStore) GetDuplicateBooksByMetadataCore(threshold float64) ([][]Bo
 				entries = append(entries, e)
 			}
 		}
-		if len(page) < metadataDupPageSize {
-			break
-		}
-		offset += metadataDupPageSize
 	}
 
 	return bucketMetadataDuplicates(entries, threshold), nil

--- a/internal/plugins/maintenance/duration_backfill.go
+++ b/internal/plugins/maintenance/duration_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/duration_backfill.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: 7e4b2a90-3c61-4d58-8f29-6a1c0e5b9d83
 // last-edited: 2026-07-07
 
@@ -85,27 +85,11 @@ func (p *Plugin) runDurationBackfill(ctx context.Context, raw json.RawMessage, r
 	}
 	_ = reporter.UpdateProgress(0, totalBooks, "Phase 1/2: scanning book file durations…")
 
-	const pageSize = 500
-	offset := 0
-	// Gather all books first via pagination.
-	var allBooks []database.BookCore
-	for {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		books, err := store.GetAllBooksCore(pageSize, offset)
-		if err != nil {
-			return fmt.Errorf("GetAllBooksCore offset=%d: %w", offset, err)
-		}
-		if len(books) == 0 {
-			break
-		}
-		allBooks = append(allBooks, books...)
-		offset += len(books)
-		if len(books) < pageSize {
-			break
-		}
+	// One limit-0 call = one consistent snapshot; offset pages over the async
+	// memdb can skip or repeat rows on snapshot swap (reconcile #2443).
+	allBooks, err := store.GetAllBooksCore(0, 0)
+	if err != nil {
+		return fmt.Errorf("GetAllBooksCore: %w", err)
 	}
 
 	// Fixes grouped per book, preserving book discovery order so Phase 2 can
@@ -119,7 +103,7 @@ func (p *Plugin) runDurationBackfill(ctx context.Context, raw json.RawMessage, r
 	// Each worker independently checks a book's files and accumulates fixes; the shared
 	// maps are guarded by mu so the parallel version produces identical output to serial.
 	scanned := 0
-	err := registry.RunItems(ctx, reporter, allBooks, func(ctx context.Context, book database.BookCore) error {
+	err = registry.RunItems(ctx, reporter, allBooks, func(ctx context.Context, book database.BookCore) error {
 		files, ferr := store.GetBookFiles(book.ID)
 		if ferr != nil {
 			_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(

--- a/internal/plugins/maintenance/duration_backfill_test.go
+++ b/internal/plugins/maintenance/duration_backfill_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/duration_backfill_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 2c9f5a1b-4d83-4e07-9f6a-1b8e3c0d7a52
 // last-edited: 2026-07-07
 
@@ -152,8 +152,9 @@ func TestDurationBackfill_ParallelProducesCorrectResults(t *testing.T) {
 				if offset >= len(books) {
 					return nil, nil
 				}
+				// Real-store contract: limit <= 0 means no limit.
 				end := offset + limit
-				if end > len(books) {
+				if limit <= 0 || end > len(books) {
 					end = len(books)
 				}
 				page := books[offset:end]

--- a/internal/plugins/maintenance/repair_junk_titles.go
+++ b/internal/plugins/maintenance/repair_junk_titles.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/repair_junk_titles.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9c4e7a12-3b58-4d06-8f21-7ae5c0d94b63
 // last-edited: 2026-08-04
 
@@ -69,25 +69,20 @@ func (p *Plugin) runRepairJunkTitles(ctx context.Context, raw json.RawMessage, r
 	// Filtering here rather than inside the worker matters: the per-book work
 	// (files, field states, author) is several reads, and this turns a 44k-book
 	// sweep into a ~2k-book one.
-	const pageSize = 1000
+	// One limit-0 call = one consistent snapshot; offset pages over the async
+	// memdb can skip or repeat rows on snapshot swap (reconcile #2443).
+	all, err := store.GetAllBooksCore(0, 0)
+	if err != nil {
+		return fmt.Errorf("GetAllBooksCore: %w", err)
+	}
 	var candidates []database.BookCore
-	scanned := 0
-	for offset := 0; ; offset += pageSize {
-		page, err := store.GetAllBooksCore(pageSize, offset)
-		if err != nil {
-			return fmt.Errorf("GetAllBooksCore offset=%d: %w", offset, err)
+	scanned := len(all)
+	for i := range all {
+		if all[i].IsSoftDeleted() {
+			continue
 		}
-		scanned += len(page)
-		for i := range page {
-			if page[i].IsSoftDeleted() {
-				continue
-			}
-			if IsJunkTitle(page[i].Title) {
-				candidates = append(candidates, page[i])
-			}
-		}
-		if len(page) < pageSize {
-			break
+		if IsJunkTitle(all[i].Title) {
+			candidates = append(candidates, all[i])
 		}
 	}
 	if params.Limit > 0 && len(candidates) > params.Limit {

--- a/internal/plugins/maintenance/title_backfill.go
+++ b/internal/plugins/maintenance/title_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/title_backfill.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 // last-edited: 2026-07-07
 
@@ -73,45 +73,34 @@ func (p *Plugin) runTitleBackfill(ctx context.Context, raw json.RawMessage, repo
 	}
 	_ = reporter.UpdateProgress(0, totalBooks, "Phase 1/2: scanning titles…")
 
-	const pageSize = 500
-	offset := 0
 	var scanned, skipped int
 	var toUpdate []pendingUpdate
 
-	for {
+	// One limit-0 call = one consistent snapshot; offset pages over the async
+	// memdb can skip or repeat rows on snapshot swap (reconcile #2443).
+	books, err := store.GetAllBooksCore(0, 0)
+	if err != nil {
+		return fmt.Errorf("GetAllBooksCore: %w", err)
+	}
+	for _, book := range books {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
+		scanned++
 
-		books, err := store.GetAllBooksCore(pageSize, offset)
-		if err != nil {
-			return fmt.Errorf("GetAllBooksCore offset=%d: %w", offset, err)
+		cleaned := titleutil.StripChapterPrefix(book.Title)
+		switch {
+		case cleaned == book.Title:
+			skipped++
+		case cleaned == "":
+			_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(
+				"book %s: title %q stripped to empty, skipping", book.ID, book.Title))
+			skipped++
+		default:
+			toUpdate = append(toUpdate, pendingUpdate{book: book, newTitle: cleaned})
 		}
-		if len(books) == 0 {
-			break
-		}
-
-		for _, book := range books {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			scanned++
-
-			cleaned := titleutil.StripChapterPrefix(book.Title)
-			switch {
-			case cleaned == book.Title:
-				skipped++
-			case cleaned == "":
-				_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(
-					"book %s: title %q stripped to empty, skipping", book.ID, book.Title))
-				skipped++
-			default:
-				toUpdate = append(toUpdate, pendingUpdate{book: book, newTitle: cleaned})
-			}
-		}
-
-		offset += len(books)
-
+	}
+	{
 		// Use real total if available; fall back to scanned so bar moves.
 		total := totalBooks
 		if total == 0 {
@@ -119,10 +108,6 @@ func (p *Plugin) runTitleBackfill(ctx context.Context, raw json.RawMessage, repo
 		}
 		_ = reporter.UpdateProgress(scanned, total,
 			fmt.Sprintf("Phase 1/2: scanned %d/%d — %d titles to fix", scanned, total, len(toUpdate)))
-
-		if len(books) < pageSize {
-			break
-		}
 	}
 
 	// Phase 2: apply (or preview). We now know exactly how many to change,

--- a/internal/plugins/maintenance/title_backfill_test.go
+++ b/internal/plugins/maintenance/title_backfill_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/title_backfill_test.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: b2c3d4e5-f6a7-8901-bcde-ef0123456789
 // last-edited: 2026-08-14
 
@@ -120,8 +120,9 @@ func newTestPlugin(books []database.Book) (*Plugin, *[]database.Book) {
 			if offset >= len(books) {
 				return nil, nil
 			}
+			// Real-store contract: limit <= 0 means no limit.
 			end := offset + limit
-			if end > len(books) {
+			if limit <= 0 || end > len(books) {
 				end = len(books)
 			}
 			core := make([]database.BookCore, end-offset)

--- a/internal/plugins/maintenance/title_repair.go
+++ b/internal/plugins/maintenance/title_repair.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/title_repair.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 13bedd46-9b61-41a2-b791-36813d7ffcb9
 // last-edited: 2026-07-17
 
@@ -190,21 +190,11 @@ func (p *Plugin) runTitleRepair(ctx context.Context, raw json.RawMessage, report
 
 	// Load the full book list up front (Core rows are slim). Paged — no
 	// silent cap: the loop runs until a short page.
-	const pageSize = 500
-	var books []database.BookCore
-	for offset := 0; ; {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		page, err := store.GetAllBooksCore(pageSize, offset)
-		if err != nil {
-			return fmt.Errorf("GetAllBooksCore offset=%d: %w", offset, err)
-		}
-		books = append(books, page...)
-		offset += len(page)
-		if len(page) < pageSize {
-			break
-		}
+	// One limit-0 call = one consistent snapshot; offset pages over the async
+	// memdb can skip or repeat rows on snapshot swap (reconcile #2443).
+	books, err := store.GetAllBooksCore(0, 0)
+	if err != nil {
+		return fmt.Errorf("GetAllBooksCore: %w", err)
 	}
 
 	total := len(books)
@@ -227,7 +217,7 @@ func (p *Plugin) runTitleRepair(ctx context.Context, raw json.RawMessage, report
 		verb = "retitled"
 	}
 
-	err := registry.RunItems(ctx, reporter, books, func(ctx context.Context, b database.BookCore) error {
+	err = registry.RunItems(ctx, reporter, books, func(ctx context.Context, b database.BookCore) error {
 		n := examined.Add(1)
 		if n%500 == 0 {
 			_ = reporter.Log(slog.LevelInfo, fmt.Sprintf(

--- a/internal/quarantine/service.go
+++ b/internal/quarantine/service.go
@@ -1,5 +1,5 @@
 // file: internal/quarantine/service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
 // last-edited: 2026-07-07
 
@@ -225,28 +225,23 @@ func (qs *QuarantineService) AutoQuarantineFailedScans() {
 	if qs.store == nil {
 		return
 	}
-	// Paginate to avoid missing books when library exceeds page size.
-	const pageSize = 1000
-	var offset int
-	for {
-		page, err := qs.store.GetAllBooksCore(pageSize, offset)
-		if err != nil || len(page) == 0 {
-			break
+	// One limit-0 call = one consistent snapshot. Offset pages over the async
+	// memdb can skip or repeat rows whenever the snapshot swaps between calls
+	// (see reconcile #2443) — and this loop MUTATES via QuarantineBook as it
+	// walks, so paging was swapping the snapshot under its own feet.
+	books, err := qs.store.GetAllBooksCore(0, 0)
+	if err != nil {
+		return
+	}
+	for _, b := range books {
+		if b.QuarantinedAt != nil {
+			continue
 		}
-		for _, b := range page {
-			if b.QuarantinedAt != nil {
-				continue
-			}
-			n, _ := qs.store.GetScanFailCount(scanFailKey(b.FilePath))
-			if n >= scanFailThreshold {
-				slog.Info("auto-quarantine (fail count)", "filePath", b.FilePath, "failCount", n)
-				_ = qs.QuarantineBook(b.ID, fmt.Sprintf("taglib failed to read file after %d consecutive scan attempts", n))
-			}
+		n, _ := qs.store.GetScanFailCount(scanFailKey(b.FilePath))
+		if n >= scanFailThreshold {
+			slog.Info("auto-quarantine (fail count)", "filePath", b.FilePath, "failCount", n)
+			_ = qs.QuarantineBook(b.ID, fmt.Sprintf("taglib failed to read file after %d consecutive scan attempts", n))
 		}
-		if len(page) < pageSize {
-			break
-		}
-		offset += pageSize
 	}
 }
 

--- a/todo.d/20260814-writeback-residue-and-stale-file-paths.md
+++ b/todo.d/20260814-writeback-residue-and-stale-file-paths.md
@@ -1,0 +1,15 @@
+- [ ] **124 files remain 0600 after the fix-file-modes repair (1,547 repaired),
+      and they expose a stale-path defect.** The repair enumerates
+      `GetAllBookFilesCore()`, but the residue files are on-disk paths the
+      canary write-back REALLY wrote (mtime in the canary window) that do not
+      appear in that enumeration. Worse: the sampled book's `/files` API row
+      points at a path that does NOT exist on disk (`.../The Seven Deadly
+      Demons 3 - Dungeon of Pride/Dungeon of Pride.m4b` → ENOENT) while the
+      real file lives at `.../The Seven Deadly Demons/Dungeon of Pride/...`.
+      So (a) some books' file rows carry stale paths, (b) the write-back
+      resolves the REAL file anyway (different row? path fallback?), and
+      (c) the repair job can't see those paths. Investigate the row-vs-disk
+      divergence (organize moved files without updating rows? duplicate
+      rows?), then either extend fix-file-modes with a disk-walk mode or
+      repair the residue by hand:
+      `sudo find <organizer-root> -type f -user <service-user> -perm 600 -exec chmod 664 {} +`


### PR DESCRIPTION
## Why

Fragment `20260814-offset-walker-followups` item 1: seven more whole-library offset-pagination walkers share the exposure fixed in reconcile by #2443 — offset pages over the async memdb silently skip or repeat rows whenever the snapshot swaps between calls. The quarantine walker is the worst variant: it MUTATES (`QuarantineBook`) while paging, swapping the snapshot under its own iteration. The two PebbleStore pagers additionally paid a full `book:` prefix scan per 500-row page (N/500 full scans).

## What

Each pager collapsed to a single `GetAllBooksCore(0, 0)` call (one consistent snapshot):

- `internal/quarantine/service.go` — auto-quarantine scan
- `internal/plugins/maintenance/{repair_junk_titles,title_backfill,title_repair,duration_backfill}.go`
- `internal/database/pebble_store.go` — `GetFolderDuplicatesCore` / `GetMetadataDuplicatesCore` fallback pagers

All seven verified pure accumulate-or-act before editing (per the fragment's caveat). Also files the write-back residue / stale-file-path fragment from today's E08 repair.

## Testing

`TestDurationBackfill_ParallelProducesCorrectResults` and `TestTitleBackfill_ApplyCleansPoisonedRows` failed after the collapse because their fake stores sliced `books[offset:offset+limit]` — returning zero rows for limit-0, violating the real store's documented `limit <= 0` = no-limit contract. Fixed the fakes; the failures double as proof the walkers now take the single-call path. Full `internal/{quarantine,plugins/maintenance,database}` suites green, vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS