### PR TITLE
docs(todo): activity log auto-compacts after 7 days, setting on the log screen

### DIFF
--- a/changelog.d/20260814_193500_activity_log_retention_todo.md
+++ b/changelog.d/20260814_193500_activity_log_retention_todo.md
@@ -1,0 +1,5 @@
+### Changed
+
+- Filed the activity-log auto-compaction todo: default 7-day retention,
+  user-configurable from the activity log screen, implemented via the
+  existing nightly cleanup job.

--- a/todo.d/20260814-activity-log-auto-compact-setting.md
+++ b/todo.d/20260814-activity-log-auto-compact-setting.md
@@ -1,0 +1,13 @@
+- [ ] **Activity log: auto-compact after 7 days, user-configurable.** Owner
+      request (2026-08-14): the activity log grows into a mess — compact
+      (prune/roll up) entries older than a retention window automatically,
+      defaulting to 7 days, with the retention period exposed as a setting on
+      the activity log screen itself (not buried in general settings). Notes:
+      `maintenance.cleanup-activity-log` already exists with a midnight-daily
+      schedule — the work is wiring a `activity_log_retention_days` config
+      key (default 7, 0 = never) into it rather than a new job, plus the
+      settings control on the ActivityLog page and a line in the log header
+      showing the active retention ("entries older than 7 days are compacted
+      automatically"). Follow the config rules: absent key keeps the shipped
+      default (#2350 class), and the stored-zeros-shadow-defaults design
+      (D111 fragment) applies to the 0=never sentinel.


### PR DESCRIPTION
Owner request: activity logs become a mess — auto-compact entries older than a configurable window (default 7 days), with the setting surfaced on the activity log screen. Implementation home: the existing nightly `maintenance.cleanup-activity-log` job + an `activity_log_retention_days` key (0 = never), with the #2350/D111 config-default rules noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS