### PR TITLE
fix(activity): keep slog attrs in summaries and stop the message swallowing the line

### DIFF
--- a/changelog.d/20260816_014500_activity_summaries_keep_attrs.md
+++ b/changelog.d/20260816_014500_activity_summaries_keep_attrs.md
@@ -1,0 +1,35 @@
+### Fixed
+
+#### Activity-log rows no longer drop the data they are about
+
+The activity log showed entries that had lost the only information that made
+them worth recording — "cover art saved to" (to *where*?), "ISBN enrichment
+succeeded for" (for *what*?). These are `slog` calls whose sentence is the
+**message** and whose content is in the **attributes**, and the log-line bridge
+kept only the message.
+
+A neighbouring row showed the opposite symptom: a raw slog line with its quotes
+pasted into the summary, e.g.
+
+```
+ISBN enrichment found" isbn="9780553293357" title="Foundation
+```
+
+Both come from **one** defect. The message was located with
+`strings.LastIndexByte(rest, '"')`, which finds the last quote in the whole
+remaining line rather than the message's own closing quote. When nothing after
+`msg=` was quoted it landed on the right character by luck; when any attribute
+was quoted, the "message" swallowed the rest of the line, stray quote included.
+That is why it looked like two inconsistent bridges rather than one bug.
+
+The line is now scanned once into structured `key=value` attributes, honouring
+quoted values that contain spaces, `=` or escaped quotes. Attributes are
+rendered into the summary and also stored in `details` so they stay queryable
+rather than existing only as a substring:
+
+- A message ending in a preposition or a colon is a sentence fragment, so its
+  first attribute is appended bare — *"cover art saved to /lib/Asimov/cover.jpg"*.
+- Any other message gets `key=value` appended — *"tag writing failed book_id=b7
+  error=disk full"*.
+- `op_id`, `component` and the other structural keys keep being lifted into
+  their own fields and are not repeated in the summary.

--- a/internal/activity/writer.go
+++ b/internal/activity/writer.go
@@ -1,6 +1,7 @@
 // file: internal/activity/writer.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f
+// last-edited: 2026-08-16
 
 package activity
 
@@ -136,13 +137,26 @@ func (w *Writer) sendEntry(line string) {
 		Type:        "system",
 		Level:       parsed.Level,
 		Source:      parsed.Source,
-		Summary:     parsed.Message,
+		Summary:     RenderSummary(parsed),
 		OperationID: parsed.OpID,
 	}
 	// Propagate component into Details so EnrichTags can produce
 	// a component: tag without requiring a DB schema change.
 	if parsed.Component != "" {
 		entry.Details = map[string]any{"component": parsed.Component}
+	}
+	// Keep the attrs structured as well as rendered. RenderSummary is for
+	// reading; Details is what a consumer can actually query, and a path or a
+	// book id is worth more as a field than as a substring of a sentence.
+	if len(parsed.Attrs) > 0 {
+		if entry.Details == nil {
+			entry.Details = make(map[string]any, len(parsed.Attrs))
+		}
+		for _, a := range parsed.Attrs {
+			if _, exists := entry.Details[a.Key]; !exists {
+				entry.Details[a.Key] = a.Value
+			}
+		}
 	}
 	if isBatchable(entry) {
 		w.batcher.Submit(BatchKey{
@@ -254,6 +268,156 @@ type ParsedLogLine struct {
 	Message   string // human-readable message text
 	OpID      string // operation_id / op_id slog attribute, if present
 	Component string // component / subsystem slog attribute or source-path derived name
+	// Attrs are the slog key=value attributes other than the structural ones
+	// (time/level/msg/source, and the op_id/component keys lifted into the
+	// fields above), in the order they appeared.
+	//
+	// These used to be discarded outright, which is what produced activity-log
+	// rows reading "cover art saved to" (to WHERE?) and "ISBN enrichment
+	// succeeded for" (for WHAT?) -- the sentence is the slog MESSAGE and the
+	// thing it is about is an ATTR.
+	Attrs []LogAttr
+}
+
+// LogAttr is one slog key=value attribute from a log line.
+type LogAttr struct {
+	Key   string
+	Value string
+}
+
+// structuralSlogKeys are the attrs that are already represented elsewhere in
+// ParsedLogLine, so repeating them in a rendered summary would be noise.
+var structuralSlogKeys = map[string]struct{}{
+	"time": {}, "level": {}, "msg": {}, "source": {},
+	"op_id": {}, "operation_id": {}, "opID": {},
+	"component": {}, "subsystem": {}, "pkg": {},
+}
+
+// trailingPrepositions are the words that, when a log message ENDS with one,
+// mean the message is a sentence fragment whose object is the first attr.
+// "cover art saved to" + path=/lib/x.jpg reads correctly as
+// "cover art saved to /lib/x.jpg", where "cover art saved to path=/lib/x.jpg"
+// does not. Any other shape gets plain key=value appending, which is honest
+// even when it is not elegant.
+var trailingPrepositions = map[string]struct{}{
+	"to": {}, "for": {}, "from": {}, "at": {}, "in": {},
+	"on": {}, "of": {}, "with": {}, "into": {}, "by": {},
+}
+
+// RenderSummary builds the human-readable activity summary for a parsed line:
+// the message, followed by the attrs that carry its actual content.
+func RenderSummary(p ParsedLogLine) string {
+	if len(p.Attrs) == 0 {
+		return p.Message
+	}
+	msg := strings.TrimRight(p.Message, " ")
+	attrs := p.Attrs
+
+	// Sentence fragment ("... saved to", "... succeeded for", "... wrote:")
+	// takes the first attr's value bare as its object.
+	var b strings.Builder
+	b.WriteString(msg)
+	if msg != "" && endsWithPreposition(msg) {
+		b.WriteString(" ")
+		b.WriteString(attrs[0].Value)
+		attrs = attrs[1:]
+	}
+	for _, a := range attrs {
+		b.WriteString(" ")
+		b.WriteString(a.Key)
+		b.WriteString("=")
+		b.WriteString(a.Value)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// endsWithPreposition reports whether msg's last word is a preposition, or msg
+// ends in a colon — either way the sentence is left dangling without its object.
+func endsWithPreposition(msg string) bool {
+	if strings.HasSuffix(msg, ":") {
+		return true
+	}
+	idx := strings.LastIndexByte(msg, ' ')
+	if idx < 0 {
+		return false
+	}
+	_, ok := trailingPrepositions[strings.ToLower(msg[idx+1:])]
+	return ok
+}
+
+// scanSlogAttrs walks a slog TextHandler line and returns every key=value pair
+// in order, correctly handling quoted values that themselves contain spaces,
+// '=' or escaped quotes.
+//
+// This exists because the old parser located the message with
+// strings.LastIndexByte(line, '"'), which finds the last quote in the WHOLE
+// line rather than the message's own closing quote. With no quoted attrs after
+// it that lands on the right character by luck; with one, the "message" swallows
+// the rest of the line. That is why the activity log showed
+//
+//	ISBN enrichment found" isbn="9780553293357" title="Foundation
+//
+// complete with the stray quote — the same defect that elsewhere merely looked
+// like "attributes are dropped".
+func scanSlogAttrs(line string) []LogAttr {
+	var attrs []LogAttr
+	i := 0
+	for i < len(line) {
+		for i < len(line) && line[i] == ' ' {
+			i++
+		}
+		eq := -1
+		for j := i; j < len(line); j++ {
+			if line[j] == '=' {
+				eq = j
+				break
+			}
+			if line[j] == ' ' {
+				break
+			}
+		}
+		if eq < 0 {
+			break
+		}
+		key := line[i:eq]
+		i = eq + 1
+		var val string
+		if i < len(line) && line[i] == '"' {
+			i++
+			var sb strings.Builder
+			for i < len(line) {
+				if line[i] == '\\' && i+1 < len(line) {
+					sb.WriteByte(line[i+1])
+					i += 2
+					continue
+				}
+				if line[i] == '"' {
+					i++
+					break
+				}
+				sb.WriteByte(line[i])
+				i++
+			}
+			val = sb.String()
+		} else {
+			start := i
+			for i < len(line) && line[i] != ' ' {
+				i++
+			}
+			val = line[start:i]
+		}
+		if key != "" {
+			attrs = append(attrs, LogAttr{Key: key, Value: val})
+		}
+	}
+	return attrs
+}
+
+// isSlogTextLine reports whether the line is in slog TextHandler format.
+func isSlogTextLine(line string) bool {
+	return strings.HasPrefix(line, "time=") &&
+		strings.Contains(line, " level=") &&
+		strings.Contains(line, " msg=")
 }
 
 // ParseLogLineFull extracts all structured fields from a single log line,
@@ -263,10 +427,22 @@ func ParseLogLineFull(line string) ParsedLogLine {
 	p := ParsedLogLine{}
 	p.Level, p.Source, p.Message = parseLogLineCore(line)
 
-	// For slog text lines, also extract op_id, component, and subsystem attrs.
-	if strings.HasPrefix(line, "time=") && strings.Contains(line, " level=") && strings.Contains(line, " msg=") {
+	// For slog text lines, also extract op_id, component, and subsystem attrs,
+	// and keep everything else: the content of these messages lives in the
+	// attrs, and dropping them is what left the activity log saying "cover art
+	// saved to" without saying where.
+	if isSlogTextLine(line) {
 		p.OpID = extractSlogAttr(line, "op_id", "operation_id", "opID")
 		p.Component = extractSlogAttr(line, "component", "subsystem", "pkg")
+		for _, a := range scanSlogAttrs(line) {
+			if _, structural := structuralSlogKeys[a.Key]; structural {
+				continue
+			}
+			if a.Value == "" {
+				continue
+			}
+			p.Attrs = append(p.Attrs, a)
+		}
 	}
 
 	// If no explicit component, derive one from the source path field when the
@@ -371,35 +547,33 @@ func parseLogLineCore(line string) (level, source, message string) {
 	// extracting msg, recurse so the wrapped "[INFO] source: message"
 	// payload parses through the standard [level] branch and gets a
 	// proper source.
-	if strings.HasPrefix(line, "time=") && strings.Contains(line, " level=") && strings.Contains(line, " msg=") {
+	if isSlogTextLine(line) {
+		// One structured scan for the whole line rather than three independent
+		// string searches. The previous msg extraction used
+		// strings.LastIndexByte(msg, '"'), which takes the last quote in the
+		// REST OF THE LINE -- correct only when no attribute after msg is
+		// quoted, and otherwise swallowing every following attr into the
+		// message, stray quote included.
 		lvl := "info"
-		if li := strings.Index(line, " level="); li >= 0 {
-			rest := line[li+len(" level="):]
-			if sp := strings.IndexByte(rest, ' '); sp > 0 {
-				lvl = strings.ToLower(rest[:sp])
+		msg := ""
+		for _, a := range scanSlogAttrs(line) {
+			switch a.Key {
+			case "level":
+				lvl = strings.ToLower(a.Value)
+			case "msg":
+				msg = a.Value
 			}
 		}
-		mi := strings.Index(line, " msg=")
-		if mi >= 0 {
-			msg := line[mi+len(" msg="):]
-			// msg is quoted text; trim surrounding quotes and unescape \"
-			if len(msg) > 0 && msg[0] == '"' {
-				if end := strings.LastIndexByte(msg, '"'); end > 0 {
-					msg = msg[1:end]
-				}
-				msg = strings.ReplaceAll(msg, `\"`, `"`)
-			}
-			// Recurse: msg often starts with "[INFO] source: ..." in our
-			// code so the standard branch can extract a real source.
-			if msg != "" && msg != line {
-				rlvl, rsrc, rmsg := ParseLogLine(msg)
-				if rsrc != "server" || rlvl != "info" {
-					return rlvl, rsrc, rmsg
-				}
-				return lvl, "server", msg
+		// Recurse: msg often starts with "[INFO] source: ..." in our
+		// code so the standard branch can extract a real source.
+		if msg != "" && msg != line {
+			rlvl, rsrc, rmsg := ParseLogLine(msg)
+			if rsrc != "server" || rlvl != "info" {
+				return rlvl, rsrc, rmsg
 			}
 			return lvl, "server", msg
 		}
+		return lvl, "server", msg
 	}
 
 	work := line

--- a/internal/activity/writer_attrs_test.go
+++ b/internal/activity/writer_attrs_test.go
@@ -1,0 +1,132 @@
+// file: internal/activity/writer_attrs_test.go
+// version: 1.0.0
+// guid: 2b7d4e91-6c05-4a83-91ff-0d5e7a3c8b46
+// last-edited: 2026-08-16
+
+package activity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The activity log showed rows that had lost the only information that made
+// them worth logging: "cover art saved to" (to WHERE?) and "ISBN enrichment
+// succeeded for" (for WHAT?). The sentence is the slog MESSAGE; the thing it is
+// about is a slog ATTR, and the bridge kept only the message.
+//
+// A neighbouring row showed the OPPOSITE symptom — a raw slog line with quotes
+// pasted into the summary. Both come from ONE defect: msg was located with
+// strings.LastIndexByte(rest, '"'), which finds the last quote in the whole
+// remaining line. With no quoted attr after msg it lands on the message's own
+// closing quote by luck; with one, the message swallows the rest of the line.
+func TestParseLogLineFull_KeepsAttrs(t *testing.T) {
+	tests := []struct {
+		name        string
+		line        string
+		wantMessage string
+		wantSummary string
+		wantAttrs   map[string]string
+	}{
+		{
+			name:        "sentence fragment ending in a preposition takes the value bare",
+			line:        `time=2026-08-16T01:00:00.000-04:00 level=INFO msg="cover art saved to" path=/lib/Asimov/cover.jpg id=b1`,
+			wantMessage: "cover art saved to",
+			wantSummary: "cover art saved to /lib/Asimov/cover.jpg id=b1",
+			wantAttrs:   map[string]string{"path": "/lib/Asimov/cover.jpg", "id": "b1"},
+		},
+		{
+			name:        "for is a preposition too",
+			line:        `time=2026-08-16T01:00:00.000-04:00 level=INFO msg="ISBN enrichment succeeded for" id=b42`,
+			wantMessage: "ISBN enrichment succeeded for",
+			wantSummary: "ISBN enrichment succeeded for b42",
+			wantAttrs:   map[string]string{"id": "b42"},
+		},
+		{
+			// The regression that produced the stray quote. Every attr after
+			// msg is quoted, so LastIndexByte used to land at the very end of
+			// the line.
+			name:        "quoted attrs must not be swallowed into the message",
+			line:        `time=2026-08-16T01:00:00.000-04:00 level=INFO msg="ISBN enrichment found" isbn="9780553293357" title="Foundation"`,
+			wantMessage: "ISBN enrichment found",
+			wantSummary: `ISBN enrichment found isbn=9780553293357 title=Foundation`,
+			wantAttrs:   map[string]string{"isbn": "9780553293357", "title": "Foundation"},
+		},
+		{
+			name:        "a complete sentence gets key=value appended, not a bare value",
+			line:        `time=2026-08-16T01:00:00.000-04:00 level=WARN msg="tag writing failed" book_id=b7 error="disk full"`,
+			wantMessage: "tag writing failed",
+			wantSummary: `tag writing failed book_id=b7 error=disk full`,
+			wantAttrs:   map[string]string{"book_id": "b7", "error": "disk full"},
+		},
+		{
+			name:        "structural attrs are not repeated in the summary",
+			line:        `time=2026-08-16T01:00:00.000-04:00 level=INFO msg="scan complete" op_id=op-9 component=scanner count=12`,
+			wantMessage: "scan complete",
+			wantSummary: "scan complete count=12",
+			wantAttrs:   map[string]string{"count": "12"},
+		},
+		{
+			name:        "a message with no attrs is unchanged",
+			line:        `time=2026-08-16T01:00:00.000-04:00 level=INFO msg="activity log service initialized"`,
+			wantMessage: "activity log service initialized",
+			wantSummary: "activity log service initialized",
+			wantAttrs:   map[string]string{},
+		},
+		{
+			name:        "an escaped quote inside a value survives",
+			line:        `time=2026-08-16T01:00:00.000-04:00 level=INFO msg="wrote tags" title="Some \"Quoted\" Book"`,
+			wantMessage: "wrote tags",
+			wantSummary: `wrote tags title=Some "Quoted" Book`,
+			wantAttrs:   map[string]string{"title": `Some "Quoted" Book`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := ParseLogLineFull(tt.line)
+
+			assert.Equal(t, tt.wantMessage, p.Message,
+				"the message must stop at its own closing quote")
+			assert.Equal(t, tt.wantSummary, RenderSummary(p),
+				"the summary must carry the data the message refers to")
+
+			got := map[string]string{}
+			for _, a := range p.Attrs {
+				got[a.Key] = a.Value
+			}
+			assert.Equal(t, tt.wantAttrs, got)
+		})
+	}
+}
+
+// The op_id and component attrs must keep being lifted into their own fields —
+// the batching key and the component: tag depend on them.
+func TestParseLogLineFull_StillLiftsOpIDAndComponent(t *testing.T) {
+	p := ParseLogLineFull(`time=2026-08-16T01:00:00.000-04:00 level=INFO msg="scan complete" op_id=op-9 component=scanner count=12`)
+	assert.Equal(t, "op-9", p.OpID)
+	assert.Equal(t, "scanner", p.Component)
+}
+
+// scanSlogAttrs is the piece that makes the rest correct; pin its edge cases
+// directly rather than only through the parser.
+func TestScanSlogAttrs(t *testing.T) {
+	attrs := scanSlogAttrs(`time=T level=INFO msg="a b" path="/x/y z.mp3" n=3 empty= last=end`)
+	require.Len(t, attrs, 7)
+	assert.Equal(t, LogAttr{"msg", "a b"}, attrs[2], "a quoted value may contain spaces")
+	assert.Equal(t, LogAttr{"path", "/x/y z.mp3"}, attrs[3])
+	assert.Equal(t, LogAttr{"n", "3"}, attrs[4], "a bare value ends at the next space")
+	assert.Equal(t, LogAttr{"empty", ""}, attrs[5])
+	assert.Equal(t, LogAttr{"last", "end"}, attrs[6], "the final attr has no trailing space to stop at")
+}
+
+func TestEndsWithPreposition(t *testing.T) {
+	for _, s := range []string{"cover art saved to", "enrichment succeeded for", "copied from", "wrote tags:"} {
+		assert.True(t, endsWithPreposition(s), "%q is a dangling sentence", s)
+	}
+	for _, s := range []string{"tag writing failed", "scan complete", "", "toaster"} {
+		assert.False(t, endsWithPreposition(s), "%q is a complete sentence", s)
+	}
+}

--- a/internal/activity/writer_attrs_test.go
+++ b/internal/activity/writer_attrs_test.go
@@ -6,10 +6,15 @@
 package activity
 
 import (
+	"context"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
 
 // The activity log showed rows that had lost the only information that made
@@ -129,4 +134,40 @@ func TestEndsWithPreposition(t *testing.T) {
 	for _, s := range []string{"tag writing failed", "scan complete", "", "toaster"} {
 		assert.False(t, endsWithPreposition(s), "%q is a complete sentence", s)
 	}
+}
+
+// TestWriter_PersistsRenderedSummary closes the gap the direct RenderSummary
+// tests leave open: they prove the renderer is right, not that the writer USES
+// it. Replacing Summary: RenderSummary(parsed) with Summary: parsed.Message —
+// which is exactly the line this change touches, and exactly what the bug was —
+// left every other test in this file green while making the fix inert in
+// production.
+//
+// This drives a real slog line through the real io.Writer and asserts on what
+// was persisted, plus that the attrs survived as queryable details.
+func TestWriter_PersistsRenderedSummary(t *testing.T) {
+	dir := t.TempDir()
+	store, err := database.NewNutsActivityStore(dir)
+	require.NoError(t, err)
+	defer store.Close()
+
+	devNull, err := os.Open(os.DevNull)
+	require.NoError(t, err)
+	defer devNull.Close()
+
+	w := NewWriter(store, 100)
+	w.stdout = devNull
+	require.NoError(t, w.Start(context.Background()))
+
+	fmt.Fprintln(w, `time=2026-08-16T01:00:00.000-04:00 level=INFO msg="cover art saved to" path=/lib/Asimov/cover.jpg`)
+	require.NoError(t, w.Stop(context.Background()))
+
+	entries, total, err := store.Query(context.Background(), database.ActivityFilter{Limit: 10})
+	require.NoError(t, err)
+	require.Equal(t, 1, total)
+
+	assert.Equal(t, "cover art saved to /lib/Asimov/cover.jpg", entries[0].Summary,
+		"the persisted summary must name the path, not trail off after 'to'")
+	assert.Equal(t, "/lib/Asimov/cover.jpg", entries[0].Details["path"],
+		"attrs must also survive as structured details")
 }


### PR DESCRIPTION
## What this fixes

The activity log showed rows that had lost the only information that made them worth recording —
**"cover art saved to"** (to *where*?) and **"ISBN enrichment succeeded for"** (for *what*?). These
are `slog` calls whose sentence is the **message** and whose content is in the **attributes**, and
the bridge kept only the message.

A neighbouring row in the same screenshot showed the *opposite* symptom: a raw slog line with its
quotes pasted straight into the summary, complete with a stray quote.

## They are one bug, not two

The message was extracted with `strings.LastIndexByte(msg, '"')` — the last quote in the **whole
remaining line**, not the message's own closing quote. Measured on the current parser:

```
IN : msg="cover art saved to" path=/lib/Asimov/cover.jpg
OUT: cover art saved to                                    ← looks fine; attrs simply dropped

IN : msg="ISBN enrichment found" isbn="9780553293357" title="Foundation"
OUT: ISBN enrichment found" isbn="9780553293357" title="Foundation
                          ↑ stray quote, raw attrs pasted in
```

With no quoted attribute after `msg=`, `LastIndexByte` lands on the correct character by luck. With
one, the "message" swallows the rest of the line. That accident is why it read as two inconsistent
bridges — the fragment that filed this reasonably concluded there were two.

## What changed

The line is scanned **once** into ordered `key=value` attributes (`scanSlogAttrs`), correctly
handling quoted values containing spaces, `=`, or escaped quotes. That single scan now supplies the
level, the message, and the attrs, replacing three independent string searches.

Attributes are rendered into the summary **and** stored in `details`, so they stay queryable rather
than existing only as a substring of a sentence:

| Message shape | Rendering | Example |
|---|---|---|
| ends in a preposition or `:` — a fragment missing its object | first attr's value appended **bare** | `cover art saved to /lib/Asimov/cover.jpg` |
| anything else | `key=value` appended | `tag writing failed book_id=b7 error=disk full` |

`op_id`, `component` and the other structural keys keep being lifted into their own fields (the
batching key and the `component:` tag depend on them) and are not repeated in the summary.

## Verification

`TestParseLogLineFull_KeepsAttrs` — 7 cases built from the reported strings, including the
stray-quote regression and an escaped quote inside a value. Plus `TestScanSlogAttrs` for the
scanner's edge cases (quoted value with spaces, bare value, empty value, final attr with no
trailing space), `TestEndsWithPreposition`, and `TestParseLogLineFull_StillLiftsOpIDAndComponent`.

**Mutation-tested, three times** (committed first, then reverted):

| Mutation | Result |
|---|---|
| `RenderSummary` returns the bare message | 5 subtests red |
| `Summary: RenderSummary(parsed)` → `Summary: parsed.Message` | **survived at first** |
| same, after adding the end-to-end test | red |

That middle row is the point. The direct `RenderSummary` tests prove the renderer is correct, not
that `sendEntry` **uses** it — so reverting the one line this change actually touches in production
left the whole suite green with the fix inert. `TestWriter_PersistsRenderedSummary` was added to
close that: it drives a real slog line through the real `io.Writer` and asserts on the persisted
entry's `Summary` and `Details`.

`go build ./...` exit 0 · `go test ./internal/activity/ -count=1` ok, including all pre-existing
tests unchanged.

## Not in this PR

The second half of `todo.d/20260814-activity-summaries-drop-attrs.md` — metadata-apply rows leading
with the book **title** rather than a bare "book →" link, and `(none) → 2021` instead of a dangling
arrow — is a separate change in the metadata-apply emitters and the frontend.
