### PR TITLE
docs(handoffs): board v1.2.0 — E-wave executed, A04 instrument defect filed

### DIFF
--- a/changelog.d/20260814_213000_board_v120.md
+++ b/changelog.d/20260814_213000_board_v120.md
@@ -1,0 +1,5 @@
+### Changed
+
+- Task board v1.2.0: C111 and E01 closed on prod, E08 canary findings
+  (perms bug + stale-path residue), E09 done, CA12 wave-2 verdict, G110 and
+  walker-collapse merged; filed the A04 wrong-instrument fragment.

--- a/docs/handoffs/2026-08-14-task-board.md
+++ b/docs/handoffs/2026-08-14-task-board.md
@@ -1,16 +1,15 @@
 <!-- file: docs/handoffs/2026-08-14-task-board.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 8d2f6a41-3c97-4e58-b0d6-1a75c9e28f30 -->
 <!-- last-edited: 2026-08-14 -->
 
 # Task board — 2026-08-14
 
 Snapshot of the 113-task breakdown (waves T/A/B/C/D/E/F/G/H) as of
-2026-08-14 ~17:45 EDT. **29 PRs merged today** (#2421–#2447), 0 open, and
-**everything is deployed**: the 13:40 EDT production deploy was built from
-main with all 29 included, and the boot came up clean (no search-index
-divergence). Owner decisions D-0…D-10 were all answered today; the outcomes
-are inlined below.
+2026-08-14 ~21:30 EDT. **33 PRs merged today** (#2421–#2453), 1 in CI
+(#2454). Third production deploy at 16:19 EDT; the entire E-wave except the
+E08 full run is now EXECUTED AND VERIFIED on prod. Owner decisions D-0…D-10
+were all answered today; the outcomes are inlined below.
 
 ## Wave 0 — Hygiene
 
@@ -27,7 +26,7 @@ are inlined below.
 | A01 | CI green before deploy | ✅ done |
 | A02 | Deploy to production (debug build) | ✅ done 10:01 |
 | A03 | Verify dry-run default (#2419) via composer-scan probe | ✅ verified — scan completed 13:04 EDT as a **preview** (492,157/492,157 files, 3h01m; the persisted 90-byte params carried the advertised dry_run:true) |
-| A04 | Verify op-ID audit trail (#2414) | 🟡 deferred to tonight's maintenance window |
+| A04 | Verify op-ID audit trail (#2414) | 🔴 probe ran, INSTRUMENT WRONG — the designated `temp-file-cleanup` records deletions to the ACTIVITY feed only, never `operation_changes`, so it cannot verify #2414 even when it deletes (fragment filed; pick an op that calls CreateOperationChange) |
 | A05 | Author 46627 repair verification | ⬜ owner, unblocked |
 | A06 | Post-deploy warmup row/key counts | ⬜ owner, unblocked |
 | A07 | Aggregate-recompute attribution sample | ⬜ needs scan/organize activity |
@@ -50,12 +49,12 @@ are inlined below.
 | Task | Description | Status |
 |---|---|---|
 | C110 | `version_group_id` filter field (D-1 ✅) | ✅ merged #2436 |
-| C111 | nil `is_primary_version` semantics (D-2) | 🟡 census merged #2438; normalize-primary-flags maintenance job (nil→explicit true for 5,702 ungrouped + the 41 false/no-VG = C314) built, PR imminent |
+| C111 | nil `is_primary_version` semantics (D-2) | ✅ **CLOSED ON PROD** — job merged #2449; dry-run matched the census EXACTLY (5,702 + 41 + 0 grouped-nils), apply wrote 5,743 with 0 errors, re-dry-run 0/0/0. C314's 41 fixed in the same pass |
 | C112–C113 | Bare-param guard extensions / declared schema | ⬜ ready / design |
 | C210–C213 | Delete-guard family | ⬜ ready (C211 ✅ closed by peer #2412) |
 | C310–C314 | Version-group integrity | ⬜ C310 gates; C314's exact 41-book population identified by the C111 census |
 | C410–C414 | Author-table hygiene | ⬜ ready / gated on C410 |
-| C510 | opstate params sweep | ✅ merged #2446 — retention job now clears state for gone/terminal ops; keeps running/queued/interrupted/unknown |
+| C510 | opstate params sweep | ✅ merged #2446 |
 | C511 | Resume-fallback metric | ✅ merged #2429 |
 | C512–C514 | Dry-run declaration / ctxOpID audit / channel drops | ⬜ design / gated A04 / ready |
 | C610 | Dangling-SeriesID copy guard | ✅ merged #2440 (repair op for the ~12K existing refs = follow-up) |
@@ -66,12 +65,12 @@ are inlined below.
 | C717 | Search-result cache | 🔒 design-gated |
 | C810–C813 | Data-shape repairs | 🔒 design / owner / ready |
 | C814 | Soft-deleted total count | ✅ merged #2425 |
-| C815–C816 | Orphan-VG pagination / memdb mutex | ✅ merged #2443 / #2444 (mutex hoist benched 1.35–1.83 → 1.21–1.25 ms/op) |
+| C815–C816 | Orphan-VG pagination / memdb mutex | ✅ merged #2443 / #2444; the 7 REMAINING offset walkers (5 jobs + 2 Pebble pagers) collapsed in #2452 |
 | C817 | DeleteBookFilesForBook memdb sync | ✅ merged #2427 |
 | C818–C819 | Aggregates coalescing / row-count bookkeeping | 🔒 need A07 / A06 |
 | C910–C911 | Dedup backlog / merge-cache-evict | ⬜ ready |
 | CA10–CA11 | SSRF alerts / zipslip batch | ⬜ ready |
-| CA12 | Log-injection sweep (D-7 ✅) | 🟡 waves 1+1.1 merged #2439/#2445 — recognition verdict came back **1/322 closed**: both sanitizers had a clean-string fast-path returning BEFORE the ReplaceAll barrier (CodeQL barriers are path-sensitive). Fixed; next main analysis is the fan-out gate |
+| CA12 | Log-injection sweep (D-7 ✅) | 🟡 waves 1+1.1 merged; post-#2445 verdict: **316 still open — the conduit's own alerts survive** because CodeQL weak-updates variadic `[]any` element writes (no code shape fixes it). Wave 2 = model-as-data sanitizer rows (fragment, with extensible-name validation caveat). Bonus find: ALL 16 existing sanitizer-model rows were inert since the module rename (jdfalk→falkcorp) — fix in #2454 |
 | CA13 | OpenAI key validation | ⬜ ready |
 | CA14 | Security-sweep status column | ✅ merged #2426 (41/41 verified) |
 | CA15 | Secrets/systemd batch (D-10: deferred, LAN trusted) | ⬜ owner-at-keyboard |
@@ -84,15 +83,15 @@ are inlined below.
 | D111 | Stored zeros must not shadow defaults | ⬜ design |
 | D112 | Scheduled-tasks residual verification | ✅ verified — dedup_refresh 6h ticker started at the 13:09 boot |
 | D113 | wipeActivity preview | ⬜ ready |
-| E01 | BookSig sidecar migrate | 🟡 dry-run done: examined 63,841, **would migrate 26,159**, 0 errors — instrument gate (≈27K) PASSED; canary apply (limit 100) is next |
-| E02 | Chapters backfill | 🟡 cohort dry-run done: 77 examined, would-persist 0 (47 already have chapters from the B06 pass, 17 multi-file by design, 12 markerless) — cohort complete; whole-library residue (~14.6K) is the remaining step |
+| E01 | BookSig sidecar migrate | ✅ **CLOSED ON PROD** — canary (limit 100, 0 errors) → full apply **migrated 26,027/26,027, 0 errors** (~559 MB inline signatures → sidecars) → re-dry-run **0 candidates of 63,841**. `phase_mb[books]` drop check at next boot |
+| E02 | Chapters backfill | 🟡 cohort complete; whole-library dry-run RUNNING (ffprobe over ~14.6K candidates) — apply follows its numbers |
 | E03 | Search-index boot repair confirmation | ✅ verified — boot gate deleted **3,983** stale docs in 1m29s (3,953 trash + 30 from the E05 canary merge); index now equals the library and the 13:40 boot showed no divergence |
 | E04 | Title-match false-series repair | ⬜ build + dry-run |
 | E05 | review_apply_enabled flip + canary | ✅ **done + verified** — flag live, canary combine applied exactly per card (31 files → 1 book); 354 items now live-appliable |
 | E06 | probe-directory-books apply | ✅ applied — examined 1,026: **434 actioned** (exactly the approved dry-run count), 592 stay in review, 0 errors |
 | E07 | iTunes PID-repair | ✅ resolved, no apply needed — live census shows only **2 duplicate PIDs** (both ambiguous, one same-content pair split across the two trees; hand review); the recorded 8,984 was stale pre-repair state. Side catch: the endpoint read dry_run from the query only and silently ignored a JSON body — fixed in #2447 |
-| E08 | Review-screen tag repair | 🟡 preview done — per-book derivation impossible; recommendation: library-wide bulk-write-back in the nightly window (owner pick pending) |
-| E09 | Prometheus metrics bearer token | ⬜ script staged on the server; owner runs it |
+| E08 | Review-screen tag repair | 🟡 owner approved canary+full; canary (100 books) ran clean on TAGS but exposed a real bug: the tag rewrite replaced files as mode 0600, zeroing ACL masks — every rewritten file went share-unreadable. Root cause fixed (#2451: OpenFile's mode arg only applies at CREATE), `fix-file-modes` repaired 1,547 files; **124 residue files expose a second defect** (book rows carrying stale paths — fragment). FULL RUN DEFERRED on measurement: ~35 s/book serial + unconditional writes = weeks, not a night; prerequisites filed (diff-skip + in-op parallelism) |
+| E09 | Prometheus metrics bearer token | ✅ **DONE** — scrape `health=up` since 14:02 EDT. The config block pre-existed; the whole fix was a valid key in the token file (minted via API straight to a server-side file). The staged script's yml editor had a guaranteed ValueError (dead indent block) — patched on-server |
 
 ## Waves F/G/H — iTunes, frontend, CI
 
@@ -103,7 +102,7 @@ are inlined below.
 | F114 | Progress propagation investigation | ⬜ ready |
 | F115 | Dead file-level playlist path | ✅ merged #2428 |
 | F116 | 2-way-sync guard scope | 🔒 owner decision |
-| G110 | Restore library sort | ⬜ ready |
+| G110 | Restore library sort | ✅ merged #2453 — grid-view Sort control restored, server-side keys, 2 mutations verified |
 | G111 | Clickable metadata links | ⬜ unblocked by C110 |
 | G112–G117 | Frontend batch | ⬜ ready / owner-gated |
 | G118 | Empty-FieldFilter trace + 400 toast | ✅ merged #2432 — no live UI path can send an empty value; 400s now surface the server message |

--- a/todo.d/20260814-a04-probe-records-activity-not-changes.md
+++ b/todo.d/20260814-a04-probe-records-activity-not-changes.md
@@ -1,0 +1,11 @@
+- [ ] **A04's designated probe cannot verify the op-ID audit trail.**
+      `maintenance.temp-file-cleanup` routes through
+      `sweep.CleanupOrphanedTempFiles`, which records each deletion via
+      `activity.LogBatch` — the ACTIVITY feed — and never calls
+      `CreateOperationChange`. So even a run that deletes files writes zero
+      `operation_changes` rows, and the 2026-08-14 probe (which found 0
+      orphans anyway) was doubly inconclusive. To verify #2414 on prod, pick
+      a mutating op whose write path actually calls `CreateOperationChange`
+      (C513's list of the 8 `ctxOpID` consumers is the menu — read the branch
+      first), or decide temp-file deletions SHOULD be operation_changes and
+      wire it, making the safest probe also a valid one.


### PR DESCRIPTION
Board refresh: C111+E01 closed on prod with verified zero-residue re-dry-runs, E08 canary findings (0600 perms bug fixed via #2451 + 124-file stale-path residue), E09 done, CA12 wave-2 verdict (variadic weak-update), G110+#2452 merged. Fragment: A04's designated probe records to the activity feed, never operation_changes — wrong instrument by construction. Scrub-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS