### PR TITLE
docs(handoffs): correct native-taglib risk statement and mark PRs merged

### DIFF
--- a/changelog.d/20260815_140000_handoff_native_linkcheck.md
+++ b/changelog.d/20260815_140000_handoff_native_linkcheck.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Handoff doc now states the native-taglib verification status accurately: the
+  production CGO build compiles and links with the write-back changes, and the
+  de-nesting pattern is runtime-verified through the WASM writer; what remains
+  unexecuted is the CGO binding itself.

--- a/docs/handoffs/2026-08-15-writeback-io-and-parallelism-session.md
+++ b/docs/handoffs/2026-08-15-writeback-io-and-parallelism-session.md
@@ -115,9 +115,10 @@ production symptom; revert the title logic → 4 fail).
 
 | | |
 |---|---|
-| Branch #2468 | `perf/writeback-io-amplification`, 7 commits, CI running at handoff |
-| Branch #2469 | `perf/server-metadata-parallelism` (agent-authored), CI running |
-| Worktrees | `.worktrees/writeback-io-amp`, `.worktrees/server-parallelism` — remove after merge |
+| #2468 | **MERGED** (`7c591529` on main) — write/tag correctness + I/O |
+| #2469 | **MERGED** — server parallelism (agent-authored) |
+| Worktrees | clean; `git worktree list` shows main only |
+| Open PRs | zero |
 | Local tests | metafetch, metadata, tagger, fileops, organizer, audiobooks: **6/6 pass** |
 | Known-noise | see below — **resolved**, they are slow, not broken |
 
@@ -137,11 +138,12 @@ to raise the timeout or split the packages, not to chase a phantom bug.
 
 ## Next actions, in order
 
-1. **Merge #2468 and #2469** once CI is green (required set: `Minimal CI / Minimal
-   CI Summary`, `Require changelog fragment`, `TODO Fragment Headers`).
-2. **Close the native-taglib gap before a bulk run.** Either build the static libs
-   locally, or deploy and run a *small* write-back cohort first and verify with
-   `ffprobe` that tags landed and files are intact.
+1. ~~Merge #2468 and #2469~~ — **done**, both merged, main at `7c591529`.
+2. **Deploy (`make deploy-debug`), then canary before any bulk run.** Pick a
+   handful of multi-file books, run write-back, and check with `ffprobe` that the
+   track tag landed, chapter titles survived, cover art is present in EVERY file,
+   and the audio is intact. Then run it a **second** time and confirm it writes
+   **0** files. That single check exercises both root causes at once.
 3. **Measure.** Nothing here has a stopwatch on it. The removed I/O is provable
    from the code; the wall-clock saving is not yet measured. Run write-back twice
    over a fixed unchanged cohort — the second run must write **0** files. Today

--- a/docs/handoffs/2026-08-15-writeback-io-and-parallelism-session.md
+++ b/docs/handoffs/2026-08-15-writeback-io-and-parallelism-session.md
@@ -1,5 +1,5 @@
 <!-- file: docs/handoffs/2026-08-15-writeback-io-and-parallelism-session.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 2d84f0a6-7e13-4b95-8c02-6f1a9d3e5b74 -->
 <!-- last-edited: 2026-08-15 -->
 
@@ -19,12 +19,28 @@ supervised deploy:
 - **#2469** `perf/server-metadata-parallelism` — the multithreading migration
 
 The reason is specific, not caution theatre: **production compiles with
-`-tags native_taglib` (CGO), and that code path has never been executed against a
-real file.** The static libs in `third_party/taglib/lib/` are absent on darwin, so
-`go test -tags native_taglib` fails to link locally, and CI builds the WASM
-variant. The native writer is type-checked only. Since this PR changes *how tags
-get written*, that gap should be closed on the box (or with a canary on a small
-cohort) before a full-library write-back runs.
+`-tags native_taglib` (CGO), and that writer has never been executed against a
+real file.**
+
+Precisely what is and is not established:
+
+- ✅ **It compiles and links.** `CC=x86_64-linux-musl-gcc GOOS=linux GOARCH=amd64
+  CGO_ENABLED=1 go build -tags "fts5 pprof native_taglib" .` produces a real
+  x86-64 ELF binary with the changes in. The static libs in
+  `third_party/taglib/lib/` are **musl/linux** archives — that is why a *darwin*
+  test binary cannot link them and `go test -tags native_taglib` fails locally.
+- ✅ **The de-nesting pattern is runtime-verified** — through the WASM writer,
+  against a real ffmpeg-synthesized file, including a full write → read-back →
+  second-pass-skips-everything cycle.
+- ❌ **The CGO binding itself has not executed.** `writeMetadataWithTaglibInPlace`
+  → `writeTagMapWithTaglib(abs, abs, tags)` has never run. The change there is
+  small and mechanical (that function opens its *second* argument and uses the
+  first only for error strings, so passing the same path twice writes in place),
+  but "small and mechanical" is an argument, not a measurement.
+
+So: deploy, then run a **small** write-back cohort and confirm with `ffprobe`
+that tags landed and the files are intact, before turning it loose on the
+library. Do not go straight to a full-library run.
 
 ## What was actually wrong (the headline)
 


### PR DESCRIPTION
Follow-up to #2468/#2469, docs only.

The handoff said the native-taglib writer was "type-checked only". That understates what was established and overstates the risk — the reader is using this doc to decide whether to deploy, so accuracy matters in both directions.

Corrected to state precisely what holds:

- ✅ **Compiles and links.** `CC=x86_64-linux-musl-gcc GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -tags "fts5 pprof native_taglib" .` produces a working x86-64 ELF binary with the changes in. The static libs in `third_party/taglib/lib/` are musl/linux archives, which is why a *darwin* test binary can't link them.
- ✅ **The de-nesting pattern is runtime-verified** through the WASM writer against a real ffmpeg-synthesized file (write → read back → second pass skips everything).
- ❌ **The CGO binding itself has not executed.** Small and mechanical, but that's an argument, not a measurement.

Also marks both PRs merged and sharpens the canary step into a concrete check that exercises both root causes at once: write-back a few multi-file books, verify with `ffprobe`, then run it again and confirm it writes **0** files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS