### PR TITLE
fix(security): CodeQL sanitizer models track the renamed module path

### DIFF
--- a/.github/codeql/models/go-sanitizers.model.yml
+++ b/.github/codeql/models/go-sanitizers.model.yml
@@ -1,5 +1,5 @@
 # file: .github/codeql/models/go-sanitizers.model.yml
-# version: 1.1.0
+# version: 1.2.0
 # guid: 9d8c7b6a-5e4f-3d2c-1b0a-9e8f7d6c5b4a
 # last-edited: 2026-05-18
 # Declares project-specific path sanitizers so CodeQL stops flagging code
@@ -10,22 +10,22 @@ extensions:
       extensible: pathInjectionSanitizer
     data:
       # util.SafeJoin: return value is a sanitized path (path injection barrier)
-      - ["github.com/jdfalk/audiobook-organizer/internal/util", "SafeJoin", "ReturnValue"]
+      - ["github.com/falkcorp/audiobook-organizer/internal/util", "SafeJoin", "ReturnValue"]
       # pathvalidation.CleanAbsolutePath: validated absolute path return value
-      - ["github.com/jdfalk/audiobook-organizer/internal/security/pathvalidation", "CleanAbsolutePath", "ReturnValue"]
+      - ["github.com/falkcorp/audiobook-organizer/internal/security/pathvalidation", "CleanAbsolutePath", "ReturnValue"]
       # pathvalidation.ValidateRelativePath: validated relative path joined to root
-      - ["github.com/jdfalk/audiobook-organizer/internal/security/pathvalidation", "ValidateRelativePath", "ReturnValue"]
+      - ["github.com/falkcorp/audiobook-organizer/internal/security/pathvalidation", "ValidateRelativePath", "ReturnValue"]
       # pathvalidation.SecureJoin: validated path return value
-      - ["github.com/jdfalk/audiobook-organizer/internal/security/pathvalidation", "SecureJoin", "ReturnValue"]
+      - ["github.com/falkcorp/audiobook-organizer/internal/security/pathvalidation", "SecureJoin", "ReturnValue"]
       # pathvalidation.SanitizeFilename: sanitized filename component
-      - ["github.com/jdfalk/audiobook-organizer/internal/security/pathvalidation", "SanitizeFilename", "ReturnValue"]
+      - ["github.com/falkcorp/audiobook-organizer/internal/security/pathvalidation", "SanitizeFilename", "ReturnValue"]
       # safepath.Join: validated SafePath value
-      - ["github.com/jdfalk/audiobook-organizer/internal/security/safepath", "Join", "ReturnValue"]
+      - ["github.com/falkcorp/audiobook-organizer/internal/security/safepath", "Join", "ReturnValue"]
       # safepath.SafePath.String: unwrapped validated string from SafePath
-      - ["github.com/jdfalk/audiobook-organizer/internal/security/safepath", "String", "ReturnValue"]
+      - ["github.com/falkcorp/audiobook-organizer/internal/security/safepath", "String", "ReturnValue"]
   - addsTo:
       pack: codeql/go-all
       extensible: pathInjectionSanitizerGuard
     data:
       # util.WithinRoot: when this returns true, the path has been validated
-      - ["github.com/jdfalk/audiobook-organizer/internal/util", "WithinRoot", "true"]
+      - ["github.com/falkcorp/audiobook-organizer/internal/util", "WithinRoot", "true"]

--- a/.github/codeql/models/path-sanitizers.model.yml
+++ b/.github/codeql/models/path-sanitizers.model.yml
@@ -1,5 +1,5 @@
 # file: .github/codeql/models/path-sanitizers.model.yml
-# version: 0.2.0
+# version: 0.3.0
 # guid: 07edd0c5-64fa-4d57-8830-fbfaa513c052
 # last-edited: 2026-05-18
 
@@ -10,31 +10,31 @@ extensions:
     data:
       # util.SafeJoin: return value is a sanitized path within root.
       # Signature: func SafeJoin(root string, parts ...string) (string, error)
-      - ["github.com/jdfalk/audiobook-organizer/internal/util", "", false, "SafeJoin", "", "", "ReturnValue[0]", "path-injection", "manual"]
+      - ["github.com/falkcorp/audiobook-organizer/internal/util", "", false, "SafeJoin", "", "", "ReturnValue[0]", "path-injection", "manual"]
 
       # pathvalidation.CleanAbsolutePath: validates and returns the cleaned absolute path.
       # Signature: func CleanAbsolutePath(path string) (string, error)
-      - ["github.com/jdfalk/audiobook-organizer/internal/security/pathvalidation", "", false, "CleanAbsolutePath", "", "", "ReturnValue[0]", "path-injection", "manual"]
+      - ["github.com/falkcorp/audiobook-organizer/internal/security/pathvalidation", "", false, "CleanAbsolutePath", "", "", "ReturnValue[0]", "path-injection", "manual"]
 
       # pathvalidation.ValidateRelativePath: validates and returns the cleaned relative path joined to root.
       # Signature: func ValidateRelativePath(root, userPath string) (string, error)
-      - ["github.com/jdfalk/audiobook-organizer/internal/security/pathvalidation", "", false, "ValidateRelativePath", "", "", "ReturnValue[0]", "path-injection", "manual"]
+      - ["github.com/falkcorp/audiobook-organizer/internal/security/pathvalidation", "", false, "ValidateRelativePath", "", "", "ReturnValue[0]", "path-injection", "manual"]
 
       # pathvalidation.SecureJoin: joins root with user parts, returns sanitized path.
       # Signature: func SecureJoin(root string, parts ...string) (string, error)
-      - ["github.com/jdfalk/audiobook-organizer/internal/security/pathvalidation", "", false, "SecureJoin", "", "", "ReturnValue[0]", "path-injection", "manual"]
+      - ["github.com/falkcorp/audiobook-organizer/internal/security/pathvalidation", "", false, "SecureJoin", "", "", "ReturnValue[0]", "path-injection", "manual"]
 
       # pathvalidation.SanitizeFilename: sanitizes a filename component.
       # Signature: func SanitizeFilename(name string) string
-      - ["github.com/jdfalk/audiobook-organizer/internal/security/pathvalidation", "", false, "SanitizeFilename", "", "", "ReturnValue", "path-injection", "manual"]
+      - ["github.com/falkcorp/audiobook-organizer/internal/security/pathvalidation", "", false, "SanitizeFilename", "", "", "ReturnValue", "path-injection", "manual"]
 
       # safepath.Join: returns a SafePath that is guaranteed to be within root.
       # Signature: func Join(root string, parts ...string) (SafePath, error)
-      - ["github.com/jdfalk/audiobook-organizer/internal/security/safepath", "", false, "Join", "", "", "ReturnValue[0]", "path-injection", "manual"]
+      - ["github.com/falkcorp/audiobook-organizer/internal/security/safepath", "", false, "Join", "", "", "ReturnValue[0]", "path-injection", "manual"]
 
       # safepath.SafePath.String: unwraps the validated path string.
       # Signature: func (SafePath) String() string
-      - ["github.com/jdfalk/audiobook-organizer/internal/security/safepath", "SafePath", false, "String", "", "", "ReturnValue", "path-injection", "manual"]
+      - ["github.com/falkcorp/audiobook-organizer/internal/security/safepath", "SafePath", false, "String", "", "", "ReturnValue", "path-injection", "manual"]
 
   - addsTo:
       pack: codeql/go-all
@@ -42,4 +42,4 @@ extensions:
     data:
       # util.WithinRoot: when this returns true, Argument[0] is within a safe root.
       # Signature: func WithinRoot(path, root string) bool
-      - ["github.com/jdfalk/audiobook-organizer/internal/util", "", false, "WithinRoot", "", "", "Argument[0]", "true", "path-injection", "manual"]
+      - ["github.com/falkcorp/audiobook-organizer/internal/util", "", false, "WithinRoot", "", "", "Argument[0]", "true", "path-injection", "manual"]

--- a/changelog.d/20260814_171500_codeql_model_path_fix.md
+++ b/changelog.d/20260814_171500_codeql_model_path_fix.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- The CodeQL sanitizer model pack still referenced the pre-rename module path
+  (`github.com/jdfalk/...`), so all 16 path-sanitizer model rows were silently
+  inert since the module became `github.com/falkcorp/...` — path-injection
+  alerts the models exist to suppress had reopened. All references updated.

--- a/todo.d/20260814-codeql-loginjection-mad-model.md
+++ b/todo.d/20260814-codeql-loginjection-mad-model.md
@@ -1,0 +1,13 @@
+- [ ] **CA12 wave 2: model `logging.Sanitize`/`SanitizeErr`/`logger.sanitizeLogLine`
+      as CodeQL log-injection sanitizers via the model pack.** #2445 removed
+      the fast-path bypass, but the conduit's own alerts
+      (`internal/logging/structured.go:51/58/65`) are STILL open at 316 total:
+      taint through the variadic `args ...any` slice survives because CodeQL
+      treats per-element slice writes as weak updates — no code shape fixes
+      that. The repo already has the mechanism
+      (`.github/codeql/models/*.model.yml`, `pathInjectionSanitizer` rows) —
+      BEFORE adding rows, verify the extensible predicate name for log
+      injection actually exists in the pinned `codeql/go-all` (an unknown
+      `extensible:` fails the pack). If none exists, the alternatives are a
+      custom .ql suite or bulk dismissal-with-justification of
+      conduit-routed alerts. Baseline to beat: 316 open go/log-injection.


### PR DESCRIPTION
All 16 sanitizer-model rows referenced `github.com/jdfalk/...` — silently inert since the module rename to `falkcorp`, which is why the path-injection alerts those models suppress reopened (5 open). Pure find-replace + version bumps; verification is the next main CodeQL analysis closing the path-injection family. Also files the CA12 wave-2 fragment (log-injection MaD model, with the extensible-name validation caveat — conduit alerts survive #2445 because CodeQL weak-updates variadic `[]any` element writes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS