### PR TITLE
fix(organizer): defer rename/copy while the author is unresolved

### DIFF
--- a/changelog.d/20260814_180000_organize_author_gate.md
+++ b/changelog.d/20260814_180000_organize_author_gate.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Organize no longer bakes "Unknown Author" into library paths: the bulk
+  organize loop defers books whose author is unresolved (counted + logged),
+  single-book in-place renames return a typed "resolve metadata first" error,
+  and the Review Organize preview replaces the rename/copy steps with an
+  explicit warning instead of proposing a placeholder path. This closes the
+  ordering hole behind the 2026-08-11 mass-reorganize (23,622 entries filed
+  under one placeholder directory).

--- a/internal/organizer/author_gate_test.go
+++ b/internal/organizer/author_gate_test.go
@@ -1,0 +1,55 @@
+// file: internal/organizer/author_gate_test.go
+// version: 1.0.0
+// guid: 9b3e6c50-2f81-4d47-a5c9-8e0d7f2b4a13
+// last-edited: 2026-08-14
+
+package organizer
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/logger"
+)
+
+// TestHasResolvedAuthor pins the gate's definition of "resolved": a real
+// non-blank name, populated directly or via AuthorID lookup. Everything that
+// would make expandPattern fall back to "Unknown Author" must report false.
+func TestHasResolvedAuthor(t *testing.T) {
+	o := NewOrganizer(&config.Config{})
+
+	if o.HasResolvedAuthor(&database.Book{}) {
+		t.Fatal("nil author must be unresolved")
+	}
+	if o.HasResolvedAuthor(&database.Book{Author: &database.Author{Name: "   "}}) {
+		t.Fatal("blank author name must be unresolved")
+	}
+	if !o.HasResolvedAuthor(&database.Book{Author: &database.Author{Name: "Brandon Sanderson"}}) {
+		t.Fatal("real author must be resolved")
+	}
+
+	// AuthorID path resolves via the store.
+	id := 7
+	o.store = &database.MockStore{GetAuthorByIDFunc: func(gotID int) (*database.Author, error) {
+		if gotID != 7 {
+			t.Fatalf("looked up author %d, want 7", gotID)
+		}
+		return &database.Author{ID: 7, Name: "N. K. Jemisin"}, nil
+	}}
+	if !o.HasResolvedAuthor(&database.Book{AuthorID: &id}) {
+		t.Fatal("AuthorID-resolvable author must be resolved")
+	}
+}
+
+// TestReOrganizeInPlace_RefusesUnresolvedAuthor pins the apply-side gate: an
+// in-root rename for a placeholder-author book returns ErrAuthorUnresolved
+// BEFORE touching the filesystem.
+func TestReOrganizeInPlace_RefusesUnresolvedAuthor(t *testing.T) {
+	svc := &Service{}
+	_, err := svc.ReOrganizeInPlace(&database.Book{Title: "X", FilePath: "/nonexistent/x.m4b"}, logger.New("test"))
+	if !errors.Is(err, ErrAuthorUnresolved) {
+		t.Fatalf("err = %v, want ErrAuthorUnresolved", err)
+	}
+}

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/organizer.go
-// version: 1.21.0
+// version: 1.22.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 // last-edited: 2026-08-13
 
@@ -361,24 +361,50 @@ func (o *Organizer) generateTargetPath(book *database.Book) (string, error) {
 	return fullPath, nil
 }
 
+// placeholderAuthor is the path fallback for books with no resolvable author.
+// Baking it into an organized path is what the 2026-08-11 mass-reorganize did
+// 23,622 times — see docs/audits/2026-08-13-mass-reorganize-duplicated-14tb-
+// under-unknown-author.md. Rename/copy paths must gate on HasResolvedAuthor
+// before using a target built from this.
+const placeholderAuthor = "Unknown Author"
+
+// resolveAuthorName returns the book's effective author name, following
+// AuthorID when the Author object is not populated. Empty string means the
+// author is UNRESOLVED and any generated path would fall back to
+// placeholderAuthor.
+func (o *Organizer) resolveAuthorName(book *database.Book) string {
+	if book.Author != nil {
+		if trimmed := strings.TrimSpace(book.Author.Name); trimmed != "" {
+			return trimmed
+		}
+	} else if book.AuthorID != nil && o.store != nil {
+		author, err := o.store.GetAuthorByID(*book.AuthorID)
+		if err == nil && author != nil {
+			if trimmed := strings.TrimSpace(author.Name); trimmed != "" {
+				return trimmed
+			}
+		}
+	}
+	return ""
+}
+
+// HasResolvedAuthor reports whether organizing this book would use a real
+// author name rather than the placeholder. Callers that RENAME or COPY into
+// the library tree must defer when this is false: a book filed under the
+// placeholder needs metadata resolution, not a rename that cements the
+// placeholder into its path (and later a content-verified purge to undo).
+func (o *Organizer) HasResolvedAuthor(book *database.Book) bool {
+	return o.resolveAuthorName(book) != ""
+}
+
 // expandPattern expands a pattern with book metadata
 func (o *Organizer) expandPattern(pattern string, book *database.Book) (string, error) {
 	result := placeholderNormalizeRegex.ReplaceAllStringFunc(pattern, strings.ToLower)
 
 	// Get author name - look up by ID if Author object is nil but AuthorID is set
-	authorName := "Unknown Author"
-	if book.Author != nil {
-		if trimmed := strings.TrimSpace(book.Author.Name); trimmed != "" {
-			authorName = trimmed
-		}
-	} else if book.AuthorID != nil && o.store != nil {
-		// Author object not populated, but we have an ID - look it up
-		author, err := o.store.GetAuthorByID(*book.AuthorID)
-		if err == nil && author != nil {
-			if trimmed := strings.TrimSpace(author.Name); trimmed != "" {
-				authorName = trimmed
-			}
-		}
+	authorName := o.resolveAuthorName(book)
+	if authorName == "" {
+		authorName = placeholderAuthor
 	}
 
 	title := strings.TrimSpace(book.Title)

--- a/internal/organizer/preview.go
+++ b/internal/organizer/preview.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/preview.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f1a2b3c4-d5e6-7890-abcd-ef1234567890
 
 package organizer
@@ -126,6 +126,20 @@ func (ops *PreviewService) PreviewOrganize(bookID string) (*PreviewResponse, err
 	}
 
 	var steps []PreviewStep
+
+	// Author gate (mirrors PerformOrganize and ReOrganizeInPlace): never
+	// propose a rename/copy whose target bakes the "Unknown Author"
+	// placeholder into the path. Tag/cover steps below are unaffected.
+	authorUnresolved := !org.HasResolvedAuthor(book)
+	if authorUnresolved && (needsRename || needsCopy) {
+		steps = append(steps, PreviewStep{
+			Action:      "warning",
+			Description: "Author is unresolved — rename deferred so 'Unknown Author' is not baked into the path. Fetch metadata to resolve the author, then organize will rename this book properly.",
+			Warning:     "author_unresolved",
+		})
+		needsRename = false
+		needsCopy = false
+	}
 
 	// Step 1: Protected path warning (only for books outside RootDir)
 	if protected && !alreadyInRoot {

--- a/internal/organizer/service.go
+++ b/internal/organizer/service.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/service.go
-// version: 1.17.0
+// version: 1.18.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
 // last-edited: 2026-08-14
 
@@ -87,6 +87,11 @@ func (orgSvc *Service) SetWriteBackBatcher(b WriteBackEnqueuer) {
 
 // SetOrganizeHooks sets optional hooks that are propagated to every
 // Organizer instance created by this service.
+// ErrAuthorUnresolved is returned when a rename/organize is refused because
+// the book's author would resolve to the "Unknown Author" placeholder. The
+// caller should surface "resolve metadata first" rather than renaming.
+var ErrAuthorUnresolved = errors.New("author unresolved — metadata fetch must resolve the author before organize renames this book")
+
 func (orgSvc *Service) SetOrganizeHooks(hooks OrganizeHooks) {
 	orgSvc.organizeHooks = hooks
 }
@@ -541,6 +546,7 @@ func (orgSvc *Service) FilterBooksNeedingOrganization(allBooks []database.Book, 
 	alreadyCorrect := make([]database.Book, 0)
 	skippedMissingFiles := 0
 	skippedDeleted := 0
+	skippedUnresolvedAuthor := 0
 	for i, book := range allBooks {
 		// Update progress during filtering so the UI doesn't show 0/0
 		if i%500 == 0 || i == len(allBooks)-1 {
@@ -618,7 +624,19 @@ func (orgSvc *Service) FilterBooksNeedingOrganization(allBooks []database.Book, 
 				continue
 			}
 		}
+		// Author gate: a rename/copy for a book with no resolvable author
+		// would bake "Unknown Author" into the target path — the 2026-08-11
+		// mass-reorganize mechanism. Defer these until metadata resolution
+		// gives them a real author. (Books already sitting under the
+		// placeholder stay put rather than being re-cemented.)
+		if !orgSvc.newOrganizer().HasResolvedAuthor(&book) {
+			skippedUnresolvedAuthor++
+			continue
+		}
 		booksToOrganize = append(booksToOrganize, book)
+	}
+	if skippedUnresolvedAuthor > 0 {
+		log.Info("Organize: Deferred %d book(s) with unresolved author — run metadata fetch, then organize renames them properly", skippedUnresolvedAuthor)
 	}
 	if skippedDeleted > 0 {
 		log.Info("Organize: Skipped %d soft-deleted book(s)", skippedDeleted)
@@ -659,6 +677,9 @@ func (orgSvc *Service) bookNeedsReOrganize(book *database.Book, log logger.Logge
 // correct location based on current metadata. Returns the new path.
 func (orgSvc *Service) ReOrganizeInPlace(book *database.Book, log logger.Logger) (string, error) {
 	org := orgSvc.newOrganizer()
+	if !org.HasResolvedAuthor(book) {
+		return "", ErrAuthorUnresolved
+	}
 	oldPath := book.FilePath
 
 	info, err := os.Stat(oldPath)


### PR DESCRIPTION
## Why

Owner report (2026-08-14, Review Organize screenshot): a book in the organizer tree was offered a rename that baked "Unknown Author" into both the directory and the filename — twice — while the book plainly carried resolvable metadata (full title, two narrators). This is the same ordering hole behind the 2026-08-11 mass-reorganize (audit `docs/audits/2026-08-13-mass-reorganize-duplicated-14tb-under-unknown-author.md`): organize runs before enrichment, the path template falls back to the placeholder, and the placeholder gets cemented on disk 23,622 times.

## What

New `Organizer.HasResolvedAuthor` (extracted from `expandPattern`'s fallback logic, single source of truth) gates all three organize surfaces:

- **Bulk organize loop**: books with unresolved authors are deferred and counted (`Deferred N book(s) with unresolved author — run metadata fetch, then organize renames them properly`).
- **`ReOrganizeInPlace`** (single-book apply): returns typed `ErrAuthorUnresolved` before touching the filesystem.
- **Review Organize preview**: rename/copy steps are replaced with an `author_unresolved` warning step; tag/cover steps unaffected.

Books already filed under the placeholder stay put (not re-cemented) until a real author exists — then organize renames them properly, which is the owner's stated requirement.

## Testing

`TestHasResolvedAuthor` (nil/blank/real/AuthorID-lookup cases) + `TestReOrganizeInPlace_RefusesUnresolvedAuthor` (typed error before any I/O). Mutations vs committed base: gate forced true → FAIL; apply guard removed → FAIL; restored green. Full organizer suite passes.

## Follow-up (separate op, owner-requested)

Content-verified purge of `Unknown Author/` duplicates where a real-author twin exists — per the audit's rules: interior-content identity (25/50/75% probes, not head/tail), twin must exist on disk, never delete on size match alone, and the 314 UA-only survivors are untouchable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS