### PR TITLE
feat(web): restore the library sort control, server-side (G110)

### DIFF
--- a/changelog.d/20260814_170000_library_sort_control.md
+++ b/changelog.d/20260814_170000_library_sort_control.md
@@ -1,0 +1,6 @@
+### Added
+
+- The library grid view has its Sort control back: a "Sort by" select and
+  direction toggle in the search bar, driving the SERVER-side sort (applied
+  before pagination, so descending page 1 really holds the last items) and
+  surviving search. The table view's column-header sort is unchanged.

--- a/todo.d/20260814-organize-bakes-unknown-author-into-paths.md
+++ b/todo.d/20260814-organize-bakes-unknown-author-into-paths.md
@@ -1,0 +1,21 @@
+- [ ] **Organize renames with placeholder metadata — "Unknown Author" gets
+      baked into directories and filenames.** Observed in a Review Organize
+      preview (2026-08-14): a book under
+      `audiobook-organizer/Unknown Author/All Jobs and Classes!…_ LitRPG/Epic Progression/`
+      was offered a rename to
+      `…/Unknown Author/All Jobs and Classes!…/… - Unknown Author - read by Ryan Dimon, Arielle Noelle.m4b`
+      — the path cleanup itself worked (series-suffix folder collapsed), but
+      the placeholder author was written into BOTH the folder and the new
+      filename, twice. The book plainly has usable metadata (full title,
+      two narrators) so an author lookup would very likely resolve.
+      Wanted behavior for anything in the organizer tree:
+      1. If the author is a placeholder ("Unknown Author"/empty), organize
+         must NOT bake it into the target path. Resolve metadata FIRST
+         (metadata fetch by title/narrators/tags), and only rename once a
+         real author exists;
+      2. otherwise route the book to review flagged "author unresolved"
+         instead of proposing a rename that cements the placeholder;
+      3. the rename template should always be built from resolved author +
+         metadata, never from whatever the current row happens to hold.
+      Audit how many books already have "Unknown Author" baked into their
+      organizer-tree paths while carrying resolvable metadata.

--- a/web/src/components/FilterPanel.tsx
+++ b/web/src/components/FilterPanel.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/FilterPanel.tsx
-// version: 1.1.0
+// version: 1.2.0
 // guid: 5c7d8e9f-0a1b-2c3d-4e5f-6a7b8c9d0e1f
 // last-edited: 2026-05-20
 
@@ -12,7 +12,7 @@ import {
 import {
   Info as InfoIcon,
 } from '@mui/icons-material';
-import { SearchBar, ViewMode } from './audiobooks/SearchBar';
+import { SearchBar, ViewMode, type SortOption } from './audiobooks/SearchBar';
 import type { ParsedSearch } from '../utils/searchParser';
 
 interface FilterPanelProps {
@@ -22,6 +22,10 @@ interface FilterPanelProps {
   viewMode: ViewMode;
   onViewModeChange: (mode: ViewMode) => void;
   onLibraryInfoClick: () => void;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
+  sortOptions?: SortOption[];
+  onSortChange?: (sortKey: string, order: 'asc' | 'desc') => void;
 }
 
 export const FilterPanel: React.FC<FilterPanelProps> = ({
@@ -31,6 +35,10 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
   viewMode,
   onViewModeChange,
   onLibraryInfoClick,
+  sortBy,
+  sortOrder,
+  sortOptions,
+  onSortChange,
 }) => {
   return (
     <Box display="flex" gap={1} alignItems="center">
@@ -41,6 +49,10 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
           onParsedSearchChange={onParsedSearchChange}
           viewMode={viewMode}
           onViewModeChange={onViewModeChange}
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          sortOptions={sortOptions}
+          onSortChange={onSortChange}
         />
       </Box>
       <Tooltip title="Library info">

--- a/web/src/components/audiobooks/SearchBar.test.tsx
+++ b/web/src/components/audiobooks/SearchBar.test.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/SearchBar.test.tsx
-// version: 1.0.0
+// version: 1.1.0
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
@@ -43,6 +43,40 @@ describe('SearchBar', () => {
       expect(screen.queryByLabelText('Sort by')).not.toBeInTheDocument();
     });
 
+  });
+
+  describe('sort controls', () => {
+    const sortProps = () =>
+      defaultProps({
+        sortBy: 'title',
+        sortOrder: 'asc' as const,
+        sortOptions: [
+          { value: 'title', label: 'Title' },
+          { value: 'created_at', label: 'Date added' },
+        ],
+        onSortChange: vi.fn(),
+      });
+
+    it('renders the Sort by control when onSortChange and options are provided', () => {
+      renderWithProviders(<SearchBar {...sortProps()} />);
+      expect(screen.getByLabelText('Sort by')).toBeInTheDocument();
+      expect(screen.getByLabelText('toggle sort direction')).toBeInTheDocument();
+    });
+
+    it('selecting a sort key calls onSortChange with the key and current order', () => {
+      const props = sortProps();
+      renderWithProviders(<SearchBar {...props} />);
+      fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Sort by' }));
+      fireEvent.click(screen.getByRole('option', { name: 'Date added' }));
+      expect(props.onSortChange).toHaveBeenCalledWith('created_at', 'asc');
+    });
+
+    it('the direction toggle flips the order for the current key', () => {
+      const props = sortProps();
+      renderWithProviders(<SearchBar {...props} />);
+      fireEvent.click(screen.getByLabelText('toggle sort direction'));
+      expect(props.onSortChange).toHaveBeenCalledWith('title', 'desc');
+    });
   });
 
   describe('view mode toggle', () => {

--- a/web/src/components/audiobooks/SearchBar.tsx
+++ b/web/src/components/audiobooks/SearchBar.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/SearchBar.tsx
-// version: 2.5.0
+// version: 2.6.0
 // guid: 1d2e3f4a-5b6c-7d8e-9f0a-1b2c3d4e5f6a
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -7,10 +7,14 @@ import {
   Autocomplete,
   Box,
   Chip,
+  FormControl,
   IconButton,
   InputAdornment,
+  InputLabel,
+  MenuItem,
   Paper,
   Popper,
+  Select,
   TextField,
   ToggleButton,
   ToggleButtonGroup,
@@ -24,6 +28,8 @@ import {
   ViewList as ViewListIcon,
   HelpOutline as HelpIcon,
   Close as CloseIcon,
+  ArrowUpward as ArrowUpwardIcon,
+  ArrowDownward as ArrowDownwardIcon,
 } from '@mui/icons-material';
 import { parseSearch, SEARCH_FIELDS, type ParsedSearch } from '../../utils/searchParser';
 import { STORAGE_KEYS } from '../../lib/storageKeys';
@@ -121,6 +127,11 @@ const SEARCH_HELP = [
   { example: 'format:(m4b|mp3)', desc: 'Match either value' },
 ];
 
+export interface SortOption {
+  value: string;
+  label: string;
+}
+
 interface SearchBarProps {
   value: string;
   onChange: (value: string) => void;
@@ -128,6 +139,18 @@ interface SearchBarProps {
   viewMode: ViewMode;
   onViewModeChange: (mode: ViewMode) => void;
   placeholder?: string;
+  /** Current server-side sort key. Only meaningful with onSortChange. */
+  sortBy?: string;
+  /** Current sort direction. Only meaningful with onSortChange. */
+  sortOrder?: 'asc' | 'desc';
+  /** Sort keys to offer. Only meaningful with onSortChange. */
+  sortOptions?: SortOption[];
+  /**
+   * When provided (with sortOptions), the bar renders a "Sort by" select and
+   * a direction toggle. The callback receives the SERVER sort key — sorting
+   * happens before pagination on the backend, never on the current page.
+   */
+  onSortChange?: (sortKey: string, order: 'asc' | 'desc') => void;
 }
 
 export const SearchBar: React.FC<SearchBarProps> = ({
@@ -137,6 +160,10 @@ export const SearchBar: React.FC<SearchBarProps> = ({
   viewMode,
   onViewModeChange,
   placeholder = 'Search audiobooks... (try author:"Name" tag:scifi)',
+  sortBy,
+  sortOrder = 'asc',
+  sortOptions,
+  onSortChange,
 }) => {
   const parsed = useMemo(() => parseSearch(value), [value]);
   const [helpOpen, setHelpOpen] = useState(false);
@@ -240,6 +267,36 @@ export const SearchBar: React.FC<SearchBarProps> = ({
           )}
         />
 
+        {onSortChange && sortOptions && sortOptions.length > 0 && (
+          <>
+            <FormControl size="small" sx={{ minWidth: 140 }}>
+              <InputLabel id="library-sort-label">Sort by</InputLabel>
+              <Select
+                labelId="library-sort-label"
+                label="Sort by"
+                value={sortBy ?? sortOptions[0].value}
+                inputProps={{ 'aria-label': 'Sort by' }}
+                onChange={(e) => onSortChange(String(e.target.value), sortOrder)}
+              >
+                {sortOptions.map((o) => (
+                  <MenuItem key={o.value} value={o.value}>
+                    {o.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <Tooltip title={sortOrder === 'asc' ? 'Ascending (click for descending)' : 'Descending (click for ascending)'}>
+              <IconButton
+                aria-label="toggle sort direction"
+                onClick={() =>
+                  onSortChange(sortBy ?? sortOptions[0].value, sortOrder === 'asc' ? 'desc' : 'asc')
+                }
+              >
+                {sortOrder === 'asc' ? <ArrowUpwardIcon /> : <ArrowDownwardIcon />}
+              </IconButton>
+            </Tooltip>
+          </>
+        )}
         <ToggleButtonGroup
           value={viewMode}
           exclusive

--- a/web/src/components/library/LibraryBookGrid.tsx
+++ b/web/src/components/library/LibraryBookGrid.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/library/LibraryBookGrid.tsx
-// version: 1.8.0
+// version: 1.9.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 // last-edited: 2026-08-08
 
@@ -32,12 +32,25 @@ import type { LibrarySoftDeletedSectionProps } from './LibrarySoftDeletedSection
 import { LibrarySoftDeletedSection } from './LibrarySoftDeletedSection';
 import { TagCloud } from './TagCloud';
 import type { ColumnDefinition } from '../../config/columnDefinitions';
-import type { Audiobook, FilterOptions, SortField, SortOrder } from '../../types';
+import type { Audiobook, FilterOptions, SortField } from '../../types';
+import { SortOrder } from '../../types';
 import type { ViewMode } from '../audiobooks/SearchBar';
 import type { ParsedSearch } from '../../utils/searchParser';
 import type { ImportPath } from '../../pages/libraryTypes';
 import { STORAGE_KEYS } from '../../lib/storageKeys';
 import { libraryContentState } from './libraryContentState';
+
+// Sort keys offered by the grid-view "Sort by" control. These are SERVER sort
+// keys (memdb summary indexes): the backend sorts before pagination, so
+// descending page 1 really holds the library's last items.
+const LIBRARY_SORT_OPTIONS = [
+  { value: 'title', label: 'Title' },
+  { value: 'author', label: 'Author' },
+  { value: 'series', label: 'Series' },
+  { value: 'year', label: 'Year' },
+  { value: 'created_at', label: 'Date added' },
+  { value: 'duration_seconds', label: 'Duration' },
+];
 
 interface LibraryBookGridProps {
   audiobooks: Audiobook[];
@@ -130,9 +143,7 @@ export const LibraryBookGrid = ({
   viewMode,
   setViewMode,
   sortBy,
-  handleSortChange: _handleSortChange,
   sortOrder,
-  setSortOrder: _setSortOrder,
   setStorageDrawerOpen,
   importPaths,
   handleManualImport,
@@ -270,6 +281,10 @@ export const LibraryBookGrid = ({
           viewMode={viewMode}
           onViewModeChange={setViewMode}
           onLibraryInfoClick={() => setStorageDrawerOpen(true)}
+          sortBy={sortBy}
+          sortOrder={sortOrder === SortOrder.Ascending ? 'asc' : 'desc'}
+          sortOptions={LIBRARY_SORT_OPTIONS}
+          onSortChange={handleColumnSortChange}
         />
 
         {availableTags.length > 0 && (


### PR DESCRIPTION
## Why

G110: the grid view lost its Sort control — the handler sat renamed to `_handleSortChange` in `LibraryBookGrid`, and `SearchBar.test.tsx` pinned only the control's ABSENCE (a vacuous assertion, since SearchBar never rendered sort controls at all).

## What

- `SearchBar`: optional `sortBy`/`sortOrder`/`sortOptions`/`onSortChange` props; renders a "Sort by" select + direction toggle only when wired. Other SearchBar consumers are untouched (props optional).
- `FilterPanel`: threads the props through.
- `LibraryBookGrid`: drives the new control with the existing `handleColumnSortChange` — the same server-key path the table headers use, so the backend sorts before pagination (`sort_by`/`sort_order` → memdb index iteration) and the sort survives search. Acceptance property: descending page 1 holds the true last items because no client ever sorts a paginated slice.
- Also carries the write-up of today's organize complaint (todo fragment: organize bakes "Unknown Author" into paths instead of resolving metadata first).

## Testing

- 3 new tests: control renders when wired; selecting a key calls back with (key, current order); direction toggle flips order. The old absence assertion stays as the negative side.
- Mutation-verified against committed base: render-gate forced false → 3 fail; toggle made a no-op → 1 fails; restored → 19/19.
- Full vitest suite: 472/472. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS