### PR TITLE
feat(web): shift-click range selection in the metadata matcher (both dialogs)

### DIFF
--- a/changelog.d/20260814_192000_matcher_shift_range.md
+++ b/changelog.d/20260814_192000_matcher_shift_range.md
@@ -1,0 +1,6 @@
+### Added
+
+- Metadata matcher: shift-click range selection on the field checkboxes, in
+  both the single-book and bulk dialogs — click one field, shift-click
+  another, and every visible field between them is selected (file-manager
+  semantics; shift never deselects).

--- a/web/src/components/audiobooks/BulkMetadataSearchDialog.tsx
+++ b/web/src/components/audiobooks/BulkMetadataSearchDialog.tsx
@@ -1,9 +1,10 @@
 // file: web/src/components/audiobooks/BulkMetadataSearchDialog.tsx
-// version: 1.4.1
+// version: 1.5.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
 // last-edited: 2026-08-07
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useRef } from 'react';
+import { applyFieldClick } from './fieldRangeSelect';
 import {
   Avatar,
   Box,
@@ -99,6 +100,8 @@ export function BulkMetadataSearchDialog({ open, books, onClose, onComplete, toa
   const [applying, setApplying] = useState(false);
   const [expandedCard, setExpandedCard] = useState<number | null>(null);
   const [selectedFields, setSelectedFields] = useState<Set<string>>(new Set());
+  // Anchor for shift-click range selection over the visible field rows.
+  const fieldAnchorRef = useRef<string | null>(null);
   const [bookStatuses, setBookStatuses] = useState<Map<string, BookStatus>>(new Map());
   const [writeToFiles, setWriteToFiles] = useState(true);
   const [undoing, setUndoing] = useState(false);
@@ -328,6 +331,17 @@ export function BulkMetadataSearchDialog({ open, books, onClose, onComplete, toa
       if (next.has(field)) next.delete(field);
       else next.add(field);
       return next;
+    });
+  };
+  void toggleField; // retained for non-range callers/tests
+
+  // Plain click toggles; shift-click selects the whole visible range from the
+  // last-clicked field (file-manager semantics). See fieldRangeSelect.ts.
+  const handleFieldClick = (field: string, shiftKey: boolean, visibleFields: string[]) => {
+    setSelectedFields((prev) => {
+      const r = applyFieldClick(prev, field, shiftKey, fieldAnchorRef.current, visibleFields);
+      fieldAnchorRef.current = r.anchor;
+      return r.next;
     });
   };
 
@@ -678,17 +692,22 @@ export function BulkMetadataSearchDialog({ open, books, onClose, onComplete, toa
                 </Button>
                 <Collapse in={expandedCard === idx}>
                   <Box sx={{ mt: 0.5, pl: 1 }}>
-                    {FIELD_OPTIONS.map((field) => {
-                      const value = candidate[field as keyof MetadataCandidate];
-                      if (value === undefined || value === null || value === '') return null;
-                      return (
-                        <FormControlLabel
-                          key={field}
-                          control={<Checkbox checked={selectedFields.has(field)} onChange={() => toggleField(field)} size="small" />}
-                          label={<Typography variant="body2">{FIELD_LABELS[field] || field}: {String(value)}</Typography>}
-                        />
-                      );
-                    })}
+                    {(() => {
+                      const visibleFields = FIELD_OPTIONS.filter((f) => {
+                        const v = candidate[f as keyof MetadataCandidate];
+                        return v !== undefined && v !== null && v !== '';
+                      });
+                      return visibleFields.map((field) => {
+                        const value = candidate[field as keyof MetadataCandidate];
+                        return (
+                          <FormControlLabel
+                            key={field}
+                            control={<Checkbox checked={selectedFields.has(field)} onClick={(e) => { e.preventDefault(); handleFieldClick(field, e.shiftKey, visibleFields); }} onChange={() => {}} size="small" />}
+                            label={<Typography variant="body2">{FIELD_LABELS[field] || field}: {String(value)}</Typography>}
+                          />
+                        );
+                      });
+                    })()}
                     <Box sx={{ mt: 0.5 }}>
                       <Button
                         variant="outlined"

--- a/web/src/components/audiobooks/MetadataSearchDialog.tsx
+++ b/web/src/components/audiobooks/MetadataSearchDialog.tsx
@@ -1,8 +1,9 @@
 // file: web/src/components/audiobooks/MetadataSearchDialog.tsx
-// version: 1.9.1
+// version: 1.10.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useRef } from 'react';
+import { applyFieldClick } from './fieldRangeSelect';
 import {
   Avatar,
   Box,
@@ -97,6 +98,8 @@ export function MetadataSearchDialog({
   const [loading, setLoading] = useState(false);
   const [expandedCard, setExpandedCard] = useState<number | null>(null);
   const [selectedFields, setSelectedFields] = useState<Set<string>>(new Set());
+  // Anchor for shift-click range selection over the visible field rows.
+  const fieldAnchorRef = useRef<string | null>(null);
   const [applying, setApplying] = useState(false);
   const [sourcesTried, setSourcesTried] = useState<string[]>([]);
   const [sourcesFailed, setSourcesFailed] = useState<Record<string, string>>({});
@@ -269,6 +272,17 @@ export function MetadataSearchDialog({
         next.add(field);
       }
       return next;
+    });
+  };
+  void toggleField; // retained for non-range callers/tests
+
+  // Plain click toggles; shift-click selects the whole visible range from the
+  // last-clicked field (file-manager semantics). See fieldRangeSelect.ts.
+  const handleFieldClick = (field: string, shiftKey: boolean, visibleFields: string[]) => {
+    setSelectedFields((prev) => {
+      const r = applyFieldClick(prev, field, shiftKey, fieldAnchorRef.current, visibleFields);
+      fieldAnchorRef.current = r.anchor;
+      return r.next;
     });
   };
 
@@ -598,25 +612,29 @@ export function MetadataSearchDialog({
                 </Button>
                 <Collapse in={expandedCard === idx}>
                   <Box sx={{ mt: 1, pl: 1 }}>
-                    {FIELD_OPTIONS.map((field) => {
-                      const value =
-                        candidate[field as keyof MetadataCandidate];
-                      if (value === undefined || value === null || value === '')
-                        return null;
-                      return (
-                        <FormControlLabel
-                          key={field}
-                          control={
-                            <Checkbox
-                              checked={selectedFields.has(field)}
-                              onChange={() => toggleField(field)}
-                              size="small"
-                            />
-                          }
-                          label={`${humanizeField(field)}: ${value}`}
-                        />
-                      );
-                    })}
+                    {(() => {
+                      const visibleFields = FIELD_OPTIONS.filter((f) => {
+                        const v = candidate[f as keyof MetadataCandidate];
+                        return v !== undefined && v !== null && v !== '';
+                      });
+                      return visibleFields.map((field) => {
+                        const value = candidate[field as keyof MetadataCandidate];
+                        return (
+                          <FormControlLabel
+                            key={field}
+                            control={
+                              <Checkbox
+                                checked={selectedFields.has(field)}
+                                onClick={(e) => { e.preventDefault(); handleFieldClick(field, e.shiftKey, visibleFields); }}
+                                onChange={() => {}}
+                                size="small"
+                              />
+                            }
+                            label={`${humanizeField(field)}: ${value}`}
+                          />
+                        );
+                      });
+                    })()}
                     <Box sx={{ mt: 1 }}>
                       <Button
                         variant="outlined"

--- a/web/src/components/audiobooks/fieldRangeSelect.test.ts
+++ b/web/src/components/audiobooks/fieldRangeSelect.test.ts
@@ -1,0 +1,43 @@
+// file: web/src/components/audiobooks/fieldRangeSelect.test.ts
+// version: 1.0.0
+// guid: 3d9b7e52-1c48-4f06-a2e7-8b5d0c3f6a29
+// last-edited: 2026-08-14
+
+import { describe, it, expect } from 'vitest';
+import { applyFieldClick } from './fieldRangeSelect';
+
+const VISIBLE = ['title', 'author', 'year', 'series', 'narrator'];
+
+describe('applyFieldClick', () => {
+  it('plain click toggles and sets the anchor', () => {
+    const r1 = applyFieldClick(new Set(), 'author', false, null, VISIBLE);
+    expect([...r1.next]).toEqual(['author']);
+    expect(r1.anchor).toBe('author');
+    const r2 = applyFieldClick(r1.next, 'author', false, r1.anchor, VISIBLE);
+    expect(r2.next.size).toBe(0);
+  });
+
+  it('shift-click selects the inclusive range in either direction', () => {
+    const r1 = applyFieldClick(new Set(), 'author', false, null, VISIBLE);
+    const r2 = applyFieldClick(r1.next, 'series', true, r1.anchor, VISIBLE);
+    expect([...r2.next].sort()).toEqual(['author', 'series', 'year']);
+    // Reverse direction from the new anchor
+    const r3 = applyFieldClick(new Set(), 'series', false, null, VISIBLE);
+    const r4 = applyFieldClick(r3.next, 'title', true, r3.anchor, VISIBLE);
+    expect([...r4.next].sort()).toEqual(['author', 'series', 'title', 'year']);
+  });
+
+  it('shift-click never deselects already-selected fields in the range', () => {
+    const pre = new Set(['year']);
+    const r1 = applyFieldClick(pre, 'title', false, null, VISIBLE);
+    const r2 = applyFieldClick(r1.next, 'author', true, r1.anchor, VISIBLE);
+    expect(r2.next.has('year')).toBe(true); // untouched outside range
+    expect(r2.next.has('title')).toBe(true);
+    expect(r2.next.has('author')).toBe(true);
+  });
+
+  it('shift-click with no anchor falls back to a plain toggle', () => {
+    const r = applyFieldClick(new Set(), 'year', true, null, VISIBLE);
+    expect([...r.next]).toEqual(['year']);
+  });
+});

--- a/web/src/components/audiobooks/fieldRangeSelect.ts
+++ b/web/src/components/audiobooks/fieldRangeSelect.ts
@@ -1,0 +1,33 @@
+// file: web/src/components/audiobooks/fieldRangeSelect.ts
+// version: 1.0.0
+// guid: 6f2c8a41-9d57-4e03-b1a6-4c7e2d9f5b18
+// last-edited: 2026-08-14
+
+/**
+ * applyFieldClick implements file-manager selection semantics for the
+ * metadata matcher's field checkboxes: a plain click toggles one field and
+ * becomes the anchor; a shift-click SELECTS (never deselects) every visible
+ * field between the anchor and the clicked field, inclusive, and moves the
+ * anchor. Fields hidden for this candidate (no value) are not part of the
+ * range because they are not in visibleFields.
+ */
+export function applyFieldClick(
+  prev: Set<string>,
+  field: string,
+  shiftKey: boolean,
+  anchor: string | null,
+  visibleFields: string[],
+): { next: Set<string>; anchor: string } {
+  const next = new Set(prev);
+  const ai = anchor ? visibleFields.indexOf(anchor) : -1;
+  const fi = visibleFields.indexOf(field);
+  if (shiftKey && ai >= 0 && fi >= 0) {
+    const [lo, hi] = ai < fi ? [ai, fi] : [fi, ai];
+    for (let i = lo; i <= hi; i++) next.add(visibleFields[i]);
+  } else if (next.has(field)) {
+    next.delete(field);
+  } else {
+    next.add(field);
+  }
+  return { next, anchor: field };
+}


### PR DESCRIPTION
## Why

Owner request (2026-08-14): in the metadata matcher, clicking one row then shift-clicking another should select everything between them.

## What

Pure helper `applyFieldClick` (file-manager semantics: plain click toggles and anchors; shift-click selects the inclusive range over the candidate's VISIBLE fields and never deselects; shift with no anchor falls back to a toggle), wired into both `MetadataSearchDialog` and `BulkMetadataSearchDialog`. Value-less hidden fields never join a range because ranges are computed over the rendered list.

## Testing

4 unit tests on the helper (toggle+anchor, both range directions, never-deselect, no-anchor fallback). Mutations vs committed base: range degraded to single-select → FAIL; toggle-off removed → FAIL; restored 4/4. Full audiobooks component suite 62/62; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS