### PR TITLE
docs(todo): matcher skip-all control + false sign-out/no-changes report

### DIFF
--- a/changelog.d/20260814_190500_matcher_todos.md
+++ b/changelog.d/20260814_190500_matcher_todos.md
@@ -1,0 +1,6 @@
+### Changed
+
+- Filed matcher follow-ups: skip-all/hide-multiples triage control, and the
+  false "signed out — no changes were made" report after long tag writes
+  (changes were made; the fix is background-op dispatch plus honest
+  connection-loss messaging).

--- a/todo.d/20260814-matcher-skip-all-and-false-signout.md
+++ b/todo.d/20260814-matcher-skip-all-and-false-signout.md
@@ -1,0 +1,18 @@
+- [ ] **Metadata matcher: "skip all" / hide-multiples control.** Owner request
+      (2026-08-14): multi-match groups need a way to be hidden in bulk —
+      a "skip all" that stashes them for a later pass — so a triage session
+      can clear the unambiguous rows without wading through the multiples
+      every time. Persist the skip set (per user or per session) so hidden
+      groups come back on demand, not on reload.
+
+- [ ] **Metadata matcher: apply falsely reports "signed out — no changes were
+      made" after a long write.** Owner observed (2026-08-14): with write-to-
+      files enabled, a multi-file apply blocks past the auth/session timeout;
+      the UI then reports a sign-out AND claims no changes were made — but
+      the writes had clearly happened. Two defects: (1) the result message is
+      dishonest — never claim "no changes" from a timeout, report "connection
+      lost, operation may still be running" and re-query; (2) the root fix is
+      the background-job dispatch already filed in
+      `20260814-matcher-writeback-background-job.md` — an op id returned
+      immediately makes the timeout impossible and the ops screen owns
+      progress/results.


### PR DESCRIPTION
Owner-reported (2026-08-14): (1) multi-match groups need a bulk skip/hide for later triage; (2) long multi-file tag writes outlive the session timeout and the UI then falsely claims 'no changes were made' — writes had happened. Ties into the background-dispatch fragment from #2459.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS