### PR TITLE
perf(metafetch): query metadata sources concurrently per book

### DIFF
--- a/changelog.d/20260815_metadata_source_fanout.md
+++ b/changelog.d/20260815_metadata_source_fanout.md
@@ -1,0 +1,16 @@
+### Changed
+
+- Metadata search now queries sources **concurrently** instead of one after
+  another. Previously every source in the priority chain was queried in series,
+  and with up to four search attempts per source plus a scoring pass, a single
+  book's search was measured at 13s on production.
+
+  Only the I/O half is parallel. The dedupe/scoring merge stays sequential and
+  in source order, because the source chain is priority-ordered and the dedupe is
+  first-wins — parallelizing the merge would make which source wins a duplicate
+  title+author nondeterministic between runs.
+
+  Width is controlled by `metadata_scoring.source_fanout_workers` (default 4).
+  This multiplies with `bulk_fetch_workers`: 4 books × 4 sources is 16 provider
+  requests in flight, each still gated by that provider's own token bucket in
+  `internal/metadata/providerhttp`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.77.0
+// version: 1.78.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-08-15
 
@@ -324,6 +324,16 @@ type MetadataScoringConfig struct {
 	// this one is disk/TagLib-bound against the library. Default 4; 0 or
 	// negative falls back to the compiled-in default.
 	WriteBackWorkers int `json:"write_back_workers" mapstructure:"write_back_workers"`
+
+	// SourceFanoutWorkers bounds how many metadata SOURCES are queried
+	// concurrently for a single book (see internal/metafetch/service_search.go
+	// sourceFanoutLimit()). This is a third, distinct axis from the two above:
+	// BulkFetchWorkers is how many BOOKS are in flight, this is how many
+	// PROVIDERS are in flight per book, and the two multiply. Keep it small —
+	// each provider has its own token bucket in internal/metadata/providerhttp,
+	// so exceeding the source count buys nothing and only deepens the queue.
+	// Default 4; 0 or negative falls back to the compiled-in default.
+	SourceFanoutWorkers int `json:"source_fanout_workers" mapstructure:"source_fanout_workers"`
 }
 
 // f64Ptr returns a pointer to v. Used to populate the pointer-typed scoring
@@ -1656,6 +1666,7 @@ func InitConfig() {
 				DurationTierScores:      getFloat64Slice("metadata_scoring.duration_tier_scores"),
 
 				BulkFetchWorkers: viper.GetInt("metadata_scoring.bulk_fetch_workers"),
+				SourceFanoutWorkers: viper.GetInt("metadata_scoring.source_fanout_workers"),
 				WriteBackWorkers: viper.GetInt("metadata_scoring.write_back_workers"),
 			},
 
@@ -2126,6 +2137,7 @@ func ResetToDefaults() {
 				DurationTierScores:      []float64{20, 15, 10, 0, -10, -20},
 
 				BulkFetchWorkers: 4,
+				SourceFanoutWorkers: 4,
 				WriteBackWorkers: 4,
 			},
 

--- a/internal/metafetch/service_search.go
+++ b/internal/metafetch/service_search.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_search.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: bcba782a-8ed4-4285-be91-2af3eddc90e3
-// last-edited: 2026-07-13
+// last-edited: 2026-08-15
 
 package metafetch
 
@@ -13,12 +13,33 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 	"github.com/falkcorp/audiobook-organizer/internal/openlibrary"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
 	"log/slog"
 	"sort"
 	"strings"
 	"time"
 )
+
+// defaultSourceFanout is the fallback for how many metadata sources are queried
+// concurrently for ONE book when config.MetadataScoring.SourceFanoutWorkers is
+// unset. Kept small on purpose: this multiplies with the per-book pool
+// (BulkFetchWorkers), so 4 books × 4 sources is already 16 provider requests in
+// flight. Each provider enforces its own token bucket in
+// internal/metadata/providerhttp, so raising this past the source count buys
+// nothing — it only makes requests queue behind a limiter instead of a channel.
+const defaultSourceFanout = 4
+
+// sourceFanoutLimit resolves the per-book source fan-out width. The `> 0` guard
+// is load-bearing: a config that never set the key unmarshals to 0, and
+// errgroup.SetLimit(0) blocks forever on the first Go call — a search that
+// simply never returns rather than one that runs slowly.
+func sourceFanoutLimit() int {
+	if w := config.AppConfig.MetadataScoring.SourceFanoutWorkers; w > 0 {
+		return w
+	}
+	return defaultSourceFanout
+}
 
 // BuildSourceChain returns metadata sources ordered by config priority.
 // Each source is wrapped with a circuit breaker that opens after 5 consecutive
@@ -592,7 +613,6 @@ func (mfs *Service) searchMetadataForBook(
 				GoogleRatingCount:    r.GoogleRatingCount,
 			})
 		}
-	}
 	}
 
 	// Try ASIN lookup: either the whole query is an ASIN, or extract one from the query

--- a/internal/metafetch/service_search.go
+++ b/internal/metafetch/service_search.go
@@ -314,115 +314,167 @@ func (mfs *Service) searchMetadataForBook(
 		return fn(ctx)
 	}
 
-	for _, src := range sources {
-		// Stop promptly if the caller cancelled — don't start another source.
-		if err := ctx.Err(); err != nil {
-			break
-		}
-		var allResults []metadata.BookMetadata
-		var lastErr error
-		sourcesTried = append(sourcesTried, src.Name())
-		cacheHit := false
+	// Fan out across sources. Each provider now has its OWN rate-limit token
+	// bucket in internal/metadata/providerhttp, so running sources concurrently
+	// does not make them contend for tokens with each other -- that is precisely
+	// what made this unsafe before and safe now. Previously every source was
+	// queried in series, and with up to four search attempts per source plus a
+	// scoring pass, one book's search took a measured 13s on production.
+	//
+	// Only the I/O half is parallel. The dedupe/scoring merge below stays
+	// sequential and in source order, because `sources` is PRIORITY-ORDERED and
+	// the dedupe is first-wins: parallelizing the merge would make which source
+	// wins a duplicate title+author nondeterministic between runs.
+	type sourceFetch struct {
+		name       string
+		results    []metadata.BookMetadata
+		baseScores []float64
+		baseTier   string
+		failedErr  string
+	}
+	fetched := make([]sourceFetch, len(sources))
 
-		// Check the metadata fetch cache before hitting the
-		// external API. Cache key is (bookID, source name) —
-		// on hit, we use the cached results as-is and skip the
-		// Search* calls entirely. On miss we fall through to
-		// the API path and write the result back at the end
-		// of the per-source block.
-		//
-		// Added 2026-04-11 after the OpenAI quota incident
-		// where re-fetching 8000 books hit every external API
-		// 8000 times even for books we'd already matched with
-		// high confidence.
-		maxAge := time.Duration(config.AppConfig.MetadataFetchCacheTTLDays) * 24 * time.Hour
-		if cached, _, cerr := database.GetCachedMetadataFetchWithMaxAge(mfs.db, id, src.Name(), maxAge); cerr == nil && cached != nil {
-			var cachedResults []metadata.BookMetadata
-			if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil {
-				// Keep the in-memory []BookMetadata internally consistent with the
-				// year-kind flag (#1940): entries cached before it shipped
-				// deserialize with PublishYearIsAudiobookRelease=false, so re-derive
-				// it from the source (cache key includes src.Name()). NOTE: on the
-				// search path this is defensive-only — candidates carry Source and
-				// re-derive the flag at apply time (service_apply.go) — but it keeps
-				// the two cache-replay sites symmetric.
-				isRelease := metadata.SourceProducesAudiobookReleaseYear(src.Name())
-				for i := range cachedResults {
-					cachedResults[i].PublishYearIsAudiobookRelease = isRelease
-				}
-				allResults = cachedResults
-				cacheHit = true
-				slog.Debug("metadata-search cache HIT for ( ) — results, age", "id", id, "name", src.Name(), "count", len(cachedResults), "value", time.Since(cached.CachedAt).Round(time.Second))
+	var fg errgroup.Group
+	fg.SetLimit(sourceFanoutLimit())
+	for srcIdx, source := range sources {
+		srcIdx, src := srcIdx, source
+		fg.Go(func() error {
+			// Stop promptly if the caller cancelled — don't start another source.
+			if err := ctx.Err(); err != nil {
+				return nil
 			}
-		}
+			var allResults []metadata.BookMetadata
+			var lastErr error
+			var failedErr string
+			cacheHit := false
 
-		if !cacheHit {
-			// If author hint provided, use title+author search for better results
-			if searchAuthor != "" {
+			// Check the metadata fetch cache before hitting the
+			// external API. Cache key is (bookID, source name) —
+			// on hit, we use the cached results as-is and skip the
+			// Search* calls entirely. On miss we fall through to
+			// the API path and write the result back at the end
+			// of the per-source block.
+			//
+			// Added 2026-04-11 after the OpenAI quota incident
+			// where re-fetching 8000 books hit every external API
+			// 8000 times even for books we'd already matched with
+			// high confidence.
+			maxAge := time.Duration(config.AppConfig.MetadataFetchCacheTTLDays) * 24 * time.Hour
+			if cached, _, cerr := database.GetCachedMetadataFetchWithMaxAge(mfs.db, id, src.Name(), maxAge); cerr == nil && cached != nil {
+				var cachedResults []metadata.BookMetadata
+				if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil {
+					// Keep the in-memory []BookMetadata internally consistent with the
+					// year-kind flag (#1940): entries cached before it shipped
+					// deserialize with PublishYearIsAudiobookRelease=false, so re-derive
+					// it from the source (cache key includes src.Name()). NOTE: on the
+					// search path this is defensive-only — candidates carry Source and
+					// re-derive the flag at apply time (service_apply.go) — but it keeps
+					// the two cache-replay sites symmetric.
+					isRelease := metadata.SourceProducesAudiobookReleaseYear(src.Name())
+					for i := range cachedResults {
+						cachedResults[i].PublishYearIsAudiobookRelease = isRelease
+					}
+					allResults = cachedResults
+					cacheHit = true
+					slog.Debug("metadata-search cache HIT for ( ) — results, age", "id", id, "name", src.Name(), "count", len(cachedResults), "value", time.Since(cached.CachedAt).Round(time.Second))
+				}
+			}
+
+			if !cacheHit {
+				// If author hint provided, use title+author search for better results
+				if searchAuthor != "" {
+					if results, serr := gatedSearch(func(c context.Context) ([]metadata.BookMetadata, error) {
+						return src.SearchByTitleAndAuthor(c, searchTitle, searchAuthor)
+					}); serr == nil {
+						allResults = append(allResults, results...)
+					} else {
+						lastErr = serr
+						slog.Debug("metadata-search SearchByTitleAndAuthor( ) error", "name", src.Name(), "searchTitle", searchTitle, "searchAuthor", searchAuthor, "error", serr)
+					}
+				}
+
+				// Narrator-as-author fallback: author/narrator fields are frequently
+				// swapped in audiobook metadata. Try searching with the narrator as
+				// author to catch these cases.
+				if bookNarrator != "" && bookNarrator != searchAuthor {
+					if results, serr := gatedSearch(func(c context.Context) ([]metadata.BookMetadata, error) {
+						return src.SearchByTitleAndAuthor(c, searchTitle, bookNarrator)
+					}); serr == nil {
+						allResults = append(allResults, results...)
+					} else {
+						slog.Debug("metadata-search narrator-as-author fallback( ) error", "name", src.Name(), "searchTitle", searchTitle, "narrator", bookNarrator, "error", serr)
+					}
+				}
+
+				// Always also search by title only to get broader results
 				if results, serr := gatedSearch(func(c context.Context) ([]metadata.BookMetadata, error) {
-					return src.SearchByTitleAndAuthor(c, searchTitle, searchAuthor)
+					return src.SearchByTitle(c, searchTitle)
 				}); serr == nil {
 					allResults = append(allResults, results...)
 				} else {
 					lastErr = serr
-					slog.Debug("metadata-search SearchByTitleAndAuthor( ) error", "name", src.Name(), "searchTitle", searchTitle, "searchAuthor", searchAuthor, "error", serr)
+					slog.Debug("metadata-search SearchByTitle() error", "name", src.Name(), "value", searchTitle, "error", serr)
 				}
-			}
-
-			// Narrator-as-author fallback: author/narrator fields are frequently
-			// swapped in audiobook metadata. Try searching with the narrator as
-			// author to catch these cases.
-			if bookNarrator != "" && bookNarrator != searchAuthor {
-				if results, serr := gatedSearch(func(c context.Context) ([]metadata.BookMetadata, error) {
-					return src.SearchByTitleAndAuthor(c, searchTitle, bookNarrator)
-				}); serr == nil {
-					allResults = append(allResults, results...)
-				} else {
-					slog.Debug("metadata-search narrator-as-author fallback( ) error", "name", src.Name(), "searchTitle", searchTitle, "narrator", bookNarrator, "error", serr)
+				// SearchByTitle with original title if different
+				if searchTitle != book.Title {
+					if results, serr := gatedSearch(func(c context.Context) ([]metadata.BookMetadata, error) {
+						return src.SearchByTitle(c, book.Title)
+					}); serr == nil {
+						allResults = append(allResults, results...)
+					} else {
+						lastErr = serr
+					}
 				}
-			}
 
-			// Always also search by title only to get broader results
-			if results, serr := gatedSearch(func(c context.Context) ([]metadata.BookMetadata, error) {
-				return src.SearchByTitle(c, searchTitle)
-			}); serr == nil {
-				allResults = append(allResults, results...)
-			} else {
-				lastErr = serr
-				slog.Debug("metadata-search SearchByTitle() error", "name", src.Name(), "value", searchTitle, "error", serr)
-			}
-			// SearchByTitle with original title if different
-			if searchTitle != book.Title {
-				if results, serr := gatedSearch(func(c context.Context) ([]metadata.BookMetadata, error) {
-					return src.SearchByTitle(c, book.Title)
-				}); serr == nil {
-					allResults = append(allResults, results...)
-				} else {
-					lastErr = serr
+				// If all calls failed (no results and there was an error), record it
+				if len(allResults) == 0 && lastErr != nil {
+					failedErr = lastErr.Error()
 				}
-			}
 
-			// If all calls failed (no results and there was an error), record it
-			if len(allResults) == 0 && lastErr != nil {
-				sourcesFailed[src.Name()] = lastErr.Error()
-			}
+				slog.Debug("metadata-search returned raw results for", "name", src.Name(), "count", len(allResults), "searchTitle", searchTitle)
 
-			slog.Debug("metadata-search returned raw results for", "name", src.Name(), "count", len(allResults), "searchTitle", searchTitle)
-
-			// Write to cache on a successful non-empty fetch.
-			// Empty and error cases are not cached so they can
-			// be retried. Cache is best-effort — a Put failure
-			// is logged but doesn't fail the outer search.
-			if len(allResults) > 0 {
-				if blob, merr := json.Marshal(allResults); merr == nil {
-					if perr := database.PutCachedMetadataFetch(mfs.db, id, src.Name(), blob, 0); perr != nil {
-						slog.Warn("metadata-search cache put failed for ( )", "id", id, "name", src.Name(), "error", perr)
+				// Write to cache on a successful non-empty fetch.
+				// Empty and error cases are not cached so they can
+				// be retried. Cache is best-effort — a Put failure
+				// is logged but doesn't fail the outer search.
+				if len(allResults) > 0 {
+					if blob, merr := json.Marshal(allResults); merr == nil {
+						if perr := database.PutCachedMetadataFetch(mfs.db, id, src.Name(), blob, 0); perr != nil {
+							slog.Warn("metadata-search cache put failed for ( )", "id", id, "name", src.Name(), "error", perr)
+						}
 					}
 				}
 			}
-		}
 
-		baseScores, baseTier := mfs.ScoreBaseCandidates(ctx, book, allResults, searchWords)
+
+			baseScores, baseTier := mfs.ScoreBaseCandidates(ctx, book, allResults, searchWords)
+			fetched[srcIdx] = sourceFetch{
+				name:       src.Name(),
+				results:    allResults,
+				baseScores: baseScores,
+				baseTier:   baseTier,
+				failedErr:  failedErr,
+			}
+			return nil
+		})
+	}
+	// Errors are never returned above (a failing source is recorded per-source and
+	// must not abort the others), so Wait's error is structurally always nil.
+	_ = fg.Wait()
+
+	// Merge in SOURCE ORDER — see the note above about first-wins dedupe.
+	for srcIdx := range sources {
+		sf := fetched[srcIdx]
+		if sf.name == "" {
+			continue // cancelled before this source ran
+		}
+		src := sources[srcIdx]
+		sourcesTried = append(sourcesTried, sf.name)
+		if sf.failedErr != "" {
+			sourcesFailed[sf.name] = sf.failedErr
+		}
+		allResults := sf.results
+		baseScores, baseTier := sf.baseScores, sf.baseTier
 		slog.Debug("metadata-search scored results from with tier", "count", len(allResults), "name", src.Name(), "baseTier", baseTier)
 
 		for i, r := range allResults {
@@ -540,6 +592,7 @@ func (mfs *Service) searchMetadataForBook(
 				GoogleRatingCount:    r.GoogleRatingCount,
 			})
 		}
+	}
 	}
 
 	// Try ASIN lookup: either the whole query is an ASIN, or extract one from the query


### PR DESCRIPTION
## Why

Every source in the priority chain was queried **in series**. With up to four search attempts per source plus a scoring pass, one book's search was measured at **13s** on production.

This is safe to do **now** and was not before: #2472 gave each provider its own token bucket in `internal/metadata/providerhttp`. Prior to that, running sources concurrently would have made them contend for a single shared limiter — which is exactly why this was left sequential.

## What changed

Sources fan out through an `errgroup` bounded by `sourceFanoutLimit()`. **Only the I/O half is parallel.**

The dedupe/scoring merge stays sequential and in source order, and that is load-bearing rather than conservative: the chain is **priority-ordered** and the dedupe is **first-wins**, so parallelizing the merge would make which source wins a duplicate `title|author` nondeterministic between runs.

Shared-state discipline:
- Each goroutine writes exactly one index of a preallocated `fetched` slice.
- The `seen` dedupe map and `sourcesFailed` are touched **only** by the sequential merge loop.
- A goroutine that returns early on `ctx.Err()` leaves its slot zero-valued; the merge skips on `name == ""`.

## Config

New knob `metadata_scoring.source_fanout_workers` (default 4). It **multiplies** with `bulk_fetch_workers` — 4 books × 4 sources is 16 provider requests in flight, each still gated by that provider's token bucket.

The `> 0` guard in `sourceFanoutLimit()` is not decoration: an unset key unmarshals to `0`, and `errgroup.SetLimit(0)` **blocks forever** on the first `Go` call. That failure mode is a search that never returns, not one that runs slowly.

## Verification

- `go build ./...` → 0
- `go vet ./internal/metafetch/...` → 0
- `go test ./internal/metafetch/... -race -count=1` → **0 DATA RACE**

The race result is only meaningful if a test traverses the new code, so that was checked rather than assumed: `searchMetadataForBook` (the function containing the fan-out) sits at **56.9% coverage**, so the race detector does run through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS