### PR TITLE
perf(metadata): apply returns immediately — cover download was ~4s of a measured 6.44s request

### DIFF
--- a/changelog.d/20260815_154500_async_cover_download.md
+++ b/changelog.d/20260815_154500_async_cover_download.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **Applying metadata to a book returns immediately instead of waiting on a cover
+  download.** Measured on production: a single-book apply took **6.44s**, and ~4s
+  of that was a synchronous cover-art HTTP download sitting on the request path —
+  its code comment described it as a "fast network fetch". Everything else the
+  apply does (tag writes, rename, write-back) was already backgrounded. The
+  download now runs in the background file-IO pool, ahead of the cover embed so
+  the newly fetched image is the one embedded. The cover appears a moment after
+  the rest of the metadata.

--- a/internal/metafetch/service_apply.go
+++ b/internal/metafetch/service_apply.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_apply.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 6ca469ca-7d2e-4738-b6f1-ae09449ed9e4
-// last-edited: 2026-07-13
+// last-edited: 2026-08-15
 
 package metafetch
 
@@ -601,20 +601,24 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 		slog.Warn("generate segment titles failed for", "id", id, "error", err)
 	}
 
-	// Download cover art (fast network fetch + file write — keep inline so
-	// the response includes the updated cover_url for the UI).
+	// Cover art is downloaded in the BACKGROUND — see pendingCover below.
+	//
+	// It used to run inline, with a comment calling it a "fast network fetch".
+	// Measured on production 2026-08-15, applying metadata to one book: the
+	// request took 6.44s end to end and ~4s of that was this download. Everything
+	// else the apply path does (tags, rename, write-back) was already backgrounded
+	// through the file-IO pool, so this single call was the majority of the wait
+	// a user sees after clicking Apply.
+	//
+	// The response no longer carries the final local cover_url. That is the
+	// deliberate trade: the caller gets the book back immediately and the cover
+	// appears a moment later. FetchMetadataResponse.PendingCoverURL has existed
+	// (documented as "set by ApplyMetadataCandidate for background download")
+	// since before this change but was never set or read by anything — the idea
+	// predates the measurement; only the wiring was missing.
+	pendingCover := ""
 	if meta.CoverURL != "" && config.AppConfig.RootDir != "" {
-		coverPath, coverErr := metadata.DownloadCoverArt(meta.CoverURL, config.AppConfig.RootDir, id)
-		if coverErr != nil {
-			slog.Warn("cover art download failed for", "id", id, "error", coverErr)
-		} else {
-			slog.Info("cover art saved to", "path", coverPath)
-			localCoverURL := "/api/v1/covers/local/" + filepath.Base(coverPath)
-			if updatedBook != nil {
-				updatedBook.CoverURL = &localCoverURL
-				mfs.db.UpdateBook(id, updatedBook)
-			}
-		}
+		pendingCover = meta.CoverURL
 	}
 
 	// Queue background ISBN/ASIN enrichment if identifiers are missing
@@ -644,10 +648,47 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 	// subsequent scan to hit the external API again.
 
 	return &FetchMetadataResponse{
-		Message: "metadata candidate applied",
-		Book:    updatedBook,
-		Source:  candidate.Source,
+		Message:         "metadata candidate applied",
+		Book:            updatedBook,
+		Source:          candidate.Source,
+		PendingCoverURL: pendingCover,
 	}, nil
+}
+
+// DownloadPendingCover fetches a candidate's cover art and points the book at
+// the local copy. Intended to run in the background off the request path — see
+// the comment in ApplyMetadataCandidate for why.
+//
+// Safe to call with an empty URL (no-op) and safe to call concurrently for
+// different books; DownloadCoverArt writes to a per-book path and skips when the
+// file already exists.
+func (mfs *Service) DownloadPendingCover(bookID, coverURL string) {
+	if bookID == "" || coverURL == "" || config.AppConfig.RootDir == "" {
+		return
+	}
+
+	coverPath, err := metadata.DownloadCoverArt(coverURL, config.AppConfig.RootDir, bookID)
+	if err != nil {
+		slog.Warn("background cover art download failed", "id", bookID, "error", err)
+		return
+	}
+	slog.Info("cover art saved to", "path", coverPath, "id", bookID)
+
+	// Re-read rather than reusing the book the caller had: the apply path and the
+	// background file-IO job both write this row, and UpdateBook does a full
+	// column replacement, so writing a stale struct here would silently revert
+	// whatever landed in between.
+	book, err := mfs.db.GetBookByID(bookID)
+	if err != nil || book == nil {
+		slog.Warn("background cover art: book vanished before cover_url update", "id", bookID, "error", err)
+		return
+	}
+
+	localCoverURL := "/api/v1/covers/local/" + filepath.Base(coverPath)
+	book.CoverURL = &localCoverURL
+	if _, err := mfs.db.UpdateBook(bookID, book); err != nil {
+		slog.Warn("background cover art: failed to update cover_url", "id", bookID, "error", err)
+	}
 }
 
 func appendMetadataVersionNote(book *database.Book, marker string) {

--- a/internal/server/handlers/metadata/handler.go
+++ b/internal/server/handlers/metadata/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/handler.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: 54bb4ad0-cab0-41fc-b9cb-557c96beee44
-// last-edited: 2026-08-11
+// last-edited: 2026-08-15
 
 // Package metadatahandler hosts the metadata-domain HTTP handlers extracted
 // from the server package's metadata_handlers.go: batch-update / validate /
@@ -618,7 +618,16 @@ func (h *Handler) applyAudiobookMetadataImpl(c *gin.Context) {
 	if pool := h.fileIOPool; pool != nil {
 		bookID := id
 		mfs := h.metadataFetchService
+		pendingCover := resp.PendingCoverURL
 		pool.Submit(bookID, func() {
+			// Cover download runs FIRST and in the background. It used to run
+			// inline in ApplyMetadataCandidate, where it was ~4s of a measured
+			// 6.44s request. It has to precede the file I/O below because
+			// ApplyMetadataFileIO embeds the cover into the audio files, and an
+			// embed that runs before the download would embed the previous image.
+			if pendingCover != "" {
+				mfs.DownloadPendingCover(bookID, pendingCover)
+			}
 			mfs.ApplyMetadataFileIO(bookID)
 			if shouldWriteBack {
 				if _, wbErr := mfs.WriteBackMetadataForBook(bookID); wbErr != nil {

--- a/internal/server/handlers/metadata/interfaces.go
+++ b/internal/server/handlers/metadata/interfaces.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/interfaces.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: b1ab2e4a-1f73-42f2-955d-c4a30f0fbaac
-// last-edited: 2026-07-13
+// last-edited: 2026-08-15
 
 // Narrow dependency interfaces for the metadata-domain HTTP handlers (the 19
 // per-book + library metadata endpoints extracted from the server package's
@@ -106,6 +106,11 @@ type MetadataFetchService interface {
 	SearchMetadataForBookWithOptions(id, query, author, narrator, series string, opts metafetch.SearchOptions) (*metafetch.SearchMetadataResponse, error)
 	ApplyMetadataCandidate(id string, candidate metafetch.MetadataCandidate, fields []string) (*metafetch.FetchMetadataResponse, error)
 	ApplyMetadataFileIO(id string)
+
+	// DownloadPendingCover fetches the candidate's cover art and repoints the
+	// book at the local copy. Runs in the background: it was ~4s of a measured
+	// 6.44s apply request when it ran inline.
+	DownloadPendingCover(bookID, coverURL string)
 	WriteBackMetadataForBook(id string, segmentFilter ...[]string) (int, error)
 	MarkNoMatch(id string) error
 	RunApplyPipelineRenameOnly(id string, book *database.Book) error

--- a/internal/server/handlers/metadata/mocks/mock_metadata_fetch_service.go
+++ b/internal/server/handlers/metadata/mocks/mock_metadata_fetch_service.go
@@ -206,6 +206,52 @@ func (_c *MockMetadataFetchService_ApplyMetadataSystemTags_Call) RunAndReturn(ru
 	return _c
 }
 
+// DownloadPendingCover provides a mock function for the type MockMetadataFetchService
+func (_mock *MockMetadataFetchService) DownloadPendingCover(bookID string, coverURL string) {
+	_mock.Called(bookID, coverURL)
+	return
+}
+
+// MockMetadataFetchService_DownloadPendingCover_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DownloadPendingCover'
+type MockMetadataFetchService_DownloadPendingCover_Call struct {
+	*mock.Call
+}
+
+// DownloadPendingCover is a helper method to define mock.On call
+//   - bookID string
+//   - coverURL string
+func (_e *MockMetadataFetchService_Expecter) DownloadPendingCover(bookID any, coverURL any) *MockMetadataFetchService_DownloadPendingCover_Call {
+	return &MockMetadataFetchService_DownloadPendingCover_Call{Call: _e.mock.On("DownloadPendingCover", bookID, coverURL)}
+}
+
+func (_c *MockMetadataFetchService_DownloadPendingCover_Call) Run(run func(bookID string, coverURL string)) *MockMetadataFetchService_DownloadPendingCover_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockMetadataFetchService_DownloadPendingCover_Call) Return() *MockMetadataFetchService_DownloadPendingCover_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockMetadataFetchService_DownloadPendingCover_Call) RunAndReturn(run func(bookID string, coverURL string)) *MockMetadataFetchService_DownloadPendingCover_Call {
+	_c.Run(run)
+	return _c
+}
+
 // FetchAndCache provides a mock function for the type MockMetadataFetchService
 func (_mock *MockMetadataFetchService) FetchAndCache(ctx context.Context, bookID string, query string, author string, narrator string, series string, opts metafetch.SearchOptions) (*metafetch.MetadataCandidateCache, error) {
 	ret := _mock.Called(ctx, bookID, query, author, narrator, series, opts)


### PR DESCRIPTION
Measured on production while applying metadata to one book ("All You Zombies"):

```
POST .../search-metadata   → 13.01s
POST .../apply-metadata    →  6.44s   ← the click-wait
```

Journal breakdown of that 6.44s:

```
~10:40:38.6  apply starts
 10:40:42.635  "cover art saved to .../01KNDC12DFBH9DQWA328M467KR.jpg"   ← ~4s
 10:40:42.752  book path updated
 10:40:42.877  wrote metadata tags
 10:40:45      response returned
```

**~4 of the 6.44 seconds was a synchronous cover-art HTTP download on the request path.** Its comment described it as a "fast network fetch". Everything else the apply path does — cover embed, tag writes, rename, write-back — was *already* dispatched to the background file-IO pool. This one call was the majority of the wait.

## The fix was half-written already

`FetchMetadataResponse.PendingCoverURL` exists and is documented as *"set by ApplyMetadataCandidate for background download"* — but a repo-wide grep shows it is **never set and never read**. The idea predates the measurement; only the wiring was missing. This finishes it.

## Details worth reviewing

- **Ordering is deliberate.** The download is submitted to the pool *before* `ApplyMetadataFileIO`, because that step embeds the cover into the audio files. Embedding before the download completes would embed the previous image.
- **`DownloadPendingCover` re-reads the book** before writing `cover_url` instead of reusing the caller's struct. `UpdateBook` does full column replacement, and both the apply path and the background file-IO job write this row — persisting a stale struct would silently revert whatever landed in between.
- **Trade-off:** the apply response no longer carries the final local `cover_url`. The caller gets the book back at once; the cover follows a moment later.

## Verification

`go build ./...` exit 0, `go vet` (which compiles tests) exit 0, `internal/server/handlers/metadata` and `internal/metafetch` both pass. Mocks regenerated via `make mocks`.

Not yet measured post-change on prod — that needs a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS