### PR TITLE
docs(todo): legacy op rows stuck pending — finished jobs show as running

### DIFF
--- a/changelog.d/20260814_200500_legacy_op_pending_todo.md
+++ b/changelog.d/20260814_200500_legacy_op_pending_todo.md
@@ -1,0 +1,5 @@
+### Changed
+
+- Filed the stuck-pending legacy op rows defect: maintenance jobs' legacy
+  operation rows never receive terminal status, so the ops UI shows finished
+  work as running for hours (misled the operator twice today).

--- a/todo.d/20260814-legacy-op-rows-stuck-pending.md
+++ b/todo.d/20260814-legacy-op-rows-stuck-pending.md
@@ -1,0 +1,17 @@
+- [ ] **Legacy operation rows never leave "pending" — the ops UI shows
+      finished jobs as running for hours.** Twice on 2026-08-14 this misled
+      the operator: the composer scan showed progress 0 while 3h into real
+      work, and the E02 chapters dry-run showed as an active 1.5-hour task
+      when it had finished at 17:57 with logged results. A
+      `GET /api/v1/operations?limit=20` dump shows EVERY maintenance-job row
+      of the day stuck at status "pending" — including `fix-file-modes` and
+      `normalize-primary-flags`, which completed with journaled summaries.
+      The v2 registry rows complete correctly; it is the LEGACY op row
+      (`maintenance:<job>` type, created for jobs dispatched via
+      `maintenance.job`) whose status/progress is write-only after creation.
+      Fix: on v2 op completion, propagate terminal status (+ final
+      progress/message) onto the paired LegacyOpID row; backfill-repair the
+      day's stuck rows; and the ops UI should render v2 state when a legacy
+      row has a live v2 twin. Note the C510 opstate sweep treats unknown
+      statuses as KEEP — stuck-pending rows also pin their opstate blobs
+      forever, so this defect quietly defeats that retention too.


### PR DESCRIPTION
Misled the operator twice today (composer scan progress-0; E02 dry-run 'running 1.5h' after finishing at 17:57). Evidence: every maintenance-job legacy row of the day sits at 'pending' in /api/v1/operations while the v2 registry rows completed. Fix direction: propagate terminal status to the LegacyOpID row, backfill today's stuck rows, UI prefers v2 twin state. Also noted: stuck rows pin their opstate blobs against the C510 retention sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS