### PR TITLE
docs(todo): metafetch is the serialized half — background it, fan out with jitter

### DIFF
--- a/changelog.d/20260814_195500_metafetch_fanout_todo.md
+++ b/changelog.d/20260814_195500_metafetch_fanout_todo.md
@@ -1,0 +1,5 @@
+### Changed
+
+- Corrected the matcher-blocking diagnosis: the metadata FETCH is the
+  serialized, foreground half (writes are already backgrounded). Filed the
+  fan-out-with-jitter background-op design todo.

--- a/todo.d/20260814-metafetch-fanout-with-jitter.md
+++ b/todo.d/20260814-metafetch-fanout-with-jitter.md
@@ -1,0 +1,20 @@
+- [ ] **CORRECTION to `20260814-matcher-writeback-background-job.md`: the
+      blocking half of the matcher is the metadata FETCH, not the file
+      write.** Owner (2026-08-14): the write side is already backgrounded;
+      the fetch side is effectively a singleton and must (1) be dispatched
+      as a background operation visible in the ops system, and (2) fan out
+      across books — WITH staggered start delays/jitter per request so the
+      fan-out doesn't flood the metadata providers all at once.
+      Evidence so far: `metafetch.chainMu` is NOT the singleton — it only
+      guards cached-chain construction, and the chain is documented safe
+      for concurrent worker pools (per-source rate limiter + circuit
+      breaker carry their own mutexes). Look instead at (a) the bulk
+      dialog's one-book-at-a-time interactive flow, and (b) whatever the
+      matcher's search endpoint serializes server-side. Design notes:
+      bounded worker pool per the concurrency mandate sized for
+      NETWORK-bound work (small fixed concurrency, e.g. 3-4), plus
+      per-worker start jitter (e.g. 250-500 ms spread) layered UNDER the
+      existing per-source limiters so providers see a ramp, not a burst;
+      progress per book surfaces through the op reporter so the UI polls
+      the op instead of holding a request open (kills the false sign-out
+      symptom at the root).


### PR DESCRIPTION
Owner correction to the earlier write-back fragment: file writes are already backgrounded; the metadata FETCH is the singleton that holds the UI hostage. Filed with evidence (chainMu exonerated — chain is pool-safe; look at the dialog's sequential flow / search endpoint), and the design constraints: background op + small fixed network-bound worker pool + per-request start jitter under the existing per-source limiters so providers see a ramp, not a burst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS