### PR TITLE
fix(metafetch): return an error from ApplyMetadataFileIO so a failed rename is reportable

### DIFF
--- a/changelog.d/20260816_004500_apply_file_io_error_return.md
+++ b/changelog.d/20260816_004500_apply_file_io_error_return.md
@@ -1,0 +1,36 @@
+### Fixed
+
+#### Batch metadata apply no longer reports success when the files never moved
+
+`POST /api/v1/metadata/cached/apply` counted a book as applied whether or not
+its audio files were actually renamed. The rename happens inside
+`ApplyMetadataFileIO`, which had **no return value** — a failure from the apply
+pipeline was swallowed into a `slog.Warn` and was unreachable to all six of its
+callers. `applyCachedCandidateForBook` therefore returned `Applied: true`
+regardless of what happened on disk, and the batch op's `write_failed` counter
+could never be incremented by a rename failure.
+
+`ApplyMetadataFileIO` now returns an `error`, and the outcome the API reports
+distinguishes the two cases:
+
+- **`Applied` stays true.** The database change is real and durable, and a
+  failed rename does not undo it. Reporting the book as unapplied would send
+  someone re-applying work that already succeeded.
+- **`WriteBackFailed` is now set** when the file work did not fully land, so the
+  batch op counts it separately and logs it naming the book.
+
+A non-nil error means "the file work did not fully land", **not** "nothing
+happened": `runApplyPipeline` deliberately persists the `book_file` rows for
+every rename that *did* succeed before returning the failure, so a partial
+rename is already recorded.
+
+The four callers that run in a background pool or a restart-recovery handler
+cannot reach an HTTP response — by the time they run, the request has been
+answered — so they log the failure with the book named instead. Tag write-back
+still runs after a file-I/O failure exactly as it did before; only the error
+that gets reported changed, with the file-I/O error taking precedence because
+"rename failed" localises the fault better than the write-back error it tends to
+cause.
+
+Follows the target-path builder unification, which is what surfaced this: that
+change made the rename correct, and this one makes its failure visible.

--- a/internal/metafetch/service_files.go
+++ b/internal/metafetch/service_files.go
@@ -1,11 +1,12 @@
 // file: internal/metafetch/service_files.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 969b284a-5657-442b-beba-275e325e000b
-// last-edited: 2026-06-16
+// last-edited: 2026-08-16
 
 package metafetch
 
 import (
+	"fmt"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/fileops"
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
@@ -77,10 +78,34 @@ func backupFileBeforeWrite(filePath string) {
 // cover embed, tag write-back, file rename. Cover download is done inline
 // in ApplyMetadataCandidate so the response includes the updated cover URL.
 // Designed to run in a background goroutine.
-func (mfs *Service) ApplyMetadataFileIO(id string) {
+//
+// It returns an error when the file work did not fully land. Until 2026-08-16
+// it returned nothing and swallowed the pipeline failure into a slog.Warn, so
+// no caller could tell a completed rename from a failed one — and
+// applyCachedCandidateForBook reported Applied:true either way, i.e. the API
+// said the apply succeeded while the files had never moved.
+//
+// WHAT A NON-NIL ERROR MEANS: "the file work did not fully land", NOT "nothing
+// happened". runApplyPipeline deliberately persists the book_file rows for
+// every rename that DID succeed before returning the failure, so a partial
+// rename is durable and already recorded. Callers must therefore keep
+// reporting the database apply as successful and flag only the file side --
+// see applyOutcome.WriteBackFailed, which exists for exactly this shape.
+//
+// The cover embed is deliberately NOT part of the returned error:
+// embedCoverInBookFiles reports nothing and a missing cover must not mask a
+// rename failure or block the pipeline below it.
+func (mfs *Service) ApplyMetadataFileIO(id string) error {
 	book, err := mfs.db.GetBookByID(id)
-	if err != nil || book == nil {
-		return
+	if err != nil {
+		return fmt.Errorf("apply file I/O: load book %s: %w", id, err)
+	}
+	if book == nil {
+		// Reported rather than ignored: the two recovery handlers replay file
+		// ops recorded before a restart, and a book that has since been deleted
+		// is the one case where this is expected and benign. Naming it lets the
+		// caller log which book vanished instead of silently doing nothing.
+		return fmt.Errorf("apply file I/O: book %s not found", id)
 	}
 
 	// Embed cover art into audio files (slow: ffmpeg)
@@ -91,9 +116,10 @@ func (mfs *Service) ApplyMetadataFileIO(id string) {
 	// Run file rename + tag write pipeline
 	if config.AppConfig.AutoRenameOnApply || config.AppConfig.AutoWriteTagsOnApply {
 		if err := mfs.runApplyPipeline(id, book); err != nil {
-			slog.Warn("apply pipeline failed for", "id", id, "error", err)
+			return fmt.Errorf("apply file I/O: pipeline for book %s: %w", id, err)
 		}
 	}
+	return nil
 }
 
 // computeITunesPath converts a local file path to an iTunes file:// URL

--- a/internal/metafetch/service_mock_test.go
+++ b/internal/metafetch/service_mock_test.go
@@ -1,12 +1,13 @@
 // file: internal/metafetch/service_mock_test.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: c3d4e5f6-a7b8-9012-cdef-012345678901
-// last-edited: 2026-07-13
+// last-edited: 2026-08-16
 
 package metafetch
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -2071,14 +2072,71 @@ func TestWriteBackMetadataForBook(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestApplyMetadataFileIO(t *testing.T) {
-	t.Run("book_not_found_no_panic", func(t *testing.T) {
+	t.Run("book_not_found_is_reported", func(t *testing.T) {
 		mock := &database.MockStore{
 			GetBookByIDFunc: func(id string) (*database.Book, error) {
 				return nil, nil
 			},
 		}
 		svc := NewService(mock)
-		// Should not panic
-		svc.ApplyMetadataFileIO("nonexistent")
+		err := svc.ApplyMetadataFileIO("nonexistent")
+		require.Error(t, err, "a missing book must be reported, not silently ignored")
+		assert.Contains(t, err.Error(), "nonexistent", "the error must name the book")
+	})
+
+	t.Run("store_error_is_reported", func(t *testing.T) {
+		mock := &database.MockStore{
+			GetBookByIDFunc: func(id string) (*database.Book, error) {
+				return nil, errors.New("pebble closed")
+			},
+		}
+		svc := NewService(mock)
+		err := svc.ApplyMetadataFileIO("b1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pebble closed")
+	})
+
+	// The one that matters. A failure inside runApplyPipeline — which is where
+	// the RENAME lives — used to be swallowed into a slog.Warn, so every caller
+	// saw the same "success" it saw when every file moved cleanly. That is what
+	// let the batch-apply API report Applied:true for books whose files had
+	// never moved.
+	t.Run("pipeline_failure_propagates", func(t *testing.T) {
+		origRename := config.AppConfig.AutoRenameOnApply
+		config.AppConfig.AutoRenameOnApply = true
+		t.Cleanup(func() { config.AppConfig.AutoRenameOnApply = origRename })
+
+		mock := &database.MockStore{
+			GetBookByIDFunc: func(id string) (*database.Book, error) {
+				return &database.Book{ID: id, Title: "A Book", FilePath: "/lib/a.m4b"}, nil
+			},
+			GetBookFilesFunc: func(bookID string) ([]database.BookFile, error) {
+				return nil, errors.New("list exploded")
+			},
+		}
+		svc := NewService(mock)
+		err := svc.ApplyMetadataFileIO("b1")
+		require.Error(t, err, "a pipeline failure must reach the caller")
+		assert.Contains(t, err.Error(), "list exploded")
+		assert.Contains(t, err.Error(), "b1", "the error must name the book")
+	})
+
+	t.Run("clean_run_returns_nil", func(t *testing.T) {
+		origRename := config.AppConfig.AutoRenameOnApply
+		origTags := config.AppConfig.AutoWriteTagsOnApply
+		config.AppConfig.AutoRenameOnApply = false
+		config.AppConfig.AutoWriteTagsOnApply = false
+		t.Cleanup(func() {
+			config.AppConfig.AutoRenameOnApply = origRename
+			config.AppConfig.AutoWriteTagsOnApply = origTags
+		})
+
+		mock := &database.MockStore{
+			GetBookByIDFunc: func(id string) (*database.Book, error) {
+				return &database.Book{ID: id, FilePath: "/lib/a.m4b"}, nil
+			},
+		}
+		svc := NewService(mock)
+		assert.NoError(t, svc.ApplyMetadataFileIO("b1"))
 	})
 }

--- a/internal/server/batch_apply_one.go
+++ b/internal/server/batch_apply_one.go
@@ -1,7 +1,7 @@
 // file: internal/server/batch_apply_one.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4e91c082-77a3-4d16-b5f8-2c0a9e3d4671
-// last-edited: 2026-08-15
+// last-edited: 2026-08-16
 
 package server
 
@@ -26,7 +26,7 @@ type cachedApplyService interface {
 	GetCachedCandidates(bookID string) (*metafetch.MetadataCandidateCache, bool, error)
 	ApplyMetadataCandidate(id string, candidate metafetch.MetadataCandidate, fields []string) (*metafetch.FetchMetadataResponse, error)
 	InvalidateCachedCandidates(bookID string) error
-	ApplyMetadataFileIO(id string)
+	ApplyMetadataFileIO(id string) error
 	WriteBackMetadataForBook(id string, segmentFilter ...[]string) (int, error)
 }
 
@@ -121,8 +121,24 @@ func applyCachedCandidateForBook(
 		release := lockPath(book.FilePath)
 		defer release()
 	}
-	svc.ApplyMetadataFileIO(id)
-	if _, wberr := svc.WriteBackMetadataForBook(id); wberr != nil {
+	// The rename lives in here, and its failure used to be unreachable: this
+	// call returned nothing, so the outcome below said Applied:true whether or
+	// not a single file had moved. Applied stays true — the database change is
+	// real and durable — but the file side is now flagged, which is exactly why
+	// WriteBackFailed is separate from !Applied.
+	//
+	// The write-back below still runs on a file-I/O failure. Skipping it would
+	// be a behaviour change beyond reporting: tag writing is independent of the
+	// rename (correct tags in a file that did not move are still correct), and
+	// it ran unconditionally before this call could report anything. Only the
+	// error we surface changes — fileErr wins because "rename failed" localises
+	// the fault better than the write-back error it would otherwise cause.
+	fileErr := svc.ApplyMetadataFileIO(id)
+	_, wberr := svc.WriteBackMetadataForBook(id)
+	if fileErr != nil {
+		return applyOutcome{Applied: true, WriteBackFailed: true, Err: fileErr}
+	}
+	if wberr != nil {
 		return applyOutcome{Applied: true, WriteBackFailed: true, Err: wberr}
 	}
 	return applyOutcome{Applied: true}

--- a/internal/server/batch_apply_one_test.go
+++ b/internal/server/batch_apply_one_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/batch_apply_one_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9d2b71fa-30c8-4e57-a614-8b5e0c7f2d93
-// last-edited: 2026-08-15
+// last-edited: 2026-08-16
 //
 // Regression tests for applying ONE book's cached metadata candidate.
 //
@@ -16,6 +16,7 @@ package server
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -27,6 +28,7 @@ type fakeApplySvc struct {
 	candidates    []json.RawMessage
 	getErr        error
 	applyErr      error
+	fileIOErr     error
 	writeBackErr  error
 	appliedIDs    []string
 	invalidatedID []string
@@ -57,7 +59,10 @@ func (f *fakeApplySvc) InvalidateCachedCandidates(bookID string) error {
 	return nil
 }
 
-func (f *fakeApplySvc) ApplyMetadataFileIO(id string) { f.fileIOIDs = append(f.fileIOIDs, id) }
+func (f *fakeApplySvc) ApplyMetadataFileIO(id string) error {
+	f.fileIOIDs = append(f.fileIOIDs, id)
+	return f.fileIOErr
+}
 
 func (f *fakeApplySvc) WriteBackMetadataForBook(id string, _ ...[]string) (int, error) {
 	f.writeBackIDs = append(f.writeBackIDs, id)
@@ -203,6 +208,66 @@ func TestApplyCachedCandidate_WriteBackFailureStaysApplied(t *testing.T) {
 	}
 	if !out.WriteBackFailed {
 		t.Errorf("WriteBackFailed not set despite a write-back error")
+	}
+}
+
+// TestApplyCachedCandidate_FileIOFailureIsReported is the regression this whole
+// change exists for. ApplyMetadataFileIO — which is where the RENAME happens —
+// used to return nothing, so a failed rename was unreachable to this function
+// and the outcome said Applied:true with WriteBackFailed:false. The API reported
+// a clean apply while the files had never moved.
+//
+// Applied must stay true (the database row really was written) and
+// WriteBackFailed must now be set, so the batch op counts and logs it.
+func TestApplyCachedCandidate_FileIOFailureIsReported(t *testing.T) {
+	svc := &fakeApplySvc{candidates: oneCandidate(t), fileIOErr: errors.New("rename files: cross-device link")}
+	store := &fakeBookReader{book: &database.Book{ID: "b1", FilePath: "/lib/a.m4b"}}
+
+	out := applyCachedCandidateForBook(svc, store, &fakeITunes{}, "b1", true, nil)
+
+	if !out.Applied {
+		t.Fatalf("a file-I/O failure must not unset Applied: %+v", out)
+	}
+	if !out.WriteBackFailed {
+		t.Fatalf("WriteBackFailed not set despite ApplyMetadataFileIO failing: %+v", out)
+	}
+	if out.Err == nil || !strings.Contains(out.Err.Error(), "cross-device link") {
+		t.Errorf("Err = %v, want the file-I/O error surfaced", out.Err)
+	}
+}
+
+// TestApplyCachedCandidate_FileIOFailureStillWritesBack pins that surfacing the
+// file-I/O error did not quietly stop tag writing. Tag writing is independent of
+// the rename — correct tags in a file that did not move are still correct — and
+// it ran unconditionally before the error could be observed. Only which error is
+// reported changed.
+func TestApplyCachedCandidate_FileIOFailureStillWritesBack(t *testing.T) {
+	svc := &fakeApplySvc{candidates: oneCandidate(t), fileIOErr: errors.New("rename files: boom")}
+	store := &fakeBookReader{book: &database.Book{ID: "b1", FilePath: "/lib/a.m4b"}}
+
+	_ = applyCachedCandidateForBook(svc, store, &fakeITunes{}, "b1", true, nil)
+
+	if len(svc.writeBackIDs) != 1 || svc.writeBackIDs[0] != "b1" {
+		t.Errorf("write-back skipped after a file-I/O failure: %v", svc.writeBackIDs)
+	}
+}
+
+// TestApplyCachedCandidate_FileIOErrorWinsOverWriteBackError pins the precedence.
+// A failed rename usually CAUSES the write-back to fail too, because the paths it
+// writes to are the ones that did not move. Reporting the write-back error would
+// name the symptom; the file-I/O error names the fault.
+func TestApplyCachedCandidate_FileIOErrorWinsOverWriteBackError(t *testing.T) {
+	svc := &fakeApplySvc{
+		candidates:   oneCandidate(t),
+		fileIOErr:    errors.New("rename files: the real fault"),
+		writeBackErr: errors.New("downstream symptom"),
+	}
+	store := &fakeBookReader{book: &database.Book{ID: "b1", FilePath: "/lib/a.m4b"}}
+
+	out := applyCachedCandidateForBook(svc, store, &fakeITunes{}, "b1", true, nil)
+
+	if out.Err == nil || !strings.Contains(out.Err.Error(), "the real fault") {
+		t.Errorf("Err = %v, want the file-I/O error to win", out.Err)
 	}
 }
 

--- a/internal/server/file_io_pool.go
+++ b/internal/server/file_io_pool.go
@@ -1,7 +1,7 @@
 // file: internal/server/file_io_pool.go
-// version: 2.3.4
+// version: 2.4.0
 // guid: c4d5e6f7-a8b9-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-07-03
+// last-edited: 2026-08-16
 //
 // Bounded worker pool for file I/O operations (cover embed, tag write,
 // rename). Tracks pending jobs in PebbleDB so they survive restarts.
@@ -227,7 +227,9 @@ func InitFileIOPool() {
 			slog.Warn("no server instance for apply_metadata recovery of book", "bookID", bookID)
 			return
 		}
-		srv.metadataFetchService.ApplyMetadataFileIO(bookID)
+		if err := srv.metadataFetchService.ApplyMetadataFileIO(bookID); err != nil {
+			slog.Warn("recovery apply file I/O failed", "bookID", bookID, "err", err)
+		}
 		if _, err := srv.metadataFetchService.WriteBackMetadataForBook(bookID); err != nil {
 			slog.Warn("recovery write-back for", "bookID", bookID, "err", err)
 		}

--- a/internal/server/handlers/metadata/handler.go
+++ b/internal/server/handlers/metadata/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/handler.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: 54bb4ad0-cab0-41fc-b9cb-557c96beee44
-// last-edited: 2026-08-15
+// last-edited: 2026-08-16
 
 // Package metadatahandler hosts the metadata-domain HTTP handlers extracted
 // from the server package's metadata_handlers.go: batch-update / validate /
@@ -628,7 +628,12 @@ func (h *Handler) applyAudiobookMetadataImpl(c *gin.Context) {
 			if pendingCover != "" {
 				mfs.DownloadPendingCover(bookID, pendingCover)
 			}
-			mfs.ApplyMetadataFileIO(bookID)
+			// Same constraint as the batch sibling: the HTTP response has
+			// already been written by the time this runs, so a failure can only
+			// be logged.
+			if err := mfs.ApplyMetadataFileIO(bookID); err != nil {
+				slog.Warn("background apply file I/O failed", "bookID", bookID, "err", err)
+			}
 			if shouldWriteBack {
 				if _, wbErr := mfs.WriteBackMetadataForBook(bookID); wbErr != nil {
 					slog.Warn("background write-back for", "bookID", bookID, "wbErr", wbErr)

--- a/internal/server/handlers/metadata/interfaces.go
+++ b/internal/server/handlers/metadata/interfaces.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/interfaces.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: b1ab2e4a-1f73-42f2-955d-c4a30f0fbaac
-// last-edited: 2026-08-15
+// last-edited: 2026-08-16
 
 // Narrow dependency interfaces for the metadata-domain HTTP handlers (the 19
 // per-book + library metadata endpoints extracted from the server package's
@@ -105,7 +105,7 @@ type MetadataFetchService interface {
 	FetchAndCache(ctx context.Context, bookID, query, author, narrator, series string, opts metafetch.SearchOptions) (*metafetch.MetadataCandidateCache, error)
 	SearchMetadataForBookWithOptions(id, query, author, narrator, series string, opts metafetch.SearchOptions) (*metafetch.SearchMetadataResponse, error)
 	ApplyMetadataCandidate(id string, candidate metafetch.MetadataCandidate, fields []string) (*metafetch.FetchMetadataResponse, error)
-	ApplyMetadataFileIO(id string)
+	ApplyMetadataFileIO(id string) error
 
 	// DownloadPendingCover fetches the candidate's cover art and repoints the
 	// book at the local copy. Runs in the background: it was ~4s of a measured

--- a/internal/server/handlers/metadata/mocks/mock_metadata_fetch_service.go
+++ b/internal/server/handlers/metadata/mocks/mock_metadata_fetch_service.go
@@ -115,9 +115,20 @@ func (_c *MockMetadataFetchService_ApplyMetadataCandidate_Call) RunAndReturn(run
 }
 
 // ApplyMetadataFileIO provides a mock function for the type MockMetadataFetchService
-func (_mock *MockMetadataFetchService) ApplyMetadataFileIO(id string) {
-	_mock.Called(id)
-	return
+func (_mock *MockMetadataFetchService) ApplyMetadataFileIO(id string) error {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ApplyMetadataFileIO")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(id)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
 }
 
 // MockMetadataFetchService_ApplyMetadataFileIO_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ApplyMetadataFileIO'
@@ -144,13 +155,13 @@ func (_c *MockMetadataFetchService_ApplyMetadataFileIO_Call) Run(run func(id str
 	return _c
 }
 
-func (_c *MockMetadataFetchService_ApplyMetadataFileIO_Call) Return() *MockMetadataFetchService_ApplyMetadataFileIO_Call {
-	_c.Call.Return()
+func (_c *MockMetadataFetchService_ApplyMetadataFileIO_Call) Return(err error) *MockMetadataFetchService_ApplyMetadataFileIO_Call {
+	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *MockMetadataFetchService_ApplyMetadataFileIO_Call) RunAndReturn(run func(id string)) *MockMetadataFetchService_ApplyMetadataFileIO_Call {
-	_c.Run(run)
+func (_c *MockMetadataFetchService_ApplyMetadataFileIO_Call) RunAndReturn(run func(id string) error) *MockMetadataFetchService_ApplyMetadataFileIO_Call {
+	_c.Call.Return(run)
 	return _c
 }
 

--- a/internal/server/handlers/metadata_cache.go
+++ b/internal/server/handlers/metadata_cache.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata_cache.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
-// last-edited: 2026-08-15
+// last-edited: 2026-08-16
 
 // Package handlers contains extracted HTTP handler types for the audiobook
 // organizer server. MetadataCacheHandler covers the persistent metadata-cache
@@ -58,7 +58,12 @@ type MetadataCacheFetchService interface {
 	// ApplyMetadataFileIO runs the slow post-apply file work: cover-art
 	// embedding, tag writing and (when enabled) renaming. Gated in prod by
 	// auto_write_tags_on_apply / auto_rename_on_apply.
-	ApplyMetadataFileIO(id string)
+	//
+	// A non-nil error means the file work did not fully land -- most often the
+	// rename failed. It does NOT mean nothing happened: rows for renames that
+	// did succeed are already persisted, so callers report the database apply
+	// as successful and flag only the file side.
+	ApplyMetadataFileIO(id string) error
 	// WriteBackMetadataForBook writes the book's current DB metadata into the
 	// audio files themselves and returns the number of files written.
 	WriteBackMetadataForBook(id string, segmentFilter ...[]string) (int, error)

--- a/internal/server/handlers/mocks/mock_metadata_cache_fetch_service.go
+++ b/internal/server/handlers/mocks/mock_metadata_cache_fetch_service.go
@@ -113,9 +113,20 @@ func (_c *MockMetadataCacheFetchService_ApplyMetadataCandidate_Call) RunAndRetur
 }
 
 // ApplyMetadataFileIO provides a mock function for the type MockMetadataCacheFetchService
-func (_mock *MockMetadataCacheFetchService) ApplyMetadataFileIO(id string) {
-	_mock.Called(id)
-	return
+func (_mock *MockMetadataCacheFetchService) ApplyMetadataFileIO(id string) error {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ApplyMetadataFileIO")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(id)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
 }
 
 // MockMetadataCacheFetchService_ApplyMetadataFileIO_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ApplyMetadataFileIO'
@@ -142,13 +153,13 @@ func (_c *MockMetadataCacheFetchService_ApplyMetadataFileIO_Call) Run(run func(i
 	return _c
 }
 
-func (_c *MockMetadataCacheFetchService_ApplyMetadataFileIO_Call) Return() *MockMetadataCacheFetchService_ApplyMetadataFileIO_Call {
-	_c.Call.Return()
+func (_c *MockMetadataCacheFetchService_ApplyMetadataFileIO_Call) Return(err error) *MockMetadataCacheFetchService_ApplyMetadataFileIO_Call {
+	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *MockMetadataCacheFetchService_ApplyMetadataFileIO_Call) RunAndReturn(run func(id string)) *MockMetadataCacheFetchService_ApplyMetadataFileIO_Call {
-	_c.Run(run)
+func (_c *MockMetadataCacheFetchService_ApplyMetadataFileIO_Call) RunAndReturn(run func(id string) error) *MockMetadataCacheFetchService_ApplyMetadataFileIO_Call {
+	_c.Call.Return(run)
 	return _c
 }
 

--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_batch_candidates.go
-// version: 3.4.0
+// version: 3.5.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
-// last-edited: 2026-08-15
+// last-edited: 2026-08-16
 //
 // HTTP handlers for the metadata candidate batch fetch / apply pipeline.
 // Pure service types and logic live in internal/metabatch.
@@ -580,7 +580,13 @@ func (s *Server) handleBatchApplyCandidates(c *gin.Context) {
 			if pool := s.fileIOPool; pool != nil {
 				bid := bookID
 				pool.Submit(bid, func() {
-					mfs.ApplyMetadataFileIO(bid)
+					// Logged, not returned: this runs in the pool AFTER the
+					// handler has already answered, so outcomes[i] is long
+					// since written. The response cannot report it; the log is
+					// the only channel left.
+					if err := mfs.ApplyMetadataFileIO(bid); err != nil {
+						slog.Warn("background apply file I/O failed", "bid", bid, "err", err)
+					}
 					if _, err := mfs.WriteBackMetadataForBook(bid); err != nil {
 						slog.Warn("write-back failed for", "bid", bid, "err", err)
 					}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 2.39.0
+// version: 2.40.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-08-12
+// last-edited: 2026-08-16
 
 package server
 
@@ -809,7 +809,9 @@ func NewServer(store database.Store) *Server {
 			slog.Warn("no server instance for apply_metadata recovery of book", "bookID", bookID)
 			return
 		}
-		server.metadataFetchService.ApplyMetadataFileIO(bookID)
+		if err := server.metadataFetchService.ApplyMetadataFileIO(bookID); err != nil {
+			slog.Warn("recovery apply file I/O failed", "bookID", bookID, "err", err)
+		}
 		if _, err := server.metadataFetchService.WriteBackMetadataForBook(bookID); err != nil {
 			slog.Warn("recovery write-back for", "bookID", bookID, "err", err)
 		}


### PR DESCRIPTION
## What this fixes

`ApplyMetadataFileIO` had **no return value**. The file rename runs inside it, and a failure
from the apply pipeline was swallowed into a `slog.Warn` — so none of its six callers could
observe it. `applyCachedCandidateForBook` therefore returned `Applied: true` regardless of what
happened on disk:

```go
svc.ApplyMetadataFileIO(id)          // rename may have failed entirely
...
return applyOutcome{Applied: true}   // reported as a clean apply
```

The batch op's `write_failed` counter existed and could never be incremented by a rename
failure. The API said the apply succeeded while the files were still where they started.

This was filed as **F7** in `todo.d/2026-08-15-organize-rename-silent-failures.md` while unifying
the target-path builders (#2479), and deliberately split out rather than widening that PR.

## What changed

`ApplyMetadataFileIO(id string) error`. Three interfaces, five production call sites, two
regenerated mocks.

**The instrument was verified before the plumbing was built.** `runApplyPipeline` does return a
real error on rename failure (`return fmt.Errorf("rename files: %w", renameErr)`) and on a broken
naming pattern, so surfacing it is a genuine fix rather than a cosmetic signature change.

### What a non-nil error means

"The file work did not fully land" — **not** "nothing happened". `runApplyPipeline` deliberately
persists the `book_file` rows for every rename that *did* succeed *before* returning the failure,
so a partial rename is durable and already recorded. Callers must therefore keep reporting the
database apply as successful and flag only the file side:

- **`Applied` stays true** — the database change is real, and reporting it as unapplied would
  send someone re-applying work that already succeeded. This is precisely why
  `applyOutcome.WriteBackFailed` exists as a field separate from `!Applied`.
- **`WriteBackFailed` is now set**, so `batch_apply_op.go` counts it and logs it naming the book.

### The four background callers

`server.go` and `file_io_pool.go` (restart-recovery handlers) and the two pool submissions in
`metadata_batch_candidates.go` / `handlers/metadata/handler.go` all run *after* the HTTP response
has been written. They cannot report anything, so they log with the book named — matching the
`WriteBackMetadataForBook` sibling already on each of those lines.

### One deliberate non-change

Tag write-back **still runs** after a file-I/O failure. Skipping it would have been a behaviour
change beyond error reporting: tag writing is independent of the rename (correct tags in a file
that did not move are still correct), and it ran unconditionally before this call could report
anything. Only *which* error is reported changed — the file-I/O error wins, because "rename
failed" localises the fault better than the write-back error it tends to cause.

The cover embed is excluded from the returned error on purpose: `embedCoverInBookFiles` reports
nothing, and a missing cover must not mask a rename failure.

## Verification

- `TestApplyCachedCandidate_FileIOFailureIsReported` — the regression itself: `Applied` true,
  `WriteBackFailed` true, error surfaced.
- `TestApplyCachedCandidate_FileIOFailureStillWritesBack` — pins the non-change above, so a later
  refactor can't quietly drop tag writing.
- `TestApplyCachedCandidate_FileIOErrorWinsOverWriteBackError` — pins the precedence.
- `TestApplyMetadataFileIO` rewritten from **"does not panic"** to four real cases. The old test
  asserted only that a missing book didn't panic — it could not have, and it would have passed
  unchanged for the entire life of this defect. The new `pipeline_failure_propagates` case is the
  one that matters.

**Mutation-tested, three times, each committed first then reverted:**

| Mutation | Result |
|---|---|
| `fileErr` ignored in `batch_apply_one.go` | 2 of 3 red — survivor is `StillWritesBack`, an equivalent mutant (that mutation doesn't change whether write-back runs) |
| pipeline error back to `slog.Warn` | `TestApplyMetadataFileIO` red |
| book-not-found back to `return nil` | `book_not_found_is_reported` red, other 3 pass as expected |

`go build ./...` exit 0 · `go vet` clean · `go test ./internal/server/... ./internal/metafetch/... -short -count=1` — **16 packages ok, 0 failures**.

## Still open from the same fragment

**F6** (`ensureLibraryCopy` treats an empty organize as success) and **F5-remainder** (adopt-on-equal-size instead of a content hash) are untouched here and remain filed.
