### PR TITLE
fix(organizer): wire the store into every organize entry point

### DIFF
--- a/changelog.d/20260814_203000_organizer_store_wiring.md
+++ b/changelog.d/20260814_203000_organizer_store_wiring.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- The organizer's database store was wired in exactly ONE of its five entry
+  points (auto-organize), so the AuthorID/SeriesID fallback in path templates
+  was dead code everywhere else: any book whose Author struct was not
+  populated organized into "Unknown Author/" with its AuthorID sitting right
+  there — the mechanism behind the 2026-08-11 mass-reorganize. The store is
+  now a narrow OrganizerStore interface wired by the bulk service, preview,
+  and rename paths too. Also updates two organize-filter tests whose
+  authorless fixtures now (correctly) trip the #2457 author gate.

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/organizer.go
-// version: 1.22.0
+// version: 1.23.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 // last-edited: 2026-08-13
 
@@ -96,7 +96,7 @@ type Organizer struct {
 	// resolution. Nil store → those lookups skip with the same
 	// semantics the pre-audit `GetGlobalStore() == nil` branches had
 	// (SERVER-GLOBAL-STORE-AUDIT phase 5).
-	store database.Store
+	store OrganizerStore
 }
 
 // SetHooks sets the optional organize hooks (e.g. collision callback).
@@ -104,9 +104,26 @@ func (o *Organizer) SetHooks(hooks OrganizeHooks) {
 	o.hooks = hooks
 }
 
+// OrganizerStore is the narrow read surface the Organizer needs: author and
+// series resolution for path templates, and book lookups for duplicate-target
+// identification. It is deliberately small so every organize entry point —
+// the bulk Service (whose composite Store is narrower than database.Store),
+// the preview/rename services, and the server's auto-organize — can wire a
+// store. Until 2026-08-14 ONLY auto-organize called SetStore, which made the
+// AuthorID fallback in expandPattern dead code everywhere else: any book
+// whose Author struct was not populated organized into "Unknown Author/"
+// with its AuthorID sitting right there. That is the mechanism behind the
+// 2026-08-11 mass-reorganize (audit, open question 2 — answered).
+type OrganizerStore interface {
+	GetAuthorByID(id int) (*database.Author, error)
+	GetSeriesByID(id int) (*database.Series, error)
+	GetBookByFileHash(hash string) (*database.Book, error)
+	GetBookByFilePath(path string) (*database.Book, error)
+}
+
 // SetStore wires the database used for duplicate-file + author/series
 // lookups. Idempotent; pass nil to disable lookups.
-func (o *Organizer) SetStore(s database.Store) {
+func (o *Organizer) SetStore(s OrganizerStore) {
 	o.store = s
 }
 

--- a/internal/organizer/preview.go
+++ b/internal/organizer/preview.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/preview.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: f1a2b3c4-d5e6-7890-abcd-ef1234567890
 
 package organizer
@@ -80,6 +80,7 @@ func (ops *PreviewService) PreviewOrganize(bookID string) (*PreviewResponse, err
 	}
 
 	org := NewOrganizer(&config.AppConfig)
+	org.SetStore(ops.db) // AuthorID/SeriesID must resolve — see OrganizerStore
 	currentPath := book.FilePath
 
 	// Always fetch book_files — this is the authoritative source for what files

--- a/internal/organizer/rename.go
+++ b/internal/organizer/rename.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/rename.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
 // last-edited: 2026-07-17
 
@@ -98,6 +98,7 @@ func (rs *RenameService) PreviewRename(bookID string) (*RenamePreview, error) {
 	}
 
 	org := NewOrganizer(&config.AppConfig)
+	org.SetStore(rs.db) // AuthorID/SeriesID must resolve — see OrganizerStore
 	proposedPath, err := org.GenerateTargetPath(book)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute proposed path: %w", err)
@@ -127,6 +128,7 @@ func (rs *RenameService) ApplyRename(bookID, operationID string) (*RenameApplyRe
 	}
 
 	org := NewOrganizer(&config.AppConfig)
+	org.SetStore(rs.db) // AuthorID/SeriesID must resolve — see OrganizerStore
 	proposedPath, err := org.GenerateTargetPath(book)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute proposed path: %w", err)

--- a/internal/organizer/service.go
+++ b/internal/organizer/service.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/service.go
-// version: 1.18.0
+// version: 1.19.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
 // last-edited: 2026-08-14
 
@@ -33,6 +33,7 @@ type Store interface {
 	database.BookFileStore
 	database.OperationStore
 	database.AuthorStore
+	database.SeriesStore
 	database.NarratorStore
 	database.MaintenanceStore
 	database.TagStore
@@ -99,6 +100,10 @@ func (orgSvc *Service) SetOrganizeHooks(hooks OrganizeHooks) {
 // newOrganizer creates an Organizer with the service's hooks pre-wired.
 func (orgSvc *Service) newOrganizer() *Organizer {
 	org := NewOrganizer(&config.AppConfig)
+	// Wire the store so AuthorID/SeriesID resolve in path templates. Without
+	// this every service-path organize treated slim books as authorless —
+	// see OrganizerStore's doc comment.
+	org.SetStore(orgSvc.db)
 	if orgSvc.organizeHooks != nil {
 		org.SetHooks(orgSvc.organizeHooks)
 	}

--- a/internal/server/organize_service_regression_test.go
+++ b/internal/server/organize_service_regression_test.go
@@ -318,11 +318,15 @@ func TestFilterBooksNeedingOrganization_SkipsSoftDeleted(t *testing.T) {
 	svc := NewOrganizeService(mockDB)
 	testLog := logger.New("test")
 
+	// Every fixture book carries a resolved author: the organize author-gate
+	// (#2457) defers authorless books, and THIS test's subject is soft-delete
+	// filtering, not the gate.
+	author := &database.Author{ID: 1, Name: "Fixture Author"}
 	books := []database.Book{
-		{ID: "1", Title: "Active Book", FilePath: "/import/book1.m4b", MarkedForDeletion: &notDeleted},
-		{ID: "2", Title: "Deleted Book", FilePath: "/import/book2.m4b", MarkedForDeletion: &deleted},
-		{ID: "3", Title: "Also Deleted", FilePath: "/import/book3.m4b", MarkedForDeletion: &deleted},
-		{ID: "4", Title: "Another Active", FilePath: "/import/book4.m4b", MarkedForDeletion: &notDeleted},
+		{ID: "1", Title: "Active Book", FilePath: "/import/book1.m4b", MarkedForDeletion: &notDeleted, Author: author},
+		{ID: "2", Title: "Deleted Book", FilePath: "/import/book2.m4b", MarkedForDeletion: &deleted, Author: author},
+		{ID: "3", Title: "Also Deleted", FilePath: "/import/book3.m4b", MarkedForDeletion: &deleted, Author: author},
+		{ID: "4", Title: "Another Active", FilePath: "/import/book4.m4b", MarkedForDeletion: &notDeleted, Author: author},
 	}
 
 	needsOrganize, _ := svc.FilterBooksNeedingOrganization(books, testLog)
@@ -393,9 +397,12 @@ func TestFilterBooksNeedingOrganization_AllowsNonPrimaryWithoutPrimary(t *testin
 	svc := NewOrganizeService(mockDB)
 	testLog := logger.New("test")
 
+	// Resolved author required — the organize author-gate (#2457) defers
+	// authorless books, and this test's subject is version-group filtering.
 	books := []database.Book{
 		{ID: "orphan-1", Title: "No Primary", FilePath: "/import/orphan.m4b",
-			IsPrimaryVersion: &isNotPrimary, VersionGroupID: &vgID},
+			IsPrimaryVersion: &isNotPrimary, VersionGroupID: &vgID,
+			Author: &database.Author{ID: 1, Name: "Fixture Author"}},
 	}
 
 	needsOrganize, _ := svc.FilterBooksNeedingOrganization(books, testLog)


### PR DESCRIPTION
## Why

Main CI broke on a docs-only PR (#2465): four organize tests failed. Two were fixture debt (#2457's author gate correctly defers authorless books, and the filter tests' fixtures were authorless). But the other two tests DID create authors via `AuthorID` — and chasing that exposed the real defect: **`Organizer.SetStore` had exactly one caller** (server auto-organize). The bulk organize Service, the Review Organize preview, and the rename service never wired a store, so `expandPattern`'s AuthorID lookup was dead code on those paths — any book whose `Author` struct wasn't populated organized into `Unknown Author/` with its AuthorID sitting right there.

**This answers the 2026-08-11 mass-reorganize audit's open question 2** ("why was author metadata unresolved at organize time?"): it usually wasn't — the organizer just couldn't see it.

## What

- `Organizer.store` narrowed to a 4-method `OrganizerStore` interface (GetAuthorByID / GetSeriesByID / GetBookByFileHash / GetBookByFilePath) so the Service's composite store qualifies; doc comment records the history.
- Wired at every entry point: `Service.newOrganizer()` (bulk + in-place + needs-reorganize), `PreviewOrganize`, both `RenameService` sites. `organizer.Store` composite gains `database.SeriesStore`.
- The two filter tests' fixtures get real authors (their subject is soft-delete/version-group filtering, not the gate).

## Testing

All four CI failures pass; full organizer suite and full `internal/server -short` suite (568s) green. Mutation: removing the service wiring → `TestOrganizeService_ViaHTTP` FAILS (proves the test now covers the wiring); restored green.

## Impact note

Until this deploys, the #2457 gate defers most bulk organizes (slim books look authorless without the store). Deploy directly after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS