### PR TITLE
fix(organizer): reject an empty organize inside OrganizeBookDirectory, not at one caller

### DIFF
--- a/changelog.d/20260816_012000_organize_empty_result_is_an_error.md
+++ b/changelog.d/20260816_012000_organize_empty_result_is_an_error.md
@@ -1,0 +1,32 @@
+### Fixed
+
+#### A multi-file organize that copied nothing no longer reports success
+
+`OrganizeBookDirectory` creates its target directory with `MkdirAll` *before*
+copying anything, and skips any source file that has vanished from disk. When
+every source was gone it therefore returned an empty directory, an empty
+`pathMap`, and a **nil error** — indistinguishable from a clean organize.
+
+This was reachable without any `book_file` row being flagged `Missing`: rows that
+look present but whose files have since disappeared all skip silently. The
+"every row is flagged missing" case was already rejected; this was the one that
+looked like success.
+
+Of the function's three callers, only `OrganizeDirectoryBook` checked for the
+empty `pathMap`. The other two took the returned directory at face value:
+
+- `ensureLibraryCopy` (`internal/metafetch/service_apply.go`) created a
+  version-linked book record pointing at the empty directory.
+- `organizeMultiFileBook` (`internal/itunes/service/importer.go`) assigned it to
+  `book.FilePath`.
+
+Both left a book in the library pointing at a directory containing no audio.
+
+The check now lives **inside** `OrganizeBookDirectory`, which returns an error
+naming the book and no target directory, so no caller can opt out of it. The
+duplicated check in `OrganizeDirectoryBook` is removed; its separate
+stat-the-destinations check is kept, because that verifies something different —
+`pathMap` records what organize believed it wrote, and the stat confirms the
+files are still there.
+
+Filed as F6 in `todo.d/2026-08-15-organize-rename-silent-failures.md`.

--- a/internal/metafetch/ensure_library_copy_test.go
+++ b/internal/metafetch/ensure_library_copy_test.go
@@ -1,0 +1,95 @@
+// file: internal/metafetch/ensure_library_copy_test.go
+// version: 1.0.0
+// guid: 6f0c81ad-9b2e-4f37-8a51-c4d739e0b182
+// last-edited: 2026-08-16
+
+package metafetch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// TestEnsureLibraryCopy_EmptyOrganizeIsNotSuccess is the F6 regression.
+//
+// ensureLibraryCopy redirects work on a protected (iTunes/import) book to a
+// library copy, creating one by organizing the files into the library folder.
+// It set newBookPath = targetDir unconditionally on a nil error from
+// OrganizeBookDirectory — and OrganizeBookDirectory MkdirAll's that directory
+// BEFORE copying anything, then skips any source that has vanished from disk.
+//
+// So a book whose files were all gone (but whose rows were NOT flagged Missing,
+// which is the case that had no guard) produced: an empty directory, an empty
+// pathMap, a nil error, and a brand-new version-linked book record pointing at
+// the empty directory. Every downstream consumer then saw a real book with no
+// files.
+//
+// The fix rejects the empty result inside OrganizeBookDirectory, so this must
+// now come back nil — "no library copy could be made" — rather than a record.
+func TestEnsureLibraryCopy_EmptyOrganizeIsNotSuccess(t *testing.T) {
+	libRoot := t.TempDir()
+	importRoot := t.TempDir()
+
+	orig := config.AppConfig
+	t.Cleanup(func() { config.AppConfig = orig })
+	config.AppConfig.RootDir = libRoot
+	config.AppConfig.FolderNamingPattern = "{author}/{title}"
+	config.AppConfig.FileNamingPattern = "{title} - {track:02d}"
+	config.AppConfig.OrganizationStrategy = "copy"
+
+	// Two segment rows that are NOT flagged Missing but whose files are gone.
+	bookDir := filepath.Join(importRoot, "Ghost Book")
+	require.NoError(t, os.MkdirAll(bookDir, 0o755))
+	segments := []database.BookFile{
+		{ID: "f1", FilePath: filepath.Join(bookDir, "ch01.mp3"), TrackNumber: 1},
+		{ID: "f2", FilePath: filepath.Join(bookDir, "ch02.mp3"), TrackNumber: 2},
+	}
+	for _, s := range segments {
+		require.NoFileExists(t, s.FilePath, "the whole scenario is that these are gone")
+	}
+
+	mock := &database.MockStore{
+		GetAllImportPathsFunc: func() ([]database.ImportPath, error) {
+			return []database.ImportPath{{ID: 1, Path: importRoot, Enabled: true}}, nil
+		},
+		GetBookFilesFunc: func(bookID string) ([]database.BookFile, error) {
+			return segments, nil
+		},
+	}
+	svc := NewService(mock)
+
+	book := &database.Book{
+		ID:       "b1",
+		Title:    "Ghost Book",
+		Format:   "mp3",
+		FilePath: bookDir,
+		Author:   &database.Author{Name: "Ghost Author"},
+	}
+	require.True(t, svc.isProtectedPath(book.FilePath),
+		"test precondition: the book must be on a protected path or ensureLibraryCopy returns early")
+
+	got := svc.ensureLibraryCopy(book)
+
+	assert.Nil(t, got, "an organize that copied nothing must not produce a library-copy book record")
+
+	// And nothing may be left claiming to be an organized book: the only thing
+	// that could exist under the library root is the empty directory organize
+	// created before it discovered every source was gone.
+	if entries, err := os.ReadDir(libRoot); err == nil {
+		for _, e := range entries {
+			sub := filepath.Join(libRoot, e.Name())
+			files, _ := os.ReadDir(sub)
+			for _, f := range files {
+				inner, _ := os.ReadDir(filepath.Join(sub, f.Name()))
+				assert.Empty(t, inner, "no audio file should have been produced")
+			}
+		}
+	}
+}

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -1,7 +1,7 @@
 // file: internal/organizer/organizer.go
-// version: 1.24.0
+// version: 1.25.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-08-15
+// last-edited: 2026-08-16
 
 package organizer
 
@@ -792,6 +792,27 @@ func (o *Organizer) OrganizeBookDirectory(book *database.Book, files []database.
 			return "", nil, fmt.Errorf("failed to organize segment %s: %w", fileName, err)
 		}
 		pathMap[srcPath] = dstPath
+	}
+
+	// Nothing landed. Report it HERE rather than leaving each caller to notice,
+	// because "returns a directory path with a nil error" is indistinguishable
+	// from success and two of the three callers took it at face value:
+	// ensureLibraryCopy (internal/metafetch/service_apply.go) created a
+	// version-linked book record pointing at this directory, and
+	// organizeMultiFileBook (internal/itunes/service/importer.go) assigned it to
+	// book.FilePath. Both would have pointed a book at a directory that
+	// MkdirAll had just created and nothing had been copied into.
+	//
+	// Only OrganizeDirectoryBook checked, and it had to re-derive the check
+	// itself — the same shape of bug as the target-path divergence: a rule that
+	// lives in the caller is a rule every future caller must remember.
+	//
+	// This is reachable WITHOUT any row being flagged Missing: the loop above
+	// skips a source that has vanished from disk since the last scan, so rows
+	// that look present can all skip and leave pathMap empty.
+	if len(pathMap) == 0 {
+		return "", nil, fmt.Errorf("organize produced no files for %q (id=%s): all %d planned source file(s) were missing or skipped — re-scan to verify, or restore from backup",
+			book.Title, book.ID, len(planned))
 	}
 
 	return targetDir, pathMap, nil

--- a/internal/organizer/organizer_regression_test.go
+++ b/internal/organizer/organizer_regression_test.go
@@ -1,6 +1,7 @@
 // file: internal/organizer/organizer_regression_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e4f5a6b7-c8d9-e0f1-a2b3-organizer-reg
+// last-edited: 2026-08-16
 
 package organizer
 
@@ -38,12 +39,25 @@ func segsFor(paths ...string) []database.BookFile {
 }
 
 // ---------------------------------------------------------------------------
-// Regression: OrganizeBookDirectory returns empty pathMap when all files missing
-// (Bug: missing source files were silently skipped, but organizeDirectoryBook
-// used to ignore the empty pathMap and mark the book as organized anyway.)
+// Regression: OrganizeBookDirectory ERRORS when nothing was copied.
+//
+// This test used to assert the opposite — (targetDir, empty pathMap, nil err) —
+// and its own comment recorded why that was survivable: "organizeDirectoryBook
+// used to ignore the empty pathMap and mark the book as organized anyway". The
+// fix then went in at that ONE caller. The function kept returning success, and
+// the other two callers never grew the same check:
+//
+//   - ensureLibraryCopy (internal/metafetch/service_apply.go) created a
+//     version-linked book record pointing at the directory.
+//   - organizeMultiFileBook (internal/itunes/service/importer.go) assigned it
+//     to book.FilePath.
+//
+// Both pointed a book at a directory MkdirAll had just created and nothing had
+// been copied into. The check now lives inside OrganizeBookDirectory, so the
+// contract this test pins has deliberately changed.
 // ---------------------------------------------------------------------------
 
-func TestOrganizeBookDirectory_AllFilesMissing_EmptyPathMap(t *testing.T) {
+func TestOrganizeBookDirectory_AllFilesMissing_IsAnError(t *testing.T) {
 	rootDir := t.TempDir()
 
 	cfg := &config.Config{
@@ -55,12 +69,15 @@ func TestOrganizeBookDirectory_AllFilesMissing_EmptyPathMap(t *testing.T) {
 	org := NewOrganizer(cfg)
 
 	book := &database.Book{
+		ID:     "ghost-1",
 		Title:  "Ghost Book",
 		Format: "mp3",
 		Author: &database.Author{Name: "Ghost Author"},
 	}
 
-	// All source paths don't exist
+	// Sources that are simply gone from disk. Note that NONE of these rows is
+	// flagged Missing — that is the whole point. The "all rows flagged missing"
+	// case was already rejected; this is the one that looked like success.
 	segmentPaths := []string{
 		"/nonexistent/ch01.mp3",
 		"/nonexistent/ch02.mp3",
@@ -68,11 +85,13 @@ func TestOrganizeBookDirectory_AllFilesMissing_EmptyPathMap(t *testing.T) {
 	}
 
 	targetDir, pathMap, err := org.OrganizeBookDirectory(book, segsFor(segmentPaths...))
-	// Should succeed (OrganizeBookDirectory skips missing files)
-	// but pathMap should be empty
-	require.NoError(t, err)
-	assert.NotEmpty(t, targetDir, "target dir is still computed even with no files")
-	assert.Empty(t, pathMap, "pathMap must be empty when all source files are missing")
+
+	require.Error(t, err, "organizing a book whose every source has vanished must not report success")
+	assert.Contains(t, err.Error(), "Ghost Book", "the error must name the book")
+	assert.Empty(t, pathMap, "no path mapping may be handed back on the failure path")
+	assert.Empty(t, targetDir,
+		"targetDir must NOT be returned: both callers that lacked the empty-pathMap check "+
+			"assigned it straight onto the book, which is how a book ended up pointing at an empty directory")
 }
 
 func TestOrganizeBookDirectory_PartialFilesMissing(t *testing.T) {

--- a/internal/organizer/service.go
+++ b/internal/organizer/service.go
@@ -1,7 +1,7 @@
 // file: internal/organizer/service.go
-// version: 1.19.0
+// version: 1.20.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
-// last-edited: 2026-08-14
+// last-edited: 2026-08-16
 
 package organizer
 
@@ -1207,12 +1207,14 @@ func (orgSvc *Service) OrganizeDirectoryBook(org *Organizer, book *database.Book
 		return "", err
 	}
 
-	// Verify at least some files were actually copied to the target
-	if len(pathMap) == 0 {
-		return "", fmt.Errorf("no files were copied for %s — all source files missing", book.Title)
-	}
-
-	// Check how many files actually exist in the target directory
+	// The "pathMap is empty" case is now rejected inside OrganizeBookDirectory
+	// itself, so it arrives here as a non-nil err above. It used to be checked
+	// only here, which left the other two callers of OrganizeBookDirectory
+	// (ensureLibraryCopy, organizeMultiFileBook) pointing books at directories
+	// nothing had been copied into.
+	//
+	// The stat check below is NOT redundant with it: pathMap records what
+	// organize believed it wrote, and this verifies the files are still there.
 	copiedCount := 0
 	for _, dstPath := range pathMap {
 		if _, statErr := os.Stat(dstPath); statErr == nil {

--- a/internal/server/organize_service_regression_test.go
+++ b/internal/server/organize_service_regression_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/organize_service_regression_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a1b2c3d4-e5f6-7890-abcd-organize-regr
 
 package server
@@ -58,7 +58,15 @@ func TestOrganizeDirectoryBook_AllSourceFilesMissing(t *testing.T) {
 
 	_, err := svc.OrganizeDirectoryBook(org, book, testLog)
 	assert.Error(t, err, "should fail when all source files are missing")
-	assert.Contains(t, err.Error(), "all source files missing")
+
+	// The wording moved with the check. This used to be OrganizeDirectoryBook's
+	// own "all source files missing" guard; the same condition is now rejected
+	// inside OrganizeBookDirectory so that ensureLibraryCopy and
+	// organizeMultiFileBook — which never had the guard, and pointed books at
+	// empty directories — get it too. What this test pins is the OUTCOME: this
+	// call still fails, and the message still identifies the book and the cause.
+	assert.Contains(t, err.Error(), "Ghost Book", "the error must name the book")
+	assert.Contains(t, err.Error(), "missing", "the error must say why")
 }
 
 func TestOrganizeDirectoryBook_NoBookFiles(t *testing.T) {


### PR DESCRIPTION
## What this fixes

`OrganizeBookDirectory` creates its target directory with `MkdirAll` **before** copying anything,
and skips any source file that has vanished from disk. When every source was gone it returned:

```go
return targetDir, pathMap, nil   // targetDir exists and is empty; pathMap is empty; err is nil
```

— indistinguishable from a clean organize.

This is reachable **without any `book_file` row being flagged `Missing`**. The all-rows-flagged
case was already rejected up front; this is the case where the rows look present and the files
have simply gone, so every copy skips silently.

### Only one of three callers noticed

| Caller | Behaviour on an empty result |
|---|---|
| `OrganizeDirectoryBook` (`internal/organizer/service.go`) | checked `len(pathMap) == 0` and errored ✅ |
| `ensureLibraryCopy` (`internal/metafetch/service_apply.go`) | created a **version-linked book record** pointing at the empty directory ❌ |
| `organizeMultiFileBook` (`internal/itunes/service/importer.go`) | assigned it to **`book.FilePath`** ❌ |

Both of the latter left a book in the library pointing at a directory containing no audio.

This is the same shape as the target-path divergence fixed in #2479, one layer up: a rule that
lives in the caller is a rule every future caller has to remember to re-derive. One did; two
didn't.

## What changed

The check moves **inside** `OrganizeBookDirectory`. It now returns an error naming the book and
**no target directory**, so a caller that ignores `err` cannot get a usable path out of it either.

The duplicated check in `OrganizeDirectoryBook` is removed. Its *other* check — stat'ing each
destination — is kept and is not redundant: `pathMap` records what organize believed it wrote, and
the stat confirms the files are actually there.

`OrganizeBook` (the single-file path) was checked and does **not** have this defect: it propagates
`organizeFile` errors, and its one early success return is the legitimate "source is already at the
target" case.

## Verification

- **`TestOrganizeBookDirectory_AllFilesMissing_EmptyPathMap` asserted the old contract and is
  rewritten** as `..._IsAnError`. Worth reading its old comment, which recorded the whole problem:
  *"organizeDirectoryBook used to ignore the empty pathMap and mark the book as organized anyway"* —
  the fix went in at that one caller, the function kept returning success, and the test pinned it
  there. It now asserts the error, that it names the book, and that `targetDir` comes back empty.
- **`TestEnsureLibraryCopy_EmptyOrganizeIsNotSuccess`** (new) drives the actual F6 outcome through
  the real caller: a protected book with two non-`Missing` rows whose files don't exist must yield
  `nil`, not a book record.
- `TestOrganizeBookDirectory_PartialFilesMissing` still passes unchanged — 1-of-3 present is a
  successful organize, and this change must not turn a partial copy into a failure.

**Mutation-tested** (committed first, then reverted): deleting the new guard turns
`TestOrganizeBookDirectory_AllFilesMissing_IsAnError` **and**
`TestEnsureLibraryCopy_EmptyOrganizeIsNotSuccess` red — so the caller-level consequence is pinned,
not just the return value.

`go build ./...` exit 0 · `go vet ./internal/organizer/...` clean · `go test ./internal/organizer/
./internal/metafetch/ ./internal/itunes/... -short -count=1` — 4 packages ok, 0 failures.

## Still open from the same fragment

**F5-remainder** — adopting an existing destination still compares file *sizes* rather than
contents (`scanner.ComputeFileHash` exists). Untouched here.
