### PR TITLE
feat(maintenance): content-verified Unknown Author duplicate purge

### DIFF
--- a/changelog.d/20260814_183000_ua_duplicate_purge.md
+++ b/changelog.d/20260814_183000_ua_duplicate_purge.md
@@ -1,0 +1,8 @@
+### Added
+
+- New `purge-unknown-author-duplicates` maintenance job (dry-run default):
+  soft-deletes "Unknown Author/" books whose EVERY file has a content-verified
+  twin outside that tree — identity measured on interior probes (25/50/75%),
+  never head/tail where tag blocks differ; the twin must exist on disk and
+  belong to a live real-author book. UA-only survivors and size-collisions
+  are kept, per the 2026-08-13 mass-reorganize audit's rules.

--- a/internal/maintenance/jobs/purge_ua_duplicates.go
+++ b/internal/maintenance/jobs/purge_ua_duplicates.go
@@ -1,0 +1,278 @@
+// file: internal/maintenance/jobs/purge_ua_duplicates.go
+// version: 1.0.0
+// guid: 7a4d1e58-9c26-4b73-b0f2-5e8c3a6d9f41
+// last-edited: 2026-08-14
+
+package jobs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
+	"golang.org/x/sync/errgroup"
+)
+
+func init() { maintenance.Register(&purgeUADuplicatesJob{}) }
+
+// purgeUADuplicatesJob soft-deletes "Unknown Author/" books that are verified
+// duplicates of a real-author copy. Rules come from the 2026-08-13 audit
+// (docs/audits/2026-08-13-mass-reorganize-duplicated-14tb-under-unknown-author.md)
+// and are NON-NEGOTIABLE:
+//
+//   - Identity is measured on INTERIOR content (probes at 25/50/75% of the
+//     file), never head/tail — tag blocks differ between an Unknown Author
+//     copy and its correctly-tagged twin even when the audio is identical.
+//   - The twin must exist ON DISK right now, outside the Unknown Author tree,
+//     and belong to a live (non-soft-deleted) book.
+//   - EVERY active file of the UA book must have a verified twin, or the book
+//     is left alone. A size match alone proves nothing (fixed-bitrate rips
+//     collide); the ~314 UA-only survivors must never match.
+//   - Purge = soft-delete (MarkedForDeletion), the same reversible state every
+//     other deletion path uses. Files are not touched here; the normal trash
+//     lifecycle owns them (blocks are ZFS-cloned — there is no space to win,
+//     this is library hygiene).
+type purgeUADuplicatesJob struct{}
+
+func (j *purgeUADuplicatesJob) ID() string       { return "purge-unknown-author-duplicates" }
+func (j *purgeUADuplicatesJob) Name() string     { return "Purge verified Unknown Author duplicates" }
+func (j *purgeUADuplicatesJob) Category() string { return "maintenance" }
+func (j *purgeUADuplicatesJob) DefaultParams() any {
+	return struct {
+		DryRun bool `json:"dry_run"`
+	}{DryRun: true}
+}
+func (j *purgeUADuplicatesJob) Description() string {
+	return "Soft-delete Unknown Author books whose every file has an interior-content-verified twin outside the Unknown Author tree"
+}
+func (j *purgeUADuplicatesJob) CanResume() bool { return false } // idempotent
+
+// uaProbeSize is how many bytes each interior probe compares. Three probes ×
+// 64 KiB reads both files at 25/50/75% — small enough to sweep hundreds of
+// thousands of files, large enough that fixed-bitrate size collisions cannot
+// pass by accident.
+const uaProbeSize = 64 * 1024
+
+func (j *purgeUADuplicatesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	root := config.AppConfig.RootDir
+	if root == "" {
+		return fmt.Errorf("purge-unknown-author-duplicates: RootDir not configured")
+	}
+	uaPrefix := filepath.Join(root, "Unknown Author") + string(filepath.Separator)
+
+	books, err := store.GetAllBooksCore(0, 0)
+	if err != nil {
+		return fmt.Errorf("list books: %w", err)
+	}
+	files, err := store.GetAllBookFilesCore()
+	if err != nil {
+		return fmt.Errorf("list book files: %w", err)
+	}
+
+	liveBook := make(map[string]*database.BookCore, len(books))
+	for i := range books {
+		if !books[i].IsSoftDeleted() {
+			liveBook[books[i].ID] = &books[i]
+		}
+	}
+
+	// Candidate twins: files OUTSIDE the UA tree owned by live books, indexed
+	// by size. UA-side files grouped per owning book.
+	twinBySize := make(map[int64][]string)
+	uaFilesByBook := make(map[string][]database.BookFileCore)
+	for i := range files {
+		f := &files[i]
+		if f.FilePath == "" || f.Missing {
+			continue
+		}
+		if _, live := liveBook[f.BookID]; !live {
+			continue
+		}
+		if strings.HasPrefix(f.FilePath, uaPrefix) {
+			uaFilesByBook[f.BookID] = append(uaFilesByBook[f.BookID], *f)
+		} else if f.FileSize > 0 {
+			twinBySize[f.FileSize] = append(twinBySize[f.FileSize], f.FilePath)
+		}
+	}
+
+	// A UA book qualifies for the sweep only if ALL its active files sit in
+	// the UA tree — a book with files on both sides is not "the Unknown copy".
+	var uaBooks []string
+	for id, uaFiles := range uaFilesByBook {
+		b := liveBook[id]
+		if b == nil || !strings.HasPrefix(b.FilePath, uaPrefix) {
+			continue
+		}
+		total := 0
+		for i := range files {
+			if files[i].BookID == id && files[i].FilePath != "" && !files[i].Missing {
+				total++
+			}
+		}
+		if total == len(uaFiles) {
+			uaBooks = append(uaBooks, id)
+		}
+	}
+
+	slog.Info("purge-ua-duplicates: census",
+		"ua_books", len(uaBooks), "twin_candidate_files", len(files)-len(uaFilesByBook), "dry_run", dryRun)
+
+	var verified, purged, skippedNoTwin, skippedMismatch, errCount int64
+	reporter.SetTotal(len(uaBooks))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(max(runtime.NumCPU(), 1))
+	var mu sync.Mutex
+	samples := []string{}
+	for _, id := range uaBooks {
+		id := id
+		g.Go(func() error {
+			if gctx.Err() != nil {
+				return gctx.Err()
+			}
+			defer reporter.Increment()
+			ok, reason := uaBookFullyTwinned(uaFilesByBook[id], twinBySize)
+			switch {
+			case ok:
+				atomic.AddInt64(&verified, 1)
+				mu.Lock()
+				if len(samples) < 20 {
+					samples = append(samples, liveBook[id].FilePath)
+				}
+				mu.Unlock()
+				if dryRun {
+					return nil
+				}
+				full, herr := store.GetBookByID(id)
+				if herr != nil || full == nil {
+					atomic.AddInt64(&errCount, 1)
+					return nil
+				}
+				t := true
+				now := time.Now()
+				full.MarkedForDeletion = &t
+				full.MarkedForDeletionAt = &now
+				if _, uerr := store.UpdateBook(full.ID, full); uerr != nil {
+					slog.Warn("purge-ua-duplicates: soft-delete failed", "book", id, "err", uerr)
+					atomic.AddInt64(&errCount, 1)
+					return nil
+				}
+				atomic.AddInt64(&purged, 1)
+			case reason == "no-twin":
+				atomic.AddInt64(&skippedNoTwin, 1)
+			default:
+				atomic.AddInt64(&skippedMismatch, 1)
+			}
+			return nil
+		})
+	}
+	if werr := g.Wait(); werr != nil {
+		return werr
+	}
+
+	for _, s := range samples {
+		slog.Info("purge-ua-duplicates: verified duplicate", "path", s, "dry_run", dryRun)
+	}
+	slog.Info("purge-ua-duplicates: complete",
+		"ua_books", len(uaBooks), "verified_duplicates", verified, "purged", purged,
+		"kept_no_twin", skippedNoTwin, "kept_content_differs", skippedMismatch,
+		"errors", errCount, "dry_run", dryRun)
+	if errCount > 0 {
+		return fmt.Errorf("purge-ua-duplicates: %d books failed", errCount)
+	}
+	return nil
+}
+
+// uaBookFullyTwinned reports whether EVERY file has an interior-verified twin.
+// reason is "no-twin" when some file had no size candidate at all, "mismatch"
+// when candidates existed but none matched content.
+func uaBookFullyTwinned(uaFiles []database.BookFileCore, twinBySize map[int64][]string) (bool, string) {
+	for _, f := range uaFiles {
+		cands := twinBySize[f.FileSize]
+		if len(cands) == 0 {
+			return false, "no-twin"
+		}
+		matched := false
+		for _, cand := range cands {
+			same, err := interiorContentEqual(f.FilePath, cand, f.FileSize)
+			if err == nil && same {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false, "mismatch"
+		}
+	}
+	return true, ""
+}
+
+// interiorContentEqual compares two files at 25/50/75% offsets (uaProbeSize
+// bytes each). Head/tail are deliberately NOT compared: tag blocks live there
+// and differ between a correctly-tagged twin and an Unknown Author copy even
+// when the audio is byte-identical (audit finding).
+func interiorContentEqual(a, b string, size int64) (bool, error) {
+	fa, err := os.Open(a)
+	if err != nil {
+		return false, err
+	}
+	defer fa.Close()
+	fb, err := os.Open(b)
+	if err != nil {
+		return false, err
+	}
+	defer fb.Close()
+
+	// The twin must actually be size-identical on disk right now — the index
+	// was built from DB rows, which can be stale.
+	sa, err := fa.Stat()
+	if err != nil {
+		return false, err
+	}
+	sb, err := fb.Stat()
+	if err != nil {
+		return false, err
+	}
+	if sa.Size() != sb.Size() || sa.Size() != size {
+		return false, nil
+	}
+
+	bufA := make([]byte, uaProbeSize)
+	bufB := make([]byte, uaProbeSize)
+	for _, frac := range []int64{25, 50, 75} {
+		off := size * frac / 100
+		if off+uaProbeSize > size {
+			off = max64(0, size-uaProbeSize)
+		}
+		na, err := fa.ReadAt(bufA, off)
+		if err != nil && err != io.EOF {
+			return false, err
+		}
+		nb, err := fb.ReadAt(bufB, off)
+		if err != nil && err != io.EOF {
+			return false, err
+		}
+		if na != nb || !bytes.Equal(bufA[:na], bufB[:nb]) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/maintenance/jobs/purge_ua_duplicates_test.go
+++ b/internal/maintenance/jobs/purge_ua_duplicates_test.go
@@ -1,0 +1,124 @@
+// file: internal/maintenance/jobs/purge_ua_duplicates_test.go
+// version: 1.0.0
+// guid: 2c9f5e73-1b48-4d06-a7e3-6d0b8f4c2a95
+// last-edited: 2026-08-14
+
+package jobs
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// uaFixture builds a root with four cases and a store describing them:
+//
+//   - DUP:     UA book whose file's INTERIOR matches a real-author twin while
+//     the head (tag region) DIFFERS — must be verified and purged.
+//   - LONER:   UA book with a unique size — no candidate anywhere; must be
+//     kept (this is the ~314 UA-only-survivor class).
+//   - COLLIDE: UA book size-identical to a real file but with different
+//     interior content — the fixed-bitrate collision; must be kept.
+//   - TWIN:    the real-author book — must never be touched.
+func uaFixture(t *testing.T) (*database.MockStore, *map[string]bool) {
+	t.Helper()
+	root := t.TempDir()
+	old := config.AppConfig.RootDir
+	config.AppConfig.RootDir = root
+	t.Cleanup(func() { config.AppConfig.RootDir = old })
+
+	const size = 1 << 20 // 1 MiB: probes land at 256/512/768 KiB
+	base := bytes.Repeat([]byte{0xAB}, size)
+
+	dupContent := append([]byte(nil), base...)
+	copy(dupContent, bytes.Repeat([]byte{0x01}, 4096)) // "UA tag block"
+	twinContent := append([]byte(nil), base...)
+	copy(twinContent, bytes.Repeat([]byte{0x02}, 4096)) // different tag block
+	collideContent := append([]byte(nil), base...)
+	copy(collideContent[size/2:], bytes.Repeat([]byte{0xEE}, 4096)) // interior differs
+	lonerContent := bytes.Repeat([]byte{0x77}, size/2)              // unique size
+
+	write := func(rel string, content []byte) string {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, content, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	dupPath := write("Unknown Author/Dup Book/dup.m4b", dupContent)
+	lonerPath := write("Unknown Author/Loner Book/loner.m4b", lonerContent)
+	collidePath := write("Unknown Author/Collide Book/collide.m4b", collideContent)
+	twinPath := write("Real Author/Dup Book/twin.m4b", twinContent)
+
+	books := []database.BookCore{
+		{ID: "DUP", FilePath: dupPath},
+		{ID: "LONER", FilePath: lonerPath},
+		{ID: "COLLIDE", FilePath: collidePath},
+		{ID: "TWIN", FilePath: twinPath},
+	}
+	bfs := []database.BookFileCore{
+		{BookID: "DUP", FilePath: dupPath, FileSize: size},
+		{BookID: "LONER", FilePath: lonerPath, FileSize: size / 2},
+		{BookID: "COLLIDE", FilePath: collidePath, FileSize: size},
+		{BookID: "TWIN", FilePath: twinPath, FileSize: size},
+	}
+
+	deleted := map[string]bool{}
+	var mu sync.Mutex
+	m := &database.MockStore{}
+	m.GetAllBooksCoreFunc = func(limit, offset int) ([]database.BookCore, error) { return books, nil }
+	m.GetAllBookFilesCoreFunc = func() ([]database.BookFileCore, error) { return bfs, nil }
+	m.GetBookByIDFunc = func(id string) (*database.Book, error) { return &database.Book{ID: id}, nil }
+	m.UpdateBookFunc = func(id string, b *database.Book) (*database.Book, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if b.MarkedForDeletion == nil || !*b.MarkedForDeletion {
+			panic("purge wrote a non-soft-delete update: " + id)
+		}
+		deleted[id] = true
+		return b, nil
+	}
+	return m, &deleted
+}
+
+func TestPurgeUADuplicates_DryRunDeletesNothing(t *testing.T) {
+	store, deleted := uaFixture(t)
+	j := &purgeUADuplicatesJob{}
+	if err := j.Run(context.Background(), store, &nopReporter{}, true); err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	if len(*deleted) != 0 {
+		t.Fatalf("dry-run soft-deleted %v, want none", *deleted)
+	}
+}
+
+func TestPurgeUADuplicates_PurgesOnlyInteriorVerified(t *testing.T) {
+	store, deleted := uaFixture(t)
+	j := &purgeUADuplicatesJob{}
+	if err := j.Run(context.Background(), store, &nopReporter{}, false); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	d := *deleted
+	if !d["DUP"] || len(d) != 1 {
+		t.Fatalf("soft-deleted %v, want exactly {DUP}", d)
+	}
+	// The keeps are the audit's non-negotiables:
+	if d["LONER"] {
+		t.Fatal("purged a UA-only survivor (no twin anywhere) — data loss class")
+	}
+	if d["COLLIDE"] {
+		t.Fatal("purged on a size match with differing interior — content gate failed")
+	}
+	if d["TWIN"] {
+		t.Fatal("purged the real-author twin")
+	}
+}


### PR DESCRIPTION
## Why

Owner request (2026-08-14): "if we have two versions in the audiobook-organizer folder we need to make sure the files in both folders are exactly the same then we should purge the unknown one if we have one with actual authors in the path." Companion to #2457 (which stops NEW placeholder paths); this cleans up the existing `Unknown Author/` duplicate rows from the 2026-08-11 mass-reorganize.

## What

New `purge-unknown-author-duplicates` maintenance job (dry-run default), implementing the audit's rules (`docs/audits/2026-08-13-mass-reorganize-duplicated-14tb-under-unknown-author.md`) verbatim:

- **Interior-content identity**: 64 KiB probes at 25/50/75% of the file — never head/tail, where tag blocks differ between a UA copy and its correctly-tagged twin even when the audio is byte-identical. Sizes are also re-stat'd on disk (the DB index can be stale).
- **Twin requirements**: exists on disk NOW, outside the UA tree, owned by a live (non-soft-deleted) book.
- **All-files rule**: every active file of the UA book must have a verified twin, or the book is kept. The ~314 UA-only survivors can never match by construction; size collisions (fixed-bitrate rips) are rejected by the content probes.
- **Purge = soft-delete** (`MarkedForDeletion`), the standard reversible state — the normal trash lifecycle owns files. No reclaim claims: the blocks are ZFS-cloned; this is library hygiene, exactly as the audit concluded.
- Bounded worker pool (NumCPU) for the probe I/O per the concurrency mandate.

## Testing

Real-file fixture: a UA/twin pair whose HEADS differ but interiors match (must purge), a UA-only unique file (must keep), a size-collision with differing interior (must keep), and the twin itself (must never be touched). The mock's `UpdateBookFunc` panics on any non-soft-delete write. Mutations vs committed base: content check bypassed → FAIL (size-match purging caught); no-twin treated as verified → FAIL (survivor protection caught); dry-run gate removed → FAIL. Restored green; vet + full jobs suite pass.

## Prod plan

Merge → deploy → dry-run (expect a census of UA books + verified/kept split; the audit measured 215,160 size-candidates over 222,965 UA files, so verified count should be large) → review the sample lines → apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS