### PR TITLE
fix(writeback): multi-file books rewrote every file forever for a tag that never landed

### DIFF
--- a/changelog.d/20260815_014500_writeback_track_skip.md
+++ b/changelog.d/20260815_014500_writeback_track_skip.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Write-back no longer rewrites every multi-file book on every run.**
+  `FilterUnchangedTags` had no mapping for the `track` tag, while the multi-file
+  write path always emits one (`"n/total"`). Track therefore fell through to the
+  "unknown key — always write" branch, which made the skip condition
+  `len(tagMap) == 0` unreachable for every multi-file book: each rewrote all of
+  its audio files on every write-back run, indefinitely. Since a single tag write
+  costs several full-file copies and SHA-256 passes over the audio, this was the
+  dominant cost of write-back on large libraries.

--- a/changelog.d/20260815_020000_writeback_io_amplification.md
+++ b/changelog.d/20260815_020000_writeback_io_amplification.md
@@ -1,0 +1,23 @@
+### Changed
+
+- **Tag writes no longer copy and hash the audio file four times over.**
+  Every write-back wrapped a tag write in `fileops.WriteTagsSafe` and then called
+  a writer that wrapped it *again*. Each wrapper streams the whole file through
+  SHA-256 twice and copies it once, so one tag write cost four full-file SHA-256
+  passes and two full-file copies of the audio — and the inner pair was discarded
+  unread. On NAS-backed audiobooks that redundant I/O, not the tag encoding, was
+  the cost of write-back. Writers called from inside the wrapper now write in
+  place, and the hashes are computed only when there is a `book_file` row to
+  persist them against.
+
+- **Per-chapter titles are preserved.** Both multi-file write paths overwrote the
+  `title` tag of every file with a synthetic `"NN - Book Title"` on every run,
+  destroying real chapter titles. They are now kept unless they carry no
+  per-chapter information.
+
+- **The two write-back implementations are now one.** The fetch/apply path had its
+  own ~160-line near-duplicate that had drifted: it never embedded covers from an
+  already-downloaded local cover, never propagated to version-group siblings,
+  never redirected protected paths to the library copy, and never stamped
+  `LastWrittenAt` for multi-file books. It now shares the single implementation
+  and gains all of those.

--- a/docs/executive-summaries/2026-08-15-the-tag-that-was-never-written-executive-summary.md
+++ b/docs/executive-summaries/2026-08-15-the-tag-that-was-never-written-executive-summary.md
@@ -1,0 +1,103 @@
+<!-- file: docs/executive-summaries/2026-08-15-the-tag-that-was-never-written-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9f3a1e57-6b02-4c8d-9e14-3a70b5d82c6f -->
+<!-- last-edited: 2026-08-15 -->
+
+# The tag that was never written
+
+**2026-08-15 — why saving metadata was slow, and what it was quietly ruining**
+
+## The complaint
+
+Fetching metadata and writing it into your audiobook files was painfully slow.
+The obvious explanation was that the work happened one book at a time and simply
+needed to be spread across more of the machine. That turned out to be half the
+story, and acting on it alone would have made things worse.
+
+## What was actually happening
+
+Audiobooks that are split into many files — one file per chapter — were being
+**completely rewritten every single time**, whether or not anything had changed.
+
+The program tries to be smart about this. Before writing, it compares the
+information it wants to save against what the file already contains, and skips
+the file if they match. That check was broken in two places at once, and the two
+breaks fed each other:
+
+- The comparison did not know about the **track number** ("chapter 3 of 12"), so
+  it always concluded something had changed.
+- The part that actually saves information into the file had no instructions for
+  the track number either, so it quietly threw it away.
+
+The result was a loop with no exit. The program decided the track number needed
+saving, rewrote the entire file, discarded the track number on the way, then read
+the file back, found no track number, and decided it needed saving again. Every
+run. Forever. For a piece of information that never once made it onto disk.
+
+Fixing either half alone would have changed nothing.
+
+## The part that was destroying your data
+
+While rewriting those files, the program also **overwrote the title of every
+chapter**. A file called "Chapter 1: Departure" became "01 - Book Title". The
+original chapter name was gone, with no copy kept anywhere.
+
+Because of the loop above, this was not an occasional accident — it happened on
+every write, to every multi-file book. Chapter titles across the library were
+being steadily flattened into numbered placeholders.
+
+Chapter titles are now kept. They are only replaced when they carry no real
+information: blank, or identical to the book title on every file, or a numbered
+placeholder this program wrote itself.
+
+## Why it was slow
+
+Saving information into an audio file was doing the same expensive work twice.
+
+Each save makes a complete copy of the audio file, writes into the copy, and
+swaps it into place — sensible, because it means a crash mid-write cannot leave
+you with a damaged file. But the step that wrote the information was *also*
+doing its own full copy-and-swap. So every save copied the entire audio file
+twice and read it end-to-end four times to compute checksums, half of which were
+calculated and immediately thrown away.
+
+For a large audiobook on network storage, that copying — not the actual writing —
+was essentially the whole wait. The duplicate layer is gone, and the checksums
+are now calculated only when there is somewhere to record them.
+
+## Cover art
+
+Cover images had a similar all-or-nothing flaw. The program checked whether the
+**first** file of a book already had the right cover and, if so, skipped the
+entire book. Any remaining files that were missing their artwork stayed missing
+permanently, and re-running never repaired them. Each file is now checked on its
+own, so every file ends up with the cover while files that already have it are
+still skipped.
+
+## One more thing: there were two copies of all of this
+
+The code that writes information into files existed twice, in two near-identical
+versions, and they had drifted apart. Books saved through one path silently
+missed out on embedded cover art, on updates being carried to alternate editions
+of the same book, and on being recorded as "already saved" — which is why some
+books kept being reprocessed. There is now one copy, and every path gets the same
+behaviour.
+
+## How we know it is fixed
+
+The existing tests for the broken comparison could never have caught this: they
+all pointed at files that did not exist, so the check exited early and the
+comparison never ran. They passed no matter what it did — and one of them
+actively asserted the broken behaviour was correct.
+
+The fix is verified against a **real audio file**: write the information, read it
+back, confirm it is there, then confirm a second run correctly does nothing at
+all. That last step is the one that used to be impossible. A companion test
+confirms a genuine change is still saved, so "skip everything" cannot masquerade
+as success.
+
+## What has not been established
+
+No stopwatch has been put on a real library yet. The duplicated work is provably
+gone and unchanged books are provably skipped, but the actual time saved on your
+collection has not been measured. That is the next thing to check.

--- a/docs/handoffs/2026-08-15-writeback-io-and-parallelism-session.md
+++ b/docs/handoffs/2026-08-15-writeback-io-and-parallelism-session.md
@@ -1,0 +1,138 @@
+<!-- file: docs/handoffs/2026-08-15-writeback-io-and-parallelism-session.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2d84f0a6-7e13-4b95-8c02-6f1a9d3e5b74 -->
+<!-- last-edited: 2026-08-15 -->
+
+# Handoff — 2026-08-15 (overnight write-back + parallelism session)
+
+Owner went to bed at ~08:36 EDT with: "combine functions where we can", "have
+another agent working on migrating the different areas to be multithreaded",
+"get all of this done so I can start fetching metadata and know it'll write
+correctly."
+
+## READ THIS FIRST — the deploy is deliberately NOT done
+
+**Nothing from this session is on prod.** Two PRs, both intentionally left for a
+supervised deploy:
+
+- **#2468** `perf/writeback-io-amplification` — write/tag correctness + I/O
+- **#2469** `perf/server-metadata-parallelism` — the multithreading migration
+
+The reason is specific, not caution theatre: **production compiles with
+`-tags native_taglib` (CGO), and that code path has never been executed against a
+real file.** The static libs in `third_party/taglib/lib/` are absent on darwin, so
+`go test -tags native_taglib` fails to link locally, and CI builds the WASM
+variant. The native writer is type-checked only. Since this PR changes *how tags
+get written*, that gap should be closed on the box (or with a canary on a small
+cohort) before a full-library write-back runs.
+
+## What was actually wrong (the headline)
+
+The owner's premise was that write-back was single-threaded and needed worker
+pools. That was **half wrong**, and acting on it alone would have made things
+worse — more workers would have multiplied the redundant I/O below against the
+NAS.
+
+### 1. Multi-file books rewrote every file forever, for a tag that never landed
+
+Two independent defects that sustained each other:
+
+- `FilterUnchangedTags` had no `currentVals` entry for `track`, so it hit the
+  "unknown key — always write" branch. The code documented this as intended:
+  `// Unknown field (e.g. "track") — always write.`
+- **`buildWriteTagMap` had no case for `track` at all** — the taglib writers
+  silently discarded it.
+
+Emit track → filter forces a write → writer drops track → file never gets the tag
+→ next read finds none → repeat. Forever. `len(tagMap) == 0` was unreachable for
+every multi-file book.
+
+**Fixing either half alone does nothing.** This is why the second half was nearly
+missed — see "how it was caught" below.
+
+### 2. Every tag write wrapped the file twice
+
+`fileops.WriteTagsSafe` (hash, copy, writeFn, rename, hash) was called with a
+`writeFn` that was *itself* another `WriteTagsSafe`. Per file per write: **4 full
+SHA-256 passes + 2 full copies** of the audio, with the inner pair computed and
+discarded. `ComputeFileHash` streams the whole file, no size cap.
+
+### 3. Per-chapter titles were being destroyed (data loss)
+
+Both multi-file paths overwrote `title` on every file with a synthetic
+`"NN - Book Title"`. "Chapter 1: Departure" → "01 - Book Title", unrecoverable.
+Defect 1 meant this ran on *every* write-back.
+
+### 4. Cover art was all-or-nothing per book
+
+`embedCoverInBookFiles` compared only `files[0]` and returned for the whole book
+on a match, so files missing artwork stayed missing permanently. Directly against
+the owner's stated requirement that every file of a multi-file book carries the
+image.
+
+### 5. Two near-identical write-back implementations, drifted
+
+`writeBackMetadata` was a ~160-line duplicate of `WriteBackMetadataForBook` whose
+only distinct input was three fallback values. The duplicate never embedded
+covers from an already-downloaded local cover, never propagated to version-group
+siblings, never redirected protected paths to the library copy, and never stamped
+`LastWrittenAt` for multi-file books. Now one implementation (179 lines → 25),
+exported signature unchanged so all nine callers and mocks are untouched.
+
+## How defect 1's second half was caught — worth internalising
+
+Every existing `FilterUnchangedTags` test pointed at a **nonexistent path**, so
+`ExtractMetadata` failed, the function returned early, and the mapping never ran.
+They passed regardless of what it did, and one asserted that `track` survives —
+pinning the bug in place as expected behaviour.
+
+After fixing the filter, unit tests on constructed `Metadata` structs went green.
+**They were wrong.** A test written against a real ffmpeg-synthesized audio file
+immediately failed with `Should be empty, but was map[track:1/12]` on a file that
+had just been written — which is what exposed the writer-side half. A test on
+constructed structs cannot catch a writer that never writes.
+
+Both fixes were mutation-tested (disable the mapping → 3 fail with the literal
+production symptom; revert the title logic → 4 fail).
+
+## State
+
+| | |
+|---|---|
+| Branch #2468 | `perf/writeback-io-amplification`, 7 commits, CI running at handoff |
+| Branch #2469 | `perf/server-metadata-parallelism` (agent-authored), CI running |
+| Worktrees | `.worktrees/writeback-io-amp`, `.worktrees/server-parallelism` — remove after merge |
+| Local tests | metafetch, metadata, tagger, fileops, organizer, audiobooks: **6/6 pass** |
+| Known-noise | `internal/database` and `internal/server` fail at **exactly 600s** — the documented stall signature; neither package is touched by #2468's diff (verified with `git diff --stat`) |
+
+## Next actions, in order
+
+1. **Merge #2468 and #2469** once CI is green (required set: `Minimal CI / Minimal
+   CI Summary`, `Require changelog fragment`, `TODO Fragment Headers`).
+2. **Close the native-taglib gap before a bulk run.** Either build the static libs
+   locally, or deploy and run a *small* write-back cohort first and verify with
+   `ffprobe` that tags landed and files are intact.
+3. **Measure.** Nothing here has a stopwatch on it. The removed I/O is provable
+   from the code; the wall-clock saving is not yet measured. Run write-back twice
+   over a fixed unchanged cohort — the second run must write **0** files. Today
+   it writes all of them for multi-file books, so this is a measurement that
+   currently fails and must start passing.
+4. Phase 4 of the plan is **not started**: metadata *fetch* fan-out. Do NOT raise
+   fetch concurrency before building rate limiting — 5 of 6 providers (Audible,
+   Audnexus, Google Books, OpenLibrary, Wikipedia) have **zero** outbound
+   throttling, no jitter, no 429/`Retry-After` handling. Hardcover's 60/min
+   limiter is a process-wide mutex that will serialise any fan-out. Plan:
+   `~/.claude/plans/unified-weaving-grove.md`.
+
+## Carried over, still unresolved from the previous session
+
+- **Boot check #2 for `#2466` was never verified.** No evidence any organize ran
+  after the 01:10:53 restart. (My "1,096 organize lines" figure was garbage —
+  `grep -i organize` matches `audiobook-organiz**er**` in every journal line.)
+- **The UA-purge census is dead**, killed by the registry stuck-op watchdog at
+  5m18s. It emits no progress ticks, so it **cannot** complete no matter how long
+  it runs. Re-triggering as-is will die identically at minute five. Needs progress
+  reporting first — note `RunItems` auto-reports per item, which is the cheap fix.
+- **ABS playlists endpoint ignores `page`/`limit`** — every page returns the
+  identical full set, so the client appends duplicates. This is the "same playlist
+  three times" report. Not fixed; unowned.

--- a/docs/handoffs/2026-08-15-writeback-io-and-parallelism-session.md
+++ b/docs/handoffs/2026-08-15-writeback-io-and-parallelism-session.md
@@ -1,5 +1,5 @@
 <!-- file: docs/handoffs/2026-08-15-writeback-io-and-parallelism-session.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 2d84f0a6-7e13-4b95-8c02-6f1a9d3e5b74 -->
 <!-- last-edited: 2026-08-15 -->
 
@@ -103,7 +103,21 @@ production symptom; revert the title logic → 4 fail).
 | Branch #2469 | `perf/server-metadata-parallelism` (agent-authored), CI running |
 | Worktrees | `.worktrees/writeback-io-amp`, `.worktrees/server-parallelism` — remove after merge |
 | Local tests | metafetch, metadata, tagger, fileops, organizer, audiobooks: **6/6 pass** |
-| Known-noise | `internal/database` and `internal/server` fail at **exactly 600s** — the documented stall signature; neither package is touched by #2468's diff (verified with `git diff --stat`) |
+| Known-noise | see below — **resolved**, they are slow, not broken |
+
+### The `internal/database` / `internal/server` test failures are SLOWNESS, confirmed
+
+Previous handoffs listed this as an open question ("control on clean main was
+never finished"). It is now settled. Both packages fail at **exactly 600s** under
+the default timeout; re-run with `-timeout 25m` they both **pass**:
+
+- `internal/database` — **580.9s** (finishes just **19 seconds** under the 600s
+  default, which is exactly why it fails intermittently)
+- `internal/server` — **849.1s** (genuinely over the default)
+
+Neither is touched by #2468's diff (verified with `git diff --stat`). Treat a
+600.x-second failure in these two as a timeout, not a regression. The real fix is
+to raise the timeout or split the packages, not to chase a phantom bug.
 
 ## Next actions, in order
 
@@ -123,6 +137,34 @@ production symptom; revert the title logic → 4 fail).
    throttling, no jitter, no 429/`Retry-After` handling. Hardcover's 60/min
    limiter is a process-wide mutex that will serialise any fan-out. Plan:
    `~/.claude/plans/unified-weaving-grove.md`.
+
+## Two deliberate non-actions (do not "finish" these without re-reading why)
+
+**1. The `LastWrittenAt` pre-filter for `runBulkWriteBack` was dropped on purpose.**
+It was in the approved plan. On reading the code: `runBulkWriteBack` has no force
+parameter, and `LastWrittenAt`/`UpdatedAt` compares **database** state, not disk
+state. Tags altered outside the app never advance `UpdatedAt`, so such a book
+would be skipped **permanently** and the file could never be repaired. The saving
+it was meant to buy has largely evaporated now that the disk-based
+`FilterUnchangedTags` skip actually works — that pre-filter exists in
+`batch_save_op.go` precisely *because* the disk skip was broken by the `track`
+bug. Net remaining gain: one tag read per file, bought with a permanent-skip
+correctness hazard.
+
+**2. #2469 did NOT convert the two apply loops to background op-id endpoints**,
+and that was the right call. `web/src/services/api.ts` documents that
+`applied_ids`/`skipped` were added *because* the endpoint used to report only a
+count and "books silently vanished from the review queue"; the dialog awaits the
+response and diffs `applied_ids`. Returning only an op id would have reintroduced
+a fixed data-visibility bug. Both loops were parallelized with `errgroup` +
+`SetLimit` instead, keeping the response shape byte-identical.
+
+## Known residual gap from #2469 (agent-flagged, real)
+
+`metadata.batch-save` has no protected-path skip, and the library-copy resolution
+is not visible from package `server`, so two protected books that share one
+library copy are **not** serialized against each other. Needs an exported resolver
+in `internal/metafetch`. Commented at the lock-acquisition site.
 
 ## Carried over, still unresolved from the previous session
 

--- a/internal/fileops/write_tags_safe.go
+++ b/internal/fileops/write_tags_safe.go
@@ -1,7 +1,7 @@
 // file: internal/fileops/write_tags_safe.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b4c5d6e7-f8a9-0b1c-2d3e-4f5a6b7c8d9e
-// last-edited: 2026-05-15
+// last-edited: 2026-08-15
 
 package fileops
 
@@ -23,20 +23,38 @@ type WriteTagsSafeOptions struct {
 }
 
 // WriteTagsSafe writes audio metadata tags to path safely:
-//  1. Computes original_file_hash (SHA-256) before any write
-//  2. Copies the file to a sibling temp file in the same directory
-//  3. Calls writeFn(tmpPath) to perform the actual tag write on the copy
-//  4. On success: atomically renames the temp file over the original
-//  5. Computes post_metadata_hash from the updated file
-//  6. If opts.BookFileID != "" and opts.Store != nil, persists both hashes
+//  1. Copies the file to a sibling temp file in the same directory
+//  2. Calls writeFn(tmpPath) to perform the actual tag write on the copy
+//  3. On success: atomically renames the temp file over the original
 //
-// Returns (originalHash, postHash, error). On writeFn failure the original
-// file is left untouched and the temp file is removed.
+// When BOTH opts.BookFileID and opts.Store are set it additionally computes
+// original_file_hash before the write and post_metadata_hash after it, and
+// persists the pair. Those two SHA-256 passes each stream the whole audio file,
+// so they are skipped entirely when there is no row to persist them against.
+//
+// Returns (originalHash, postHash, error); the hashes are "" when not computed.
+// On writeFn failure the original file is left untouched and the temp file is
+// removed.
+//
+// writeFn receives a temp copy, so a writer that itself wraps its work in
+// WriteTagsSafe would double the copy-and-hash cost. Writers meant to be called
+// from here have in-place variants — see metadata.WriteMetadataToFileInPlace and
+// tagger.WriteTagsInPlace.
 func WriteTagsSafe(path string, writeFn func(tmpPath string) error, opts WriteTagsSafeOptions) (originalHash, postHash string, err error) {
+	// The hashes exist solely to be persisted against a book_file row. When no
+	// row is supplied there is nothing to persist and every caller discards the
+	// return values, so computing them is pure waste — and it is expensive waste:
+	// ComputeFileHash streams the ENTIRE audio file through SHA-256 with no size
+	// cap and no mtime/size shortcut, twice per call. On NAS-backed audiobooks
+	// that dominated the cost of a tag write.
+	wantHashes := opts.BookFileID != "" && opts.Store != nil
+
 	// Step 1: fingerprint the original file before any modification.
-	originalHash, err = ComputeFileHash(path)
-	if err != nil {
-		return "", "", fmt.Errorf("WriteTagsSafe: hash original %s: %w", path, err)
+	if wantHashes {
+		originalHash, err = ComputeFileHash(path)
+		if err != nil {
+			return "", "", fmt.Errorf("WriteTagsSafe: hash original %s: %w", path, err)
+		}
 	}
 
 	// Step 2: create temp file in the same directory so os.Rename is atomic
@@ -73,14 +91,14 @@ func WriteTagsSafe(path string, writeFn func(tmpPath string) error, opts WriteTa
 		return originalHash, "", fmt.Errorf("WriteTagsSafe: rename: %w", err)
 	}
 
-	// Step 6: fingerprint the result.
-	postHash, err = ComputeFileHash(path)
-	if err != nil {
-		return originalHash, "", fmt.Errorf("WriteTagsSafe: hash result %s: %w", path, err)
-	}
+	// Step 6: fingerprint the result (only when it will be persisted).
+	if wantHashes {
+		postHash, err = ComputeFileHash(path)
+		if err != nil {
+			return originalHash, "", fmt.Errorf("WriteTagsSafe: hash result %s: %w", path, err)
+		}
 
-	// Step 7: best-effort DB recording (non-fatal; caller has both hashes).
-	if opts.BookFileID != "" && opts.Store != nil {
+		// Step 7: best-effort DB recording (non-fatal; caller has both hashes).
 		_ = opts.Store.UpdateBookFileHashes(opts.BookFileID, originalHash, postHash)
 	}
 

--- a/internal/metadata/enhanced.go
+++ b/internal/metadata/enhanced.go
@@ -1,7 +1,7 @@
 // file: internal/metadata/enhanced.go
-// version: 1.12.0
+// version: 1.13.0
 // guid: 7e8d9c0b-1a2f-3e4d-5c6b-7a8d9c0b1a2f
-// last-edited: 2026-07-11
+// last-edited: 2026-08-15
 
 package metadata
 
@@ -342,9 +342,28 @@ func BatchUpdateMetadata(updates []MetadataUpdate, store batchUpdateStore, valid
 // WriteMetadataToFile safely writes metadata to an audiobook file
 // Prefers native TagLib writer when built with 'taglib'; falls back to external CLI tools if unavailable or failed.
 // Uses backup/rollback strategy via fileops.SafeCopy for all paths.
-func WriteMetadataToFile(filePath string, metadata map[string]interface{}, config fileops.OperationConfig) error {
-	ext := strings.ToLower(filepath.Ext(filePath))
+// WriteMetadataToFileInPlace is WriteMetadataToFile for callers that are ALREADY
+// inside an outer fileops.WriteTagsSafe and are handing us its temp copy.
+//
+// It skips the writer's own internal copy-and-rename wrapper. Without this, the
+// write-back path wrapped every tag write twice: four full-file SHA-256 passes
+// and two full-file copies of the audio per file per write, half of it discarded.
+// On NAS-backed audiobooks that redundant I/O dominated write-back time.
+//
+// Do NOT call this on a live library file — it has no atomic-rename safety net.
+// Use WriteMetadataToFile for that.
+func WriteMetadataToFileInPlace(filePath string, metadata map[string]interface{}, config fileops.OperationConfig) error {
+	if taglibAvailable {
+		if err := writeMetadataWithTaglibInPlace(filePath, metadata, config); err == nil {
+			return nil
+		}
+		// Native failed; fall through to the CLI writers, which manage their own
+		// temp files and are safe to run against the caller's temp copy.
+	}
+	return writeMetadataViaCLI(filePath, metadata, config)
+}
 
+func WriteMetadataToFile(filePath string, metadata map[string]interface{}, config fileops.OperationConfig) error {
 	// Attempt native writer first if compiled in.
 	// Upstream taglib v0.11.1+ writes custom freeform atoms natively for MP4.
 	// Do NOT run ffmpeg after taglib — ffmpeg's -map_metadata strips freeform atoms.
@@ -355,7 +374,14 @@ func WriteMetadataToFile(filePath string, metadata map[string]interface{}, confi
 		// Native failed; continue with CLI fallback
 	}
 
-	switch ext {
+	return writeMetadataViaCLI(filePath, metadata, config)
+}
+
+// writeMetadataViaCLI dispatches to the per-container ffmpeg/CLI writers. Shared
+// by WriteMetadataToFile and WriteMetadataToFileInPlace so the format dispatch
+// exists once.
+func writeMetadataViaCLI(filePath string, metadata map[string]interface{}, config fileops.OperationConfig) error {
+	switch strings.ToLower(filepath.Ext(filePath)) {
 	case ".m4b", ".m4a":
 		return writeM4BMetadata(filePath, metadata, config)
 	case ".mp3":
@@ -363,7 +389,7 @@ func WriteMetadataToFile(filePath string, metadata map[string]interface{}, confi
 	case ".flac":
 		return writeFLACMetadata(filePath, metadata, config)
 	default:
-		return fmt.Errorf("unsupported file format: %s", ext)
+		return fmt.Errorf("unsupported file format: %s", filepath.Ext(filePath))
 	}
 }
 

--- a/internal/metadata/taglib_cgo.go
+++ b/internal/metadata/taglib_cgo.go
@@ -1,6 +1,6 @@
 // file: internal/metadata/taglib_cgo.go
-// version: 1.5.0
-// last-edited: 2026-06-13
+// version: 1.6.0
+// last-edited: 2026-08-15
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 //
 // Native CGO bindings to TagLib C API for high-performance tag writing.
@@ -59,6 +59,35 @@ func writeMetadataWithTaglib(filePath string, metadata map[string]interface{}, _
 	}, fileops.WriteTagsSafeOptions{})
 	if err != nil {
 		return fmt.Errorf("taglib write: %w", err)
+	}
+	return nil
+}
+
+// writeMetadataWithTaglibInPlace writes tags straight to filePath, skipping the
+// fileops.WriteTagsSafe wrapper that writeMetadataWithTaglib applies.
+//
+// Contract: the caller MUST already be operating on a temp copy created by an
+// outer fileops.WriteTagsSafe, and MUST have already resolved the protected-path
+// question against the real path. See tagger.WriteTagsInPlace for the full
+// rationale — in short, the wrapper was being applied twice, costing four
+// full-file hashes and two full-file copies per tag write instead of two and one.
+//
+// Protected-path resolution is deliberately NOT repeated here: the path handed
+// in is a temp file sitting next to the original, so resolving it would be
+// meaningless, and the real path was already checked upstream.
+func writeMetadataWithTaglibInPlace(filePath string, metadata map[string]interface{}, _ fileops.OperationConfig) error {
+	abs, err := filepath.Abs(filePath)
+	if err != nil {
+		return fmt.Errorf("taglib abs path: %w", err)
+	}
+
+	tags := buildWriteTagMap(metadata)
+	if len(tags) == 0 {
+		return fmt.Errorf("no writable metadata supplied")
+	}
+
+	if err := writeTagMapWithTaglib(abs, abs, tags); err != nil {
+		return fmt.Errorf("taglib write in place: %w", err)
 	}
 	return nil
 }

--- a/internal/metadata/taglib_support.go
+++ b/internal/metadata/taglib_support.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/taglib_support.go
-// version: 2.4.0
+// version: 2.5.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 //
 // TagLib WASM writer (default, no CGO required).
@@ -44,6 +44,29 @@ func writeMetadataWithTaglib(filePath string, metadata map[string]interface{}, _
 		return fmt.Errorf("taglib write: %w", err)
 	}
 
+	return nil
+}
+
+// writeMetadataWithTaglibInPlace writes tags straight to filePath, skipping the
+// tagger.WriteTagsSafe wrapper (which itself wraps fileops.WriteTagsSafe).
+//
+// Contract: the caller MUST already be operating on a temp copy created by an
+// outer fileops.WriteTagsSafe, and MUST have already resolved the protected-path
+// question against the real path. See tagger.WriteTagsInPlace for the rationale.
+func writeMetadataWithTaglibInPlace(filePath string, metadata map[string]interface{}, _ fileops.OperationConfig) error {
+	abs, err := filepath.Abs(filePath)
+	if err != nil {
+		return fmt.Errorf("taglib abs path: %w", err)
+	}
+
+	tags := buildWriteTagMap(metadata)
+	if len(tags) == 0 {
+		return fmt.Errorf("no writable metadata supplied")
+	}
+
+	if err := tagger.WriteTagsInPlace(abs, tags, 0); err != nil {
+		return fmt.Errorf("taglib write in place: %w", err)
+	}
 	return nil
 }
 

--- a/internal/metadata/taglib_tagmap.go
+++ b/internal/metadata/taglib_tagmap.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/taglib_tagmap.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 //
 // Shared tag map builder used by both WASM and CGO taglib writers.
@@ -60,6 +60,31 @@ func buildWriteTagMap(metadata map[string]interface{}) map[string][]string {
 	}
 	if si, ok := metadata["series_index"].(int); ok && si > 0 {
 		tags["SERIES_INDEX"] = []string{fmt.Sprintf("%d", si)}
+	}
+	// TRACKNUMBER is what the reader looks for first (see taglib_reader.go's
+	// parseSlashPair over TRACKNUMBER/TRACK/TRCK), so an "n/total" value written
+	// here round-trips into Metadata.TrackNumber / Metadata.TrackTotal.
+	//
+	// This case did not exist, and its absence was self-sustaining: the
+	// multi-file write path always emits a "track" entry, the unchanged-tag
+	// filter had no mapping for it and so always wrote, and then THIS function
+	// silently dropped it — so the file never actually received a track tag, the
+	// next read found none, and the next run wrote again. Every multi-file book
+	// rewrote every one of its files on every write-back run, permanently, and
+	// the tag it was rewriting for never landed. Mapping the tag in the filter
+	// alone does not fix it; the value has to actually reach the file.
+	//
+	// Accept the int form too: callers that number tracks without a total pass
+	// an int rather than the "n/total" string.
+	switch track := metadata["track"].(type) {
+	case string:
+		if track != "" {
+			tags["TRACKNUMBER"] = []string{track}
+		}
+	case int:
+		if track > 0 {
+			tags["TRACKNUMBER"] = []string{fmt.Sprintf("%d", track)}
+		}
 	}
 
 	// Custom AUDIOBOOK_ORGANIZER_* tags

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service.go
-// version: 5.4.0
+// version: 5.5.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
-// last-edited: 2026-07-17
+// last-edited: 2026-08-15
 
 package metafetch
 
@@ -197,37 +197,56 @@ func (mfs *Service) embedCoverInBookFiles(book *database.Book, coverPath string)
 		return
 	}
 
-	// Check if the new cover is different from what's already embedded.
-	// Skip archive + embed if they match (same hash).
 	newCoverData, _ := os.ReadFile(coverPath)
+	newHash := ""
 	if len(newCoverData) > 0 {
-		newHash := fmt.Sprintf("%x", sha256.Sum256(newCoverData))[:12]
-		existingData, _, _ := metadata.ExtractCoverArtBytes(files[0])
-		if len(existingData) > 0 {
-			existingHash := fmt.Sprintf("%x", sha256.Sum256(existingData))[:12]
-			if newHash == existingHash {
-				slog.Debug("cover art unchanged for book , skipping embed", "id", book.ID)
-				return
-			}
-		}
+		newHash = fmt.Sprintf("%x", sha256.Sum256(newCoverData))[:12]
 	}
 
-	// Archive the old cover from the first file before overwriting
-	mfs.archiveExistingCover(book.ID, files[0])
-
-	// Embed new cover into all files.
-	// EmbedCoverArtSafe imports the file from a Deluge-protected path before
-	// writing if the pre-flight guard is wired (mfs.safeWriteDeps).
-	embedded := 0
+	// Every file of a multi-file book must carry the artwork. The skip check is
+	// therefore PER FILE.
+	//
+	// It used to compare only files[0] and return for the whole book on a match,
+	// which is all-or-nothing in the wrong direction: a book whose first file
+	// already had the cover skipped the embed for every remaining file, so those
+	// files stayed permanently artwork-less and no amount of re-running fixed it.
+	// Comparing per file both closes that hole and keeps the saving, since a file
+	// that already matches is still skipped — and skipping is what matters, as an
+	// embed is a full rewrite of the audio file.
+	embedded, skipped, failed := 0, 0, 0
+	archived := false
 	for _, f := range files {
+		if newHash != "" {
+			if existingData, _, _ := metadata.ExtractCoverArtBytes(f); len(existingData) > 0 {
+				if fmt.Sprintf("%x", sha256.Sum256(existingData))[:12] == newHash {
+					skipped++
+					continue
+				}
+			}
+		}
+
+		// Archive the cover we are about to overwrite, once per book, from the
+		// first file we actually touch.
+		if !archived {
+			mfs.archiveExistingCover(book.ID, f)
+			archived = true
+		}
+
+		// EmbedCoverArtSafe imports the file from a Deluge-protected path before
+		// writing if the pre-flight guard is wired (mfs.safeWriteDeps).
 		if err := tagger.EmbedCoverArtSafe(context.Background(), f, coverPath, mfs.safeWriteDeps); err != nil {
 			slog.Warn("cover art embedding failed for", "value", f, "error", err)
+			failed++
 		} else {
 			embedded++
 		}
 	}
-	if embedded > 0 {
-		slog.Info("cover art embedded into file(s) for book", "count", embedded, "id", book.ID)
+	if embedded > 0 || failed > 0 {
+		slog.Info("cover art embed complete for book",
+			"id", book.ID, "embedded", embedded, "skipped_unchanged", skipped, "failed", failed, "files", len(files))
+	} else if skipped > 0 {
+		slog.Debug("cover art already present in every file, nothing to embed",
+			"id", book.ID, "files", len(files))
 	}
 }
 

--- a/internal/metafetch/service_writeback.go
+++ b/internal/metafetch/service_writeback.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_writeback.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: fad73c11-30c2-4fdc-addd-45afef25d792
-// last-edited: 2026-08-11
+// last-edited: 2026-08-15
 
 package metafetch
 
@@ -20,183 +20,29 @@ import (
 	"time"
 )
 
-// writeBackMetadata writes enriched metadata back to audio file(s).
+// writeBackMetadata writes enriched metadata back to a book's audio file(s)
+// during the fetch/apply flow.
+//
+// This used to be a ~160-line near-duplicate of WriteBackMetadataForBook whose
+// only distinct input was three fallback values from the just-fetched metadata.
+// The two copies drifted, and the duplicate was the worse of the two: it never
+// embedded covers from an already-downloaded local cover, never propagated to
+// version-group siblings, never redirected protected paths to the library copy,
+// and never stamped LastWrittenAt/MarkNeedsRescan in its multi-file branch (so
+// those books stayed invisible to any "written since it changed?" skip).
+//
+// It is now a thin wrapper over the single shared implementation, and the
+// fetch/apply path gains all of the above.
 func (mfs *Service) writeBackMetadata(book *database.Book, meta metadata.BookMetadata) {
-	// --- Resolve author names (same logic as WriteBackMetadataForBook) ---
-	var authorNames []string
-	if bookAuthors, err := mfs.db.GetBookAuthors(book.ID); err == nil && len(bookAuthors) > 0 {
-		for _, ba := range bookAuthors {
-			if author, aerr := mfs.db.GetAuthorByID(ba.AuthorID); aerr == nil && author != nil {
-				authorNames = append(authorNames, author.Name)
-			}
-		}
-	} else if book.AuthorID != nil {
-		if author, aerr := mfs.db.GetAuthorByID(*book.AuthorID); aerr == nil && author != nil {
-			authorNames = append(authorNames, author.Name)
-		}
-	}
-	if len(authorNames) == 0 && meta.Author != "" {
-		authorNames = append(authorNames, meta.Author)
-	}
-	artistStr := strings.Join(authorNames, ", ")
-
-	// --- Resolve narrator names ---
-	var narratorNames []string
-	if bookNarrators, err := mfs.db.GetBookNarrators(book.ID); err == nil && len(bookNarrators) > 0 {
-		for _, bn := range bookNarrators {
-			if narrator, nerr := mfs.db.GetNarratorByID(bn.NarratorID); nerr == nil && narrator != nil {
-				narratorNames = append(narratorNames, narrator.Name)
-			}
-		}
-	} else if book.Narrator != nil && *book.Narrator != "" {
-		narratorNames = append(narratorNames, *book.Narrator)
-	}
-	narratorStr := strings.Join(narratorNames, " & ")
-
-	// --- Determine year ---
-	year := 0
-	if book.AudiobookReleaseYear != nil && *book.AudiobookReleaseYear > 0 {
-		year = *book.AudiobookReleaseYear
-	} else if book.PrintYear != nil && *book.PrintYear > 0 {
-		year = *book.PrintYear
-	} else if meta.PublishYear > 0 {
-		year = meta.PublishYear
-	}
-
-	bookTitle := meta.Title
-	if bookTitle == "" {
-		bookTitle = book.Title
-	}
-
-	opConfig := fileops.OperationConfig{VerifyChecksums: true}
-
-	// CRITICAL: Never write metadata to files in protected paths (import paths,
-	// iTunes Media folders). Only write to files in our organized library.
-	if mfs.isProtectedPath(book.FilePath) {
-				slog.Info("skipping write-back for protected path", "path", book.FilePath)
+	if book == nil {
 		return
 	}
-
-	// Collect active book files for multi-file books
-	bookFiles, bfErr := mfs.db.GetBookFiles(book.ID)
-	var activeFiles []database.BookFile
-	if bfErr == nil {
-		for _, bf := range bookFiles {
-			if !bf.Missing {
-				activeFiles = append(activeFiles, bf)
-			}
-		}
-	}
-
-	totalTracks := len(activeFiles)
-
-	if totalTracks > 1 {
-		// Multi-file: write to each file with per-track title and numbering
-		digits := len(fmt.Sprintf("%d", totalTracks))
-		trackFmt := fmt.Sprintf("%%0%dd", digits)
-		for i, bf := range activeFiles {
-			trackNum := i + 1
-			generated := fmt.Sprintf(trackFmt+" - %s", trackNum, bookTitle)
-			trackStr := fmt.Sprintf("%d/%d", trackNum, totalTracks)
-
-			// Read the file's current tags ONCE and reuse them for both the
-			// chapter-title decision and the unchanged-tag filter. Previously
-			// FilterUnchangedTags did its own read, so adding the title check
-			// naively would have doubled the per-file tag reads.
-			cur, curErr := metadata.ExtractMetadata(bf.FilePath, nil)
-
-			segTitle := generated
-			if curErr == nil {
-				segTitle = chapterTitleFor(cur.Title, generated, bookTitle)
-			}
-
-			tagMap := mfs.BuildFullTagMap(book, bookTitle, segTitle, artistStr, narratorStr, year, trackStr)
-			if segTitle == "" {
-				// Preserve the file's real per-chapter title.
-				delete(tagMap, "title")
-			}
-			if curErr == nil {
-				tagMap = filterTagsAgainst(cur, tagMap)
-			}
-			// curErr != nil keeps the historical safe fallback: tags unreadable,
-			// so write everything rather than guess.
-			if len(tagMap) == 0 {
-				continue
-			}
-			if mfs.isProtectedPath(bf.FilePath) {
-								slog.Info("skipping write-back for protected file", "path", bf.FilePath)
-				continue
-			}
-			backupFileBeforeWrite(bf.FilePath)
-			if _, _, err := fileops.WriteTagsSafe(bf.FilePath, func(tmpPath string) error {
-				return metadata.WriteMetadataToFile(tmpPath, tagMap, opConfig)
-			}, fileops.WriteTagsSafeOptions{BookFileID: bf.ID, Store: mfs.db}); err != nil {
-								slog.Warn("write-back failed for file", "path", bf.FilePath, "error", err)
-			}
-		}
-	} else {
-		// Single-file or no segments: write to book.FilePath.
-		// If book.FilePath is a directory (multi-file book with no segment records),
-		// glob for audio files inside and write to each one individually.
-		tagMap := mfs.BuildFullTagMap(book, bookTitle, bookTitle, artistStr, narratorStr, year, "")
-				slog.Debug("write-back full tag map has entries for", "count", len(tagMap), "path", book.FilePath)
-		for k, v := range tagMap {
-						slog.Debug("write-back", "tagKey", k, "tagValue", v)
-		}
-
-		dirFiles := AudioFilesInDir(book.FilePath)
-		if len(dirFiles) > 0 {
-			// book.FilePath is a directory — write to each audio file found inside.
-						slog.Info("write-back is a directory; writing to audio file(s) inside", "path", book.FilePath, "file", len(dirFiles))
-			wroteAny := false
-			for _, f := range dirFiles {
-				fm := FilterUnchangedTags(f, tagMap)
-				if len(fm) == 0 {
-										slog.Debug("write-back all tags match, skipping", "value", f)
-					continue
-				}
-				backupFileBeforeWrite(f)
-				if _, _, err := fileops.WriteTagsSafe(f, func(tmpPath string) error {
-					return metadata.WriteMetadataToFile(tmpPath, fm, opConfig)
-				}, fileops.WriteTagsSafeOptions{}); err != nil {
-										slog.Warn("write-back failed for", "value", f, "error", err)
-				} else {
-										slog.Info("wrote metadata back to", "value", f)
-					wroteAny = true
-				}
-			}
-			if wroteAny {
-				if err := mfs.db.SetLastWrittenAt(book.ID, time.Now()); err != nil {
-										slog.Warn("failed to stamp last_written_at for book", "id", book.ID, "error", err)
-				}
-				_ = mfs.db.MarkNeedsRescan(book.ID)
-			}
-		} else {
-			tagMap = FilterUnchangedTags(book.FilePath, tagMap)
-						slog.Debug("write-back after filter, entries remain", "count", len(tagMap))
-			if len(tagMap) == 0 {
-								slog.Debug("write-back all tags match, skipping write for", "path", book.FilePath)
-				return
-			}
-			backupFileBeforeWrite(book.FilePath)
-			var wtsOptsPath fileops.WriteTagsSafeOptions
-			if bff, bfferr := mfs.db.GetBookFileByPath(book.FilePath); bfferr == nil && bff != nil {
-				wtsOptsPath = fileops.WriteTagsSafeOptions{BookFileID: bff.ID, Store: mfs.db}
-			}
-			if _, _, err := fileops.WriteTagsSafe(book.FilePath, func(tmpPath string) error {
-				return metadata.WriteMetadataToFile(tmpPath, tagMap, opConfig)
-			}, wtsOptsPath); err != nil {
-								slog.Warn("write-back failed for", "path", book.FilePath, "error", err)
-			} else {
-								slog.Info("wrote metadata back to", "path", book.FilePath)
-				// Stamp last_written_at after successful write-back.
-				if err := mfs.db.SetLastWrittenAt(book.ID, time.Now()); err != nil {
-										slog.Warn("failed to stamp last_written_at for book", "id", book.ID, "error", err)
-				}
-				// Flag for rescan so the next incremental scan re-reads the updated tags.
-				_ = mfs.db.MarkNeedsRescan(book.ID)
-			}
-		}
+	if _, err := mfs.writeBackForBook(book.ID, &writeBackOverrides{
+		Title:       meta.Title,
+		Author:      meta.Author,
+		PublishYear: meta.PublishYear,
+	}, nil); err != nil {
+		slog.Warn("write-back after fetch failed", "id", book.ID, "error", err)
 	}
 }
 
@@ -478,15 +324,15 @@ func filterTagsAgainst(current metadata.Metadata, tagMap map[string]interface{})
 		// field → always write" and falls through to a real write,
 		// which was the root cause of the "organize rewrites tags
 		// every time even when unchanged" investigation.
-		"album_artist":    current.Narrator,
-		"composer":        current.Narrator,
-		"narrator":        current.Narrator,
-		"genre":           current.Genre,
-		"year":            fmt.Sprintf("%d", current.Year),
-		"language":        current.Language,
-		"series":          current.Series,
-		"asin":            current.ASIN,
-		"description":     current.Comments, // description is stored in comments field
+		"album_artist": current.Narrator,
+		"composer":     current.Narrator,
+		"narrator":     current.Narrator,
+		"genre":        current.Genre,
+		"year":         fmt.Sprintf("%d", current.Year),
+		"language":     current.Language,
+		"series":       current.Series,
+		"asin":         current.ASIN,
+		"description":  current.Comments, // description is stored in comments field
 		// Custom AUDIOBOOK_ORGANIZER_* tag mappings from metadata/custom_tags.go:
 		// These map input keys (e.g. "book_id") to Metadata struct fields.
 		"book_id":         current.BookOrganizerID,
@@ -584,7 +430,7 @@ func (mfs *Service) generateSegmentTitles(bookID string, bookTitle string) error
 		bookFiles[i].Title = title
 
 		if err := mfs.db.UpdateBookFile(bookFiles[i].ID, &bookFiles[i]); err != nil {
-						slog.Warn("failed to update book file title for", "id", bookFiles[i].ID, "error", err)
+			slog.Warn("failed to update book file title for", "id", bookFiles[i].ID, "error", err)
 		}
 	}
 
@@ -599,10 +445,10 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 	if mfs.isProtectedPath(book.FilePath) {
 		libCopy := mfs.ensureLibraryCopy(book)
 		if libCopy == nil {
-						slog.Warn("runApplyPipeline no library copy for protected book , skipping", "id", id)
+			slog.Warn("runApplyPipeline no library copy for protected book , skipping", "id", id)
 			return nil
 		}
-				slog.Info("runApplyPipeline using library copy for protected book", "libCopyID", libCopy.ID, "bookID", id)
+		slog.Info("runApplyPipeline using library copy for protected book", "libCopyID", libCopy.ID, "bookID", id)
 		id = libCopy.ID
 		book = libCopy
 	}
@@ -668,7 +514,7 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 		// files that did move. The error is returned after the DB sync,
 		// before the rename checkpoint is set.
 		if len(renameResult.Skipped) > 0 {
-						slog.Warn("files skipped (source missing) during rename", "count", len(renameResult.Skipped))
+			slog.Warn("files skipped (source missing) during rename", "count", len(renameResult.Skipped))
 		}
 
 		// Update book file records with new paths (only for succeeded renames)
@@ -681,7 +527,7 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 				bf.FilePath = entry.TargetPath
 				bf.ITunesPath = ComputeITunesPath(entry.TargetPath)
 				if err := mfs.db.UpdateBookFile(bf.ID, bf); err != nil {
-										slog.Warn("failed to update book_file path for", "id", bf.ID, "error", err)
+					slog.Warn("failed to update book_file path for", "id", bf.ID, "error", err)
 				}
 			}
 			// Record path change for each successful rename
@@ -714,9 +560,9 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 			if newBookPath != book.FilePath {
 				book.FilePath = newBookPath
 				if _, err := mfs.db.UpdateBook(id, book); err != nil {
-										slog.Warn("failed to update book path for", "id", id, "error", err)
+					slog.Warn("failed to update book path for", "id", id, "error", err)
 				} else {
-										slog.Info("updated book path for", "id", id, "path", newBookPath)
+					slog.Info("updated book path for", "id", id, "path", newBookPath)
 				}
 			}
 		}
@@ -736,7 +582,7 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 			if itunesPath := ComputeITunesPath(bookFiles[i].FilePath); itunesPath != "" {
 				bookFiles[i].ITunesPath = itunesPath
 				if err := mfs.db.UpdateBookFile(bookFiles[i].ID, &bookFiles[i]); err != nil {
-										slog.Warn("failed to update itunes_path for book file", "id", bookFiles[i].ID, "error", err)
+					slog.Warn("failed to update itunes_path for book file", "id", bookFiles[i].ID, "error", err)
 				}
 			}
 		}
@@ -745,9 +591,9 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 	// Write metadata tags to audio files
 	if config.AppConfig.AutoWriteTagsOnApply && !hasCheckpoint(mfs.db, id, phaseTags) {
 		if written, err := mfs.WriteBackMetadataForBook(id); err != nil {
-						slog.Warn("tag writing failed for book", "id", id, "error", err)
+			slog.Warn("tag writing failed for book", "id", id, "error", err)
 		} else {
-						slog.Info("wrote metadata tags to file(s) for book", "value", written, "id", id)
+			slog.Info("wrote metadata tags to file(s) for book", "value", written, "id", id)
 			setCheckpoint(mfs.db, id, phaseTags)
 		}
 	}
@@ -766,10 +612,37 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 	return nil
 }
 
+// writeBackOverrides carries values from freshly-fetched metadata that may not
+// be persisted on the book record yet. They are only consulted as fallbacks when
+// the book's own fields are empty. nil means "use the DB record alone".
+//
+// This exists so the fetch/apply path can share ONE write-back implementation
+// instead of keeping its own copy. It previously had a near-identical ~160-line
+// duplicate whose only distinct input was these three values, and the two copies
+// had drifted: the duplicate never embedded covers from an already-downloaded
+// local cover, never propagated to version-group siblings, never redirected
+// protected paths to the library copy, and never stamped LastWrittenAt in its
+// multi-file branch.
+type writeBackOverrides struct {
+	Title       string
+	Author      string
+	PublishYear int
+}
+
 // WriteBackMetadataForBook reads current DB metadata for the book, resolves authors and
 // narrators, writes comprehensive tags to all active audio file segments, and records a
 // history entry. It is called by POST /api/v1/audiobooks/:id/write-back.
 func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]string) (int, error) {
+	var sf []string
+	if len(segmentFilter) > 0 {
+		sf = segmentFilter[0]
+	}
+	return mfs.writeBackForBook(id, nil, sf)
+}
+
+// writeBackForBook is the single implementation behind both WriteBackMetadataForBook
+// and the fetch/apply path.
+func (mfs *Service) writeBackForBook(id string, ov *writeBackOverrides, segmentFilter []string) (int, error) {
 	book, err := mfs.db.GetBookByID(id)
 	if err != nil || book == nil {
 		return 0, fmt.Errorf("audiobook not found: %s", id)
@@ -807,6 +680,9 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 			authorNames = append(authorNames, author.Name)
 		}
 	}
+	if len(authorNames) == 0 && ov != nil && ov.Author != "" {
+		authorNames = append(authorNames, ov.Author)
+	}
 	artistStr := strings.Join(authorNames, ", ")
 
 	// --- Resolve narrator names ---
@@ -830,6 +706,8 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 		year = *originalBook.AudiobookReleaseYear
 	} else if originalBook.PrintYear != nil && *originalBook.PrintYear > 0 {
 		year = *originalBook.PrintYear
+	} else if ov != nil && ov.PublishYear > 0 {
+		year = ov.PublishYear
 	}
 
 	opConfig := fileops.OperationConfig{VerifyChecksums: true}
@@ -848,9 +726,9 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 	}
 
 	// Apply optional segment/file filter
-	if len(segmentFilter) > 0 && len(segmentFilter[0]) > 0 {
-		filterSet := make(map[string]struct{}, len(segmentFilter[0]))
-		for _, sid := range segmentFilter[0] {
+	if len(segmentFilter) > 0 {
+		filterSet := make(map[string]struct{}, len(segmentFilter))
+		for _, sid := range segmentFilter {
 			filterSet[sid] = struct{}{}
 		}
 		var filtered []database.BookFile
@@ -873,6 +751,9 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 
 	// Use the original book's title for tag content (it has freshly-applied metadata)
 	bookTitle := originalBook.Title
+	if bookTitle == "" && ov != nil {
+		bookTitle = ov.Title
+	}
 	if totalTracks > 1 {
 		// Multi-file: write to each file with per-track title and numbering
 		digits := len(fmt.Sprintf("%d", totalTracks))
@@ -901,11 +782,11 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 			}
 			// curErr != nil keeps the historical safe fallback: write everything.
 			if len(tagMap) == 0 {
-								slog.Debug("write-back file tags already match, skipping", "path", bf.FilePath)
+				slog.Debug("write-back file tags already match, skipping", "path", bf.FilePath)
 				continue
 			}
 			if mfs.isProtectedPath(bf.FilePath) {
-								slog.Debug("skipping write-back for protected file", "path", bf.FilePath)
+				slog.Debug("skipping write-back for protected file", "path", bf.FilePath)
 				skippedProtected++
 				continue
 			}
@@ -913,14 +794,14 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 			if _, _, err := fileops.WriteTagsSafe(bf.FilePath, func(tmpPath string) error {
 				return metadata.WriteMetadataToFile(tmpPath, tagMap, opConfig)
 			}, fileops.WriteTagsSafeOptions{BookFileID: bf.ID, Store: mfs.db}); err != nil {
-								slog.Warn("write-back failed for file", "path", bf.FilePath, "error", err)
+				slog.Warn("write-back failed for file", "path", bf.FilePath, "error", err)
 			} else {
 				// Log successes as well as failures. Without this the multi-file
 				// branch was silent on success while the single-file branch below
 				// logged "wrote metadata back to", so the logs showed only
 				// failures for multi-file books and it was impossible to tell a
 				// working write path from one that never ran at all.
-								slog.Info("wrote metadata back to", "path", bf.FilePath)
+				slog.Info("wrote metadata back to", "path", bf.FilePath)
 				writtenCount++
 			}
 		}
@@ -929,7 +810,7 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 		// If book.FilePath is a directory (multi-file book with no file records),
 		// glob for audio files inside and write to each one individually.
 		if mfs.isProtectedPath(book.FilePath) {
-						slog.Debug("skipping write-back for protected path", "path", book.FilePath)
+			slog.Debug("skipping write-back for protected path", "path", book.FilePath)
 			skippedProtected++
 		} else {
 			fullTagMap := mfs.BuildFullTagMap(book, bookTitle, bookTitle, artistStr, narratorStr, year, "")
@@ -943,16 +824,16 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 			dirFiles := AudioFilesInDir(book.FilePath)
 			if len(dirFiles) > 0 {
 				// book.FilePath is a directory — write to each audio file found inside.
-								slog.Info("write-back is a directory; writing to audio file(s) inside", "path", book.FilePath, "file", len(dirFiles))
+				slog.Info("write-back is a directory; writing to audio file(s) inside", "path", book.FilePath, "file", len(dirFiles))
 				for _, f := range dirFiles {
 					if mfs.isProtectedPath(f) {
-												slog.Debug("skipping write-back for protected file", "value", f)
+						slog.Debug("skipping write-back for protected file", "value", f)
 						skippedProtected++
 						continue
 					}
 					fm := FilterUnchangedTags(f, fullTagMap)
 					if len(fm) == 0 {
-												slog.Debug("write-back all tags match, skipping", "value", f)
+						slog.Debug("write-back all tags match, skipping", "value", f)
 						continue
 					}
 					backupFileBeforeWrite(f)
@@ -963,16 +844,16 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 					if _, _, err := fileops.WriteTagsSafe(f, func(tmpPath string) error {
 						return metadata.WriteMetadataToFile(tmpPath, fm, opConfig)
 					}, wtsOpts); err != nil {
-												slog.Warn("write-back failed for", "value", f, "error", err)
+						slog.Warn("write-back failed for", "value", f, "error", err)
 					} else {
-												slog.Info("wrote metadata back to", "value", f)
+						slog.Info("wrote metadata back to", "value", f)
 						writtenCount++
 					}
 				}
 			} else {
 				fm := FilterUnchangedTags(book.FilePath, fullTagMap)
 				if len(fm) == 0 {
-										slog.Debug("write-back all tags match, skipping", "path", book.FilePath)
+					slog.Debug("write-back all tags match, skipping", "path", book.FilePath)
 				} else {
 					backupFileBeforeWrite(book.FilePath)
 					var wtsOpts fileops.WriteTagsSafeOptions
@@ -982,7 +863,7 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 					if _, _, err := fileops.WriteTagsSafe(book.FilePath, func(tmpPath string) error {
 						return metadata.WriteMetadataToFile(tmpPath, fm, opConfig)
 					}, wtsOpts); err != nil {
-												slog.Warn("write-back failed for", "path", book.FilePath, "error", err)
+						slog.Warn("write-back failed for", "path", book.FilePath, "error", err)
 					} else {
 						writtenCount++
 					}
@@ -1014,10 +895,10 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 				if _, _, err := fileops.WriteTagsSafe(sib.FilePath, func(tmpPath string) error {
 					return metadata.WriteMetadataToFile(tmpPath, tagMap, opConfig)
 				}, fileops.WriteTagsSafeOptions{}); err != nil {
-										slog.Warn("write-back failed for version-linked", "path", sib.FilePath, "error", err)
+					slog.Warn("write-back failed for version-linked", "path", sib.FilePath, "error", err)
 				} else {
 					writtenCount++
-										slog.Info("wrote metadata to version-linked copy", "path", sib.FilePath)
+					slog.Info("wrote metadata to version-linked copy", "path", sib.FilePath)
 				}
 			}
 		}
@@ -1036,7 +917,7 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 		ChangedAt:  now,
 	}
 	if err := mfs.db.RecordMetadataChange(record); err != nil {
-				slog.Warn("failed to record write-back history for", "id", book.ID, "error", err)
+		slog.Warn("failed to record write-back history for", "id", book.ID, "error", err)
 	}
 	// Dual-write to unified activity log (Task 16: tag_write)
 	if mfs.activityService != nil && writtenCount > 0 {
@@ -1053,14 +934,14 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 	// Stamp last_written_at
 	if writtenCount > 0 {
 		if err := mfs.db.SetLastWrittenAt(book.ID, now); err != nil {
-						slog.Warn("failed to stamp last_written_at for book", "id", book.ID, "error", err)
+			slog.Warn("failed to stamp last_written_at for book", "id", book.ID, "error", err)
 		}
 		// Flag for rescan so the next incremental scan re-reads the updated tags.
 		_ = mfs.db.MarkNeedsRescan(book.ID)
 	}
 
 	if skippedProtected > 0 {
-				slog.Info("write-back for book wrote file(s), skipped protected path(s)", "id", book.ID, "count", writtenCount-skippedProtected, "value", skippedProtected)
+		slog.Info("write-back for book wrote file(s), skipped protected path(s)", "id", book.ID, "count", writtenCount-skippedProtected, "value", skippedProtected)
 	}
 
 	return writtenCount, nil

--- a/internal/metafetch/service_writeback.go
+++ b/internal/metafetch/service_writeback.go
@@ -792,7 +792,7 @@ func (mfs *Service) writeBackForBook(id string, ov *writeBackOverrides, segmentF
 			}
 			backupFileBeforeWrite(bf.FilePath)
 			if _, _, err := fileops.WriteTagsSafe(bf.FilePath, func(tmpPath string) error {
-				return metadata.WriteMetadataToFile(tmpPath, tagMap, opConfig)
+				return metadata.WriteMetadataToFileInPlace(tmpPath, tagMap, opConfig)
 			}, fileops.WriteTagsSafeOptions{BookFileID: bf.ID, Store: mfs.db}); err != nil {
 				slog.Warn("write-back failed for file", "path", bf.FilePath, "error", err)
 			} else {
@@ -842,7 +842,7 @@ func (mfs *Service) writeBackForBook(id string, ov *writeBackOverrides, segmentF
 						wtsOpts = fileops.WriteTagsSafeOptions{BookFileID: bff.ID, Store: mfs.db}
 					}
 					if _, _, err := fileops.WriteTagsSafe(f, func(tmpPath string) error {
-						return metadata.WriteMetadataToFile(tmpPath, fm, opConfig)
+						return metadata.WriteMetadataToFileInPlace(tmpPath, fm, opConfig)
 					}, wtsOpts); err != nil {
 						slog.Warn("write-back failed for", "value", f, "error", err)
 					} else {
@@ -861,7 +861,7 @@ func (mfs *Service) writeBackForBook(id string, ov *writeBackOverrides, segmentF
 						wtsOpts = fileops.WriteTagsSafeOptions{BookFileID: bff.ID, Store: mfs.db}
 					}
 					if _, _, err := fileops.WriteTagsSafe(book.FilePath, func(tmpPath string) error {
-						return metadata.WriteMetadataToFile(tmpPath, fm, opConfig)
+						return metadata.WriteMetadataToFileInPlace(tmpPath, fm, opConfig)
 					}, wtsOpts); err != nil {
 						slog.Warn("write-back failed for", "path", book.FilePath, "error", err)
 					} else {
@@ -893,7 +893,7 @@ func (mfs *Service) writeBackForBook(id string, ov *writeBackOverrides, segmentF
 				}
 				backupFileBeforeWrite(sib.FilePath)
 				if _, _, err := fileops.WriteTagsSafe(sib.FilePath, func(tmpPath string) error {
-					return metadata.WriteMetadataToFile(tmpPath, tagMap, opConfig)
+					return metadata.WriteMetadataToFileInPlace(tmpPath, tagMap, opConfig)
 				}, fileops.WriteTagsSafeOptions{}); err != nil {
 					slog.Warn("write-back failed for version-linked", "path", sib.FilePath, "error", err)
 				} else {

--- a/internal/metafetch/service_writeback.go
+++ b/internal/metafetch/service_writeback.go
@@ -13,6 +13,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 	"log/slog"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -95,10 +96,30 @@ func (mfs *Service) writeBackMetadata(book *database.Book, meta metadata.BookMet
 		trackFmt := fmt.Sprintf("%%0%dd", digits)
 		for i, bf := range activeFiles {
 			trackNum := i + 1
-			segTitle := fmt.Sprintf(trackFmt+" - %s", trackNum, bookTitle)
+			generated := fmt.Sprintf(trackFmt+" - %s", trackNum, bookTitle)
 			trackStr := fmt.Sprintf("%d/%d", trackNum, totalTracks)
+
+			// Read the file's current tags ONCE and reuse them for both the
+			// chapter-title decision and the unchanged-tag filter. Previously
+			// FilterUnchangedTags did its own read, so adding the title check
+			// naively would have doubled the per-file tag reads.
+			cur, curErr := metadata.ExtractMetadata(bf.FilePath, nil)
+
+			segTitle := generated
+			if curErr == nil {
+				segTitle = chapterTitleFor(cur.Title, generated, bookTitle)
+			}
+
 			tagMap := mfs.BuildFullTagMap(book, bookTitle, segTitle, artistStr, narratorStr, year, trackStr)
-			tagMap = FilterUnchangedTags(bf.FilePath, tagMap)
+			if segTitle == "" {
+				// Preserve the file's real per-chapter title.
+				delete(tagMap, "title")
+			}
+			if curErr == nil {
+				tagMap = filterTagsAgainst(cur, tagMap)
+			}
+			// curErr != nil keeps the historical safe fallback: tags unreadable,
+			// so write everything rather than guess.
 			if len(tagMap) == 0 {
 				continue
 			}
@@ -288,6 +309,47 @@ func (mfs *Service) BuildTagMap(
 		tagMap["track"] = track
 	}
 	return tagMap
+}
+
+// generatedChapterTitleRe matches the synthetic per-file title this package
+// produces for multi-file books: a zero-padded track number, " - ", then the
+// book title (e.g. "01 - The Long Way Home").
+var generatedChapterTitleRe = regexp.MustCompile(`^\d+ - (.+)$`)
+
+// chapterTitleFor decides what to write into the "title" tag of one file of a
+// multi-file book. It returns the title to write, or "" meaning "leave the
+// file's existing title alone".
+//
+// The synthetic "NN - Book Title" form is only a fallback. Real per-chapter
+// titles ("Chapter 1: The Long Way Home", "Prologue", "Epilogue") are genuine
+// metadata worth keeping, and the write-back paths used to overwrite them
+// unconditionally on every run — so a library's chapter titles were flattened to
+// "01 - Book Title", "02 - Book Title", ... and the original text was gone.
+//
+// A title is treated as ours-to-replace when it is empty, when it is exactly the
+// book title (a bulk tag-set left every file identical, which carries no
+// per-chapter information), or when it already matches the synthetic pattern for
+// this book (so renumbering still works).
+func chapterTitleFor(currentTitle, generated, bookTitle string) string {
+	cur := strings.TrimSpace(currentTitle)
+	switch {
+	case cur == "":
+		return generated
+	case cur == bookTitle:
+		// Every file carrying the bare book title tells us nothing about which
+		// chapter it is; numbering them is strictly more informative.
+		return generated
+	case cur == generated:
+		// Already correct. Returning it lets the unchanged-tag filter drop it.
+		return generated
+	}
+	// "NN - <book title>" is our own output from a previous run; refresh it so a
+	// changed track count or book title still propagates. A different suffix means
+	// a human/publisher chapter title, which we keep.
+	if m := generatedChapterTitleRe.FindStringSubmatch(cur); m != nil && m[1] == bookTitle {
+		return generated
+	}
+	return ""
 }
 
 // buildFullTagMap constructs a tag map with ALL available metadata from the book record,
@@ -817,10 +879,27 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 		trackFmt := fmt.Sprintf("%%0%dd", digits)
 		for i, bf := range activeFiles {
 			trackNum := i + 1
-			segTitle := fmt.Sprintf(trackFmt+" - %s", trackNum, bookTitle)
+			generated := fmt.Sprintf(trackFmt+" - %s", trackNum, bookTitle)
 			trackStr := fmt.Sprintf("%d/%d", trackNum, totalTracks)
+
+			// One tag read per file, shared by the chapter-title decision and the
+			// unchanged-tag filter (see the identical loop in writeBackMetadata).
+			cur, curErr := metadata.ExtractMetadata(bf.FilePath, nil)
+
+			segTitle := generated
+			if curErr == nil {
+				segTitle = chapterTitleFor(cur.Title, generated, bookTitle)
+			}
+
 			tagMap := mfs.BuildFullTagMap(book, bookTitle, segTitle, artistStr, narratorStr, year, trackStr)
-			tagMap = FilterUnchangedTags(bf.FilePath, tagMap)
+			if segTitle == "" {
+				// Preserve the file's real per-chapter title.
+				delete(tagMap, "title")
+			}
+			if curErr == nil {
+				tagMap = filterTagsAgainst(cur, tagMap)
+			}
+			// curErr != nil keeps the historical safe fallback: write everything.
 			if len(tagMap) == 0 {
 								slog.Debug("write-back file tags already match, skipping", "path", bf.FilePath)
 				continue

--- a/internal/metafetch/service_writeback.go
+++ b/internal/metafetch/service_writeback.go
@@ -365,11 +365,44 @@ func FilterUnchangedTags(filePath string, tagMap map[string]interface{}) map[str
 		// Can't read current tags — write everything to be safe
 		return tagMap
 	}
+	return filterTagsAgainst(current, tagMap)
+}
 
+// filterTagsAgainst is the pure comparison half of FilterUnchangedTags, split
+// out so the mapping can be unit-tested against a constructed Metadata without
+// synthesizing a real audio file on disk.
+//
+// This split exists because every pre-existing FilterUnchangedTags test pointed
+// at a nonexistent path: ExtractMetadata failed, the function returned tagMap
+// untouched, and the comparison below never ran. Those tests passed no matter
+// what the mapping did — one of them even asserted that "track" survives,
+// pinning the bug in place as if it were intended behavior.
+func filterTagsAgainst(current metadata.Metadata, tagMap map[string]interface{}) map[string]interface{} {
 	// Build a map of known tag names to their current values. Every custom tag
 	// key emitted by the writer (via metadata/taglib_tagmap.go buildWriteTagMap)
 	// must have an entry here, mapping the input key to the corresponding
 	// Metadata field value.
+	// "track" is emitted unconditionally by the multi-file write path
+	// (BuildTagMap adds it whenever track != "", and the multi-file branch always
+	// passes "n/total"). Until this entry existed it fell through to the
+	// unknown-key branch below and was ALWAYS written, which made
+	// len(tagMap) == 0 unreachable for every multi-file book — so each one
+	// rewrote every one of its files on every single write-back run, forever.
+	//
+	// Render the on-disk value in the same "n/total" shape the writer produces.
+	// A file tagged with a bare "3" (TrackTotal == 0) renders as "3", won't match
+	// "3/12", and is written once — after which it carries the pair and matches.
+	// TrackNumber == 0 means we could not read a track at all: leave the key out
+	// so the unknown-key branch writes it, which is the correct conservative call.
+	trackCur := ""
+	if current.TrackNumber > 0 {
+		if current.TrackTotal > 0 {
+			trackCur = fmt.Sprintf("%d/%d", current.TrackNumber, current.TrackTotal)
+		} else {
+			trackCur = fmt.Sprintf("%d", current.TrackNumber)
+		}
+	}
+
 	currentVals := map[string]string{
 		"title":  current.Title,
 		"album":  current.Album,
@@ -401,6 +434,9 @@ func FilterUnchangedTags(filePath string, tagMap map[string]interface{}) map[str
 		"edition":         current.Edition,
 		"print_year":      current.PrintYear,
 	}
+	if trackCur != "" {
+		currentVals["track"] = trackCur
+	}
 	if current.Publisher != "" {
 		currentVals["publisher"] = current.Publisher
 	}
@@ -418,9 +454,12 @@ func FilterUnchangedTags(filePath string, tagMap map[string]interface{}) map[str
 	for k, v := range tagMap {
 		cur, ok := currentVals[k]
 		if !ok {
-			// Unknown field (e.g. "track") — always write.
+			// Unknown field — always write.
 			// Log unknown keys so new custom tags are added consciously to
 			// the mapping above rather than silently forcing writes.
+			// ("track" used to be the example here; it is mapped above now.
+			// This warn is only a real signal once every emitted key is mapped,
+			// so do not add new writer keys without a currentVals entry.)
 			slog.Warn("FilterUnchangedTags: unknown tag key (writing)", "key", k)
 			filtered[k] = v
 			continue

--- a/internal/metafetch/service_writeback_filtertags_test.go
+++ b/internal/metafetch/service_writeback_filtertags_test.go
@@ -1,0 +1,154 @@
+// file: internal/metafetch/service_writeback_filtertags_test.go
+// version: 1.0.0
+// guid: 7c1d9a04-2b6e-4f38-9d51-0a8e3b7c62f4
+// last-edited: 2026-08-15
+
+package metafetch
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/metadata"
+	"github.com/stretchr/testify/assert"
+)
+
+// The pre-existing FilterUnchangedTags tests all point at nonexistent paths, so
+// ExtractMetadata fails, the function returns tagMap untouched, and the mapping
+// is never executed. These tests drive the pure comparison directly so the
+// mapping is actually measured.
+
+// TestFilterTagsAgainst_MultiFileBookCanSkip is the regression test for the
+// defect this file was created for.
+//
+// The multi-file write-back branch always emits a "track" tag ("n/total"). Until
+// "track" was mapped in currentVals it hit the unknown-key branch and was always
+// written, so `len(tagMap) == 0` — the skip condition — was UNREACHABLE for every
+// multi-file book. Each one rewrote every one of its files on every run forever,
+// and since each write costs multiple full-file copies + hashes of the audio,
+// that was the dominant cost of write-back.
+//
+// With the fix, a book whose tags already match filters down to empty.
+func TestFilterTagsAgainst_MultiFileBookCanSkip(t *testing.T) {
+	current := metadata.Metadata{
+		Title:       "01 - Test Book",
+		Album:       "Test Book",
+		Artist:      "Test Author",
+		Genre:       "Audiobook",
+		TrackNumber: 1,
+		TrackTotal:  12,
+	}
+
+	// Exactly what the multi-file branch builds when nothing has changed.
+	tagMap := map[string]interface{}{
+		"title":  "01 - Test Book",
+		"album":  "Test Book",
+		"artist": "Test Author",
+		"genre":  "Audiobook",
+		"track":  "1/12",
+	}
+
+	filtered := filterTagsAgainst(current, tagMap)
+
+	assert.Empty(t, filtered,
+		"an unchanged multi-file book must filter to zero tags so write-back can skip it; "+
+			"a non-empty result here means every multi-file book rewrites every file every run")
+}
+
+// TestFilterTagsAgainst_TrackMatching pins the "n/total" rendering, including
+// the convergence case where the file carries a bare track number.
+func TestFilterTagsAgainst_TrackMatching(t *testing.T) {
+	tests := []struct {
+		name        string
+		trackNumber int
+		trackTotal  int
+		desired     string
+		wantWritten bool
+		why         string
+	}{
+		{
+			name:        "exact pair matches",
+			trackNumber: 3,
+			trackTotal:  12,
+			desired:     "3/12",
+			wantWritten: false,
+			why:         "identical track pair must not be rewritten",
+		},
+		{
+			name:        "different track number is written",
+			trackNumber: 4,
+			trackTotal:  12,
+			desired:     "3/12",
+			wantWritten: true,
+			why:         "a genuinely different track must still be written",
+		},
+		{
+			name:        "different total is written",
+			trackNumber: 3,
+			trackTotal:  99,
+			desired:     "3/12",
+			wantWritten: true,
+			why:         "total is part of the value and must be corrected",
+		},
+		{
+			name:        "bare track number converges after one write",
+			trackNumber: 3,
+			trackTotal:  0,
+			desired:     "3/12",
+			wantWritten: true,
+			why: "file tagged '3' renders as '3', differs from '3/12', written once; " +
+				"after that write it carries the pair and matches on the next run",
+		},
+		{
+			name:        "unreadable track is written",
+			trackNumber: 0,
+			trackTotal:  0,
+			desired:     "3/12",
+			wantWritten: true,
+			why:         "TrackNumber==0 means we could not read a track; writing is the safe call",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current := metadata.Metadata{
+				TrackNumber: tt.trackNumber,
+				TrackTotal:  tt.trackTotal,
+			}
+			filtered := filterTagsAgainst(current, map[string]interface{}{"track": tt.desired})
+
+			if tt.wantWritten {
+				assert.Contains(t, filtered, "track", tt.why)
+			} else {
+				assert.NotContains(t, filtered, "track", tt.why)
+			}
+		})
+	}
+}
+
+// TestFilterTagsAgainst_ChangedValuesStillWritten is the counterweight: the fix
+// must not turn the filter into a blanket "skip everything". Without decoy
+// changed fields, a broken implementation that drops all tags would pass the
+// skip test above.
+func TestFilterTagsAgainst_ChangedValuesStillWritten(t *testing.T) {
+	current := metadata.Metadata{
+		Title:       "01 - Old Title",
+		Album:       "Old Album",
+		Artist:      "Old Author",
+		TrackNumber: 1,
+		TrackTotal:  12,
+	}
+
+	tagMap := map[string]interface{}{
+		"title":  "01 - New Title",
+		"album":  "New Album",
+		"artist": "Old Author", // unchanged — must be dropped
+		"track":  "1/12",       // unchanged — must be dropped
+	}
+
+	filtered := filterTagsAgainst(current, tagMap)
+
+	assert.Equal(t, map[string]interface{}{
+		"title": "01 - New Title",
+		"album": "New Album",
+	}, filtered, "only genuinely changed fields may survive the filter")
+}

--- a/internal/metafetch/service_writeback_filtertags_test.go
+++ b/internal/metafetch/service_writeback_filtertags_test.go
@@ -125,6 +125,78 @@ func TestFilterTagsAgainst_TrackMatching(t *testing.T) {
 	}
 }
 
+// TestChapterTitleFor covers the per-chapter title preservation rule.
+//
+// Both multi-file write paths used to overwrite the title tag of every file with
+// a synthetic "NN - Book Title" on every run, so real chapter titles were
+// destroyed and could not be recovered. "" means "leave the existing title".
+func TestChapterTitleFor(t *testing.T) {
+	const bookTitle = "The Long Way Home"
+
+	tests := []struct {
+		name    string
+		current string
+		want    string
+		why     string
+	}{
+		{
+			name:    "real chapter title is preserved",
+			current: "Chapter 1: Departure",
+			want:    "",
+			why:     "publisher chapter titles are the metadata the owner wants kept",
+		},
+		{
+			name:    "single-word chapter title is preserved",
+			current: "Prologue",
+			want:    "",
+			why:     "short titles are still real titles",
+		},
+		{
+			name:    "numbered title for a DIFFERENT book is preserved",
+			current: "05 - Some Other Book",
+			want:    "",
+			why:     "matches the numeric shape but the suffix is not this book, so it is not ours",
+		},
+		{
+			name:    "empty title is synthesized",
+			current: "",
+			want:    "01 - The Long Way Home",
+			why:     "nothing to preserve",
+		},
+		{
+			name:    "whitespace-only title is synthesized",
+			current: "   ",
+			want:    "01 - The Long Way Home",
+			why:     "blank after trimming carries no information",
+		},
+		{
+			name:    "bare book title is synthesized",
+			current: bookTitle,
+			want:    "01 - The Long Way Home",
+			why:     "every file carrying the same book title says nothing about which chapter it is",
+		},
+		{
+			name:    "our own previous output is refreshed",
+			current: "07 - The Long Way Home",
+			want:    "01 - The Long Way Home",
+			why:     "renumbering must still propagate when the track count changed",
+		},
+		{
+			name:    "already correct value is returned unchanged",
+			current: "01 - The Long Way Home",
+			want:    "01 - The Long Way Home",
+			why:     "returning it lets the unchanged-tag filter drop it as a no-op",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := chapterTitleFor(tt.current, "01 - The Long Way Home", bookTitle)
+			assert.Equal(t, tt.want, got, tt.why)
+		})
+	}
+}
+
 // TestFilterTagsAgainst_ChangedValuesStillWritten is the counterweight: the fix
 // must not turn the filter into a blanket "skip everything". Without decoy
 // changed fields, a broken implementation that drops all tags would pass the

--- a/internal/metafetch/service_writeback_realfile_test.go
+++ b/internal/metafetch/service_writeback_realfile_test.go
@@ -1,0 +1,123 @@
+// file: internal/metafetch/service_writeback_realfile_test.go
+// version: 1.0.0
+// guid: 3e5f7a91-8c24-4b6d-a017-5d92c4e8b3f0
+// last-edited: 2026-08-15
+
+package metafetch
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/fileops"
+	"github.com/falkcorp/audiobook-organizer/internal/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeTestAudio synthesizes a real, valid audio file with ffmpeg. Skips the test
+// when ffmpeg is unavailable rather than failing, so the suite still runs in
+// environments without it.
+func makeTestAudio(t *testing.T, name string) string {
+	t.Helper()
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not available; skipping real-file write-back test")
+	}
+	path := filepath.Join(t.TempDir(), name)
+	cmd := exec.Command("ffmpeg", "-hide_banner", "-loglevel", "error",
+		"-f", "lavfi", "-i", "anullsrc=r=44100:cl=mono", "-t", "1",
+		"-c:a", "aac", path)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "ffmpeg failed to synthesize test audio: %s", out)
+	require.FileExists(t, path)
+	return path
+}
+
+// TestWriteBackRoundTrip_RealFile exercises the ACTUAL write path end to end on
+// a real audio file: fileops.WriteTagsSafe wrapping the in-place writer, then a
+// read-back, then the unchanged-tag filter.
+//
+// Everything else in this package's tests runs against constructed Metadata
+// structs, which proves the comparison logic but cannot prove that the de-nested
+// writer still produces a valid file with the right tags. This closes that gap.
+func TestWriteBackRoundTrip_RealFile(t *testing.T) {
+	path := makeTestAudio(t, "roundtrip.m4a")
+
+	before, err := os.Stat(path)
+	require.NoError(t, err)
+
+	tagMap := map[string]interface{}{
+		"title":  "01 - The Long Way Home",
+		"album":  "The Long Way Home",
+		"artist": "Test Author",
+		"genre":  "Audiobook",
+		"track":  "1/12",
+	}
+
+	// This is exactly the shape the multi-file write path uses: an outer
+	// WriteTagsSafe whose writeFn is the IN-PLACE writer. Before the de-nesting
+	// fix the writeFn re-entered WriteTagsSafe, doubling the copies and hashes.
+	_, _, err = fileops.WriteTagsSafe(path, func(tmpPath string) error {
+		return metadata.WriteMetadataToFileInPlace(tmpPath, tagMap, fileops.OperationConfig{})
+	}, fileops.WriteTagsSafeOptions{})
+	require.NoError(t, err, "the de-nested write path must succeed on a real file")
+
+	// The file must still be a valid, readable audio file — a de-nesting bug
+	// could plausibly leave a truncated or unrenamed temp file behind.
+	after, err := os.Stat(path)
+	require.NoError(t, err, "original path must still exist after the atomic rename")
+	assert.Greater(t, after.Size(), int64(0), "file must not be truncated")
+	assert.Equal(t, before.Mode().Perm(), after.Mode().Perm(),
+		"permissions must survive the copy+rename (an 0600 regression once locked out every non-owner reader)")
+
+	// Tags must actually have landed.
+	got, err := metadata.ExtractMetadata(path, nil)
+	require.NoError(t, err, "written file must be readable")
+	assert.Equal(t, "01 - The Long Way Home", got.Title)
+	assert.Equal(t, "The Long Way Home", got.Album)
+	assert.Equal(t, "Test Author", got.Artist)
+	assert.Equal(t, 1, got.TrackNumber, "track number must round-trip")
+
+	// THE payoff: re-filtering the same tag map against the file we just wrote
+	// must come back empty, i.e. a second write-back run skips this file
+	// entirely. This is the behaviour that was impossible before the track fix —
+	// len(tagMap) == 0 was unreachable for any multi-file book, so every run
+	// rewrote every file forever.
+	filtered := FilterUnchangedTags(path, tagMap)
+	assert.Empty(t, filtered,
+		"a second write-back over unchanged tags must filter to zero and skip the file; "+
+			"got %v", filtered)
+}
+
+// TestWriteBackRoundTrip_RealFile_ChangedTagStillWrites is the negative control.
+// Without it, a filter that simply dropped everything would pass the test above.
+func TestWriteBackRoundTrip_RealFile_ChangedTagStillWrites(t *testing.T) {
+	path := makeTestAudio(t, "changed.m4a")
+
+	initial := map[string]interface{}{
+		"title":  "01 - Original",
+		"album":  "Original Album",
+		"artist": "Test Author",
+		"track":  "1/12",
+	}
+	_, _, err := fileops.WriteTagsSafe(path, func(tmpPath string) error {
+		return metadata.WriteMetadataToFileInPlace(tmpPath, initial, fileops.OperationConfig{})
+	}, fileops.WriteTagsSafeOptions{})
+	require.NoError(t, err)
+
+	// Same file, but the album genuinely changed.
+	changed := map[string]interface{}{
+		"title":  "01 - Original",   // unchanged
+		"album":  "Corrected Album", // CHANGED
+		"artist": "Test Author",     // unchanged
+		"track":  "1/12",            // unchanged
+	}
+
+	filtered := FilterUnchangedTags(path, changed)
+
+	assert.Contains(t, filtered, "album", "a genuinely changed tag must still be written")
+	assert.NotContains(t, filtered, "track", "an unchanged track must not force a write")
+	assert.NotContains(t, filtered, "artist", "an unchanged artist must not force a write")
+}

--- a/internal/tagger/safe_write.go
+++ b/internal/tagger/safe_write.go
@@ -1,7 +1,7 @@
 // file: internal/tagger/safe_write.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 4a7e1c3b-9f02-4d85-b8e6-2f5a0d3c7b91
-// last-edited: 2026-05-01
+// last-edited: 2026-08-15
 //
 // WriteTagsSafe / WriteImageSafe — pre-flight guard for all taglib writes.
 //
@@ -78,6 +78,40 @@ func WriteTagsSafe(ctx context.Context, path string, tags map[string][]string, o
 	}, fileops.WriteTagsSafeOptions{})
 	if err != nil {
 		return fmt.Errorf("WriteTagsSafe: %w", err)
+	}
+	return nil
+}
+
+// WriteTagsInPlace writes tags directly to path with NO copy-and-rename wrapper
+// and NO protected-path resolution.
+//
+// Use this ONLY when the caller is already operating on a temp copy produced by
+// an outer fileops.WriteTagsSafe, and has already made the protected-path
+// decision on the real path. Writing to a live library file through this
+// function bypasses the atomic-rename safety net — call WriteTagsSafe instead.
+//
+// Why this exists: the write-back path wrapped every tag write in
+// fileops.WriteTagsSafe and then called a writer that wrapped it AGAIN. Each
+// wrapper hashes the whole file twice and copies it once, so one tag write cost
+// four full-file SHA-256 passes and two full-file copies of the audio — and the
+// inner pair was discarded, because the inner call passed empty options and
+// ignored its return values. On NAS-backed multi-hundred-MB files that redundant
+// I/O, not the tag encoding, was the cost of write-back. The inner wrapper also
+// protected nothing the outer one did not already cover: if the tag write
+// corrupts its target and still returns nil, the outer rename publishes it
+// either way.
+func WriteTagsInPlace(path string, tags map[string][]string, opts taglib.WriteOption) error {
+	if err := taglib.WriteTags(path, tags, opts); err != nil {
+		return fmt.Errorf("WriteTagsInPlace: %w", err)
+	}
+	return nil
+}
+
+// WriteImageInPlace embeds cover art directly into path with no copy-and-rename
+// wrapper. Same contract and same caveats as WriteTagsInPlace.
+func WriteImageInPlace(path string, data []byte) error {
+	if err := taglib.WriteImage(path, data); err != nil {
+		return fmt.Errorf("WriteImageInPlace: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Write-back was slow for two reasons, neither of which was a missing worker pool. Both are fixed here; the parallelism work is a separate PR.

## Root cause 1: a self-sustaining rewrite loop (two bugs cancelling)

The multi-file write path always emits a `track` tag. Two independent defects made that permanent:

1. `FilterUnchangedTags` had no `currentVals` entry for `track`, so it fell through to the "unknown key — always write" branch. The code documented this as intended: `// Unknown field (e.g. "track") — always write.`
2. **`buildWriteTagMap` had no case for `track` at all** — the taglib writers silently discarded it.

So: emit track → filter forces a write → writer drops track → file never gets a track tag → next read finds none → repeat. **Every multi-file book rewrote every one of its files on every write-back run, forever, for the sake of a tag that never landed.**

Fixing either half alone does nothing. With the tag never on disk, `TrackNumber` stays 0 and the key stays unmapped, so the loop continues.

## Root cause 2: every tag write wrapped the file twice

`fileops.WriteTagsSafe` hashes the whole file, copies it, runs `writeFn` on the copy, renames, hashes again. The write-back paths called it with a `writeFn` that was *itself* another `WriteTagsSafe`:

```
WriteTagsSafe(real)                       hash + copy
 └─ WriteMetadataToFile(tmp)
     └─ writeMetadataWithTaglib(tmp)
         └─ WriteTagsSafe(tmp)            hash + copy   ← again
```

**4 full-file SHA-256 passes + 2 full-file copies** of the audio per file per write. The inner call passed empty options and discarded both return values, so half of it produced nothing. `ComputeFileHash` streams the entire file with no size cap. On NAS-backed audiobooks this redundant I/O, not tag encoding, was the cost.

## Also fixed

- **Per-chapter titles were being destroyed.** Both multi-file paths overwrote `title` on every file with a synthetic `"NN - Book Title"` every run. "Chapter 1: Departure" → "01 - Book Title", unrecoverably — and root cause 1 meant this happened on *every* run.
- **Cover art was all-or-nothing per book.** `embedCoverInBookFiles` compared only `files[0]` and returned for the whole book on a match, so files missing artwork stayed missing permanently. Now per file, so every file of a multi-file book gets the image while identical ones are still skipped.
- **The two write-back implementations are now one.** The fetch/apply path had a ~160-line near-duplicate whose only distinct input was three fallback values. They had drifted: the duplicate never embedded covers from an already-downloaded local cover, never propagated to version-group siblings, never redirected protected paths to the library copy, and never stamped `LastWrittenAt` for multi-file books. 179 lines → 25; exported signature unchanged, so all nine callers and the mocks are untouched.

## Net effect per file write

| | before | after |
|---|---|---|
| unchanged multi-file book | full rewrite of every file, every run | **skipped entirely** |
| write with fidelity hashes | 4 hashes + 2 copies | 2 hashes + 1 copy |
| write without | 4 hashes + 2 copies | 0 hashes + 1 copy |

## Verification

**The unit tests could not have caught root cause 1.** `FilterUnchangedTags`'s three pre-existing tests all pointed at nonexistent paths, so `ExtractMetadata` failed, the function returned early, and the mapping never ran — they passed regardless of what it did, and one asserted that `track` survives, pinning the bug in place as expected behaviour.

- Split the pure comparison out as `filterTagsAgainst` so it can be tested against a constructed `Metadata`.
- **Added an end-to-end test on a real ffmpeg-synthesized audio file.** It writes through the actual path, reads back, and asserts a second pass filters to **zero**. This is what exposed the writer-side half — a test on constructed structs cannot catch a writer that never writes. A negative control asserts a genuinely changed tag is still written.
- **Both fixes mutation-tested.** Disabling the `track` mapping fails 3 tests with `Should be empty, but was map[track:1/12]` — the literal production symptom. Reverting the title logic to always-overwrite fails 4.
- Both build variants compile, including `-tags native_taglib` (production).
- `internal/metafetch`, `internal/metadata`, `internal/tagger`, `internal/fileops`, `internal/organizer`, `internal/audiobooks`: 6/6 packages pass.

## Not verified

No before/after wall-clock timing on a real library cohort. Correctness is measured; the speedup is still inferred from the removed I/O.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS