### PR TITLE
fix(metadata): keep the existing cover until the new one is downloaded

### DIFF
--- a/changelog.d/20260815_160000_cover_blank_on_apply.md
+++ b/changelog.d/20260815_160000_cover_blank_on_apply.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Applying metadata no longer blanks the cover art.** `ApplyMetadataToBook`
+  writes the candidate's remote cover URL into `cover_url`, and the UI serves
+  covers through `/api/v1/covers/proxy`, which rejects hosts outside its
+  allow-list (production returned `400 URL not from an allowed cover source` for
+  `m.media-amazon.com`). That was invisible while the download ran inline and
+  replaced the value microseconds later; once the download moved to the
+  background it became observable and the cover rendered blank until a refresh.
+  The previous cover is now kept until the new image is actually on disk.

--- a/internal/metafetch/helpers.go
+++ b/internal/metafetch/helpers.go
@@ -245,7 +245,7 @@ func (mfs *Service) loadMetadataState(bookID string) (map[string]metadataFieldSt
 	}
 
 	if err := mfs.saveMetadataState(bookID, legacy); err != nil {
-				slog.Warn("failed to migrate legacy metadata state for", "id", bookID, "error", err)
+		slog.Warn("failed to migrate legacy metadata state for", "id", bookID, "error", err)
 	}
 	return legacy, nil
 }

--- a/internal/metafetch/isbn.go
+++ b/internal/metafetch/isbn.go
@@ -66,7 +66,7 @@ func (s *ISBNService) EnrichBookISBN(ctx context.Context, bookID string) (bool, 
 			if _, err := s.db.UpdateBook(bookID, book); err != nil {
 				return false, err
 			}
-						logging.Info(ctx, "ISBN enrichment found", "isbn", isbn, "title", title, "source", src.Name())
+			logging.Info(ctx, "ISBN enrichment found", "isbn", isbn, "title", title, "source", src.Name())
 			updated = true
 			break
 		}
@@ -86,7 +86,7 @@ func (s *ISBNService) EnrichBookISBN(ctx context.Context, bookID string) (bool, 
 			if _, err := s.db.UpdateBook(bookID, book); err != nil {
 				return updated, err
 			}
-						logging.Info(ctx, "ASIN enrichment found", "asin", asin, "title", title)
+			logging.Info(ctx, "ASIN enrichment found", "asin", asin, "title", title)
 			updated = true
 			break
 		}
@@ -132,7 +132,7 @@ func (s *ISBNService) EnrichMissingISBNs(ctx context.Context, limit int, w *acti
 			checked++
 			found, err := s.EnrichBookISBN(ctx, books[i].ID)
 			if err != nil {
-								logging.Warn(ctx, "ISBN enrichment failed for during batch scan", "id", books[i].ID, "error", err)
+				logging.Warn(ctx, "ISBN enrichment failed for during batch scan", "id", books[i].ID, "error", err)
 			} else if found {
 				updated++
 				activity.LogBatch(w, opID, "isbn-enrich", "isbn-enrichment",

--- a/internal/metafetch/metadata_state_service.go
+++ b/internal/metafetch/metadata_state_service.go
@@ -68,7 +68,7 @@ func (mss *MetadataStateService) LoadMetadataState(bookID string) (map[string]me
 
 	// Migrate legacy state
 	if err := mss.SaveMetadataState(bookID, legacy); err != nil {
-				slog.Warn("failed to migrate legacy metadata state for", "id", bookID, "error", err)
+		slog.Warn("failed to migrate legacy metadata state for", "id", bookID, "error", err)
 	}
 
 	return legacy, nil
@@ -147,7 +147,7 @@ func (mss *MetadataStateService) recordChange(bookID, field, changeType, source 
 		ChangedAt:     time.Now(),
 	}
 	if err := mss.db.RecordMetadataChange(record); err != nil {
-				slog.Warn("failed to record metadata change for /", "id", bookID, "field", field, "error", err)
+		slog.Warn("failed to record metadata change for /", "id", bookID, "field", field, "error", err)
 	}
 }
 

--- a/internal/metafetch/openlibrary.go
+++ b/internal/metafetch/openlibrary.go
@@ -48,12 +48,12 @@ func NewOpenLibraryService() *OpenLibraryService {
 	if info, err := os.Stat(storePath); err == nil && info.IsDir() {
 		// Auto-enable if store directory exists on disk
 		if !config.AppConfig.OpenLibraryDumpEnabled {
-						slog.Info("Found existing OL dump store at , auto-enabling OpenLibraryDumpEnabled", "path", storePath)
+			slog.Info("Found existing OL dump store at , auto-enabling OpenLibraryDumpEnabled", "path", storePath)
 			config.AppConfig.OpenLibraryDumpEnabled = true
 		}
 		store, err := openlibrary.NewOLStore(storePath)
 		if err != nil {
-						slog.Warn("Failed to open OL dump store", "error", err)
+			slog.Warn("Failed to open OL dump store", "error", err)
 		} else {
 			svc.OLStore = store
 		}
@@ -116,7 +116,7 @@ func (svc *OpenLibraryService) Import(ctx context.Context, progress operations.P
 		svc.Mu.Lock()
 		if svc.Importing[dumpType] {
 			svc.Mu.Unlock()
-						slog.Warn("OL import already in progress for", "value", dumpType)
+			slog.Warn("OL import already in progress for", "value", dumpType)
 			continue
 		}
 		svc.Importing[dumpType] = true
@@ -136,7 +136,7 @@ func (svc *OpenLibraryService) Import(ctx context.Context, progress operations.P
 			}()
 
 			filePath := filepath.Join(targetDir, openlibrary.DumpFilename(dt))
-						slog.Info("Starting OL dump import from", "value", dt, "path", filePath)
+			slog.Info("Starting OL dump import from", "value", dt, "path", filePath)
 
 			lastReported := 0
 			err := svc.OLStore.ImportDump(dt, filePath, func(count int) {
@@ -146,12 +146,12 @@ func (svc *OpenLibraryService) Import(ctx context.Context, progress operations.P
 						msg := fmt.Sprintf("Importing %s: %dk records", dt, count/1000)
 						_ = progress.UpdateProgress(idx, len(types), msg)
 					}
-										slog.Info("OL import progress records", "value", dt, "count", count)
+					slog.Info("OL import progress records", "value", dt, "count", count)
 				}
 			})
 
 			if err != nil {
-								slog.Error("OL dump import failed for", "value", dt, "error", err)
+				slog.Error("OL dump import failed for", "value", dt, "error", err)
 				if progress != nil {
 					_ = progress.Log("error", fmt.Sprintf("%s import failed: %v", dt, err), nil)
 				}
@@ -159,7 +159,7 @@ func (svc *OpenLibraryService) Import(ctx context.Context, progress operations.P
 				importErr = err
 				mu.Unlock()
 			} else {
-								slog.Info("OL dump import complete", "value", dt)
+				slog.Info("OL dump import complete", "value", dt)
 				if progress != nil {
 					_ = progress.Log("info", fmt.Sprintf("%s import complete", dt), nil)
 				}
@@ -175,6 +175,6 @@ func (svc *OpenLibraryService) Import(ctx context.Context, progress operations.P
 			_ = progress.UpdateProgress(len(types), len(types), "All Open Library dump imports complete")
 		}
 	}
-		slog.Info("All OL dump imports complete")
+	slog.Info("All OL dump imports complete")
 	return importErr
 }

--- a/internal/metafetch/service_apply.go
+++ b/internal/metafetch/service_apply.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_apply.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 6ca469ca-7d2e-4738-b6f1-ae09449ed9e4
 // last-edited: 2026-08-15
 
@@ -22,6 +22,26 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/util"
 	"github.com/oklog/ulid/v2"
 )
+
+// renderableCoverURL decides what cover_url to persist during an apply.
+//
+// applied is what ApplyMetadataToBook just wrote; when the candidate carried a
+// cover that is the candidate's REMOTE url. The UI serves covers through
+// /api/v1/covers/proxy, which rejects hosts outside its allow-list, so a remote
+// url renders as NOTHING. Return the previous (local, working) cover instead and
+// let the background download repoint it once the image is on disk.
+//
+// If the applied value is anything other than that remote url — a local path, or
+// unchanged because the candidate had no cover — keep it.
+func renderableCoverURL(previous, applied *string, candidateRemote string) *string {
+	if candidateRemote == "" || applied == nil {
+		return applied
+	}
+	if *applied == candidateRemote {
+		return previous
+	}
+	return applied
+}
 
 func (mfs *Service) ApplyMetadataToBook(book *database.Book, meta metadata.BookMetadata) {
 	originalTitle := book.Title
@@ -551,7 +571,25 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 	// Record history BEFORE applying changes so old values are correct
 	mfs.RecordChangeHistory(book, meta, candidate.Source)
 
+	// Remember the cover we are currently serving. ApplyMetadataToBook overwrites
+	// book.CoverURL with the candidate's REMOTE url, which is not renderable by
+	// the UI: it proxies covers through /api/v1/covers/proxy, which rejects hosts
+	// outside its allow-list ("URL not from an allowed cover source", observed as
+	// a 400 for m.media-amazon.com).
+	//
+	// That was harmless while the download ran inline, because the remote value
+	// was replaced with the local path microseconds later and never observed.
+	// Once the download moved to the background it became visible: the apply
+	// response carried the remote url, the UI proxied it, got a 400, and the
+	// cover went BLANK until the background download finished and a refresh
+	// picked up the local path.
+	previousCoverURL := book.CoverURL
+
 	mfs.ApplyMetadataToBook(book, meta)
+
+	// Keep serving the previous cover until the new one is actually on disk.
+	// DownloadPendingCover repoints this at the local path when it completes.
+	book.CoverURL = renderableCoverURL(previousCoverURL, book.CoverURL, meta.CoverURL)
 
 	// Set review status and record which provider supplied the metadata
 	matched := "matched"

--- a/internal/metafetch/service_apply_cover_test.go
+++ b/internal/metafetch/service_apply_cover_test.go
@@ -1,0 +1,112 @@
+// file: internal/metafetch/service_apply_cover_test.go
+// version: 1.0.0
+// guid: e2a71c84-5d03-4f19-b7a6-1c40e9d3b825
+// last-edited: 2026-08-15
+
+package metafetch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRenderableCoverURL is the regression test for a blank cover on apply.
+//
+// The UI serves covers through /api/v1/covers/proxy, which rejects hosts outside
+// its allow-list — production returned 400 "URL not from an allowed cover source"
+// for m.media-amazon.com. ApplyMetadataToBook writes the candidate's REMOTE url
+// into book.CoverURL, which was harmless only because the cover download ran
+// inline and replaced it microseconds later. Once the download moved to the
+// background, that remote url became observable and the cover rendered BLANK
+// until a refresh after the download landed.
+func TestRenderableCoverURL(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+	const remote = "https://m.media-amazon.com/images/I/51Iuc4TUM2L._SL500_.jpg"
+	const localOld = "/api/v1/covers/local/01ABC.jpg"
+
+	tests := []struct {
+		name      string
+		previous  *string
+		applied   *string
+		candidate string
+		want      *string
+		why       string
+	}{
+		{
+			name:      "remote url is replaced by the previous local cover",
+			previous:  ptr(localOld),
+			applied:   ptr(remote),
+			candidate: remote,
+			want:      ptr(localOld),
+			why:       "the existing image must keep rendering until the new one is on disk",
+		},
+		{
+			name:      "no previous cover leaves it unset rather than remote",
+			previous:  nil,
+			applied:   ptr(remote),
+			candidate: remote,
+			want:      nil,
+			why:       "persisting an unrenderable url is worse than none; the background download fills it in",
+		},
+		{
+			name:      "candidate without a cover leaves the applied value alone",
+			previous:  ptr(localOld),
+			applied:   ptr(localOld),
+			candidate: "",
+			want:      ptr(localOld),
+			why:       "nothing to defer; do not disturb the existing value",
+		},
+		{
+			name:      "an applied value that is not the remote url is kept",
+			previous:  ptr(localOld),
+			applied:   ptr("/api/v1/covers/local/NEW.jpg"),
+			candidate: remote,
+			want:      ptr("/api/v1/covers/local/NEW.jpg"),
+			why:       "a local path already on disk must not be reverted to the old cover",
+		},
+		{
+			name:      "nil applied stays nil",
+			previous:  ptr(localOld),
+			applied:   nil,
+			candidate: remote,
+			want:      nil,
+			why:       "no value was applied; nothing to correct",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderableCoverURL(tt.previous, tt.applied, tt.candidate)
+			if tt.want == nil {
+				assert.Nil(t, got, tt.why)
+				return
+			}
+			if assert.NotNil(t, got, tt.why) {
+				assert.Equal(t, *tt.want, *got, tt.why)
+			}
+		})
+	}
+}
+
+// TestRenderableCoverURL_NeverReturnsTheRemoteURL is the property that matters,
+// stated directly: whatever the inputs, this function must never hand back the
+// candidate's remote url, because that is the value the UI cannot render.
+func TestRenderableCoverURL_NeverReturnsTheRemoteURL(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+	const remote = "https://m.media-amazon.com/images/I/x.jpg"
+
+	previouses := []*string{nil, ptr("/api/v1/covers/local/old.jpg"), ptr(remote)}
+	applieds := []*string{nil, ptr(remote), ptr("/api/v1/covers/local/new.jpg")}
+
+	for _, prev := range previouses {
+		for _, app := range applieds {
+			got := renderableCoverURL(prev, app, remote)
+			// The one legitimate way remote can come back is if the PREVIOUS value
+			// was already remote, i.e. it was persisted before this fix existed.
+			if got != nil && *got == remote && (prev == nil || *prev != remote) {
+				t.Fatalf("returned the unrenderable remote url (previous=%v applied=%v)", prev, app)
+			}
+		}
+	}
+}

--- a/internal/metafetch/service_files.go
+++ b/internal/metafetch/service_files.go
@@ -66,11 +66,11 @@ func backupFileBeforeWrite(filePath string) {
 	if err := os.Link(filePath, backupPath); err != nil {
 		// Hardlink failed — fall back to copy
 		if err := fileops.SafeCopy(filePath, backupPath, fileops.OperationConfig{}); err != nil {
-						slog.Warn("backup before tag write failed:", "path", filePath, "error", err)
+			slog.Warn("backup before tag write failed:", "path", filePath, "error", err)
 			return
 		}
 	}
-		slog.Debug("backup before tag write", "path", backupPath)
+	slog.Debug("backup before tag write", "path", backupPath)
 }
 
 // ApplyMetadataFileIO runs the slow file operations after metadata is applied:
@@ -91,7 +91,7 @@ func (mfs *Service) ApplyMetadataFileIO(id string) {
 	// Run file rename + tag write pipeline
 	if config.AppConfig.AutoRenameOnApply || config.AppConfig.AutoWriteTagsOnApply {
 		if err := mfs.runApplyPipeline(id, book); err != nil {
-						slog.Warn("apply pipeline failed for", "id", id, "error", err)
+			slog.Warn("apply pipeline failed for", "id", id, "error", err)
 		}
 	}
 }
@@ -123,7 +123,7 @@ func removeEmptyDirs(dir, stopAt string) {
 		if err := os.Remove(dir); err != nil {
 			break
 		}
-				slog.Info("removed empty directory", "value", dir)
+		slog.Info("removed empty directory", "value", dir)
 		dir = filepath.Dir(dir)
 	}
 }

--- a/internal/metafetch/service_scoring.go
+++ b/internal/metafetch/service_scoring.go
@@ -817,12 +817,12 @@ func (mfs *Service) RerankTopK(
 	}
 	if ambiguousEnd < 2 {
 		// Only one candidate within epsilon — nothing to resolve.
-				slog.Debug("metadata-search rerank skipped — only 1 candidate within epsilon of best", "epsilon", epsilon, "bestScore", bestScore)
+		slog.Debug("metadata-search rerank skipped — only 1 candidate within epsilon of best", "epsilon", epsilon, "bestScore", bestScore)
 		return candidates
 	}
 
 	topCands := candidates[:ambiguousEnd]
-		slog.Debug("metadata-search rerank firing on top candidates", "count", len(topCands), "epsilon", epsilon, "bestScore", bestScore)
+	slog.Debug("metadata-search rerank firing on top candidates", "count", len(topCands), "epsilon", epsilon, "bestScore", bestScore)
 
 	// Resolve the book's author name for the query payload.
 	authorName := ""
@@ -850,9 +850,9 @@ func (mfs *Service) RerankTopK(
 	llmScores, err := mfs.llmScorer.Score(ctx, query, llmCands)
 	if err != nil || len(llmScores) != len(topCands) {
 		if err != nil {
-						slog.Warn("metadata-search rerank LLM call failed, keeping base scores", "error", err)
+			slog.Warn("metadata-search rerank LLM call failed, keeping base scores", "error", err)
 		} else {
-						slog.Warn("metadata-search rerank returned scores for candidates, keeping base scores", "llmScoreCount", len(llmScores), "candidateCount", len(topCands))
+			slog.Warn("metadata-search rerank returned scores for candidates, keeping base scores", "llmScoreCount", len(llmScores), "candidateCount", len(topCands))
 		}
 		return candidates
 	}
@@ -906,7 +906,7 @@ func ApplySeriesPositionFilter(
 	wantPos := strconv.Itoa(knownPosition)
 	best := results[0]
 	if best.SeriesPosition != "" && best.SeriesPosition != wantPos {
-				slog.Debug("scorer rejecting result (series position ! expected )", "title", best.Title, "seriesPosition", best.SeriesPosition, "wantPos", wantPos)
+		slog.Debug("scorer rejecting result (series position ! expected )", "title", best.Title, "seriesPosition", best.SeriesPosition, "wantPos", wantPos)
 		return nil
 	}
 	return results

--- a/internal/metafetch/service_search_test.go
+++ b/internal/metafetch/service_search_test.go
@@ -14,16 +14,16 @@ func TestFilterCoverlessCandidates(t *testing.T) {
 		name        string
 		input       []MetadataCandidate
 		wantIndices map[int]bool // indices that should be in the output
-		wantCount   int            // expected count of results
+		wantCount   int          // expected count of results
 	}{
 		{
 			name: "ASIN candidate survives",
 			input: []MetadataCandidate{
 				{
-					Title:     "Cover-less ASIN",
-					CoverURL:  "",
-					Source:    "Audnexus (Audible)",
-					Score:     1.0,
+					Title:    "Cover-less ASIN",
+					CoverURL: "",
+					Source:   "Audnexus (Audible)",
+					Score:    1.0,
 				},
 				{
 					Title:    "With Cover",

--- a/internal/metafetch/service_test.go
+++ b/internal/metafetch/service_test.go
@@ -576,15 +576,15 @@ func TestFilterUnchangedTags_UnchangedCustomTags(t *testing.T) {
 	// Prepare a tag map with custom tag values that match what ExtractMetadata
 	// would return from a real file
 	tagMap := map[string]interface{}{
-		"title":            "Test Book",
-		"album":            "Test Album",
-		"artist":           "Test Author",
-		"book_id":          "book-123",
-		"open_library_id":  "ol-456",
-		"hardcover_id":     "hc-789",
-		"google_books_id":  "gb-012",
-		"edition":          "1st",
-		"print_year":       "2020",
+		"title":           "Test Book",
+		"album":           "Test Album",
+		"artist":          "Test Author",
+		"book_id":         "book-123",
+		"open_library_id": "ol-456",
+		"hardcover_id":    "hc-789",
+		"google_books_id": "gb-012",
+		"edition":         "1st",
+		"print_year":      "2020",
 	}
 
 	// Since the file doesn't exist, all tags will be returned (safe fallback).
@@ -616,8 +616,8 @@ func TestFilterUnchangedTags_MissingFile(t *testing.T) {
 	missingFile := "/tmp/nonexistent-file-xyz.m4b"
 
 	tagMap := map[string]interface{}{
-		"title":    "Test Book",
-		"book_id":  "test-id",
+		"title":   "Test Book",
+		"book_id": "test-id",
 	}
 
 	filtered := FilterUnchangedTags(missingFile, tagMap)

--- a/internal/metafetch/transcription_boost_test.go
+++ b/internal/metafetch/transcription_boost_test.go
@@ -84,7 +84,7 @@ func TestTranscribedTitleAgrees(t *testing.T) {
 		want              bool
 	}{
 		{"The Way of Kings", "The Way of Kings", true},
-		{"the way of kings", "The Way of Kings", true},         // normalized
+		{"the way of kings", "The Way of Kings", true},                // normalized
 		{"The Way of Kings (Stormlight 1)", "The Way of Kings", true}, // substring
 		{"The Final Empire", "The Way of Kings", false},
 		{"", "The Way of Kings", false},

--- a/todo.d/20260815-search-placeholder-missing-on-nav-to-all-books.md
+++ b/todo.d/20260815-search-placeholder-missing-on-nav-to-all-books.md
@@ -1,0 +1,25 @@
+### Search placeholder hint missing when navigating to All Books from Finished
+
+Navigating from **Finished** directly to **All Books** leaves the search bar
+without its `try author:"Name"` placeholder hint. Clicking away to the Dashboard
+and then back to All Books makes it appear.
+
+Reported 2026-08-15.
+
+The refresh-fixes-it shape points at state that is computed on mount (or on a
+particular route transition) rather than derived from the current route/filter on
+every render — so the Finished → All Books transition reuses a mounted component
+without recomputing the hint, while Dashboard → All Books remounts it.
+
+Worth checking:
+- whether the placeholder is derived from a `useState` initialized once vs a
+  `useMemo`/derived value keyed on the active view
+- whether the Finished and All Books routes share a component instance (same
+  route element, differing only by a query param or filter prop), which would
+  skip the remount
+- whether the hint depends on a fetched field list that is only requested on
+  mount
+
+Low severity, cosmetic, but it makes the search syntax undiscoverable for anyone
+arriving via that path — which is the one path where a user has just finished a
+book and is most likely to go looking for another by the same author.


### PR DESCRIPTION
**Regression from #2471**, reported and reproduced in production.

Applying metadata blanked the book's cover until a manual refresh.

## Cause

`ApplyMetadataToBook` writes the candidate's **remote** cover URL into `book.CoverURL`. The UI does not load that directly — it proxies through `/api/v1/covers/proxy`, which rejects hosts outside its allow-list. Production, one second after the apply returned:

```
10:57:08  POST .../apply-metadata → 200 (6.9s)
10:57:09  GET  /api/v1/covers/proxy?url=...m.media-amazon.com... → 400
          "URL not from an allowed cover source"
```

**This was latent, not new.** The value was always wrong; the inline cover download replaced it with the local path microseconds later, so it was never observed. Moving that download to the background in #2471 (which took ~4s off the request) widened the window from microseconds to seconds and made it user-visible. The background download then repointed `cover_url` locally, which is why a refresh brought the image back.

## Fix

`cover_url` keeps the **previous** local cover through the apply; `DownloadPendingCover` repoints it once the new image is on disk. With no previous cover it is left unset rather than persisting an unrenderable URL — no image beats a broken one, and the background download fills it in shortly.

The decision is extracted as `renderableCoverURL` so it is testable without a store.

## Verification

- 2 tests + 5 subtests pass, including a **property test** asserting the function can never return the remote URL — that is the invariant that actually matters, and it holds across every combination of inputs rather than the five I happened to enumerate.
- **Mutation-tested:** disabling the guard fails 4 tests including the property test.
- `go build ./...` exit 0; `internal/metafetch` passes.

## Also included

A `todo.d/` fragment for a separate report: the search bar's `try author:"Name"` placeholder is missing when navigating **Finished → All Books**, and appears after bouncing through the Dashboard. The refresh-fixes-it shape points at state computed on mount rather than derived per render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS