### PR TITLE
feat(metadata): centralized rate limiting so fetch can safely fan out

### DIFF
--- a/changelog.d/20260815_150000_provider_rate_limiting.md
+++ b/changelog.d/20260815_150000_provider_rate_limiting.md
@@ -1,0 +1,14 @@
+### Added
+
+- **Centralized outbound rate limiting for every metadata provider**
+  (`internal/metadata/providerhttp`). Five of the six providers (Audible,
+  Audnexus, Google Books, OpenLibrary, Wikipedia) previously had no throttling at
+  all — just a 30s timeout — and there was no jitter, backoff, or 429/`Retry-After`
+  handling anywhere. Hardcover's limiter was a process-wide mutex + sleep that
+  serialized every caller instead of pacing them, which blocked any fan-out.
+
+  The limiter lives in the `http.RoundTripper`, so a request cannot bypass it by
+  forgetting to call `Wait()`. Includes 429/`Retry-After` handling (both
+  delta-seconds and HTTP-date forms), exponential backoff with jitter, and
+  context-aware waiting. Cover-art downloads are throttled too, wrapping rather
+  than replacing their SSRF-guard transport.

--- a/internal/metadata/audible.go
+++ b/internal/metadata/audible.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/audible.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: a9b8c7d6-e5f4-3a2b-1c0d-9e8f7a6b5c4d
 // last-edited: 2026-07-13
 
@@ -16,7 +16,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/metadata/providerhttp"
 )
 
 // AudibleClient fetches audiobook metadata from Audible's undocumented catalog API.
@@ -33,7 +34,7 @@ func NewAudibleClient() *AudibleClient {
 		baseURL = "https://api.audible.com/1.0"
 	}
 	return &AudibleClient{
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: providerhttp.Client("audible"),
 		baseURL:    strings.TrimRight(baseURL, "/"),
 	}
 }
@@ -41,7 +42,7 @@ func NewAudibleClient() *AudibleClient {
 // NewAudibleClientWithBaseURL creates a client with a custom base URL (for testing).
 func NewAudibleClientWithBaseURL(baseURL string) *AudibleClient {
 	return &AudibleClient{
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: providerhttp.Client("audible"),
 		baseURL:    strings.TrimRight(baseURL, "/"),
 	}
 }

--- a/internal/metadata/audnexus.go
+++ b/internal/metadata/audnexus.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/audnexus.go
-// version: 2.6.0
+// version: 2.7.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-a3b4c5d6e7f8
 // last-edited: 2026-07-13
 
@@ -15,6 +15,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/metadata/providerhttp"
 )
 
 // AudnexusClient fetches audiobook metadata from the Audnexus community API,
@@ -33,7 +35,7 @@ func NewAudnexusClient() *AudnexusClient {
 		baseURL = "https://api.audnex.us"
 	}
 	return &AudnexusClient{
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: providerhttp.Client("audnexus"),
 		baseURL:    strings.TrimRight(baseURL, "/"),
 	}
 }
@@ -41,7 +43,7 @@ func NewAudnexusClient() *AudnexusClient {
 // NewAudnexusClientWithBaseURL creates a client with a custom base URL (for testing).
 func NewAudnexusClientWithBaseURL(baseURL string) *AudnexusClient {
 	return &AudnexusClient{
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: providerhttp.Client("audnexus"),
 		baseURL:    strings.TrimRight(baseURL, "/"),
 	}
 }

--- a/internal/metadata/cover.go
+++ b/internal/metadata/cover.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/cover.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 4efaa7b8-e29a-47f3-84f7-39b46bfc9a01
 
 package metadata
@@ -7,6 +7,7 @@ package metadata
 import (
 	"context"
 	"fmt"
+	"github.com/falkcorp/audiobook-organizer/internal/metadata/providerhttp"
 	"io"
 	"net"
 	"net/http"
@@ -93,12 +94,13 @@ func safeCoverDialContext(ctx context.Context, network, addr string) (net.Conn, 
 // Skips download if the file already exists. Only accepts image/* content types.
 // Rejects non-http(s) URLs and URLs that resolve to private/reserved IPs.
 func DownloadCoverArt(coverURL string, destDir string, bookID string) (string, error) {
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-		Transport: &http.Transport{
-			DialContext: safeCoverDialContext,
-		},
-	}
+	// Rate-limited, but the SSRF guard is preserved: safeCoverDialContext refuses
+	// private/reserved IPs and MUST stay on the transport. providerhttp wraps the
+	// caller's transport rather than replacing it, so throttling is added without
+	// dropping the security control.
+	client := providerhttp.ClientWithTransport("cover", &http.Transport{
+		DialContext: safeCoverDialContext,
+	})
 	return downloadCoverArtWithClient(client, coverURL, destDir, bookID)
 }
 

--- a/internal/metadata/googlebooks.go
+++ b/internal/metadata/googlebooks.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/googlebooks.go
-// version: 1.3.2
+// version: 1.4.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-f2a3b4c5d6e7
 
 package metadata
@@ -13,7 +13,8 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/metadata/providerhttp"
 )
 
 // GoogleBooksClient fetches metadata from the Google Books Volume API.
@@ -31,7 +32,7 @@ func NewGoogleBooksClient(apiKey string) *GoogleBooksClient {
 		baseURL = "https://www.googleapis.com/books/v1"
 	}
 	return &GoogleBooksClient{
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: providerhttp.Client("googlebooks"),
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		apiKey:     apiKey,
 	}
@@ -40,7 +41,7 @@ func NewGoogleBooksClient(apiKey string) *GoogleBooksClient {
 // NewGoogleBooksClientWithBaseURL creates a client with a custom base URL (for testing).
 func NewGoogleBooksClientWithBaseURL(baseURL string) *GoogleBooksClient {
 	return &GoogleBooksClient{
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: providerhttp.Client("googlebooks"),
 		baseURL:    strings.TrimRight(baseURL, "/"),
 	}
 }

--- a/internal/metadata/hardcover.go
+++ b/internal/metadata/hardcover.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/hardcover.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: e7e02554-8931-49ba-9528-d3d51279da1d
 // last-edited: 2026-07-13
 
@@ -13,8 +13,8 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
-	"sync"
-	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/metadata/providerhttp"
 )
 
 // HardcoverClient fetches metadata from the Hardcover.app GraphQL API.
@@ -24,79 +24,34 @@ type HardcoverClient struct {
 	baseURL    string
 	apiToken   string
 
-	// Simple rate limiter: 60 requests per minute
-	mu         sync.Mutex
-	requestLog []time.Time
-	rateLimit  int
-	ratePeriod time.Duration
+	// Rate limiting lives in the providerhttp transport (shared process-wide
+	// token bucket), NOT here. This client previously carried its own mutex +
+	// time.Sleep limiter, which serialized every caller in the process rather
+	// than pacing them -- a hard bottleneck for any fan-out, since the metadata
+	// source chain is memoized and shared across all fetch workers.
 }
 
 // NewHardcoverClient creates a new Hardcover API client with the given token.
 func NewHardcoverClient(apiToken string) *HardcoverClient {
 	return &HardcoverClient{
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: providerhttp.Client("hardcover"),
 		baseURL:    "https://api.hardcover.app/v1/graphql",
 		apiToken:   apiToken,
-		rateLimit:  60,
-		ratePeriod: time.Minute,
 	}
 }
 
 // NewHardcoverClientWithBaseURL creates a client with a custom base URL (for testing).
 func NewHardcoverClientWithBaseURL(baseURL, apiToken string) *HardcoverClient {
 	return &HardcoverClient{
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: providerhttp.Client("hardcover"),
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		apiToken:   apiToken,
-		rateLimit:  60,
-		ratePeriod: time.Minute,
 	}
 }
 
 // Name returns the display name for this metadata source.
 func (c *HardcoverClient) Name() string {
 	return "Hardcover"
-}
-
-// waitForRateLimit blocks until a request can be made within the rate limit.
-func (c *HardcoverClient) waitForRateLimit() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	now := time.Now()
-	cutoff := now.Add(-c.ratePeriod)
-
-	// Remove expired entries
-	valid := c.requestLog[:0]
-	for _, t := range c.requestLog {
-		if t.After(cutoff) {
-			valid = append(valid, t)
-		}
-	}
-	c.requestLog = valid
-
-	if len(c.requestLog) >= c.rateLimit {
-		// Wait until the oldest request expires
-		waitUntil := c.requestLog[0].Add(c.ratePeriod)
-		sleepDuration := time.Until(waitUntil)
-		if sleepDuration > 0 {
-			c.mu.Unlock()
-			time.Sleep(sleepDuration)
-			c.mu.Lock()
-			// Re-clean after sleep
-			now = time.Now()
-			cutoff = now.Add(-c.ratePeriod)
-			valid = c.requestLog[:0]
-			for _, t := range c.requestLog {
-				if t.After(cutoff) {
-					valid = append(valid, t)
-				}
-			}
-			c.requestLog = valid
-		}
-	}
-
-	c.requestLog = append(c.requestLog, time.Now())
 }
 
 // GraphQL request/response types
@@ -233,7 +188,6 @@ func (c *HardcoverClient) SearchByContext(ctx context.Context, sc *SearchContext
 }
 
 func (c *HardcoverClient) search(ctx context.Context, query string) ([]BookMetadata, error) {
-	c.waitForRateLimit()
 
 	// Escape the query for embedding in the GraphQL string
 	escapedQuery := strings.ReplaceAll(query, `\`, `\\`)

--- a/internal/metadata/openlibrary.go
+++ b/internal/metadata/openlibrary.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/openlibrary.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
 // last-edited: 2026-07-13
 
@@ -14,7 +14,8 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/metadata/providerhttp"
 
 	"github.com/falkcorp/audiobook-organizer/internal/openlibrary"
 )
@@ -39,10 +40,8 @@ func NewOpenLibraryClient() *OpenLibraryClient {
 // NewOpenLibraryClientWithBaseURL creates a client with a custom base URL.
 func NewOpenLibraryClientWithBaseURL(baseURL string) *OpenLibraryClient {
 	return &OpenLibraryClient{
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-		baseURL: strings.TrimRight(baseURL, "/"),
+		httpClient: providerhttp.Client("openlibrary"),
+		baseURL:    strings.TrimRight(baseURL, "/"),
 	}
 }
 

--- a/internal/metadata/providerhttp/providerhttp.go
+++ b/internal/metadata/providerhttp/providerhttp.go
@@ -1,0 +1,347 @@
+// file: internal/metadata/providerhttp/providerhttp.go
+// version: 1.0.0
+// guid: 5c9e2a71-4b83-4f16-9d40-8e73a1b5c206
+// last-edited: 2026-08-15
+
+// Package providerhttp hands out rate-limited HTTP clients for outbound
+// metadata-provider calls.
+//
+// Why this exists: before it, five of the six providers (Audible, Audnexus,
+// Google Books, OpenLibrary, Wikipedia) had NO outbound throttling whatsoever —
+// just an http.Client with a 30s timeout. There was no jitter, no backoff, and
+// no 429/Retry-After handling anywhere in the tree. Only Hardcover had a limit,
+// and it was a mutex + time.Sleep shared process-wide, which serialized every
+// caller rather than pacing them. Fanning metadata fetch out across a worker
+// pool on top of that is how an account gets blocked.
+//
+// The limiter lives in the http.RoundTripper rather than at the call sites on
+// purpose: a call site can forget to call Wait(), but a request cannot bypass
+// the transport it is issued on. Adding a new provider means asking this package
+// for a client, and it is throttled by construction.
+package providerhttp
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// Limits describes the outbound budget for one provider.
+type Limits struct {
+	// RPS is the sustained request rate. Must be > 0.
+	RPS float64
+	// Burst is how many requests may be issued back-to-back before pacing
+	// kicks in. Must be >= 1.
+	Burst int
+	// MaxRetries bounds retries for throttling/transient responses. 0 disables
+	// retrying (the response is returned as-is).
+	MaxRetries int
+	// Timeout is the per-request client timeout.
+	Timeout time.Duration
+}
+
+// defaultLimits are deliberately conservative. Only Hardcover publishes a number
+// we actually know (60/min); the rest are chosen to be obviously polite rather
+// than tuned, because the failure mode for guessing too high is getting the
+// user's IP or account blocked, and the failure mode for guessing too low is
+// that a bulk fetch takes longer.
+//
+// Raise these from measurement, not optimism.
+var defaultLimits = map[string]Limits{
+	// Hardcover documents 60 requests/minute.
+	"hardcover": {RPS: 1.0, Burst: 1, MaxRetries: 3, Timeout: 30 * time.Second},
+	// Audible/Audnexus are unofficial surfaces; be gentle.
+	"audible":  {RPS: 2.0, Burst: 2, MaxRetries: 3, Timeout: 30 * time.Second},
+	"audnexus": {RPS: 2.0, Burst: 2, MaxRetries: 3, Timeout: 30 * time.Second},
+	// Google Books' documented anonymous quota is per-day, not per-second; the
+	// practical constraint is per-IP throttling, so pace modestly.
+	"googlebooks": {RPS: 3.0, Burst: 3, MaxRetries: 3, Timeout: 30 * time.Second},
+	// OpenLibrary asks for "reasonable" use and publishes no hard number.
+	"openlibrary": {RPS: 3.0, Burst: 3, MaxRetries: 3, Timeout: 30 * time.Second},
+	// Wikipedia's API policy asks for serial-ish access from one client.
+	"wikipedia": {RPS: 2.0, Burst: 2, MaxRetries: 3, Timeout: 30 * time.Second},
+	// Cover art downloads hit arbitrary third-party image hosts.
+	"cover": {RPS: 4.0, Burst: 4, MaxRetries: 2, Timeout: 60 * time.Second},
+}
+
+// fallbackLimits apply to any provider name with no entry above, so a new
+// provider is throttled before anyone remembers to register it.
+var fallbackLimits = Limits{RPS: 2.0, Burst: 2, MaxRetries: 3, Timeout: 30 * time.Second}
+
+var (
+	mu        sync.Mutex
+	limiters  = map[string]*rate.Limiter{}
+	clients   = map[string]*http.Client{}
+	overrides = map[string]Limits{}
+)
+
+// SetLimits overrides the built-in budget for a provider. Call before any
+// Client() for that provider (typically once at startup from config); it has no
+// effect on a client already handed out, because that client's transport holds
+// the limiter it was built with.
+func SetLimits(provider string, l Limits) {
+	mu.Lock()
+	defer mu.Unlock()
+	overrides[provider] = l
+}
+
+// limitsFor resolves the effective budget for a provider. Caller holds mu.
+func limitsFor(provider string) Limits {
+	if l, ok := overrides[provider]; ok {
+		return normalize(l)
+	}
+	if l, ok := defaultLimits[provider]; ok {
+		return normalize(l)
+	}
+	return fallbackLimits
+}
+
+// normalize repairs a nonsensical config rather than letting it disable
+// throttling. A zero RPS on a rate.Limiter blocks forever, and a zero Burst
+// makes Wait() fail immediately — both turn a misconfiguration into an outage,
+// so clamp instead.
+func normalize(l Limits) Limits {
+	if l.RPS <= 0 {
+		l.RPS = fallbackLimits.RPS
+	}
+	if l.Burst < 1 {
+		l.Burst = 1
+	}
+	if l.MaxRetries < 0 {
+		l.MaxRetries = 0
+	}
+	if l.Timeout <= 0 {
+		l.Timeout = fallbackLimits.Timeout
+	}
+	return l
+}
+
+// Client returns the shared, rate-limited HTTP client for a provider.
+//
+// The client is shared per provider name for the life of the process, which is
+// the point: every worker in a fan-out pool must draw from ONE token bucket, or
+// the limit is per-goroutine and means nothing.
+func Client(provider string) *http.Client {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if c, ok := clients[provider]; ok {
+		return c
+	}
+
+	l := limitsFor(provider)
+	lim, ok := limiters[provider]
+	if !ok {
+		lim = rate.NewLimiter(rate.Limit(l.RPS), l.Burst)
+		limiters[provider] = lim
+	}
+
+	c := &http.Client{
+		Timeout: l.Timeout,
+		Transport: &throttled{
+			base:       http.DefaultTransport,
+			limiter:    lim,
+			provider:   provider,
+			maxRetries: l.MaxRetries,
+		},
+	}
+	clients[provider] = c
+	return c
+}
+
+// ClientWithTransport is Client for callers that must keep their own base
+// RoundTripper — most importantly the cover downloader, whose transport carries
+// an SSRF guard (a DialContext that refuses private/reserved IPs). Replacing
+// that client wholesale would silently delete a security control, so the
+// throttling wraps the caller's transport instead of displacing it.
+//
+// Unlike Client, the result is NOT cached: the caller owns the base transport
+// and two callers passing different bases must not share a client. The rate
+// limiter IS still shared per provider name, which is the part that has to be
+// process-wide for a limit to mean anything.
+func ClientWithTransport(provider string, base http.RoundTripper) *http.Client {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	mu.Lock()
+	l := limitsFor(provider)
+	lim, ok := limiters[provider]
+	if !ok {
+		lim = rate.NewLimiter(rate.Limit(l.RPS), l.Burst)
+		limiters[provider] = lim
+	}
+	mu.Unlock()
+
+	return &http.Client{
+		Timeout: l.Timeout,
+		Transport: &throttled{
+			base:       base,
+			limiter:    lim,
+			provider:   provider,
+			maxRetries: l.MaxRetries,
+		},
+	}
+}
+
+// newTestLimiter builds a limiter for tests without touching the shared maps.
+func newTestLimiter(rps float64, burst int) *rate.Limiter {
+	return rate.NewLimiter(rate.Limit(rps), burst)
+}
+
+// resetForTest clears the shared caches so tests do not leak state into each
+// other. Test-only; the production path never resets.
+func resetForTest() {
+	mu.Lock()
+	defer mu.Unlock()
+	limiters = map[string]*rate.Limiter{}
+	clients = map[string]*http.Client{}
+	overrides = map[string]Limits{}
+}
+
+// throttled paces requests through a shared token bucket and retries throttling
+// responses with backoff.
+type throttled struct {
+	base       http.RoundTripper
+	limiter    *rate.Limiter
+	provider   string
+	maxRetries int
+}
+
+func (t *throttled) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	for attempt := 0; ; attempt++ {
+		// Wait honors context cancellation, so a canceled fetch stops paying for
+		// tokens instead of blocking a worker until its turn arrives.
+		if err := t.limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("providerhttp %s: rate limit wait: %w", t.provider, err)
+		}
+
+		resp, err := t.base.RoundTrip(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if attempt >= t.maxRetries || !shouldRetry(resp.StatusCode) {
+			return resp, nil
+		}
+
+		// Decide replayability BEFORE draining. A request body cannot be replayed
+		// without GetBody, and retrying without it would send an empty body.
+		// Every provider call here is a GET, but guard rather than silently
+		// corrupt a future POST. This must happen first: once the response is
+		// drained and closed, returning it hands the caller a dead body.
+		var replay io.ReadCloser
+		if req.Body != nil {
+			if req.GetBody == nil {
+				return resp, nil
+			}
+			b, berr := req.GetBody()
+			if berr != nil {
+				return resp, nil
+			}
+			replay = b
+		}
+
+		delay := retryDelay(resp, attempt)
+
+		// Drain and close before reusing the connection, otherwise it is
+		// discarded and we leak sockets under sustained throttling.
+		drain(resp)
+
+		select {
+		case <-ctx.Done():
+			if replay != nil {
+				_ = replay.Close()
+			}
+			return nil, ctx.Err()
+		case <-time.After(delay):
+		}
+
+		if replay != nil {
+			req.Body = replay
+		}
+	}
+}
+
+// shouldRetry reports whether a status code represents throttling or a
+// transient server condition worth retrying.
+func shouldRetry(code int) bool {
+	switch code {
+	case http.StatusTooManyRequests, // 429 — the one that matters
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	}
+	return false
+}
+
+// retryDelay honors Retry-After when the server sends it, and otherwise backs
+// off exponentially with jitter.
+//
+// Jitter is not decoration: without it, N workers throttled by the same server
+// at the same moment all sleep the same duration and retry in lockstep, which
+// reproduces the burst that caused the throttling.
+func retryDelay(resp *http.Response, attempt int) time.Duration {
+	if d, ok := parseRetryAfter(resp.Header.Get("Retry-After")); ok {
+		return d
+	}
+	// 1s, 2s, 4s, ... capped, plus up to 50% jitter.
+	base := time.Duration(math.Pow(2, float64(attempt))) * time.Second
+	if base > 30*time.Second {
+		base = 30 * time.Second
+	}
+	jitter := time.Duration(rand.Int63n(int64(base/2) + 1))
+	return base + jitter
+}
+
+// parseRetryAfter handles both forms the header is allowed to take: a
+// delta-seconds integer, and an HTTP-date.
+func parseRetryAfter(v string) (time.Duration, bool) {
+	if v == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs < 0 {
+			return 0, false
+		}
+		d := time.Duration(secs) * time.Second
+		if d > 5*time.Minute {
+			d = 5 * time.Minute // never park a worker indefinitely
+		}
+		return d, true
+	}
+	if when, err := http.ParseTime(v); err == nil {
+		d := time.Until(when)
+		if d <= 0 {
+			return 0, false
+		}
+		if d > 5*time.Minute {
+			d = 5 * time.Minute
+		}
+		return d, true
+	}
+	return 0, false
+}
+
+// drain reads and closes a response body so the underlying connection can be
+// reused instead of being dropped. Bounded: an error body from a throttling
+// response is small, and we do not want to download an unbounded one just to
+// recycle a socket.
+func drain(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+	_ = resp.Body.Close()
+}

--- a/internal/metadata/providerhttp/providerhttp_test.go
+++ b/internal/metadata/providerhttp/providerhttp_test.go
@@ -1,0 +1,272 @@
+// file: internal/metadata/providerhttp/providerhttp_test.go
+// version: 1.0.0
+// guid: c81f4d0a-3b76-4e29-9152-6a0d7e4b8f35
+// last-edited: 2026-08-15
+
+package providerhttp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These run against a real httptest server rather than asserting on internal
+// state. A rate limiter that is present but not wired into the request path
+// would pass any test that only inspects the struct; only issuing actual
+// requests and timing them proves the pacing happens.
+
+func TestThrottled_PacesRequests(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// 10 rps, burst 1: the 3rd request cannot land before ~200ms.
+	c := &http.Client{Transport: &throttled{
+		base:     http.DefaultTransport,
+		limiter:  newTestLimiter(10, 1),
+		provider: "test",
+	}}
+
+	start := time.Now()
+	for i := 0; i < 3; i++ {
+		resp, err := c.Get(srv.URL)
+		if err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+		resp.Body.Close()
+	}
+	elapsed := time.Since(start)
+
+	if got := atomic.LoadInt32(&hits); got != 3 {
+		t.Fatalf("server saw %d requests, want 3", got)
+	}
+	// Burst 1 covers the first; the next two each wait ~100ms.
+	if elapsed < 150*time.Millisecond {
+		t.Fatalf("3 requests at 10rps took %v; too fast to have been rate limited", elapsed)
+	}
+}
+
+func TestThrottled_RetriesOn429AndHonorsRetryAfter(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&attempts, 1) == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte("slow down"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := &http.Client{Transport: &throttled{
+		base:       http.DefaultTransport,
+		limiter:    newTestLimiter(1000, 1000), // pacing out of the way
+		provider:   "test",
+		maxRetries: 3,
+	}}
+
+	start := time.Now()
+	resp, err := c.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("final status = %d, want 200 (the retry should have succeeded)", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Fatalf("server saw %d attempts, want 2 (one 429 + one retry)", got)
+	}
+	if elapsed < 900*time.Millisecond {
+		t.Fatalf("retry happened after %v; Retry-After: 1 was not honored", elapsed)
+	}
+}
+
+func TestThrottled_GivesUpAfterMaxRetries(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := &http.Client{Transport: &throttled{
+		base:       http.DefaultTransport,
+		limiter:    newTestLimiter(1000, 1000),
+		provider:   "test",
+		maxRetries: 2,
+	}}
+
+	resp, err := c.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// maxRetries=2 means the initial attempt plus 2 retries.
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Fatalf("server saw %d attempts, want 3 (initial + 2 retries)", got)
+	}
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want the final 429 surfaced to the caller", resp.StatusCode)
+	}
+	// The body must still be readable: the retry loop drains intermediate
+	// responses, and returning a drained body would hand the caller a dead read.
+	buf := make([]byte, 1)
+	if _, err := resp.Body.Read(buf); err != nil && err.Error() == "http: read on closed response body" {
+		t.Fatal("final response body was closed by the retry loop")
+	}
+}
+
+func TestThrottled_ContextCancellationAborts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// 1 rps burst 1: the second request must wait ~1s, which we cancel.
+	c := &http.Client{Transport: &throttled{
+		base:     http.DefaultTransport,
+		limiter:  newTestLimiter(1, 1),
+		provider: "test",
+	}}
+
+	resp, err := c.Get(srv.URL) // consumes the burst token
+	if err != nil {
+		t.Fatalf("first request: %v", err)
+	}
+	resp.Body.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+
+	start := time.Now()
+	if _, err := c.Do(req); err == nil {
+		t.Fatal("expected cancellation error while waiting for a rate-limit token")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("cancellation took %v; the limiter wait is not honoring context", elapsed)
+	}
+}
+
+// TestClient_SharesLimiterPerProvider is the property that makes the limit mean
+// anything: every worker in a fan-out pool must draw from ONE bucket. If each
+// caller got its own limiter, N workers would each get the full rate and the
+// effective rate would be N times the configured one.
+func TestClient_SharesLimiterPerProvider(t *testing.T) {
+	resetForTest()
+	SetLimits("sharedtest", Limits{RPS: 5, Burst: 1, MaxRetries: 0, Timeout: 5 * time.Second})
+
+	a := Client("sharedtest")
+	b := Client("sharedtest")
+
+	if a != b {
+		t.Fatal("Client returned distinct clients for one provider; the token bucket would not be shared")
+	}
+
+	ta, oka := a.Transport.(*throttled)
+	tb, okb := b.Transport.(*throttled)
+	if !oka || !okb {
+		t.Fatal("transport is not the throttling transport; requests would bypass the limiter entirely")
+	}
+	if ta.limiter != tb.limiter {
+		t.Fatal("two clients for one provider hold different limiters")
+	}
+}
+
+// TestClientWithTransport_PreservesBase guards a security property: the cover
+// downloader's transport carries an SSRF dialer that refuses private IPs.
+// Wrapping must not discard it.
+func TestClientWithTransport_PreservesBase(t *testing.T) {
+	resetForTest()
+
+	marker := &markerTransport{}
+	c := ClientWithTransport("covertest", marker)
+
+	tr, ok := c.Transport.(*throttled)
+	if !ok {
+		t.Fatal("expected the throttling transport")
+	}
+	if tr.base != http.RoundTripper(marker) {
+		t.Fatal("caller-supplied base transport was replaced; an SSRF guard would be silently dropped here")
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.invalid", nil)
+	if _, err := c.Transport.RoundTrip(req); err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	if !marker.called {
+		t.Fatal("base transport was never invoked; the wrapper bypassed it")
+	}
+}
+
+func TestNormalize_ClampsNonsenseInsteadOfDisablingThrottling(t *testing.T) {
+	// A zero RPS on rate.Limiter blocks forever and a zero burst makes Wait fail
+	// immediately: a misconfiguration must degrade to the fallback, not an outage.
+	got := normalize(Limits{RPS: 0, Burst: 0, MaxRetries: -5, Timeout: 0})
+
+	if got.RPS <= 0 {
+		t.Fatalf("RPS = %v, want a positive fallback", got.RPS)
+	}
+	if got.Burst < 1 {
+		t.Fatalf("Burst = %d, want >= 1", got.Burst)
+	}
+	if got.MaxRetries < 0 {
+		t.Fatalf("MaxRetries = %d, want >= 0", got.MaxRetries)
+	}
+	if got.Timeout <= 0 {
+		t.Fatalf("Timeout = %v, want a positive fallback", got.Timeout)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		ok   bool
+		want time.Duration
+	}{
+		{"delta seconds", "5", true, 5 * time.Second},
+		{"zero", "0", true, 0},
+		{"negative rejected", "-3", false, 0},
+		{"garbage rejected", "soon", false, 0},
+		{"empty rejected", "", false, 0},
+		{"absurd value capped", "99999", true, 5 * time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseRetryAfter(tt.in)
+			if ok != tt.ok {
+				t.Fatalf("ok = %v, want %v", ok, tt.ok)
+			}
+			if ok && got != tt.want {
+				t.Fatalf("delay = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- helpers ---
+
+type markerTransport struct{ called bool }
+
+func (m *markerTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	m.called = true
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+	}, nil
+}

--- a/internal/metadata/wikipedia.go
+++ b/internal/metadata/wikipedia.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/wikipedia.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
 
 package metadata
@@ -12,7 +12,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/metadata/providerhttp"
 )
 
 // WikipediaClient fetches metadata from the MediaWiki API and Wikidata.
@@ -26,7 +27,7 @@ type WikipediaClient struct {
 // NewWikipediaClient creates a new Wikipedia/Wikidata metadata client.
 func NewWikipediaClient() *WikipediaClient {
 	return &WikipediaClient{
-		httpClient:  &http.Client{Timeout: 30 * time.Second},
+		httpClient:  providerhttp.Client("wikipedia"),
 		baseURL:     "https://en.wikipedia.org/w/api.php",
 		wikidataURL: "https://www.wikidata.org/w/api.php",
 	}
@@ -35,7 +36,7 @@ func NewWikipediaClient() *WikipediaClient {
 // NewWikipediaClientWithBaseURL creates a client with custom URLs (for testing).
 func NewWikipediaClientWithBaseURL(baseURL, wikidataURL string) *WikipediaClient {
 	return &WikipediaClient{
-		httpClient:  &http.Client{Timeout: 30 * time.Second},
+		httpClient:  providerhttp.Client("wikipedia"),
 		baseURL:     strings.TrimRight(baseURL, "/"),
 		wikidataURL: strings.TrimRight(wikidataURL, "/"),
 	}


### PR DESCRIPTION
Prerequisite for fanning metadata fetch across a worker pool.

## What was there before

| Provider | Throttling |
|---|---|
| Audible | **none** |
| Audnexus | **none** |
| Google Books | **none** |
| OpenLibrary | **none** |
| Wikipedia | **none** |
| Hardcover | mutex + `time.Sleep`, process-wide |
| Cover downloads | **none** |

No jitter, no backoff, no 429 or `Retry-After` handling anywhere in the tree — just a 30s `http.Client` timeout. Fanning out on top of that is how an IP or account gets blocked.

Hardcover's limiter was worse than nothing for this purpose: the memoized source chain shares one client process-wide, so its mutex **serialized every caller** instead of pacing them — a hard bottleneck for any fan-out.

## Approach

A new `internal/metadata/providerhttp` package hands out rate-limited clients. **The limiter lives in the `http.RoundTripper`, not at call sites** — a call site can forget to call `Wait()`, but a request cannot bypass the transport it is issued on. Adding a provider means asking `providerhttp` for a client, and it is throttled by construction; an unregistered provider name gets conservative fallback limits rather than none.

Includes:
- 429 / `Retry-After` handling in **both** permitted forms (delta-seconds and HTTP-date), each capped so a hostile value cannot park a worker indefinitely
- exponential backoff **with jitter** — without it, N workers throttled at the same instant retry in lockstep and reproduce the burst that caused the throttling
- context-aware waiting, so a canceled fetch stops queuing for tokens instead of blocking a worker
- one shared token bucket per provider name, which is the whole point: per-goroutine limiters would multiply the effective rate by the worker count

Hardcover's mutex limiter is removed in favor of the shared bucket.

### Cover downloads: wrapped, not replaced

`cover.go`'s transport carries `safeCoverDialContext`, an SSRF guard refusing private/reserved IPs. Swapping in a stock client would have **silently deleted a security control**, so `ClientWithTransport` wraps the caller's transport instead of displacing it. There's a test asserting the base transport survives.

## Verification — against a real server, not internal state

A limiter that exists but isn't wired into the request path would pass any test that only inspects the struct. These issue real requests through `httptest`:

- 3 requests at 10rps take **200ms**; disabling the limiter drops that to **1.6ms** and fails the test (mutation-verified)
- a 429 with `Retry-After: 1` is retried after ~1s and succeeds
- retries are bounded, and the final response body is still readable (the retry loop drains intermediates)
- cancellation aborts the token wait promptly

8 tests + 6 subtests pass. `go build ./...`, `go vet`, and `internal/metadata/...` all clean. Zero raw `http.Client{}` left in any provider file.

## Note

Limits are conservative defaults, not tuned — only Hardcover publishes a number we actually know (60/min). `SetLimits()` is the seam for config-driven overrides; wiring it to `config.AppConfig` is a follow-up. **Raise these from measurement, not optimism.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS