### PR TITLE
fix(logging): make write-back and organize warnings name the book and file

### DIFF
--- a/changelog.d/20260815_actionable_writeback_warnings.md
+++ b/changelog.d/20260815_actionable_writeback_warnings.md
@@ -1,0 +1,21 @@
+### Fixed
+
+- Write-back and organize warnings now name what they could not write. Every
+  warning on the metadata-apply path used to report a bare count or an opaque
+  `"value"` key, so a production log could tell you that something failed but
+  never which tag, which file, or which book:
+  - `write-back: unmapped tag key` now carries the tag key, its value, the file
+    path, and the file's current title/album, plus a hint that an unmapped key
+    forces a rewrite of the file on every run.
+  - `files skipped during rename` now names the book and lists the missing
+    source paths (capped at 20, with a `truncated` flag) instead of logging only
+    `count`.
+  - `write-back failed for file` now carries the book id/title, the book-file
+    id, the file's position in the book (`3 of 12`), and the tag keys that were
+    being written.
+  - `organizeFile skipping unsafe destination` logged only an error with no path
+    at all; it now names the book, the source, the computed destination, and the
+    target directory.
+  - `organizeFile skipping missing source file`, `tag writing failed for book`,
+    `cover art embedding failed`, and the two "protected book has no library
+    copy" warnings all gained book title and path context.

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service.go
-// version: 5.5.0
+// version: 5.6.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
 // last-edited: 2026-08-15
 
@@ -161,7 +161,9 @@ func (mfs *Service) embedCoverInBookFiles(book *database.Book, coverPath string)
 	if mfs.isProtectedPath(book.FilePath) {
 		libCopy := mfs.ensureLibraryCopy(book)
 		if libCopy == nil {
-			slog.Warn("cannot embed cover no library copy for protected book", "id", book.ID)
+			slog.Warn("cannot embed cover: protected book has no library copy",
+				"book_id", book.ID, "book_title", book.Title,
+				"protected_path", book.FilePath)
 			return
 		}
 		book = libCopy
@@ -176,7 +178,8 @@ func (mfs *Service) embedCoverInBookFiles(book *database.Book, coverPath string)
 		// Multi-file book
 		bookFiles, err := mfs.db.GetBookFiles(book.ID)
 		if err != nil {
-			slog.Warn("failed to list book files for cover embedding on book", "id", book.ID, "error", err)
+			slog.Warn("failed to list book files for cover embedding",
+				"book_id", book.ID, "book_title", book.Title, "error", err)
 			return
 		}
 		for _, bf := range bookFiles {
@@ -235,7 +238,10 @@ func (mfs *Service) embedCoverInBookFiles(book *database.Book, coverPath string)
 		// EmbedCoverArtSafe imports the file from a Deluge-protected path before
 		// writing if the pre-flight guard is wired (mfs.safeWriteDeps).
 		if err := tagger.EmbedCoverArtSafe(context.Background(), f, coverPath, mfs.safeWriteDeps); err != nil {
-			slog.Warn("cover art embedding failed for", "value", f, "error", err)
+			slog.Warn("cover art embedding failed for file",
+				"path", f, "error", err,
+				"book_id", book.ID, "book_title", book.Title,
+				"cover_path", coverPath)
 			failed++
 		} else {
 			embedded++

--- a/internal/metafetch/service_writeback.go
+++ b/internal/metafetch/service_writeback.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_writeback.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: fad73c11-30c2-4fdc-addd-45afef25d792
 // last-edited: 2026-08-15
 
@@ -19,6 +19,20 @@ import (
 	"strings"
 	"time"
 )
+
+// sortedKeys returns a tag map's keys in a stable order so a failure log names
+// which tags were being written. Without it a write-back failure told you only
+// that "a write failed" — not whether it was trying to set one field or twenty,
+// which is the difference between a benign retry and a book about to be
+// rewritten wholesale.
+func sortedKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
 
 // writeBackMetadata writes enriched metadata back to a book's audio file(s)
 // during the fetch/apply flow.
@@ -273,7 +287,7 @@ func FilterUnchangedTags(filePath string, tagMap map[string]interface{}) map[str
 		// Can't read current tags — write everything to be safe
 		return tagMap
 	}
-	return filterTagsAgainst(current, tagMap)
+	return filterTagsAgainst(filePath, current, tagMap)
 }
 
 // filterTagsAgainst is the pure comparison half of FilterUnchangedTags, split
@@ -285,7 +299,7 @@ func FilterUnchangedTags(filePath string, tagMap map[string]interface{}) map[str
 // untouched, and the comparison below never ran. Those tests passed no matter
 // what the mapping did — one of them even asserted that "track" survives,
 // pinning the bug in place as if it were intended behavior.
-func filterTagsAgainst(current metadata.Metadata, tagMap map[string]interface{}) map[string]interface{} {
+func filterTagsAgainst(filePath string, current metadata.Metadata, tagMap map[string]interface{}) map[string]interface{} {
 	// Build a map of known tag names to their current values. Every custom tag
 	// key emitted by the writer (via metadata/taglib_tagmap.go buildWriteTagMap)
 	// must have an entry here, mapping the input key to the corresponding
@@ -368,7 +382,16 @@ func filterTagsAgainst(current metadata.Metadata, tagMap map[string]interface{})
 			// ("track" used to be the example here; it is mapped above now.
 			// This warn is only a real signal once every emitted key is mapped,
 			// so do not add new writer keys without a currentVals entry.)
-			slog.Warn("FilterUnchangedTags: unknown tag key (writing)", "key", k)
+			// Name the FILE, not just the key. This warn used to carry only the
+			// key, so it told you a tag was being force-written every run and
+			// gave you no way to find which file or book it was on.
+			slog.Warn("write-back: unmapped tag key, forcing a write",
+				"key", k,
+				"value", v,
+				"path", filePath,
+				"title", current.Title,
+				"album", current.Album,
+				"hint", "add this key to currentVals in filterTagsAgainst or it rewrites the file on every run")
 			filtered[k] = v
 			continue
 		}
@@ -445,7 +468,10 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 	if mfs.isProtectedPath(book.FilePath) {
 		libCopy := mfs.ensureLibraryCopy(book)
 		if libCopy == nil {
-			slog.Warn("runApplyPipeline no library copy for protected book , skipping", "id", id)
+			slog.Warn("runApplyPipeline skipping protected book: no library copy exists",
+				"book_id", id, "book_title", book.Title,
+				"protected_path", book.FilePath,
+				"hint", "book lives under a protected path (iTunes/import); rename and tag-write are skipped until a library copy is made")
 			return nil
 		}
 		slog.Info("runApplyPipeline using library copy for protected book", "libCopyID", libCopy.ID, "bookID", id)
@@ -514,7 +540,29 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 		// files that did move. The error is returned after the DB sync,
 		// before the rename checkpoint is set.
 		if len(renameResult.Skipped) > 0 {
-			slog.Warn("files skipped (source missing) during rename", "count", len(renameResult.Skipped))
+			// Name the files. This used to log only the count, which told you
+			// something was wrong and nothing about what — you could not find the
+			// offending file without going and diffing the library by hand.
+			//
+			// Capped so one pathological book cannot flood the log; the count is
+			// always reported in full so a truncated list is never mistaken for
+			// the whole set.
+			const maxListed = 20
+			skippedPaths := make([]string, 0, min(len(renameResult.Skipped), maxListed))
+			for i, e := range renameResult.Skipped {
+				if i >= maxListed {
+					break
+				}
+				skippedPaths = append(skippedPaths, e.SourcePath)
+			}
+			slog.Warn("files skipped during rename (source missing on disk)",
+				"book_id", id,
+				"book_title", book.Title,
+				"skipped_count", len(renameResult.Skipped),
+				"total_files", len(bookFiles),
+				"listed", len(skippedPaths),
+				"truncated", len(renameResult.Skipped) > maxListed,
+				"missing_sources", skippedPaths)
 		}
 
 		// Update book file records with new paths (only for succeeded renames)
@@ -591,7 +639,9 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 	// Write metadata tags to audio files
 	if config.AppConfig.AutoWriteTagsOnApply && !hasCheckpoint(mfs.db, id, phaseTags) {
 		if written, err := mfs.WriteBackMetadataForBook(id); err != nil {
-			slog.Warn("tag writing failed for book", "id", id, "error", err)
+			slog.Warn("tag writing failed for book",
+				"book_id", id, "book_title", book.Title,
+				"book_path", book.FilePath, "error", err)
 		} else {
 			slog.Info("wrote metadata tags to file(s) for book", "value", written, "id", id)
 			setCheckpoint(mfs.db, id, phaseTags)
@@ -778,7 +828,7 @@ func (mfs *Service) writeBackForBook(id string, ov *writeBackOverrides, segmentF
 				delete(tagMap, "title")
 			}
 			if curErr == nil {
-				tagMap = filterTagsAgainst(cur, tagMap)
+				tagMap = filterTagsAgainst(bf.FilePath, cur, tagMap)
 			}
 			// curErr != nil keeps the historical safe fallback: write everything.
 			if len(tagMap) == 0 {
@@ -794,7 +844,11 @@ func (mfs *Service) writeBackForBook(id string, ov *writeBackOverrides, segmentF
 			if _, _, err := fileops.WriteTagsSafe(bf.FilePath, func(tmpPath string) error {
 				return metadata.WriteMetadataToFileInPlace(tmpPath, tagMap, opConfig)
 			}, fileops.WriteTagsSafeOptions{BookFileID: bf.ID, Store: mfs.db}); err != nil {
-				slog.Warn("write-back failed for file", "path", bf.FilePath, "error", err)
+				slog.Warn("write-back failed for file",
+					"path", bf.FilePath, "error", err,
+					"book_id", book.ID, "book_title", book.Title,
+					"book_file_id", bf.ID, "file_index", i+1, "file_count", len(activeFiles),
+					"tag_keys", sortedKeys(tagMap))
 			} else {
 				// Log successes as well as failures. Without this the multi-file
 				// branch was silent on success while the single-file branch below
@@ -844,9 +898,12 @@ func (mfs *Service) writeBackForBook(id string, ov *writeBackOverrides, segmentF
 					if _, _, err := fileops.WriteTagsSafe(f, func(tmpPath string) error {
 						return metadata.WriteMetadataToFileInPlace(tmpPath, fm, opConfig)
 					}, wtsOpts); err != nil {
-						slog.Warn("write-back failed for", "value", f, "error", err)
+						slog.Warn("write-back failed for file",
+							"path", f, "error", err,
+							"book_id", book.ID, "book_title", book.Title,
+							"tag_keys", sortedKeys(fm))
 					} else {
-						slog.Info("wrote metadata back to", "value", f)
+						slog.Info("wrote metadata back to", "path", f)
 						writtenCount++
 					}
 				}
@@ -863,7 +920,10 @@ func (mfs *Service) writeBackForBook(id string, ov *writeBackOverrides, segmentF
 					if _, _, err := fileops.WriteTagsSafe(book.FilePath, func(tmpPath string) error {
 						return metadata.WriteMetadataToFileInPlace(tmpPath, fm, opConfig)
 					}, wtsOpts); err != nil {
-						slog.Warn("write-back failed for", "path", book.FilePath, "error", err)
+						slog.Warn("write-back failed for file",
+							"path", book.FilePath, "error", err,
+							"book_id", book.ID, "book_title", book.Title,
+							"tag_keys", sortedKeys(fm))
 					} else {
 						writtenCount++
 					}

--- a/internal/metafetch/service_writeback_filtertags_test.go
+++ b/internal/metafetch/service_writeback_filtertags_test.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_writeback_filtertags_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7c1d9a04-2b6e-4f38-9d51-0a8e3b7c62f4
 // last-edited: 2026-08-15
 
@@ -47,7 +47,7 @@ func TestFilterTagsAgainst_MultiFileBookCanSkip(t *testing.T) {
 		"track":  "1/12",
 	}
 
-	filtered := filterTagsAgainst(current, tagMap)
+	filtered := filterTagsAgainst("/tmp/test.m4b", current, tagMap)
 
 	assert.Empty(t, filtered,
 		"an unchanged multi-file book must filter to zero tags so write-back can skip it; "+
@@ -114,7 +114,7 @@ func TestFilterTagsAgainst_TrackMatching(t *testing.T) {
 				TrackNumber: tt.trackNumber,
 				TrackTotal:  tt.trackTotal,
 			}
-			filtered := filterTagsAgainst(current, map[string]interface{}{"track": tt.desired})
+			filtered := filterTagsAgainst("/tmp/test.m4b", current, map[string]interface{}{"track": tt.desired})
 
 			if tt.wantWritten {
 				assert.Contains(t, filtered, "track", tt.why)
@@ -217,7 +217,7 @@ func TestFilterTagsAgainst_ChangedValuesStillWritten(t *testing.T) {
 		"track":  "1/12",       // unchanged — must be dropped
 	}
 
-	filtered := filterTagsAgainst(current, tagMap)
+	filtered := filterTagsAgainst("/tmp/test.m4b", current, tagMap)
 
 	assert.Equal(t, map[string]interface{}{
 		"title": "01 - New Title",

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -1,7 +1,7 @@
 // file: internal/organizer/organizer.go
-// version: 1.23.0
+// version: 1.24.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-08-13
+// last-edited: 2026-08-15
 
 package organizer
 
@@ -762,7 +762,11 @@ func (o *Organizer) OrganizeBookDirectory(book *database.Book, segmentPaths []st
 
 		// Verify dstPath stays inside targetDir (defense against crafted filenames)
 		if err := ensureUnderRoot(dstPath, targetDir); err != nil {
-			slog.Warn("organizeFile skipping unsafe destination", "error", err)
+			slog.Warn("organizeFile skipping unsafe destination",
+				"error", err,
+				"book_id", book.ID, "book_title", book.Title,
+				"source_path", srcPath, "dest_path", dstPath,
+				"target_dir", targetDir, "file_name", fileName)
 			continue
 		}
 
@@ -780,7 +784,10 @@ func (o *Organizer) OrganizeBookDirectory(book *database.Book, segmentPaths []st
 		if _, err := o.organizeFile(srcPath, dstPath); err != nil {
 			// Skip missing source files instead of aborting the entire book
 			if os.IsNotExist(err) || strings.Contains(err.Error(), "no such file") {
-				slog.Warn("organizeFile skipping missing source file", "path", srcPath)
+				slog.Warn("organizeFile skipping missing source file",
+					"source_path", srcPath, "dest_path", dstPath,
+					"book_id", book.ID, "book_title", book.Title,
+					"error", err)
 				continue
 			}
 			// Handle race: another worker may have created the file between our stat and copy


### PR DESCRIPTION
## Why

Every warning on the metadata-apply path reported a bare count or an opaque `"value"` key. A production log could tell you that a write failed but never **which tag, which file, or which book** — so none of them were actionable.

The `unmapped tag key` warning is the sharp example: it fires on every unmapped key and forces a rewrite of the file, which is exactly how the missing `track` mapping stayed invisible long enough for multi-file books to rewrite every file on every run, permanently. The warning was firing the whole time and said nothing useful.

## What changed

| Warning | Before | After |
|---|---|---|
| `write-back: unmapped tag key` | no key, no file | `key`, `value`, `path`, current `title`/`album`, + hint that it forces a rewrite |
| `files skipped during rename` | `count` only, despite holding the full list | book id/title, `skipped_count`, `total_files`, `missing_sources` (capped 20, `truncated` flag) |
| `write-back failed for file` | path + error | + book id/title, book-file id, `file_index`/`file_count`, `tag_keys` |
| `organizeFile skipping unsafe destination` | **error only, no path at all** | book, source, computed destination, target dir, file name |
| `organizeFile skipping missing source file` | source path | + book, destination, error |
| `tag writing failed for book` | id | + title, book path |
| `cover art embedding failed` | `"value", f` | `path`, book id/title, cover path |
| protected-book-no-library-copy (×2) | id | + title, protected path, hint |

Two supporting changes: `filterTagsAgainst` takes the file path so the unmapped-key warning can name the file, and `sortedKeys` gives failure logs a stable tag-key list.

## Verification

- `go build ./...` → 0
- `go vet ./internal/metafetch/... ./internal/organizer/...` → 0
- `go test ./internal/metafetch/... ./internal/organizer/... -short -count=1` → both `ok`

Pure logging change — no control flow altered. The three `filterTagsAgainst` test call sites were updated for the new signature; assertions unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS