### PR TITLE
docs(todo): activity summaries drop attrs and never name the book

### DIFF
--- a/changelog.d/20260814_194500_activity_summary_todos.md
+++ b/changelog.d/20260814_194500_activity_summary_todos.md
@@ -1,0 +1,5 @@
+### Changed
+
+- Filed the activity-log summary defects: slog attrs dropped by the
+  activity bridge ("cover art saved to" with no path), inconsistent
+  raw-text bridging, and metadata-apply rows that never name the book.

--- a/todo.d/20260814-activity-summaries-drop-attrs.md
+++ b/todo.d/20260814-activity-summaries-drop-attrs.md
@@ -1,0 +1,21 @@
+- [ ] **Activity-log summaries drop their data — "cover art saved to" (to
+      WHERE?), "ISBN enrichment succeeded for" (for WHAT?).** Owner
+      screenshot 2026-08-14 18:03. Root cause located: these are slog calls
+      whose sentence is in the MESSAGE and whose data is in ATTRS —
+      `internal/metafetch/service_apply.go:611`
+      `slog.Info("cover art saved to", "path", coverPath)`,
+      `service_fetch.go:37` ("ISBN enrichment succeeded for", "id"),
+      `service_fetch.go:292` — and the slog→activity bridge keeps only the
+      message. A neighboring row ("ISBN enrichment found" isbn=… title=…
+      with a stray quote) shows the OPPOSITE bridge behavior: a raw slog
+      TextHandler line, quotes and all, pasted into the summary — so two
+      inconsistent bridges exist. Fix: one bridge that renders attrs into
+      the summary (book title resolved from id where present), and sweep
+      metafetch's sentence-shaped slog messages onto it.
+
+- [ ] **Metadata-apply activity rows don't NAME the book.** Same screenshot:
+      "Applied narrator: Alex Kozlowski → Grant Cartwright" with a bare
+      "book →" link — the summary must lead with the book title ("The
+      Whispering Night: applied narrator …"); a link target is not a
+      summary. Also "Applied audiobook_release_year: → 2021" renders an
+      empty FROM value as a dangling arrow — show "(none) → 2021".


### PR DESCRIPTION
Owner screenshot (18:03): 'cover art saved to' with no path, 'ISBN enrichment succeeded for' with no book, raw slog text (quotes included) in another row, and metadata-apply rows with a bare 'book →' link instead of a title. Root cause located to the slog→activity bridge keeping only the message while callsites put data in attrs (file:line refs in the fragment); two inconsistent bridge behaviors exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS