### PR TITLE
fix(authors): entity-safe separator split + dirty-name creation gate (C413)

### DIFF
--- a/changelog.d/20260814_172500_dirty_author_gate.md
+++ b/changelog.d/20260814_172500_dirty_author_gate.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Artist tags no longer mint garbage author rows: HTML-entity semicolons are
+  protected from the author-separator split (an "&#169;2013 by ..." tag had
+  sheared into an "&#169" author), and creation now rejects obviously-dirty
+  names (leading "©"/"&#", leading 4-digit year, existing publisher rules) so
+  copyright lines become authorless books instead of repair jobs.

--- a/internal/dedup/author.go
+++ b/internal/dedup/author.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/author.go
-// version: 1.12.0
+// version: 1.13.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90
 // last-edited: 2026-08-14
 
@@ -147,9 +147,22 @@ func extractBaseAuthor(name string) string {
 	return strings.TrimSpace(name)
 }
 
-// isDirtyAuthorName returns true if the name is obviously not a real author
-func isDirtyAuthorName(name string) bool {
+// IsDirtyAuthorName returns true if the name is obviously not a real author:
+// publisher/production names, "A - B" separators, copyright fragments and
+// HTML-entity shrapnel (leading "©" or "&#"), and strings that OPEN with a
+// 4-digit year ("2013 by HarperCollinsPublishers") — those are rights lines
+// from artist tags, never people. Exported so CREATION paths can reject these
+// up front instead of minting rows that need repair later (C413; author rows
+// 46583 "&#169" and 51870 "&#169;2013 by HarperCollinsPublishers").
+func IsDirtyAuthorName(name string) bool {
+	name = strings.TrimSpace(name)
 	if strings.Contains(name, " - ") {
+		return true
+	}
+	if strings.HasPrefix(name, "©") || strings.HasPrefix(name, "&#") {
+		return true
+	}
+	if leadingYearRe.MatchString(name) {
 		return true
 	}
 
@@ -172,6 +185,11 @@ func isDirtyAuthorName(name string) bool {
 
 	return IsProductionCompany(name)
 }
+
+// leadingYearRe matches names that BEGIN with a standalone 4-digit year —
+// copyright lines, not people. Anchored so "1984 George Orwell" style titles
+// are caught but "Agent 47" style names (year not leading) are not.
+var leadingYearRe = regexp.MustCompile(`^\d{4}\b`)
 
 // SplitCompositeAuthorName splits "Author1 / Author2" or "Author1, Author2" into parts.
 // Returns nil or single-element slice if the name doesn't look composite.
@@ -421,7 +439,7 @@ func isCompositeAuthorName(name string) bool {
 // Much stricter than raw Jaro-Winkler — requires last name match.
 func areAuthorsDuplicate(name1, name2 string) bool {
 	// Skip dirty names (book titles, publishers)
-	if isDirtyAuthorName(name1) || isDirtyAuthorName(name2) {
+	if IsDirtyAuthorName(name1) || IsDirtyAuthorName(name2) {
 		return false
 	}
 
@@ -873,7 +891,7 @@ func findDuplicateAuthorsInternal(authors []database.Author, threshold float64, 
 			index:  i,
 			author: a,
 		}
-		if isMultiAuthorString(a.Name) || isCompositeAuthorName(a.Name) || isDirtyAuthorName(a.Name) {
+		if isMultiAuthorString(a.Name) || isCompositeAuthorName(a.Name) || IsDirtyAuthorName(a.Name) {
 			pre.skip = true
 		} else {
 			pre.norm = strings.ToLower(NormalizeAuthorName(a.Name))

--- a/internal/dedup/author_dirty_test.go
+++ b/internal/dedup/author_dirty_test.go
@@ -1,0 +1,39 @@
+// file: internal/dedup/author_dirty_test.go
+// version: 1.0.0
+// guid: 5c8f2e91-3a67-4b04-9d2e-7f1a6c3b8d50
+// last-edited: 2026-08-14
+
+package dedup
+
+import "testing"
+
+// TestIsDirtyAuthorName_CopyrightAndEntityShrapnel pins the C413 creation-gate
+// rules. The dirty side is drawn from REAL author rows minted from artist
+// tags; the clean side guards against overreach (years inside names, real
+// people, the ampersand that survives entity decoding).
+func TestIsDirtyAuthorName_CopyrightAndEntityShrapnel(t *testing.T) {
+	dirty := []string{
+		"&#169",                                // row 46583 — entity shrapnel
+		"&#169;2013 by HarperCollinsPublishers", // row 51870 — whole rights line
+		"©2013 by HarperCollinsPublishers",     // decoded form is just as dirty
+		"© Big Finish",
+		"2013 by HarperCollinsPublishers", // leading standalone year
+		"BBC Audio",                       // existing publisher rule still holds
+	}
+	for _, name := range dirty {
+		if !IsDirtyAuthorName(name) {
+			t.Errorf("IsDirtyAuthorName(%q) = false, want true", name)
+		}
+	}
+	clean := []string{
+		"Brandon Sanderson",
+		"J. R. R. Tolkien",
+		"Agent 47 Fan",       // year-like digits NOT leading
+		"Simone de Beauvoir", // lowercase particle mid-name
+	}
+	for _, name := range clean {
+		if IsDirtyAuthorName(name) {
+			t.Errorf("IsDirtyAuthorName(%q) = true, want false", name)
+		}
+	}
+}

--- a/internal/dedup/author_test.go
+++ b/internal/dedup/author_test.go
@@ -102,7 +102,7 @@ func TestIsDirtyAuthorName(t *testing.T) {
 		"Penguin Random House",
 	}
 	for _, name := range dirty {
-		if !isDirtyAuthorName(name) {
+		if !IsDirtyAuthorName(name) {
 			t.Errorf("expected %q to be flagged as dirty", name)
 		}
 	}
@@ -114,7 +114,7 @@ func TestIsDirtyAuthorName(t *testing.T) {
 		"Natalie Maher (aka Thundamoo)",
 	}
 	for _, name := range clean {
-		if isDirtyAuthorName(name) {
+		if IsDirtyAuthorName(name) {
 			t.Errorf("expected %q to NOT be flagged as dirty", name)
 		}
 	}

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -1,5 +1,5 @@
 // file: internal/importer/service.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5b
 // last-edited: 2026-06-16
 
@@ -18,6 +18,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/dedup"
 	"github.com/falkcorp/audiobook-organizer/internal/fileops"
 	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
+	"github.com/falkcorp/audiobook-organizer/internal/logging"
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 	"github.com/falkcorp/audiobook-organizer/internal/versions"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
@@ -146,15 +147,23 @@ func (is *ImportService) ImportFile(req *ImportFileRequest) (*ImportFileResponse
 	// Set author if available
 	if meta.Artist != "" {
 		normalizedArtist := dedup.NormalizeAuthorName(meta.Artist)
-		author, err := is.db.GetAuthorByName(normalizedArtist)
-		if err != nil {
-			author, err = is.db.CreateAuthor(normalizedArtist)
+		// Creation gate (C413): copyright fragments and entity shrapnel from
+		// artist tags must not become author rows. A book with NO author is
+		// honest; an author named "&#169" is a repair job.
+		if dedup.IsDirtyAuthorName(normalizedArtist) {
+			slog.Warn("importer: artist tag rejected as author name",
+				"artist", logging.Sanitize(meta.Artist), "path", logging.Sanitize(req.FilePath))
+		} else {
+			author, err := is.db.GetAuthorByName(normalizedArtist)
 			if err != nil {
-				return nil, fmt.Errorf("failed to create author: %w", err)
+				author, err = is.db.CreateAuthor(normalizedArtist)
+				if err != nil {
+					return nil, fmt.Errorf("failed to create author: %w", err)
+				}
 			}
-		}
-		if author != nil {
-			book.AuthorID = &author.ID
+			if author != nil {
+				book.AuthorID = &author.ID
+			}
 		}
 	}
 

--- a/internal/metadata/folder_parser.go
+++ b/internal/metadata/folder_parser.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/folder_parser.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: f1e2d3c4-b5a6-7890-abcd-ef1234567890
 
 package metadata
@@ -385,13 +385,26 @@ func looksLikeAuthorSegment(s string) bool {
 	return true
 }
 
+// htmlEntityRe matches an HTML entity ("&#169;", "&amp;") so its terminating
+// semicolon can be protected from the author-separator split below. Splitting
+// "&#169;2013 by HarperCollinsPublishers" on the raw ";" sheared it into an
+// "&#169" author row (id 46583) — the entity's ";" is not a separator.
+var htmlEntityRe = regexp.MustCompile(`&#?[a-zA-Z0-9]+;`)
+
 // splitMultipleAuthors splits "Author A & Author B" or "Author A; Author B" into a slice.
 // Each author is trimmed. Returns a slice with at least one element.
 func splitMultipleAuthors(s string) []string {
+	// Protect HTML-entity semicolons (see htmlEntityRe) with a sentinel that
+	// cannot appear in tag text, split, then restore.
+	const sentinel = "\x00"
+	s = htmlEntityRe.ReplaceAllStringFunc(s, func(m string) string {
+		return strings.TrimSuffix(m, ";") + sentinel
+	})
 	// Split on " & " first, then " and " (case-insensitive), then ";".
 	var parts []string
 	for _, chunk := range strings.Split(s, " & ") {
 		for _, sub := range strings.Split(chunk, ";") {
+			sub = strings.ReplaceAll(sub, sentinel, ";")
 			trimmed := strings.TrimSpace(sub)
 			if trimmed != "" {
 				parts = append(parts, trimmed)

--- a/internal/metadata/split_authors_internal_test.go
+++ b/internal/metadata/split_authors_internal_test.go
@@ -1,0 +1,31 @@
+// file: internal/metadata/split_authors_internal_test.go
+// version: 1.0.0
+// guid: 8e4b7d20-6f19-4c53-a2b8-3d9e5f7c1a06
+// last-edited: 2026-08-14
+
+package metadata
+
+import "testing"
+
+// TestSplitMultipleAuthors_HTMLEntitySemicolons pins the C413 shear fix: an
+// HTML entity's terminating ";" is NOT an author separator. Splitting
+// "&#169;2013 by HarperCollinsPublishers" on the raw ";" minted an "&#169"
+// author row (id 46583 in prod).
+func TestSplitMultipleAuthors_HTMLEntitySemicolons(t *testing.T) {
+	got := splitMultipleAuthors("&#169;2013 by HarperCollinsPublishers")
+	if len(got) != 1 || got[0] != "&#169;2013 by HarperCollinsPublishers" {
+		t.Fatalf("entity semicolon treated as separator: %#v", got)
+	}
+
+	// A REAL separator still splits, entity or not on either side.
+	got = splitMultipleAuthors("Terry Pratchett; Neil Gaiman")
+	if len(got) != 2 || got[0] != "Terry Pratchett" || got[1] != "Neil Gaiman" {
+		t.Fatalf("plain separator broken: %#v", got)
+	}
+
+	// Mixed: entity inside a name survives, separator still works.
+	got = splitMultipleAuthors("Johnson &amp; Johnson; Neil Gaiman")
+	if len(got) != 2 || got[0] != "Johnson &amp; Johnson" || got[1] != "Neil Gaiman" {
+		t.Fatalf("mixed entity + separator: %#v", got)
+	}
+}


### PR DESCRIPTION
## Why

Fragment `20260814-author-html-entity-rows`: author row 46583 is literally named `&#169`, and 51870 is a whole copyright line. The truncation hunt (the fragment had exonerated `SplitCompositeAuthorName`'s semicolon branch) lands on `splitMultipleAuthors` in `internal/metadata/folder_parser.go`: it splits artist tags on raw `";"`, and an HTML entity's terminating semicolon is not a separator — `&#169;2013 by HarperCollinsPublishers` sheared at the entity, minting `&#169` as an author.

## What

- `splitMultipleAuthors`: entity semicolons (`&#169;`, `&amp;`) are sentinel-protected around the split, then restored. Real `;` separators still split.
- `IsDirtyAuthorName` (now exported): new rules — leading `©`, leading `&#`, leading standalone 4-digit year (rights lines, never people) — on top of the existing publisher rules.
- Importer creation gate: a dirty normalized artist yields an authorless book + a sanitized warn log, not a garbage author row. Other 7 `CreateAuthor` call sites left for a follow-up sweep (noted in the fragment).

## Testing

- `TestSplitMultipleAuthors_HTMLEntitySemicolons` — the shear case, a plain separator, and mixed entity+separator.
- `TestIsDirtyAuthorName_CopyrightAndEntityShrapnel` — dirty side from the real prod rows; clean side guards overreach (`Agent 47 Fan`, decoded `©` forms both ways).
- Mutations vs committed base: entity protection removed → FAIL; entity-prefix rule removed → FAIL; year rule removed → FAIL; restored green. Full importer/dedup/metadata suites pass.

## Prod follow-up (after merge)

Delete row 51870 (0 books), reattribute 46583's 1 book, per the fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS