### PR TITLE
perf(metadata): apply cached metadata in a background op, not the HTTP request

### DIFF
--- a/changelog.d/20260815_background_batch_apply.md
+++ b/changelog.d/20260815_background_batch_apply.md
@@ -1,0 +1,23 @@
+### Changed
+
+- **Applying metadata to many books no longer holds the HTTP request open.**
+  `POST /api/v1/audiobooks/metadata/batch-apply-cached` now enqueues a
+  `metadata.batch-apply-cached` operation and returns `202` with an `op_id`
+  immediately; the UI polls the operation for progress.
+
+  A 250-book apply measured **2m0s** inline on production. Go's HTTP server does
+  not kill a handler when the client disconnects, and `ApplyMetadataCandidate`
+  took no `context.Context`, so the browser timed out, the UI reported
+  "session expired — nothing was applied", and the server kept applying for
+  another minute. Every one of those requests returned HTTP 200 and the work
+  really happened; the message was wrong on both counts.
+
+  The apply was already parallel and already pushed file work to a pool — the
+  problem was never a missing worker pool, it was the request duration.
+
+### Fixed
+
+- The background operation can now be **cancelled**, and reports progress per
+  book so the registry stuck-op watchdog can tell a slow run from a wedged one.
+  `PerItemTimeout` is set below the watchdog's 5-minute progress timeout so one
+  wedged book fails its own item instead of killing the whole batch.

--- a/internal/server/batch_apply_one.go
+++ b/internal/server/batch_apply_one.go
@@ -1,0 +1,129 @@
+// file: internal/server/batch_apply_one.go
+// version: 1.0.0
+// guid: 4e91c082-77a3-4d16-b5f8-2c0a9e3d4671
+// last-edited: 2026-08-15
+
+package server
+
+import (
+	"encoding/json"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
+)
+
+// cachedApplyService is the narrow slice of *metafetch.Service that applying one
+// cached candidate needs. It exists so the per-book logic can be tested against
+// fakes without standing up a Server — the four regression tests that used to
+// drive this through the HTTP handler now drive applyCachedCandidateForBook
+// directly, so the behaviour they pin is still the behaviour production runs.
+//
+// That equivalence is the whole point of the interface. Before this extraction
+// the logic lived inline in the gin handler; moving it to a background op
+// without extracting it would have left the tests exercising a code path
+// production no longer used.
+type cachedApplyService interface {
+	GetCachedCandidates(bookID string) (*metafetch.MetadataCandidateCache, bool, error)
+	ApplyMetadataCandidate(id string, candidate metafetch.MetadataCandidate, fields []string) (*metafetch.FetchMetadataResponse, error)
+	InvalidateCachedCandidates(bookID string) error
+	ApplyMetadataFileIO(id string)
+	WriteBackMetadataForBook(id string, segmentFilter ...[]string) (int, error)
+}
+
+// applyBookReader is the single store read the per-book path needs.
+type applyBookReader interface {
+	GetBookByID(id string) (*database.Book, error)
+}
+
+// itunesEnqueuer mirrors handlers.WriteBackEnqueuer: the iTunes library sync
+// batcher, which does NOT touch audio tags. Named explicitly here because
+// confusing it for the tag writer is exactly the defect this path once had —
+// metadata landed in the database, the iTunes batcher was enqueued, and no audio
+// file was ever written.
+type itunesEnqueuer interface {
+	Enqueue(bookID string)
+}
+
+// applyOutcome is the result of applying one book's cached candidate.
+type applyOutcome struct {
+	Applied bool
+	// Reason is set when Applied is false, using the batchSkip* vocabulary.
+	Reason string
+	Err    error
+	// WriteBackFailed is true when the metadata WAS applied to the database but
+	// writing it into the audio files failed. Deliberately separate from
+	// !Applied: the database change is real and durable, and reporting the book
+	// as "not applied" would send someone re-applying work that succeeded.
+	WriteBackFailed bool
+}
+
+// Skip reason vocabulary, shared with the HTTP response shape in
+// internal/server/handlers/metadata_cache.go.
+const (
+	applySkipNoCachedCandidates = "no_cached_candidates"
+	applySkipDecodeFailed       = "decode_failed"
+	applySkipApplyFailed        = "apply_failed"
+)
+
+// applyCachedCandidateForBook applies the highest-scored cached candidate for
+// one book and, when writeBack is true, writes the result into the audio files.
+//
+// FILE I/O — KEEP IN STEP WITH THE SINGLE-BOOK PATH. The sibling is
+// applyAudiobookMetadataImpl in internal/server/handlers/metadata/handler.go.
+// The two drifted apart once: the sibling wrote tags and embedded cover art
+// while this path only updated the database and enqueued the iTunes batcher, so
+// applied metadata never reached the files and nothing logged a failure. If you
+// add file-side work to either path, add it to both.
+//
+// The caller supplies concurrency and path locking; this function does the work
+// for exactly one book and never spawns goroutines.
+func applyCachedCandidateForBook(
+	svc cachedApplyService,
+	store applyBookReader,
+	itunes itunesEnqueuer,
+	id string,
+	writeBack bool,
+	lockPath func(path string) func(),
+) applyOutcome {
+	entry, _, err := svc.GetCachedCandidates(id)
+	if err != nil || entry == nil || len(entry.Candidates) == 0 {
+		return applyOutcome{Reason: applySkipNoCachedCandidates, Err: err}
+	}
+
+	var cand metafetch.MetadataCandidate
+	if derr := json.Unmarshal(entry.Candidates[0], &cand); derr != nil {
+		return applyOutcome{Reason: applySkipDecodeFailed, Err: derr}
+	}
+
+	if _, aerr := svc.ApplyMetadataCandidate(id, cand, nil); aerr != nil {
+		return applyOutcome{Reason: applySkipApplyFailed, Err: aerr}
+	}
+	_ = svc.InvalidateCachedCandidates(id)
+
+	if !writeBack {
+		return applyOutcome{Applied: true}
+	}
+
+	// iTunes library sync is enqueued BEFORE the file work (matching the
+	// single-book path) so a failure writing tags cannot lose it.
+	if itunes != nil {
+		itunes.Enqueue(id)
+	}
+
+	// Re-read the book: ApplyMetadataCandidate just rewrote its row, and the
+	// file path we lock and write must be the post-apply one.
+	book, berr := store.GetBookByID(id)
+	if berr != nil || book == nil {
+		return applyOutcome{Applied: true, WriteBackFailed: true, Err: berr}
+	}
+
+	if lockPath != nil {
+		release := lockPath(book.FilePath)
+		defer release()
+	}
+	svc.ApplyMetadataFileIO(id)
+	if _, wberr := svc.WriteBackMetadataForBook(id); wberr != nil {
+		return applyOutcome{Applied: true, WriteBackFailed: true, Err: wberr}
+	}
+	return applyOutcome{Applied: true}
+}

--- a/internal/server/batch_apply_one_test.go
+++ b/internal/server/batch_apply_one_test.go
@@ -1,0 +1,231 @@
+// file: internal/server/batch_apply_one_test.go
+// version: 1.0.0
+// guid: 9d2b71fa-30c8-4e57-a614-8b5e0c7f2d93
+// last-edited: 2026-08-15
+//
+// Regression tests for applying ONE book's cached metadata candidate.
+//
+// These moved here from internal/server/handlers/metadata_cache_test.go when
+// the batch apply became a background op. They pin the same three defects the
+// handler tests pinned, against the same code — the logic was EXTRACTED rather
+// than reimplemented, so these still cover the path production runs. Testing
+// the handler instead would now only prove that an op was enqueued.
+
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
+)
+
+// fakeApplySvc records which of the file-side calls were made.
+type fakeApplySvc struct {
+	candidates    []json.RawMessage
+	getErr        error
+	applyErr      error
+	writeBackErr  error
+	appliedIDs    []string
+	invalidatedID []string
+	fileIOIDs     []string
+	writeBackIDs  []string
+}
+
+func (f *fakeApplySvc) GetCachedCandidates(bookID string) (*metafetch.MetadataCandidateCache, bool, error) {
+	if f.getErr != nil {
+		return nil, false, f.getErr
+	}
+	if len(f.candidates) == 0 {
+		return nil, false, nil
+	}
+	return &metafetch.MetadataCandidateCache{Candidates: f.candidates}, true, nil
+}
+
+func (f *fakeApplySvc) ApplyMetadataCandidate(id string, _ metafetch.MetadataCandidate, _ []string) (*metafetch.FetchMetadataResponse, error) {
+	if f.applyErr != nil {
+		return nil, f.applyErr
+	}
+	f.appliedIDs = append(f.appliedIDs, id)
+	return &metafetch.FetchMetadataResponse{}, nil
+}
+
+func (f *fakeApplySvc) InvalidateCachedCandidates(bookID string) error {
+	f.invalidatedID = append(f.invalidatedID, bookID)
+	return nil
+}
+
+func (f *fakeApplySvc) ApplyMetadataFileIO(id string) { f.fileIOIDs = append(f.fileIOIDs, id) }
+
+func (f *fakeApplySvc) WriteBackMetadataForBook(id string, _ ...[]string) (int, error) {
+	f.writeBackIDs = append(f.writeBackIDs, id)
+	if f.writeBackErr != nil {
+		return 0, f.writeBackErr
+	}
+	return 1, nil
+}
+
+type fakeBookReader struct {
+	book *database.Book
+	err  error
+}
+
+func (f *fakeBookReader) GetBookByID(id string) (*database.Book, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.book, nil
+}
+
+type fakeITunes struct{ ids []string }
+
+func (f *fakeITunes) Enqueue(bookID string) { f.ids = append(f.ids, bookID) }
+
+func oneCandidate(t *testing.T) []json.RawMessage {
+	t.Helper()
+	blob, err := json.Marshal(metafetch.MetadataCandidate{Title: "A Title", Author: "An Author"})
+	if err != nil {
+		t.Fatalf("marshal candidate: %v", err)
+	}
+	return []json.RawMessage{blob}
+}
+
+// TestApplyCachedCandidate_WritesFilesForAppliedBook is the regression test for
+// the original defect: metadata landed in the database and the iTunes batcher
+// was enqueued, but no audio file was ever written and nothing logged a
+// failure. It looked like success.
+func TestApplyCachedCandidate_WritesFilesForAppliedBook(t *testing.T) {
+	svc := &fakeApplySvc{candidates: oneCandidate(t)}
+	store := &fakeBookReader{book: &database.Book{ID: "b1", Title: "A Title", FilePath: "/lib/a.m4b"}}
+	itunes := &fakeITunes{}
+
+	out := applyCachedCandidateForBook(svc, store, itunes, "b1", true, nil)
+
+	if !out.Applied || out.WriteBackFailed {
+		t.Fatalf("expected clean apply, got %+v", out)
+	}
+	if len(svc.fileIOIDs) != 1 || svc.fileIOIDs[0] != "b1" {
+		t.Errorf("ApplyMetadataFileIO not called for b1: %v", svc.fileIOIDs)
+	}
+	if len(svc.writeBackIDs) != 1 || svc.writeBackIDs[0] != "b1" {
+		t.Errorf("WriteBackMetadataForBook not called for b1: %v", svc.writeBackIDs)
+	}
+	if len(itunes.ids) != 1 {
+		t.Errorf("iTunes batcher not enqueued: %v", itunes.ids)
+	}
+	if len(svc.invalidatedID) != 1 {
+		t.Errorf("cache not invalidated: %v", svc.invalidatedID)
+	}
+}
+
+// TestApplyCachedCandidate_WriteBackFalseSuppressesFileIO pins the opt-out:
+// write_back=false must change the database and touch NO file.
+func TestApplyCachedCandidate_WriteBackFalseSuppressesFileIO(t *testing.T) {
+	svc := &fakeApplySvc{candidates: oneCandidate(t)}
+	store := &fakeBookReader{book: &database.Book{ID: "b1", FilePath: "/lib/a.m4b"}}
+	itunes := &fakeITunes{}
+
+	out := applyCachedCandidateForBook(svc, store, itunes, "b1", false, nil)
+
+	if !out.Applied {
+		t.Fatalf("expected applied, got %+v", out)
+	}
+	if len(svc.fileIOIDs) != 0 || len(svc.writeBackIDs) != 0 {
+		t.Errorf("file work ran despite write_back=false: fileIO=%v writeBack=%v",
+			svc.fileIOIDs, svc.writeBackIDs)
+	}
+	if len(itunes.ids) != 0 {
+		t.Errorf("iTunes enqueued despite write_back=false: %v", itunes.ids)
+	}
+}
+
+// TestApplyCachedCandidate_ReportsSkipReasons covers the second defect: a book
+// with nothing cached must report WHY rather than being silently counted as
+// applied.
+func TestApplyCachedCandidate_ReportsSkipReasons(t *testing.T) {
+	tests := []struct {
+		name       string
+		svc        *fakeApplySvc
+		wantReason string
+	}{
+		{"no cached candidates", &fakeApplySvc{}, applySkipNoCachedCandidates},
+		{"cache read failed", &fakeApplySvc{getErr: errors.New("boom")}, applySkipNoCachedCandidates},
+		{"undecodable candidate", &fakeApplySvc{candidates: []json.RawMessage{[]byte("{not json")}}, applySkipDecodeFailed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := applyCachedCandidateForBook(tt.svc, &fakeBookReader{}, &fakeITunes{}, "b1", true, nil)
+			if out.Applied {
+				t.Fatalf("expected not applied, got %+v", out)
+			}
+			if out.Reason != tt.wantReason {
+				t.Errorf("reason = %q, want %q", out.Reason, tt.wantReason)
+			}
+			if len(tt.svc.fileIOIDs) != 0 {
+				t.Errorf("file work ran for a skipped book: %v", tt.svc.fileIOIDs)
+			}
+		})
+	}
+}
+
+// TestApplyCachedCandidate_ApplyFailureIsNotReportedAsApplied guards the
+// distinction the response vocabulary depends on.
+func TestApplyCachedCandidate_ApplyFailureIsNotReportedAsApplied(t *testing.T) {
+	svc := &fakeApplySvc{candidates: oneCandidate(t), applyErr: errors.New("apply exploded")}
+
+	out := applyCachedCandidateForBook(svc, &fakeBookReader{}, &fakeITunes{}, "b1", true, nil)
+
+	if out.Applied {
+		t.Fatalf("apply failed but was reported applied: %+v", out)
+	}
+	if out.Reason != applySkipApplyFailed {
+		t.Errorf("reason = %q, want %q", out.Reason, applySkipApplyFailed)
+	}
+	if len(svc.writeBackIDs) != 0 {
+		t.Errorf("wrote files for a book whose apply failed: %v", svc.writeBackIDs)
+	}
+}
+
+// TestApplyCachedCandidate_WriteBackFailureStaysApplied is the honesty check.
+// The database change is real and durable even when writing the audio files
+// fails, so the book must NOT be reported as unapplied — that would send
+// someone re-applying work that already succeeded.
+func TestApplyCachedCandidate_WriteBackFailureStaysApplied(t *testing.T) {
+	svc := &fakeApplySvc{candidates: oneCandidate(t), writeBackErr: errors.New("disk full")}
+	store := &fakeBookReader{book: &database.Book{ID: "b1", FilePath: "/lib/a.m4b"}}
+
+	out := applyCachedCandidateForBook(svc, store, &fakeITunes{}, "b1", true, nil)
+
+	if !out.Applied {
+		t.Fatalf("write-back failure must not unset Applied: %+v", out)
+	}
+	if !out.WriteBackFailed {
+		t.Errorf("WriteBackFailed not set despite a write-back error")
+	}
+}
+
+// TestApplyCachedCandidate_TakesPathLockOnPostApplyPath pins that the lock is
+// taken on the path read AFTER the apply, not a stale one. ApplyMetadataCandidate
+// can rewrite the book's row, and locking the pre-apply path would serialize
+// against the wrong key.
+func TestApplyCachedCandidate_TakesPathLockOnPostApplyPath(t *testing.T) {
+	svc := &fakeApplySvc{candidates: oneCandidate(t)}
+	store := &fakeBookReader{book: &database.Book{ID: "b1", FilePath: "/lib/new-location.m4b"}}
+
+	var locked []string
+	lock := func(p string) func() {
+		locked = append(locked, p)
+		return func() {}
+	}
+
+	out := applyCachedCandidateForBook(svc, store, &fakeITunes{}, "b1", true, lock)
+
+	if !out.Applied {
+		t.Fatalf("expected applied, got %+v", out)
+	}
+	if len(locked) != 1 || locked[0] != "/lib/new-location.m4b" {
+		t.Errorf("locked %v, want the post-apply path", locked)
+	}
+}

--- a/internal/server/batch_apply_op.go
+++ b/internal/server/batch_apply_op.go
@@ -1,0 +1,187 @@
+// file: internal/server/batch_apply_op.go
+// version: 1.0.0
+// guid: 8a3f21d7-6c04-4b91-a2e5-7d0f3b8c5194
+// last-edited: 2026-08-15
+//
+// batch_apply_op registers the "metadata.batch-apply-cached" v2 OperationDef.
+// The HTTP handler BatchApplyFromCache enqueues this and returns the op id
+// immediately instead of holding the request open for the whole batch.
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/auth"
+	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+)
+
+// errText renders an error for a log attribute, tolerating nil. The callers
+// below log a reason on a branch that can be reached with err == nil (an empty
+// candidate list is not an error), so a bare err.Error() would panic exactly on
+// the "nothing was cached" case.
+func errText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+// batchApplyOpParams is the JSON params for the metadata.batch-apply-cached op.
+type batchApplyOpParams struct {
+	BookIDs []string `json:"book_ids"`
+	// WriteBack mirrors the handler's body.WriteBack: when true (the default at
+	// the handler) the applied metadata is also written into the audio files and
+	// enqueued for iTunes sync. When false only the database rows change.
+	WriteBack bool `json:"write_back"`
+}
+
+// RegisterBatchApplyFromCacheOp registers the "metadata.batch-apply-cached" op.
+//
+// Why this exists at all: BatchApplyFromCache used to do the whole batch inline
+// in the gin request goroutine. It was already parallel (errgroup at
+// batchApplyConcurrency) and already pushed the file work to the I/O pool, so
+// the problem was never a missing worker pool — it was the REQUEST DURATION. A
+// 250-book apply measured 2m0s on production. Go's HTTP server does not kill a
+// handler when the client disconnects, and ApplyMetadataCandidate takes no
+// context, so the browser timed out, the UI reported "session expired, nothing
+// was applied", and the server kept applying for another minute. The user was
+// told the opposite of what happened.
+//
+// As an op it gets the three things the inline version could not have: a real
+// ctx that cancels, a progress stream the UI can poll, and the registry
+// watchdog. The handler now returns an op id in milliseconds.
+func (s *Server) RegisterBatchApplyFromCacheOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "metadata.batch-apply-cached",
+		Plugin:          "metadata",
+		DisplayName:     "Apply Cached Metadata",
+		Description:     "Apply the highest-scored cached metadata candidate to each of a set of books, optionally writing tags back into the audio files.",
+		DefaultPriority: opsregistry.PriorityNormal,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         4 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "metadata.batch-apply-cached",
+		Permissions:     []auth.Permission{auth.PermLibraryEditMetadata},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapFilesWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p batchApplyOpParams
+			if len(rawParams) > 0 {
+				if err := json.Unmarshal(rawParams, &p); err != nil {
+					return fmt.Errorf("batch-apply-cached: decode params: %w", err)
+				}
+			}
+
+			svc := s.metadataFetchService
+			if svc == nil {
+				return fmt.Errorf("batch-apply-cached: metadata fetch service not initialized")
+			}
+
+			progress := registryProgressAdapter{r: reporter}
+			bookIDs := p.BookIDs
+			total := len(bookIDs)
+			_ = progress.UpdateProgress(0, total, "starting metadata apply")
+
+			var applied, noCandidates, decodeFailed, applyFailed, writeFailed atomic.Int64
+
+			// itunes may be a typed nil (*itunesservice.WriteBackBatcher)(nil), which
+			// is NOT == nil once boxed in an interface. Normalize to an untyped nil
+			// so the guard inside applyCachedCandidateForBook actually fires.
+			var itunes itunesEnqueuer
+			if s.writeBackBatcher != nil {
+				itunes = s.writeBackBatcher
+			}
+
+			// The file work runs inline in the op's own worker, NOT via
+			// fileIOPool.Submit as the old handler did. That is deliberate and is
+			// the whole point of the change: Submit returns immediately, so an op
+			// using it would report 100% complete while tags were still being
+			// written to disk — which defeats the status the op exists to provide.
+			// Running it here makes the progress bar mean what it says, and brings
+			// the work under the same path lock the batch-save op uses.
+			//
+			// Concurrency is writeBackWorkers() (disk/TagLib-bound), NOT the old
+			// batchApplyConcurrency=4, because this loop now does the file I/O
+			// rather than delegating it.
+			runOne := func(ctx context.Context, id string) error {
+				out := applyCachedCandidateForBook(
+					svc, s.Store(), itunes, id, p.WriteBack, writeBackPathLocks.lock)
+
+				if !out.Applied {
+					switch out.Reason {
+					case applySkipNoCachedCandidates:
+						noCandidates.Add(1)
+					case applySkipDecodeFailed:
+						decodeFailed.Add(1)
+					case applySkipApplyFailed:
+						applyFailed.Add(1)
+					}
+					reporter.Log(slog.LevelWarn, "book not applied",
+						slog.String("book_id", id),
+						slog.String("reason", out.Reason),
+						slog.String("error", errText(out.Err)))
+					return nil
+				}
+
+				applied.Add(1)
+				if out.WriteBackFailed {
+					// Counted separately and logged, but NOT subtracted from
+					// applied: the database change is real and durable. Reporting
+					// it as unapplied would send someone re-applying work that
+					// succeeded.
+					writeFailed.Add(1)
+					reporter.Log(slog.LevelWarn, "applied to database but write-back to files failed",
+						slog.String("book_id", id),
+						slog.String("error", errText(out.Err)))
+				}
+				return nil
+			}
+
+			// RunItems reports progress after EVERY item, which is what resets the
+			// registry stuck-op watchdog. This def sets Timeout: 4h but no explicit
+			// ProgressTimeout, so it inherits the 5-minute default. PerItemTimeout
+			// is 3 minutes — deliberately BELOW that 5-minute watchdog, so a single
+			// wedged book fails its own item and lets the loop report progress
+			// again, rather than starving the watchdog and killing the whole op.
+			// That is precisely how the UA-purge census died: no progress for
+			// 5m18s against a 5m0s timeout.
+			//
+			// ErrModeCollect, NOT the default ErrModeFail: the loop this replaces
+			// recorded every per-book failure as a skip and carried on, and
+			// ErrModeFail would cancel the whole batch on the first bad book.
+			//
+			// The Label is deliberately COARSE and constant: reporter_db.go writes
+			// one op_logs_v2 row per DISTINCT progress message, so a label carrying
+			// the book id would write one DB row per book.
+			runErr := opsregistry.RunItems(ctx, reporter, bookIDs, runOne, opsregistry.RunItemsOptions{
+				Concurrency:    writeBackWorkers(),
+				PerItemTimeout: 3 * time.Minute,
+				ErrMode:        opsregistry.ErrModeCollect,
+				Label:          func(int, int) string { return "applying cached metadata" },
+			})
+			// Return BEFORE the "complete" row, so a canceled batch does not report
+			// success on its way out. runOne never returns a non-nil error (per-book
+			// failures land in the counters), so runErr is exactly ctx.Err() on
+			// cancellation and nil otherwise.
+			if runErr != nil {
+				return runErr
+			}
+
+			_ = progress.UpdateProgress(total, total, fmt.Sprintf(
+				"complete: applied %d of %d (no candidates %d, decode failed %d, apply failed %d, write-back failed %d)",
+				applied.Load(), total, noCandidates.Load(), decodeFailed.Load(),
+				applyFailed.Load(), writeFailed.Load()))
+			return nil
+		},
+	})
+}
+
+func init() {
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterBatchApplyFromCacheOp(reg) })
+}

--- a/internal/server/handlers/metadata_cache.go
+++ b/internal/server/handlers/metadata_cache.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"net/http"
 	"sort"
 	"time"
 
@@ -21,8 +22,8 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/metabatch"
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
+	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/gin-gonic/gin"
-	"golang.org/x/sync/errgroup"
 )
 
 // MetadataCacheBookStore is the narrow persistence interface required by
@@ -75,6 +76,17 @@ type MetadataCacheHandler struct {
 	// path. May be nil; when it is, BatchApplyFromCache logs at warn rather
 	// than skipping silently (see the comment in BatchApplyFromCache).
 	fileIOPool FileIOPool
+	// ops enqueues the background apply op. When nil, BatchApplyFromCache
+	// reports 503 rather than silently falling back to an inline apply: an
+	// inline fallback would be a second implementation that only ever ran in
+	// tests, so the tested path and the shipped path would diverge.
+	ops OpEnqueuer
+}
+
+// OpEnqueuer is the slice of the v2 operations registry this handler needs:
+// enqueue a definition with params, get an op id back immediately.
+type OpEnqueuer interface {
+	EnqueueOp(ctx context.Context, defID string, params any, opts ...opsregistry.EnqueueOption) (string, error)
 }
 
 // NewMetadataCacheHandler constructs a MetadataCacheHandler.
@@ -82,8 +94,8 @@ type MetadataCacheHandler struct {
 // fileIOPool may be nil (tests, or a server built without a pool). Callers must
 // pass a nil INTERFACE, not a typed-nil pointer, or the nil guards below become
 // false-negatives — see the wiring in wire_handlers.go.
-func NewMetadataCacheHandler(store MetadataCacheBookStore, svc MetadataCacheFetchService, batcher WriteBackEnqueuer, fileIOPool FileIOPool) *MetadataCacheHandler {
-	return &MetadataCacheHandler{store: store, svc: svc, batcher: batcher, fileIOPool: fileIOPool}
+func NewMetadataCacheHandler(store MetadataCacheBookStore, svc MetadataCacheFetchService, batcher WriteBackEnqueuer, fileIOPool FileIOPool, ops OpEnqueuer) *MetadataCacheHandler {
+	return &MetadataCacheHandler{store: store, svc: svc, batcher: batcher, fileIOPool: fileIOPool, ops: ops}
 }
 
 // ListCachedCandidates handles GET /api/v1/audiobooks/metadata/cached.
@@ -310,64 +322,40 @@ func (h *MetadataCacheHandler) GetCacheReviewResults(c *gin.Context) {
 	})
 }
 
-// Skip reasons reported per book by BatchApplyFromCache. Stable string values —
-// the Metadata Review UI keys off them to decide whether to leave a row in the
-// queue and what to tell the user.
-const (
-	batchSkipNoCachedCandidates = "no_cached_candidates"
-	batchSkipDecodeFailed       = "decode_failed"
-	batchSkipApplyFailed        = "apply_failed"
-	// batchSkipCanceled marks a book the server never attempted because the
-	// request context died (in practice: the client disconnected) before a worker
-	// picked it up. Distinct from batchSkipApplyFailed on purpose — reporting
-	// "apply_failed" for a book nothing tried to apply is simply untrue, and this
-	// is a response body, not a log line.
-	batchSkipCanceled = "canceled"
-)
-
-// batchApplyConcurrency bounds how many books BatchApplyFromCache applies at
-// once. The per-book work left on the request path is database-bound (read the
-// cached candidate, apply it, invalidate the cache entry) — the slow file work
-// already goes to h.fileIOPool — so this is deliberately modest: enough to stop
-// a several-hundred-book "Apply All" from being a strictly serial chain of
-// round-trips, without turning one HTTP request into a write storm against the
-// store while other requests are being served.
-const batchApplyConcurrency = 4
-
-// BatchApplySkip describes one book that was requested but not applied.
-type BatchApplySkip struct {
-	BookID string `json:"book_id"`
-	Reason string `json:"reason"`
-	Error  string `json:"error,omitempty"`
-}
-
 // BatchApplyFromCache handles POST /api/v1/audiobooks/metadata/batch-apply-cached.
 //
-// Applies the highest-scored cached candidate for each book_id in the request.
+// This is a DISPATCHER. It enqueues the "metadata.batch-apply-cached" op and
+// returns 202 with an op id; it applies nothing itself.
 //
-// FILE I/O — KEEP IN STEP WITH THE SINGLE-BOOK PATH.
+// It used to apply the whole batch inline. That was already parallel and
+// already pushed the file work to a pool, so the problem was never a missing
+// worker pool — it was the REQUEST DURATION. A 250-book apply measured 2m0s on
+// production. Go's HTTP server does not kill a handler when the client
+// disconnects, and ApplyMetadataCandidate takes no context, so the browser
+// timed out, the UI reported "session expired, nothing was applied", and the
+// server went on applying for another minute. The user was told the opposite of
+// what happened.
 //
-// This handler has a sibling: applyAudiobookMetadataImpl in
-// internal/server/handlers/metadata/handler.go (POST /audiobooks/:id/apply-metadata).
-// The two drifted apart. The sibling submits ApplyMetadataFileIO +
-// WriteBackMetadataForBook to the file-I/O pool, which is what actually writes
-// tags and embeds cover art INTO the audio files; this handler did neither. It
-// updated the database and enqueued h.batcher — but h.batcher is the *iTunes*
-// write-back batcher (itunesservice.WriteBackBatcher), which syncs to the iTunes
-// library and never touches audio tags.
+// The per-book logic now lives in applyCachedCandidateForBook
+// (internal/server/batch_apply_one.go), which the op calls. There is
+// deliberately NO inline fallback here: a fallback would be a second
+// implementation reachable only when the registry is absent, so the tested path
+// and the shipped path would diverge.
 //
-// The visible symptom: metadata applied from the Metadata Review screen existed
-// in the database but was never written to the files, and no cover art was
-// embedded. It looked like success because nothing logged a failure.
-//
-// If you add file-side work to either path, add it to both.
-//
-// The work goes through the pool, never inline: "Apply All" can carry hundreds
-// of book IDs and rewriting tags for each synchronously would hold the request
-// open for minutes.
+// FILE I/O — KEEP IN STEP WITH THE SINGLE-BOOK PATH. The sibling is
+// applyAudiobookMetadataImpl in internal/server/handlers/metadata/handler.go.
+// The two drifted apart once: the sibling wrote tags and embedded cover art
+// while this path only updated the database and enqueued h.batcher — which is
+// the *iTunes* library batcher, not the tag writer. Applied metadata never
+// reached the files and nothing logged a failure. If you add file-side work to
+// either path, add it to both.
 func (h *MetadataCacheHandler) BatchApplyFromCache(c *gin.Context) {
 	if h.store == nil || h.svc == nil {
 		httputil.RespondWithInternalError(c, "metadata service not initialized")
+		return
+	}
+	if h.ops == nil {
+		httputil.RespondWithInternalError(c, "operations registry not initialized")
 		return
 	}
 	var body struct {
@@ -383,120 +371,25 @@ func (h *MetadataCacheHandler) BatchApplyFromCache(c *gin.Context) {
 
 	shouldWriteBack := body.WriteBack == nil || *body.WriteBack
 
-	// Apply in parallel, but assemble the response strictly in request order.
-	//
-	// Each slot is written by exactly ONE goroutine (the one that owns index i)
-	// and read only after g.Wait(), so no lock is needed on the slice itself.
-	// Ordering is not cosmetic: the Metadata Review UI diffs `applied_ids` and
-	// `skipped` against the ids it sent, and a nondeterministic order would make
-	// the same request produce a different-looking response every time.
-	type applyOutcome struct {
-		applied bool
-		skip    BatchApplySkip
-	}
-	outcomes := make([]applyOutcome, len(body.BookIDs))
-
-	g, gctx := errgroup.WithContext(c.Request.Context())
-	g.SetLimit(batchApplyConcurrency)
-
-	for i, bookID := range body.BookIDs {
-		i, bookID := i, bookID
-		g.Go(func() error {
-			if gctx.Err() != nil {
-				outcomes[i] = applyOutcome{skip: BatchApplySkip{
-					BookID: bookID,
-					Reason: batchSkipCanceled,
-					Error:  gctx.Err().Error(),
-				}}
-				return nil
-			}
-
-			entry, _, err := h.svc.GetCachedCandidates(bookID)
-			if err != nil || entry == nil || len(entry.Candidates) == 0 {
-				slog.Warn("BatchApplyFromCache no cached candidates", "bookID", bookID, "err", err)
-				outcomes[i] = applyOutcome{skip: BatchApplySkip{
-					BookID: bookID,
-					Reason: batchSkipNoCachedCandidates,
-					Error:  errString(err),
-				}}
-				return nil
-			}
-			var cand metafetch.MetadataCandidate
-			if err := json.Unmarshal(entry.Candidates[0], &cand); err != nil {
-				slog.Warn("BatchApplyFromCache decode candidate", "bookID", bookID, "err", err)
-				outcomes[i] = applyOutcome{skip: BatchApplySkip{
-					BookID: bookID,
-					Reason: batchSkipDecodeFailed,
-					Error:  errString(err),
-				}}
-				return nil
-			}
-			if _, err := h.svc.ApplyMetadataCandidate(bookID, cand, nil); err != nil {
-				slog.Warn("BatchApplyFromCache apply", "bookID", bookID, "err", err)
-				outcomes[i] = applyOutcome{skip: BatchApplySkip{
-					BookID: bookID,
-					Reason: batchSkipApplyFailed,
-					Error:  errString(err),
-				}}
-				return nil
-			}
-			_ = h.svc.InvalidateCachedCandidates(bookID)
-
-			// iTunes library sync. Enqueued before the pool submission (matching the
-			// single-book path) so a panic in the background file job cannot lose it.
-			if shouldWriteBack && h.batcher != nil {
-				h.batcher.Enqueue(bookID)
-			}
-
-			if shouldWriteBack {
-				if pool := h.fileIOPool; pool != nil {
-					id := bookID
-					svc := h.svc
-					pool.Submit(id, func() {
-						svc.ApplyMetadataFileIO(id)
-						if _, wbErr := svc.WriteBackMetadataForBook(id); wbErr != nil {
-							slog.Warn("BatchApplyFromCache background write-back", "bookID", id, "err", wbErr)
-						}
-					})
-				} else {
-					// Never skip silently. A silent skip here is exactly the shape of
-					// the defect this code path is fixing: the DB says applied, the
-					// files were never touched, and nothing in the logs says so.
-					slog.Warn("BatchApplyFromCache: no file-I/O pool wired, audio tags and cover art NOT written",
-						"bookID", bookID, "reason", "fileIOPool is nil")
-				}
-			}
-
-			outcomes[i] = applyOutcome{applied: true}
-			return nil
-		})
-	}
-	// runOne never returns a non-nil error (every per-book failure is recorded as
-	// a skip so the UI can show a reason), so Wait cannot fail here — but check it
-	// rather than discarding it, in case that invariant is ever changed.
-	if err := g.Wait(); err != nil {
-		httputil.InternalError(c, "failed to apply cached candidates", err)
+	opID, err := h.ops.EnqueueOp(c.Request.Context(), "metadata.batch-apply-cached", map[string]any{
+		"book_ids":   body.BookIDs,
+		"write_back": shouldWriteBack,
+	})
+	if err != nil {
+		httputil.InternalError(c, "failed to enqueue metadata apply", err)
 		return
 	}
 
-	appliedIDs := make([]string, 0, len(body.BookIDs))
-	skipped := make([]BatchApplySkip, 0)
-	for i, bookID := range body.BookIDs {
-		if outcomes[i].applied {
-			appliedIDs = append(appliedIDs, bookID)
-			continue
-		}
-		skipped = append(skipped, outcomes[i].skip)
-	}
-
-	// "applied" stays an int at the top level: the Metadata Review UI already
-	// reads it, so changing its type would break the frontend.
-	httputil.RespondWithOK(c, gin.H{
-		"applied":     len(appliedIDs),
-		"applied_ids": appliedIDs,
-		"skipped":     skipped,
-		"requested":   len(body.BookIDs),
-		"write_back":  shouldWriteBack,
+	// 202 with an op id, NOT a completed result. The response no longer carries
+	// applied_ids/skipped because nothing has been applied yet — the caller polls
+	// the op and then re-reads the review list, which is the only description of
+	// what actually happened that cannot go stale.
+	c.JSON(http.StatusAccepted, gin.H{
+		"data": gin.H{
+			"op_id":      opID,
+			"requested":  len(body.BookIDs),
+			"write_back": shouldWriteBack,
+		},
 	})
 }
 

--- a/internal/server/handlers/metadata_cache.go
+++ b/internal/server/handlers/metadata_cache.go
@@ -24,6 +24,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
 	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/gin-gonic/gin"
+	"golang.org/x/sync/errgroup"
 )
 
 // MetadataCacheBookStore is the narrow persistence interface required by

--- a/internal/server/handlers/metadata_cache_test.go
+++ b/internal/server/handlers/metadata_cache_test.go
@@ -1,35 +1,41 @@
 // file: internal/server/handlers/metadata_cache_test.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 6b1c0a94-2f7d-4c8e-9a15-3d0e7b28c4f1
-// last-edited: 2026-08-11
+// last-edited: 2026-08-15
 
-// Tests for BatchApplyFromCache's file-I/O behaviour.
+// Tests for BatchApplyFromCache's DISPATCH behaviour.
 //
-// These exist because the endpoint the Metadata Review screen calls updated
-// only the database: it never scheduled ApplyMetadataFileIO /
-// WriteBackMetadataForBook, so applied metadata never reached the audio files
-// and no cover art was embedded. A test that only asserted "Submit was called"
-// would not have caught it, and neither would one that asserted with
-// mock.Anything — so every assertion below is on a CAPTURED argument value,
-// and the captured pool closure is actually INVOKED so the work inside it is
-// exercised rather than merely scheduled.
+// This endpoint used to apply the whole batch inline, and the tests here
+// asserted the file-side work (ApplyMetadataFileIO / WriteBackMetadataForBook)
+// actually ran — because the original defect was that applied metadata never
+// reached the audio files and nothing logged a failure.
+//
+// That work now happens in the metadata.batch-apply-cached op, so those
+// assertions moved to internal/server/batch_apply_one_test.go, against the same
+// extracted function the op calls. They were NOT deleted; testing them here
+// would now only prove that an op was enqueued.
+//
+// What is left to test here is the dispatch contract, and it still matters:
+// the params are the only thing carrying write_back to the op, and a dropped or
+// defaulted flag would silently turn "database only" into "rewrite every file".
+// So every assertion below is on a CAPTURED argument value, never mock.Anything.
 
 package handlers_test
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"testing"
 
-	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
+	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
 	handlersmocks "github.com/falkcorp/audiobook-organizer/internal/server/handlers/mocks"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,228 +50,142 @@ func batchApplyCtx(body string) (*gin.Context, *httptest.ResponseRecorder) {
 	return c, w
 }
 
-// cachedCandidateFor returns a cache entry whose single candidate carries the
-// given title, so the decode step has something real to decode.
-func cachedCandidateFor(t *testing.T, title string) *metafetch.MetadataCandidate {
-	t.Helper()
-	return &metafetch.MetadataCandidate{Title: title}
+// capturingEnqueuer records exactly what was enqueued.
+type capturingEnqueuer struct {
+	defID  string
+	params any
+	calls  int
+	opID   string
+	err    error
 }
 
-func cacheEntry(t *testing.T, title string) *metafetch.MetadataCandidateCache {
+func (e *capturingEnqueuer) EnqueueOp(_ context.Context, defID string, params any, _ ...opsregistry.EnqueueOption) (string, error) {
+	e.calls++
+	e.defID = defID
+	e.params = params
+	if e.err != nil {
+		return "", e.err
+	}
+	if e.opID == "" {
+		return "op-123", nil
+	}
+	return e.opID, nil
+}
+
+// paramsMap re-reads the captured params through JSON, so the assertion covers
+// the shape the op will actually decode rather than the in-memory Go value.
+func paramsMap(t *testing.T, v any) map[string]any {
 	t.Helper()
-	raw, err := json.Marshal(cachedCandidateFor(t, title))
+	blob, err := json.Marshal(v)
 	require.NoError(t, err)
-	return &metafetch.MetadataCandidateCache{Candidates: []json.RawMessage{raw}}
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(blob, &out))
+	return out
 }
 
-// recordedPoolCall is one captured pool.Submit invocation.
-type recordedPoolCall struct {
-	bookID string
-	fn     func()
-}
-
-// TestBatchApplyFromCache_SubmitsFileIOForEachAppliedBook is the regression
-// test for the defect: applying from the review screen must schedule the audio
-// tag / cover-art work for every book it applies, with the default (absent)
-// write_back treated as ON.
-func TestBatchApplyFromCache_SubmitsFileIOForEachAppliedBook(t *testing.T) {
+func newDispatchHandler(t *testing.T, ops handlers.OpEnqueuer) *handlers.MetadataCacheHandler {
+	t.Helper()
 	store := handlersmocks.NewMockMetadataCacheBookStore(t)
 	svc := handlersmocks.NewMockMetadataCacheFetchService(t)
-	pool := handlersmocks.NewMockFileIOPool(t)
 	batcher := handlersmocks.NewMockWriteBackEnqueuer(t)
+	return handlers.NewMetadataCacheHandler(store, svc, batcher, nil, ops)
+}
 
-	bookIDs := []string{"book-1", "book-2"}
+// TestBatchApplyFromCache_EnqueuesOpWithBookIDs pins the core contract: the
+// request returns immediately with an op id instead of holding the connection
+// open for the whole batch. A 250-book apply measured 2m0s inline; the browser
+// gave up first and reported "session expired, nothing was applied" while the
+// server kept writing.
+func TestBatchApplyFromCache_EnqueuesOpWithBookIDs(t *testing.T) {
+	ops := &capturingEnqueuer{opID: "op-abc"}
+	h := newDispatchHandler(t, ops)
 
-	for _, id := range bookIDs {
-		svc.EXPECT().GetCachedCandidates(id).Return(cacheEntry(t, "Title "+id), true, nil).Once()
-		svc.EXPECT().ApplyMetadataCandidate(id, mock.AnythingOfType("metafetch.MetadataCandidate"), []string(nil)).
-			Return(&metafetch.FetchMetadataResponse{}, nil).Once()
-		svc.EXPECT().InvalidateCachedCandidates(id).Return(nil).Once()
-		batcher.EXPECT().Enqueue(id).Once()
-	}
-
-	// Capture the real arguments. Asserting only that Submit happened is what
-	// let a previous bug on this exact endpoint survive a passing test.
-	var mu sync.Mutex
-	var submitted []recordedPoolCall
-	pool.EXPECT().Submit(mock.AnythingOfType("string"), mock.AnythingOfType("func()")).
-		Run(func(bookID string, fn func()) {
-			mu.Lock()
-			submitted = append(submitted, recordedPoolCall{bookID: bookID, fn: fn})
-			mu.Unlock()
-		}).Times(len(bookIDs))
-
-	// The pool closure must actually DO the file work when run, so assert on
-	// what it calls, not merely that it exists.
-	var fileIOCalls []string
-	var writeBackCalls []string
-	for _, id := range bookIDs {
-		svc.EXPECT().ApplyMetadataFileIO(id).Run(func(gotID string) {
-			mu.Lock()
-			fileIOCalls = append(fileIOCalls, gotID)
-			mu.Unlock()
-		}).Once()
-		svc.EXPECT().WriteBackMetadataForBook(id).Run(func(gotID string, _ ...[]string) {
-			mu.Lock()
-			writeBackCalls = append(writeBackCalls, gotID)
-			mu.Unlock()
-		}).Return(3, nil).Once()
-	}
-
-	h := handlers.NewMetadataCacheHandler(store, svc, batcher, pool)
-	c, w := batchApplyCtx(`{"book_ids":["book-1","book-2"]}`)
+	c, w := batchApplyCtx(`{"book_ids":["b1","b2","b3"]}`)
 	h.BatchApplyFromCache(c)
 
-	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, http.StatusAccepted, w.Code, "must return 202, not a completed result")
+	require.Equal(t, 1, ops.calls)
+	assert.Equal(t, "metadata.batch-apply-cached", ops.defID)
 
-	// Exactly one submission per applied book, carrying that book's ID.
-	require.Len(t, submitted, 2)
-	gotIDs := []string{submitted[0].bookID, submitted[1].bookID}
-	assert.ElementsMatch(t, bookIDs, gotIDs, "pool.Submit must receive each applied book ID")
+	p := paramsMap(t, ops.params)
+	assert.Equal(t, []any{"b1", "b2", "b3"}, p["book_ids"])
 
-	// Run the captured closures: a mockery mock does NOT invoke fn on its own,
-	// so without this the test would prove scheduling and nothing else.
-	for _, call := range submitted {
-		require.NotNil(t, call.fn, "captured pool closure must not be nil")
-		call.fn()
-	}
-
-	assert.ElementsMatch(t, bookIDs, fileIOCalls, "ApplyMetadataFileIO must run for each applied book")
-	assert.ElementsMatch(t, bookIDs, writeBackCalls, "WriteBackMetadataForBook must run for each applied book")
-
-	// Response reports the truth, per book.
-	var resp struct {
+	var body struct {
 		Data struct {
-			Applied    int      `json:"applied"`
-			AppliedIDs []string `json:"applied_ids"`
-			Skipped    []struct {
-				BookID string `json:"book_id"`
-				Reason string `json:"reason"`
-			} `json:"skipped"`
-			Requested int  `json:"requested"`
-			WriteBack bool `json:"write_back"`
+			OpID      string `json:"op_id"`
+			Requested int    `json:"requested"`
 		} `json:"data"`
 	}
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, 2, resp.Data.Applied)
-	assert.ElementsMatch(t, bookIDs, resp.Data.AppliedIDs)
-	assert.Empty(t, resp.Data.Skipped)
-	assert.Equal(t, 2, resp.Data.Requested)
-	assert.True(t, resp.Data.WriteBack, "write_back defaults to true when the field is absent")
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "op-abc", body.Data.OpID)
+	assert.Equal(t, 3, body.Data.Requested)
 }
 
-// TestBatchApplyFromCache_WriteBackFalseSuppressesFileIO pins the opt-out:
-// write_back:false must apply to the database and schedule NO file work.
-func TestBatchApplyFromCache_WriteBackFalseSuppressesFileIO(t *testing.T) {
-	store := handlersmocks.NewMockMetadataCacheBookStore(t)
-	svc := handlersmocks.NewMockMetadataCacheFetchService(t)
-	pool := handlersmocks.NewMockFileIOPool(t)
-	batcher := handlersmocks.NewMockWriteBackEnqueuer(t)
+// TestBatchApplyFromCache_WriteBackDefaultsOn pins the default. An absent
+// write_back means TRUE, matching the single-book path. Getting this wrong in
+// the params silently turns a tag-writing apply into a database-only one.
+func TestBatchApplyFromCache_WriteBackDefaultsOn(t *testing.T) {
+	ops := &capturingEnqueuer{}
+	h := newDispatchHandler(t, ops)
 
-	svc.EXPECT().GetCachedCandidates("book-1").Return(cacheEntry(t, "Title"), true, nil).Once()
-	svc.EXPECT().ApplyMetadataCandidate("book-1", mock.AnythingOfType("metafetch.MetadataCandidate"), []string(nil)).
-		Return(&metafetch.FetchMetadataResponse{}, nil).Once()
-	svc.EXPECT().InvalidateCachedCandidates("book-1").Return(nil).Once()
-
-	// No pool.Submit, no batcher.Enqueue, no ApplyMetadataFileIO and no
-	// WriteBackMetadataForBook expectations are registered — mockery fails the
-	// test on any unexpected call, which is the assertion.
-
-	h := handlers.NewMetadataCacheHandler(store, svc, batcher, pool)
-	c, w := batchApplyCtx(`{"book_ids":["book-1"],"write_back":false}`)
+	c, _ := batchApplyCtx(`{"book_ids":["b1"]}`)
 	h.BatchApplyFromCache(c)
 
-	require.Equal(t, http.StatusOK, w.Code)
-
-	var resp struct {
-		Data struct {
-			Applied   int  `json:"applied"`
-			WriteBack bool `json:"write_back"`
-		} `json:"data"`
-	}
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, 1, resp.Data.Applied, "the DB apply still happens with write_back:false")
-	assert.False(t, resp.Data.WriteBack)
+	require.Equal(t, 1, ops.calls)
+	assert.Equal(t, true, paramsMap(t, ops.params)["write_back"],
+		"absent write_back must reach the op as true")
 }
 
-// TestBatchApplyFromCache_ReportsSkippedBooks covers the second defect: a book
-// with no cached candidates was counted as nothing at all, and the UI reported
-// the REQUESTED count as applied. The response must name the skip and its
-// reason so the caller can leave that row in the queue.
-func TestBatchApplyFromCache_ReportsSkippedBooks(t *testing.T) {
-	store := handlersmocks.NewMockMetadataCacheBookStore(t)
-	svc := handlersmocks.NewMockMetadataCacheFetchService(t)
-	pool := handlersmocks.NewMockFileIOPool(t)
-	batcher := handlersmocks.NewMockWriteBackEnqueuer(t)
+// TestBatchApplyFromCache_WriteBackFalseIsForwarded pins the opt-out surviving
+// the hop into the op params. The inverse of the test above, and the reason
+// both exist: a params bug that hard-coded true would pass the default test.
+func TestBatchApplyFromCache_WriteBackFalseIsForwarded(t *testing.T) {
+	ops := &capturingEnqueuer{}
+	h := newDispatchHandler(t, ops)
 
-	// book-1 applies; book-2 has an empty cache entry (the prod case: the
-	// entry expired between the review list loading and APPLY being clicked).
-	svc.EXPECT().GetCachedCandidates("book-1").Return(cacheEntry(t, "Title"), true, nil).Once()
-	svc.EXPECT().ApplyMetadataCandidate("book-1", mock.AnythingOfType("metafetch.MetadataCandidate"), []string(nil)).
-		Return(&metafetch.FetchMetadataResponse{}, nil).Once()
-	svc.EXPECT().InvalidateCachedCandidates("book-1").Return(nil).Once()
-	batcher.EXPECT().Enqueue("book-1").Once()
-	svc.EXPECT().ApplyMetadataFileIO("book-1").Once()
-	svc.EXPECT().WriteBackMetadataForBook("book-1").Return(1, nil).Once()
-
-	svc.EXPECT().GetCachedCandidates("book-2").
-		Return(&metafetch.MetadataCandidateCache{}, false, nil).Once()
-
-	var submitted []recordedPoolCall
-	pool.EXPECT().Submit(mock.AnythingOfType("string"), mock.AnythingOfType("func()")).
-		Run(func(bookID string, fn func()) {
-			submitted = append(submitted, recordedPoolCall{bookID: bookID, fn: fn})
-		}).Once()
-
-	h := handlers.NewMetadataCacheHandler(store, svc, batcher, pool)
-	c, w := batchApplyCtx(`{"book_ids":["book-1","book-2"]}`)
+	c, _ := batchApplyCtx(`{"book_ids":["b1"],"write_back":false}`)
 	h.BatchApplyFromCache(c)
 
-	require.Equal(t, http.StatusOK, w.Code)
-
-	// Only the applied book got file work — assert on the captured ID, not that
-	// "a" submission happened.
-	require.Len(t, submitted, 1)
-	assert.Equal(t, "book-1", submitted[0].bookID)
-	submitted[0].fn()
-
-	var resp struct {
-		Data struct {
-			Applied    int      `json:"applied"`
-			AppliedIDs []string `json:"applied_ids"`
-			Skipped    []struct {
-				BookID string `json:"book_id"`
-				Reason string `json:"reason"`
-			} `json:"skipped"`
-			Requested int `json:"requested"`
-		} `json:"data"`
-	}
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, 1, resp.Data.Applied, "applied must be the count actually applied, not requested")
-	assert.Equal(t, []string{"book-1"}, resp.Data.AppliedIDs)
-	assert.Equal(t, 2, resp.Data.Requested)
-	require.Len(t, resp.Data.Skipped, 1)
-	assert.Equal(t, "book-2", resp.Data.Skipped[0].BookID)
-	assert.Equal(t, "no_cached_candidates", resp.Data.Skipped[0].Reason)
+	require.Equal(t, 1, ops.calls)
+	assert.Equal(t, false, paramsMap(t, ops.params)["write_back"],
+		"write_back=false must reach the op as false")
 }
 
-// TestBatchApplyFromCache_NilPoolStillApplies pins the nil-pool path: the DB
-// apply must still happen and the handler must not panic. The warn log this
-// emits is the point — a silent skip here is the defect being fixed.
-func TestBatchApplyFromCache_NilPoolStillApplies(t *testing.T) {
-	store := handlersmocks.NewMockMetadataCacheBookStore(t)
-	svc := handlersmocks.NewMockMetadataCacheFetchService(t)
-	batcher := handlersmocks.NewMockWriteBackEnqueuer(t)
+// TestBatchApplyFromCache_NoRegistryIsAnError guards against a silent
+// regression to inline applying. There is deliberately no inline fallback: one
+// would be a second implementation that only ever ran when the registry was
+// absent, so the tested path and the shipped path would diverge.
+func TestBatchApplyFromCache_NoRegistryIsAnError(t *testing.T) {
+	h := newDispatchHandler(t, nil)
 
-	svc.EXPECT().GetCachedCandidates("book-1").Return(cacheEntry(t, "Title"), true, nil).Once()
-	svc.EXPECT().ApplyMetadataCandidate("book-1", mock.AnythingOfType("metafetch.MetadataCandidate"), []string(nil)).
-		Return(&metafetch.FetchMetadataResponse{}, nil).Once()
-	svc.EXPECT().InvalidateCachedCandidates("book-1").Return(nil).Once()
-	batcher.EXPECT().Enqueue("book-1").Once()
-
-	h := handlers.NewMetadataCacheHandler(store, svc, batcher, nil)
-	c, w := batchApplyCtx(`{"book_ids":["book-1"]}`)
+	c, w := batchApplyCtx(`{"book_ids":["b1"]}`)
 	h.BatchApplyFromCache(c)
 
-	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestBatchApplyFromCache_EnqueueFailureIsReported keeps a failed enqueue from
+// reading as a successful start. Returning 202 here would tell the UI to poll
+// an op id that does not exist.
+func TestBatchApplyFromCache_EnqueueFailureIsReported(t *testing.T) {
+	ops := &capturingEnqueuer{err: errors.New("registry down")}
+	h := newDispatchHandler(t, ops)
+
+	c, w := batchApplyCtx(`{"book_ids":["b1"]}`)
+	h.BatchApplyFromCache(c)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.NotEqual(t, http.StatusAccepted, w.Code)
+}
+
+// TestBatchApplyFromCache_RejectsMalformedBody keeps the binding guard.
+func TestBatchApplyFromCache_RejectsMalformedBody(t *testing.T) {
+	ops := &capturingEnqueuer{}
+	h := newDispatchHandler(t, ops)
+
+	c, w := batchApplyCtx(`{"book_ids":`)
+	h.BatchApplyFromCache(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, 0, ops.calls, "nothing may be enqueued for an unparseable body")
 }

--- a/internal/server/wire_handlers.go
+++ b/internal/server/wire_handlers.go
@@ -63,7 +63,7 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 	if s.fileIOPool != nil {
 		mcFileIOPool = s.fileIOPool
 	}
-	metaCacheH := handlers.NewMetadataCacheHandler(s.Store(), s.metadataFetchService, s.writeBackBatcher, mcFileIOPool)
+	metaCacheH := handlers.NewMetadataCacheHandler(s.Store(), s.metadataFetchService, s.writeBackBatcher, mcFileIOPool, s.opRegistry)
 	organizeH := handlers.NewOrganizeHandler(
 		s.Store(),
 		NewRenameService(s.Store()),

--- a/web/src/components/audiobooks/MetadataReviewDialog.tsx
+++ b/web/src/components/audiobooks/MetadataReviewDialog.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/audiobooks/MetadataReviewDialog.tsx
-// version: 1.14.0
+// version: 1.15.0
 // guid: e7f8a9b0-c1d2-3e4f-5a6b-7c8d9e0f1a2b
-// last-edited: 2026-08-11
+// last-edited: 2026-08-15
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
@@ -26,6 +26,7 @@ import {
   ToggleButton,
   ToggleButtonGroup,
   Tooltip,
+  LinearProgress,
   Typography,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
@@ -176,6 +177,14 @@ export function MetadataReviewDialog({
   const [onlyWithTranscription, setOnlyWithTranscription] = useState(false);
   const [onlyTranscriptionMatched, setOnlyTranscriptionMatched] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
+  // Live progress of the background apply op, so a long batch shows movement
+  // instead of a spinner that looks identical to a hung request.
+  const [applyOpId, setApplyOpId] = useState<string | null>(null);
+  const [applyProgress, setApplyProgress] = useState<{
+    current: number;
+    total: number;
+    message: string;
+  } | null>(null);
   // Books in this set have been manually split from their duplicate group and
   // render as standalone rows. Reset when the page changes.
   const [ungroupedIds, setUngroupedIds] = useState<Set<string>>(new Set());
@@ -319,76 +328,79 @@ export function MetadataReviewDialog({
   // server skipped (expired cache entry, apply error) disappeared from the
   // queue as if it had worked, then came back on the next load. Skipped rows
   // are reverted to 'pending' so they stay visible and re-appliable.
-  const applyServerOutcome = useCallback(
-    (
-      requestedIds: string[],
-      result: api.BatchApplyFromCacheResult,
-      undoLabel: string
-    ) => {
-      const appliedSet = new Set(result.applied_ids);
-      setRowStates((prev) => {
-        const next = new Map(prev);
-        requestedIds.forEach((id) => next.set(id, appliedSet.has(id) ? 'applied' : 'pending'));
-        return next;
-      });
-      if (result.applied > 0) {
-        const undoIds = result.applied_ids;
+  // An auth bounce during a batch apply does NOT mean nothing was applied.
+  //
+  // The code here used to assert that it did — every row was reverted to
+  // 'pending' with a "nothing was applied" toast — on the reasoning that when
+  // Cloudflare Access bounces a request to a login page the origin never sees
+  // it. That holds only while the request is short. Measured on production: a
+  // 250-book apply ran 2m0s, the origin returned HTTP 200, 67 files were
+  // written in that window, and the user was told nothing had been applied.
+  // Reverting the rows then invites a re-apply of work that already succeeded.
+  //
+  // So: keep the detection (an expired session really is indistinguishable from
+  // success without it), report it accurately, and re-read server state rather
+  // than guessing. Dispatch is now a sub-second request, which makes the bounce
+  // far less likely to begin with.
+  const handleApplyError = useCallback(
+    (err: unknown, requestedIds: string[]) => {
+      setRefreshKey((k) => k + 1);
+      if (isAuthRedirectError(err)) {
         toast(
-          `Applied metadata to ${result.applied} book${result.applied > 1 ? 's' : ''}`,
-          'success',
-          {
-            label: undoLabel,
-            onClick: async () => {
-              for (const id of undoIds) {
-                try {
-                  await api.undoLastApply(id);
-                } catch {
-                  /* ignore */
-                }
-              }
-              setRowStates((prev) => {
-                const next = new Map(prev);
-                undoIds.forEach((id) => next.set(id, 'pending'));
-                return next;
-              });
-              toast(`Undid ${undoIds.length} apply(s)`, 'info');
-            },
-          }
+          'Session expired — sign in again. Any books already applied were kept; the list has been refreshed.',
+          'error'
         );
+        return;
       }
-      if (result.skipped.length > 0) {
-        const expired = result.skipped.filter(
-          (s) => s.reason === 'no_cached_candidates'
-        ).length;
-        const detail =
-          expired === result.skipped.length
-            ? 'no cached match — refresh and try again'
-            : 'see server logs for details';
-        toast(
-          `Skipped ${result.skipped.length} book${result.skipped.length > 1 ? 's' : ''} (${detail})`,
-          'warning'
-        );
-      }
+      toast(`Failed to start applying ${requestedIds.length} book(s)`, 'error');
     },
     [toast]
   );
 
-  // Session expiry is NOT a generic failure. When Cloudflare Access bounces the
-  // request to a login page the write never happened, so every optimistic row
-  // must revert and the user has to be told to sign in — not shown a generic
-  // "Failed to apply" they will retry against a dead session.
-  const handleApplyError = useCallback(
-    (err: unknown, requestedIds: string[]) => {
-      setRowStates((prev) => {
-        const next = new Map(prev);
-        requestedIds.forEach((id) => next.set(id, 'pending'));
-        return next;
-      });
-      if (isAuthRedirectError(err)) {
-        toast('Session expired, sign in again — nothing was applied', 'error');
-        return;
+  // runApplyOp dispatches the background apply, polls it, and then RE-READS the
+  // review list rather than diffing a client-side guess.
+  //
+  // The previous version trusted an applied_ids/skipped list returned inline.
+  // That list no longer exists: at dispatch time nothing has been applied yet.
+  // Re-reading is also strictly more honest — it reflects what the server
+  // actually did, including work finished after any client-side timeout.
+  const runApplyOp = useCallback(
+    async (requestedIds: string[], writeBack?: boolean): Promise<boolean> => {
+      const dispatch = await api.batchApplyFromCache(requestedIds, writeBack);
+      setApplyOpId(dispatch.op_id);
+      setApplyProgress({ current: 0, total: requestedIds.length, message: 'starting…' });
+      try {
+        const op = await api.pollOperationV2(dispatch.op_id, (o) => {
+          setApplyProgress({
+            current: o.progress_current ?? 0,
+            total: o.progress_total ?? requestedIds.length,
+            message: o.progress_message ?? o.current_item ?? 'applying…',
+          });
+        });
+        if (op.status === 'completed') {
+          hasChangesRef.current = true;
+          // progress_message carries the op's own tally, e.g.
+          // "complete: applied 248 of 250 (no candidates 2, ...)".
+          toast(op.progress_message || `Applied metadata to ${requestedIds.length} books`, 'success');
+          return true;
+        }
+        if (op.status === 'canceled') {
+          // Partial work is real and already on disk. Say so instead of
+          // implying the batch left no trace.
+          hasChangesRef.current = true;
+          toast('Metadata apply canceled — books applied before the cancel were kept', 'warning');
+          return true;
+        }
+        toast(op.progress_message || 'Metadata apply failed', 'error');
+        return true;
+      } finally {
+        setApplyOpId(null);
+        setApplyProgress(null);
+        // Always re-read: even a failed or canceled op may have applied some
+        // books before it stopped, and leaving the list stale would show rows
+        // as pending that are already done.
+        setRefreshKey((k) => k + 1);
       }
-      toast('Failed to apply', 'error');
     },
     [toast]
   );
@@ -398,15 +410,11 @@ export function MetadataReviewDialog({
     applyQueueRef.current = [];
     if (ids.length === 0) return;
     try {
-      const result = await api.batchApplyFromCache(ids);
-      if (result.applied > 0) {
-        hasChangesRef.current = true;
-      }
-      applyServerOutcome(ids, result, 'Undo');
+      await runApplyOp(ids);
     } catch (err) {
       handleApplyError(err, ids);
     }
-  }, [applyServerOutcome, handleApplyError]);
+  }, [runApplyOp, handleApplyError]);
 
   const handleApplyOne = (bookId: string) => {
     // Optimistic UI update
@@ -421,15 +429,11 @@ export function MetadataReviewDialog({
     if (bookIds.length === 0) return;
     setApplying(true);
     try {
-      const result = await api.batchApplyFromCache(bookIds);
-      // Clear the selection only for books that actually applied, so a skipped
-      // book stays selected and the user can retry it after a refresh.
-      const appliedSet = new Set(result.applied_ids);
-      setSelectedIds((prev) => new Set([...prev].filter((id) => !appliedSet.has(id))));
-      if (result.applied > 0) {
-        hasChangesRef.current = true;
-      }
-      applyServerOutcome(bookIds, result, 'Undo All');
+      await runApplyOp(bookIds);
+      // The refresh triggered by runApplyOp re-derives every row from the
+      // server, so clearing the whole selection is safe: anything that did not
+      // apply comes back as pending and can be re-selected.
+      setSelectedIds(new Set());
     } catch (err) {
       handleApplyError(err, bookIds);
     } finally {
@@ -1582,7 +1586,32 @@ export function MetadataReviewDialog({
             </>
           )}
         </DialogContent>
-        <DialogActions>
+        <DialogActions sx={{ gap: 2 }}>
+          {/* Live op progress. A long batch used to be indistinguishable from a
+              hung request — same spinner either way — which is what made a
+              working 2-minute apply read as a failure. */}
+          {applyProgress && (
+            <Box sx={{ flex: 1, minWidth: 0, mr: 1 }}>
+              <LinearProgress
+                variant={applyProgress.total > 0 ? 'determinate' : 'indeterminate'}
+                value={
+                  applyProgress.total > 0
+                    ? Math.min(100, (applyProgress.current / applyProgress.total) * 100)
+                    : 0
+                }
+              />
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                noWrap
+                title={applyProgress.message}
+                sx={{ display: 'block' }}
+              >
+                {applyProgress.current}/{applyProgress.total} — {applyProgress.message}
+                {applyOpId ? ` (op ${applyOpId.slice(0, 8)})` : ''}
+              </Typography>
+            </Box>
+          )}
           <Button onClick={handleClose}>Close</Button>
           <Button
             variant="contained"

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.58.0
+// version: 2.59.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-08-15
 
@@ -3604,33 +3604,74 @@ export interface BatchApplyFromCacheResult {
   write_back: boolean;
 }
 
-// batchApplyFromCache applies the highest-scored cached candidate for each
-// book in book_ids. Cache-mode replacement for batchApplyCandidates.
+/** What the server returns when a batch apply is DISPATCHED (HTTP 202). */
+export interface BatchApplyDispatch {
+  op_id: string;
+  requested: number;
+  write_back: boolean;
+}
+
+// batchApplyFromCache STARTS a background apply of the highest-scored cached
+// candidate for each book in book_ids, and returns the operation id.
 //
-// applied_ids / skipped were added because this endpoint used to report only a
-// count: books whose cache entry had expired were skipped server-side, the UI
-// reported them as applied anyway, and they silently vanished from the review
-// queue and then reappeared on the next load.
+// It no longer returns applied_ids/skipped, because at the moment it returns
+// nothing has been applied yet. Applying inline held the request open for the
+// whole batch — 2m0s for 250 books on production — and because Go does not kill
+// a handler when the client disconnects, the browser timed out while the server
+// kept working. The UI reported "session expired, nothing was applied" for a
+// request that returned HTTP 200 and wrote over a thousand files.
+//
+// Callers poll the op, then RE-READ the review list. Server state after the op
+// is the only description of what happened that cannot go stale.
 export async function batchApplyFromCache(
-  bookIds: string[]
-): Promise<BatchApplyFromCacheResult> {
+  bookIds: string[],
+  writeBack?: boolean
+): Promise<BatchApplyDispatch> {
+  const body: Record<string, unknown> = { book_ids: bookIds };
+  if (writeBack !== undefined) body.write_back = writeBack;
   const response = await apiFetch(`${API_BASE}/audiobooks/metadata/batch-apply-cached`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ book_ids: bookIds }),
+    body: JSON.stringify(body),
   });
-  if (!response.ok) throw await buildApiError(response, 'Failed to apply cached candidates');
+  if (!response.ok) throw await buildApiError(response, 'Failed to start metadata apply');
   const data = await response.json();
   const payload = data.data ?? data;
-  // Tolerate an older server that returns only `applied`: treat every
-  // requested id as applied ONLY when the server did not tell us otherwise.
+  if (!payload?.op_id) {
+    throw new Error('Server did not return an operation id for the metadata apply');
+  }
   return {
-    applied: typeof payload.applied === 'number' ? payload.applied : 0,
-    applied_ids: Array.isArray(payload.applied_ids) ? payload.applied_ids : bookIds,
-    skipped: Array.isArray(payload.skipped) ? payload.skipped : [],
+    op_id: payload.op_id,
     requested: typeof payload.requested === 'number' ? payload.requested : bookIds.length,
     write_back: payload.write_back !== false,
   };
+}
+
+/** Terminal states for a v2 operation. */
+const OP_V2_TERMINAL = [
+  'completed',
+  'failed',
+  'canceled',
+  'interrupted_dropped',
+  'interrupted_restart',
+];
+
+// pollOperationV2 polls a v2 operation until it reaches a terminal state.
+//
+// Separate from pollOperation, which polls the v1 `/operations/:id/status`
+// endpoint — a v2 op id is not addressable there, so reusing it would poll
+// forever against a 404.
+export async function pollOperationV2(
+  id: string,
+  onProgress?: (op: OperationV2) => void,
+  intervalMs = 1000
+): Promise<OperationV2> {
+  for (;;) {
+    const op = await getOperationV2(id);
+    onProgress?.(op);
+    if (OP_V2_TERMINAL.includes(op.status)) return op;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
 }
 
 // clearMetadataNoMatch clears a book's MetadataReviewStatus back to null


### PR DESCRIPTION
## The bug you actually hit

Applying 250 books showed **"Session expired. Nothing was applied."**

Both halves of that message were false. From the production journal:

```
11:04:25 | 200 |  29.14s | POST /metadata/batch-apply-cached
11:05:15 | 200 |  26.51s
11:06:19 | 200 |  27.66s
11:07:21 | 200 |  26.79s
11:10:12 | 200 |  27.02s
11:12:36 | 200 |  27.91s
11:15:20 | 200 |   1m40s
11:26:14 | 200 |    2m0s   ← the 250-book apply
```

**Every request returned HTTP 200.** 1,134 files were written between 11:04:58 and 11:27:41; 67 of them inside that last 2-minute window. The apply worked. The browser gave up first.

## Why it wasn't a threading problem

The plan going in assumed `BatchApplyFromCache` was a sequential loop needing a worker pool. **It wasn't.** It already ran an `errgroup` at `batchApplyConcurrency = 4`, and already pushed the file work to `fileIOPool`. Cover downloads were already backgrounded too.

The problem was **request duration**: N × `ApplyMetadataCandidate` ÷ 4 ≈ 1.9s/book of database work, held open in the gin goroutine. Go's HTTP server does not kill a handler when the client disconnects, and `ApplyMetadataCandidate` takes no `context.Context`, so there was nothing to cancel. The server kept applying for a full minute after the UI declared failure.

## What changed

The handler is now a **dispatcher**: it enqueues `metadata.batch-apply-cached` and returns `202` with an `op_id`. The op gets the three things the inline version structurally could not have — a `ctx` that cancels, a progress stream to poll, and the registry watchdog.

**The per-book logic was extracted, not reimplemented.** `applyCachedCandidateForBook` is called by the op, and the three regression tests that pinned real shipped defects (file I/O per applied book, `write_back=false` opt-out, skip reasons) moved with it to `batch_apply_one_test.go`. They still exercise the code production runs. Testing the handler would now only prove an op was enqueued.

There is deliberately **no inline fallback** — it would be a second implementation reachable only when the registry is absent, so the tested path and the shipped path would diverge.

### Two details that matter

**File work runs inline in the op's worker, not via `pool.Submit`.** `Submit` returns immediately, so an op using it would report **100% complete while tags were still being written** — defeating the entire point of the status. This also brings the work under `writeBackPathLocks`.

**`PerItemTimeout` (3m) sits below the watchdog's 5m progress timeout**, so one wedged book fails its own item instead of starving the watchdog. That is precisely how the UA-purge census died — no progress for 5m18s against a 5m0s timeout.

## Also fixed: the UI's false claim

`handleApplyError` reverted every row and said "nothing was applied" on an auth redirect, reasoning that a Cloudflare Access bounce means the origin never saw the request. That holds only for short requests — the evidence above disproves it for long ones. Detection is kept (an expired session is otherwise indistinguishable from success); only the **conclusion** changed, and the list refreshes rather than reverting. A false revert is what makes someone re-fire and double-apply.

## Verification

- `go build ./...` → 0, `go vet ./internal/server/...` → 0
- `go test ./internal/server ./internal/server/handlers` → ok
- `tsc --noEmit` clean, **vitest 476/476 passed**

**Mutation-tested** (committed first, per the rule that `git checkout --` wipes uncommitted work). All four mutants killed by the right test:

| Mutation | Killed by |
|---|---|
| Never call `ApplyMetadataFileIO` (the original defect) | `WritesFilesForAppliedBook` |
| `write_back` forced true | `WriteBackFalseIsForwarded` |
| Return 200 instead of 202 | `EnqueuesOpWithBookIDs` |
| Write-back failure marks book unapplied | `WriteBackFailureStaysApplied` |

A fifth mutation attempt only broke the *build*, which is not a kill — it was redone as a compiling mutant before being counted.

## Note on merge order

Touches `internal/server/handlers/metadata_cache.go`, which #2475 also edits. Whichever lands second needs a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS