### PR TITLE
fix(authors): person-shape gate for comma and and-branch splits (C414)

### DIFF
--- a/changelog.d/20260814_185500_comma_split_person_shape.md
+++ b/changelog.d/20260814_185500_comma_split_person_shape.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Author splitting no longer manufactures authors from book titles: comma and
+  "and"/"&" clauses must be person-shaped (2-4 words, no leading/interior
+  function words — name particles like "de"/"van" stay allowed, no subtitle
+  punctuation, no trailing parenthetical), and the space-concatenation
+  fallback refuses comma-bearing names whose clauses already failed that
+  gate. Refused splits stay visibly broken instead of laundering a title
+  fragment into a plausible name.

--- a/internal/dedup/author.go
+++ b/internal/dedup/author.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/author.go
-// version: 1.13.0
+// version: 1.14.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90
 // last-edited: 2026-08-14
 
@@ -11,6 +11,7 @@ import (
 	"math"
 	"regexp"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -191,11 +192,59 @@ func IsDirtyAuthorName(name string) bool {
 // are caught but "Agent 47" style names (year not leading) are not.
 var leadingYearRe = regexp.MustCompile(`^\d{4}\b`)
 
+// looksLikePersonName is the comma-branch gate (C414): 2–4 words, does not
+// open with a lowercase word (title clauses read "and …", "the …"; person
+// names capitalize), and carries no title-ish punctuation or trailing
+// parenthetical ("… (DBY)"). Deliberately conservative — a refused split
+// keeps the composite row visibly broken instead of laundering a book-title
+// fragment into a plausible-looking author.
+// nameParticles are lowercase words that legitimately appear inside personal
+// names and must not be mistaken for title-clause function words.
+var nameParticles = map[string]bool{
+	"de": true, "la": true, "le": true, "van": true, "von": true,
+	"del": true, "della": true, "di": true, "da": true, "dos": true,
+	"du": true, "den": true, "ter": true, "bin": true, "ibn": true,
+	"al": true, "el": true, "st.": true, "mac": true,
+}
+
+func looksLikePersonName(part string) bool {
+	fields := strings.Fields(part)
+	if len(fields) < 2 || len(fields) > 4 {
+		return false
+	}
+	first := []rune(fields[0])
+	if len(first) == 0 || unicode.IsLower(first[0]) {
+		return false
+	}
+	// Interior lowercase FUNCTION words mark title clauses ("A Game of
+	// Thrones"); lowercase name PARTICLES ("Simone de Beauvoir", "Ludwig van
+	// Beethoven") are legitimate and stay allowed.
+	for _, w := range fields[1:] {
+		r := []rune(w)
+		if len(r) > 0 && unicode.IsLower(r[0]) && !nameParticles[strings.ToLower(w)] {
+			return false
+		}
+	}
+	if strings.ContainsAny(part, ":!?") {
+		return false
+	}
+	if strings.HasSuffix(strings.TrimSpace(part), ")") {
+		return false
+	}
+	return true
+}
+
 // SplitCompositeAuthorName splits "Author1 / Author2" or "Author1, Author2" into parts.
 // Returns nil or single-element slice if the name doesn't look composite.
 func SplitCompositeAuthorName(name string) []string {
 	// Don't split AKA patterns
 	if regexp.MustCompile(`(?i)\(aka\s`).MatchString(name) {
+		return nil
+	}
+
+	// A source carrying subtitle punctuation is a title, not a credit list —
+	// refuse every split rather than guessing at its clauses (C414).
+	if strings.ContainsAny(name, ":!?") {
 		return nil
 	}
 
@@ -216,7 +265,14 @@ func SplitCompositeAuthorName(name string) []string {
 
 	// Try comma: "Author1, Author2" — but not "Last, First" format
 	// "Last, First" has exactly 2 parts where the second is a single name without spaces
-	// "Author1, Author2" has parts where both sides have spaces
+	// "Author1, Author2" has parts where both sides have spaces.
+	//
+	// C414: "contains a space" alone let TITLE clauses through — a comma-split
+	// of "So Long, and Thanks for All the Fish" minted "and Thanks for All the
+	// Fish" as an author (row 46595; also 46989 "and the Farm Boy (DBY)" and
+	// 47193 "and Make Better Decisions"). Every part must be person-shaped or
+	// the whole split is refused — refusing leaves the composite VISIBLY wrong
+	// for repair rather than laundering a title fragment into a name.
 	parts := strings.Split(name, ",")
 	if len(parts) >= 2 {
 		var result []string
@@ -226,12 +282,15 @@ func SplitCompositeAuthorName(name string) []string {
 			if p == "" {
 				continue
 			}
-			// A name part should contain a space (first + last) to be a separate author
-			if !strings.Contains(p, " ") {
+			// Shape-check the NORMALIZED part: credit lists legitimately read
+			// "…, and Conrad Westmaas" and the normalizer strips that leading
+			// conjunction; a title clause's remainder still fails the shape.
+			normalized := NormalizeAuthorName(p)
+			if !looksLikePersonName(normalized) {
 				allLookLikeNames = false
 				break
 			}
-			result = append(result, NormalizeAuthorName(p))
+			result = append(result, normalized)
 		}
 		if allLookLikeNames && len(result) > 1 {
 			return result
@@ -279,14 +338,22 @@ func SplitCompositeAuthorName(name string) []string {
 				}
 				if idx < 0 {
 					p := strings.TrimSpace(remaining)
-					if len(p) > 2 && strings.Contains(p, " ") {
-						result = append(result, NormalizeAuthorName(p))
+					// Same person-shape gate as the comma branch (C414):
+					// "So Long, and Thanks for All the Fish" reaches THIS
+					// branch via its " and ", and a title clause here is just
+					// as capable of minting a fake author.
+					if norm := NormalizeAuthorName(p); len(p) > 2 && looksLikePersonName(norm) {
+						result = append(result, norm)
+					} else if len(p) > 2 {
+						return nil // one non-name clause poisons the whole split
 					}
 					break
 				}
 				p := strings.TrimSpace(remaining[:idx])
-				if len(p) > 2 && strings.Contains(p, " ") {
-					result = append(result, NormalizeAuthorName(p))
+				if norm := NormalizeAuthorName(p); len(p) > 2 && looksLikePersonName(norm) {
+					result = append(result, norm)
+				} else if len(p) > 2 {
+					return nil // one non-name clause poisons the whole split
 				}
 				// Skip past separator
 				for _, s := range []string{" and ", " And ", " AND ", " & "} {
@@ -307,8 +374,12 @@ func SplitCompositeAuthorName(name string) []string {
 	// Heuristic: try splitting at each word boundary and check if both halves
 	// look like valid author names (each has at least first+last).
 	// Only attempt this for names with 4+ words (minimum for two "First Last" names).
+	// A comma-bearing name already had its chance in the comma branch above;
+	// reaching here means its clauses FAILED the person-shape gate, and
+	// re-splitting them on spaces would launder the same title fragments the
+	// gate just refused (C414).
 	words := strings.Fields(name)
-	if len(words) >= 4 {
+	if len(words) >= 4 && !strings.Contains(name, ",") {
 		result := trySplitConcatenatedAuthors(name, words)
 		if len(result) > 1 {
 			return result

--- a/internal/dedup/comma_split_corpus_test.go
+++ b/internal/dedup/comma_split_corpus_test.go
@@ -1,0 +1,46 @@
+// file: internal/dedup/comma_split_corpus_test.go
+// version: 1.0.0
+// guid: 4e7a2c95-8d10-4f68-b3c7-1a5e9d2f6b84
+// last-edited: 2026-08-14
+
+package dedup
+
+import "testing"
+
+// TestSplitCompositeAuthorName_TitleClauseCorpus pins C414: the comma branch
+// must not mint author rows from book-title clauses. The corpus is the three
+// real rows this defect created, plus the credit-list shapes that MUST keep
+// splitting (the leading-conjunction contract), plus the "Last, First" form
+// that must stay unsplit.
+func TestSplitCompositeAuthorName_TitleClauseCorpus(t *testing.T) {
+	// Title clauses — the split must be REFUSED (nil or 1 part), leaving the
+	// composite visibly broken rather than laundering a fragment into a name.
+	refuse := []string{
+		"So Long, and Thanks for All the Fish",            // minted row 46595
+		"The Princess Bride, and the Farm Boy (DBY)",      // minted row 46989
+		"Steal Like an Artist: Be Creative, and Make Better Decisions", // row 47193's shape (subtitle punctuation)
+		"A Game of Thrones, A Clash of Kings, A Storm of Swords", // series list, 4+ word clauses
+	}
+	for _, name := range refuse {
+		if got := SplitCompositeAuthorName(name); len(got) > 1 {
+			t.Errorf("SplitCompositeAuthorName(%q) = %v, want refusal (title clause)", name, got)
+		}
+	}
+
+	// Credit lists — MUST still split, including the trailing "and Name" the
+	// normalizer strips.
+	if got := SplitCompositeAuthorName("Paul McGann, India Fisher, and Conrad Westmaas"); len(got) != 3 {
+		t.Errorf("credit list with 'and': got %v, want 3 parts", got)
+	}
+	if got := SplitCompositeAuthorName("Terry Pratchett, Neil Gaiman"); len(got) != 2 {
+		t.Errorf("plain credit pair: got %v, want 2 parts", got)
+	}
+	if got := SplitCompositeAuthorName("James S. A. Corey, Daniel Abraham"); len(got) != 2 {
+		t.Errorf("4-word name: got %v, want 2 parts", got)
+	}
+
+	// "Last, First" must stay unsplit (single-word second part).
+	if got := SplitCompositeAuthorName("Sanderson, Brandon"); len(got) > 1 {
+		t.Errorf("Last, First split into %v", got)
+	}
+}

--- a/todo.d/20260814-matcher-shift-click-range-select.md
+++ b/todo.d/20260814-matcher-shift-click-range-select.md
@@ -1,0 +1,5 @@
+- [ ] **Metadata matcher: shift-click range selection.** Owner request
+      (2026-08-14): clicking one row then shift-clicking another should select
+      every row between them, like a file manager. Track the anchor index of
+      the last plain click; on shift-click select the inclusive range
+      (respecting current sort/filter order). Frontend-only.

--- a/todo.d/20260814-matcher-writeback-background-job.md
+++ b/todo.d/20260814-matcher-writeback-background-job.md
@@ -1,0 +1,11 @@
+- [ ] **Metadata matcher: multi-file write-to-files must dispatch as a
+      background operation.** Owner request (2026-08-14): with "write to
+      files" enabled and more than 1 file affected, the apply currently
+      blocks the UI until every file is rewritten — at the measured
+      ~35 s/file for a full tag rewrite that is minutes-to-forever from the
+      user's chair. Route the >1-file case through the operations system
+      (`maintenance.bulk-write-back` already exists, takes explicit
+      book_ids, and shows in the ops UI) and return immediately with the
+      op id; single-file applies can stay synchronous. Note bulk-write-back
+      is serial ~35 s/book — the E08 prerequisites fragment
+      (diff-skip + in-op parallelism) applies here too.


### PR DESCRIPTION
## Why

Fragment `20260814-author-html-entity-rows` §2: the comma branch's only per-part test was "contains a space", so book-title clauses became author rows — real minted rows `and Thanks for All the Fish` (46595), `and the Farm Boy (DBY)` (46989), `and Make Better Decisions` (47193). Investigation found the leak is wider than the comma branch: the `" and "/" & "` branch and the space-concatenation fallback both accept title clauses.

## What

New `looksLikePersonName` gate: 2–4 words, no leading or interior lowercase function word (a particle allowlist keeps "Simone de Beauvoir"/"Ludwig van Beethoven" legal), no subtitle punctuation, no trailing parenthetical. Applied:

- **Comma branch** — on the NORMALIZED part, so credit lists ("…, and Conrad Westmaas") keep splitting via the conjunction strip; one failing clause refuses the whole split (laundering rule: refused composites stay visibly broken).
- **`" and "/" & "` branch** — same gate, same poison-pill refusal ("So Long, and Thanks for All the Fish" reaches THIS branch).
- **Concatenation fallback** — refuses comma-bearing names whose clauses already failed the gate (it was re-splitting "A Game of Thrones, A Clash of Kings, …" on spaces).
- Whole-name subtitle punctuation (`: ! ?`) refuses all splitting up front.

Also files the two metadata-matcher todos from today (shift-click range select; multi-file write-to-files must dispatch as a background op).

## Testing

Corpus test: the three minted rows' shapes must refuse; credit lists (incl. trailing-"and" and 4-word names) must split; "Last, First" must stay unsplit. Mutations vs committed base: comma gate off → FAIL; fallback guard off → FAIL; restored green. Full dedup suite passes (the pre-existing leading-conjunction contract test held throughout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS