### PR TITLE
perf(review): batch the book reads and parallelize the review listing

### DIFF
--- a/changelog.d/20260815_170000_review_list_n_plus_one.md
+++ b/changelog.d/20260815_170000_review_list_n_plus_one.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **The metadata review listing no longer takes 20–35 seconds.** It is requested
+  with `limit=0` ("return all rows"), and it did two sequential `GetBookByID`
+  point reads per entry — once to compute status counts and again to build each
+  row — plus a serial `GetCachedCandidates` per entry, over the entire pending
+  set. Production served it in 21.7s and 35.2s, which was timing the UI out.
+  Books are now fetched in one batch call (`GetBooksByIDs`, which preserves input
+  order) and reused across both passes, and the cached-candidate reads run
+  concurrently with the response order preserved.

--- a/internal/server/handlers/metadata_cache.go
+++ b/internal/server/handlers/metadata_cache.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/metadata_cache.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
 // last-edited: 2026-08-15
 
@@ -28,8 +28,18 @@ import (
 // MetadataCacheBookStore is the narrow persistence interface required by
 // MetadataCacheHandler. It also satisfies metabatch.BookFilesGetter so that
 // BuildCandidateBookInfo can be called with the same store value.
+// reviewListConcurrency bounds the concurrent cached-candidate reads when
+// building the review listing. These are store reads, not network calls, and
+// this runs inline on a user-facing request — a small fixed pool, not
+// runtime.NumCPU(), so one large listing cannot starve the rest of the server.
+const reviewListConcurrency = 8
+
 type MetadataCacheBookStore interface {
 	GetBookByID(id string) (*database.Book, error)
+	// GetBooksByIDs fetches many books in one store call, preserving input
+	// order. The review listing is served with limit=0 and previously did two
+	// GetBookByID point reads per entry over the whole pending set.
+	GetBooksByIDs(ids []string) ([]database.Book, error)
 	UpdateBook(id string, book *database.Book) (*database.Book, error)
 	// GetBookFiles is required to satisfy metabatch.BookFilesGetter.
 	GetBookFiles(bookID string) ([]database.BookFile, error)
@@ -158,10 +168,48 @@ func (h *MetadataCacheHandler) GetCacheReviewResults(c *gin.Context) {
 		sum    metafetch.MetadataCacheSummary
 		status string // "matched" | "no_match" | "applied"
 	}
+	// Fetch every book in ONE batch read instead of a GetBookByID per summary.
+	//
+	// This endpoint is called with limit=0 ("return all rows"), so the loops below
+	// run over the entire pending set. It previously did GetBookByID once here to
+	// compute status counts and AGAIN further down to build each row — 2N
+	// sequential point reads. Production served it in 21.7s and 35.2s, which is
+	// what was timing the UI out.
+	//
+	// GetBooksByIDs preserves input order and is a single store call.
+	bookIDs := make([]string, 0, total)
+	for _, sum := range summaries {
+		bookIDs = append(bookIDs, sum.BookID)
+	}
+	booksByID := make(map[string]*database.Book, total)
+	if fetched, berr := h.store.GetBooksByIDs(bookIDs); berr == nil {
+		for i := range fetched {
+			booksByID[fetched[i].ID] = &fetched[i]
+		}
+	} else {
+		slog.Warn("GetCacheReviewResults batch book fetch failed; falling back to per-book reads", "err", berr)
+	}
+
+	// lookupBook serves from the batch result and falls back to a point read only
+	// when the batch missed the row (or the batch call itself failed), so a
+	// partial batch degrades in behavior-preserving fashion rather than dropping
+	// entries.
+	lookupBook := func(id string) *database.Book {
+		if b, ok := booksByID[id]; ok {
+			return b
+		}
+		b, err := h.store.GetBookByID(id)
+		if err != nil || b == nil {
+			return nil
+		}
+		booksByID[id] = b
+		return b
+	}
+
 	prepared := make([]entryWithStatus, 0, total)
 	for _, sum := range summaries {
-		book, err := h.store.GetBookByID(sum.BookID)
-		if err != nil || book == nil {
+		book := lookupBook(sum.BookID)
+		if book == nil {
 			continue
 		}
 		st := "matched"
@@ -206,15 +254,37 @@ func (h *MetadataCacheHandler) GetCacheReviewResults(c *gin.Context) {
 		}
 	}
 
+	// Read each page entry's cached candidates CONCURRENTLY. This was a serial
+	// GetCachedCandidates per entry, on top of a second GetBookByID per entry
+	// that is now gone (lookupBook serves it from the batch above).
+	//
+	// Results are written to a pre-sized slot per index and assembled in order
+	// below, so the response ordering is byte-identical to the serial version —
+	// this is a paginated listing and reordering it would scramble the UI.
+	cachedByIdx := make([]*metafetch.MetadataCandidateCache, len(page))
+	var cg errgroup.Group
+	cg.SetLimit(reviewListConcurrency)
+	for i := range page {
+		i := i
+		cg.Go(func() error {
+			entry, _, cerr := h.svc.GetCachedCandidates(page[i].sum.BookID)
+			if cerr == nil {
+				cachedByIdx[i] = entry
+			}
+			return nil // a per-entry failure skips that row, never the whole page
+		})
+	}
+	_ = cg.Wait()
+
 	results := make([]metabatch.CandidateResult, 0, len(page))
-	for _, p := range page {
+	for pageIdx, p := range page {
 		sum := p.sum
-		book, err := h.store.GetBookByID(sum.BookID)
-		if err != nil || book == nil {
+		book := lookupBook(sum.BookID)
+		if book == nil {
 			continue
 		}
-		entry, _, err := h.svc.GetCachedCandidates(sum.BookID)
-		if err != nil || entry == nil || len(entry.Candidates) == 0 {
+		entry := cachedByIdx[pageIdx]
+		if entry == nil || len(entry.Candidates) == 0 {
 			continue
 		}
 		var cand metafetch.MetadataCandidate

--- a/internal/server/handlers/mocks/mock_metadata_cache_book_store.go
+++ b/internal/server/handlers/mocks/mock_metadata_cache_book_store.go
@@ -160,6 +160,68 @@ func (_c *MockMetadataCacheBookStore_GetBookFiles_Call) RunAndReturn(run func(bo
 	return _c
 }
 
+// GetBooksByIDs provides a mock function for the type MockMetadataCacheBookStore
+func (_mock *MockMetadataCacheBookStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
+	ret := _mock.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBooksByIDs")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
+		return returnFunc(ids)
+	}
+	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
+		r0 = returnFunc(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = returnFunc(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockMetadataCacheBookStore_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
+type MockMetadataCacheBookStore_GetBooksByIDs_Call struct {
+	*mock.Call
+}
+
+// GetBooksByIDs is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockMetadataCacheBookStore_Expecter) GetBooksByIDs(ids any) *MockMetadataCacheBookStore_GetBooksByIDs_Call {
+	return &MockMetadataCacheBookStore_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
+}
+
+func (_c *MockMetadataCacheBookStore_GetBooksByIDs_Call) Run(run func(ids []string)) *MockMetadataCacheBookStore_GetBooksByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockMetadataCacheBookStore_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockMetadataCacheBookStore_GetBooksByIDs_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockMetadataCacheBookStore_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockMetadataCacheBookStore_GetBooksByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateBook provides a mock function for the type MockMetadataCacheBookStore
 func (_mock *MockMetadataCacheBookStore) UpdateBook(id string, book *database.Book) (*database.Book, error) {
 	ret := _mock.Called(id, book)


### PR DESCRIPTION
## Why

The metadata review listing was measured at **21–35s** in production. With `limit=0` it did **2N sequential point reads** — one `GetBookByID` and one `GetCachedCandidates` per summary row, serially, inside the request goroutine.

## What changed

`internal/server/handlers/metadata_cache.go`:

1. **Batch the book reads.** Collect every `BookID` up front and issue one `GetBooksByIDs`, then serve from a map. A per-id point read remains as a fallback so a partial batch result can't drop rows.
2. **Parallelize the candidate reads.** `GetCachedCandidates` now runs through an `errgroup` at `reviewListConcurrency = 8`, writing into `cachedByIdx[i]` so **response order is preserved exactly**.

`GetBooksByIDs` was added to the narrow `MetadataCacheBookStore` interface and mocks were regenerated.

## Verification

- `go build ./...` → 0
- Rebased on current `main` before opening (a sibling PR went red recently purely from an out-of-date base).

Order preservation is the correctness risk here, and it's handled by indexing into a preallocated slice rather than appending from goroutines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS