### PR TITLE
fix(registry): mirror a v2 op's terminal status onto its legacy operations row

### DIFF
--- a/changelog.d/20260816_022000_legacy_op_terminal_status.md
+++ b/changelog.d/20260816_022000_legacy_op_terminal_status.md
@@ -1,0 +1,35 @@
+### Fixed
+
+#### Finished maintenance jobs no longer show as still running
+
+Jobs dispatched through `maintenance.job` and the scheduler create a **v1**
+`operations` row and then enqueue a **v2** registry op carrying that row's id in
+its params. Nothing ever wrote the v1 row again — its status was effectively
+write-only after creation.
+
+The operations UI reads v1. So on 2026-08-14 every maintenance-job row of the
+day sat at `"pending"`, including `fix-file-modes` and
+`normalize-primary-flags`, both of which had completed with journalled
+summaries. A composer scan showed 0% three hours into real work, and a chapters
+dry-run showed as an active 1.5-hour task after finishing at 17:57.
+
+A handful of ops already mirrored the status by hand at their own call sites
+(`itunes_ops.go`, `diagnostics_ops.go`, `folder_autoscan_op.go`). Everything the
+scheduler dispatched did not.
+
+The terminal status is now mirrored centrally in `publishOpTerminal`, which
+every terminal path in the registry already funnels through — so a new terminal
+path cannot forget it. `completed`, `failed` and `canceled` pass through;
+`interrupted_ask` and `interrupted_dropped` collapse to the single
+`interrupted` that the v1 vocabulary uses.
+
+Existing progress counters are preserved rather than overwritten with zeros: a
+completed job rendering at 0% would trade "stuck at pending" for "finished at
+zero", which is no more honest. A completed row that never carried counters is
+reported as fully done.
+
+Note that this also unblocks the C510 opstate sweep, which treats unknown
+statuses as KEEP — permanently-pending rows pinned their opstate blobs forever.
+
+**Not included:** a backfill repairing rows already stuck from before this
+change. Those remain stuck until repaired separately.

--- a/internal/operations/registry/legacy_op_status.go
+++ b/internal/operations/registry/legacy_op_status.go
@@ -1,0 +1,118 @@
+// file: internal/operations/registry/legacy_op_status.go
+// version: 1.0.0
+// guid: 4a8c2f61-b703-49de-95e7-1c0d8b5a3e27
+// last-edited: 2026-08-16
+
+package registry
+
+import (
+	"encoding/json"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// legacyOpStore is the slice of the v1 operations surface needed to keep a
+// legacy operation row in step with the v2 run that superseded it.
+//
+// It is an OPTIONAL capability, discovered by type assertion on r.store rather
+// than added to database.OpsV2Store. The registry's store is an OpsV2Store, and
+// several test fakes implement exactly that interface and nothing more; widening
+// it would break them for a concern none of them models. PebbleStore — the only
+// production implementation — satisfies this already.
+type legacyOpStore interface {
+	GetOperationByID(id string) (*database.Operation, error)
+	UpdateOperationStatus(id, status string, progress, total int, message string) error
+}
+
+// legacyOpParams is the shape every enqueue site uses to carry the legacy row's
+// id into the v2 op's params. The field name is fixed by the JSON tag those
+// param structs already declare (`json:"legacy_op_id"`), so this reads all of
+// them — MaintenanceWindowOpParams, schedulerExtraOpParams, seriesPruneOpParams
+// and the rest — without importing any of them.
+type legacyOpParams struct {
+	LegacyOpID string `json:"legacy_op_id"`
+}
+
+// legacyStatusFor maps a v2 terminal status onto the v1 vocabulary.
+//
+// The two vocabularies overlap but are not identical: v2 has interrupted_ask /
+// interrupted_dropped where v1 has a single "interrupted", which is the value
+// server_lifecycle.go already writes when it sweeps rows on restart.
+func legacyStatusFor(v2Status string) string {
+	switch v2Status {
+	case "completed", "failed", "canceled":
+		return v2Status
+	case "interrupted_ask", "interrupted_dropped", "interrupted":
+		return "interrupted"
+	default:
+		return ""
+	}
+}
+
+// propagateLegacyOpStatus mirrors a v2 op's terminal status onto the legacy
+// operations row it was created alongside.
+//
+// WHY THIS EXISTS. Jobs dispatched through maintenance.job and the scheduler
+// create a v1 operations row with store.CreateOperation(...) and then enqueue a
+// v2 op carrying that row's id in its params. Nothing wrote the v1 row again.
+// Its status was effectively write-only after creation, so the ops UI — which
+// reads v1 — showed finished jobs as still running: on 2026-08-14 EVERY
+// maintenance-job row of the day sat at "pending", including fix-file-modes and
+// normalize-primary-flags, both of which had completed with journalled
+// summaries. That misled the operator twice in one day.
+//
+// A handful of ops already did this by hand at their own call sites
+// (internal/server/itunes_ops.go, diagnostics_ops.go, folder_autoscan_op.go).
+// Everything dispatched by the scheduler did not, and never would have — which
+// is the argument for doing it here instead of at a twenty-first call site.
+// This runs from publishOpTerminal, which every terminal path already funnels
+// through, so an op cannot reach a terminal state without passing this.
+//
+// It is deliberately best-effort and silent about absence: the vast majority of
+// v2 ops have no legacy twin at all, and that is not a problem to report.
+func (r *Registry) propagateLegacyOpStatus(opID, v2Status string) {
+	legacyStatus := legacyStatusFor(v2Status)
+	if legacyStatus == "" {
+		return // not a terminal status; nothing to mirror
+	}
+	store, ok := r.store.(legacyOpStore)
+	if !ok {
+		return
+	}
+
+	row, err := r.store.GetOperationV2(opID)
+	if err != nil || row == nil || row.Params == "" {
+		return
+	}
+	var p legacyOpParams
+	if err := json.Unmarshal([]byte(row.Params), &p); err != nil || p.LegacyOpID == "" {
+		return // no legacy twin — the common case
+	}
+
+	// Preserve the counters. UpdateOperationStatus takes progress and total
+	// positionally and overwrites both, so passing 0,0 would leave a completed
+	// job rendering as 0% — trading "stuck at pending" for "finished at zero",
+	// which is no more honest. A completed run with no counters is reported as
+	// fully done, since that is what completing means.
+	progress, total, message := 0, 0, legacyStatus
+	if legacy, lerr := store.GetOperationByID(p.LegacyOpID); lerr == nil && legacy != nil {
+		if legacy.Status == legacyStatus {
+			return // already terminal at this status; nothing to write
+		}
+		progress, total, message = legacy.Progress, legacy.Total, legacy.Message
+	}
+	if legacyStatus == "completed" && total == 0 {
+		progress, total = 1, 1
+	}
+	if message == "" {
+		message = legacyStatus
+	}
+
+	if err := store.UpdateOperationStatus(p.LegacyOpID, legacyStatus, progress, total, message); err != nil {
+		r.logger.Warn("registry: failed to propagate terminal status to legacy op row",
+			"op_id", opID, "legacy_op_id", p.LegacyOpID, "status", legacyStatus, "error", err)
+		return
+	}
+	r.logger.Debug("registry: mirrored terminal status onto legacy op row",
+		"op_id", opID, "legacy_op_id", p.LegacyOpID, "status", legacyStatus)
+}

--- a/internal/operations/registry/legacy_op_status_internal_test.go
+++ b/internal/operations/registry/legacy_op_status_internal_test.go
@@ -1,0 +1,192 @@
+// file: internal/operations/registry/legacy_op_status_internal_test.go
+// version: 1.0.0
+// guid: 8e35b0d7-4a91-4c26-bf08-73d9a15c6e42
+// last-edited: 2026-08-16
+
+package registry
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// legacyUpdate records one UpdateOperationStatus call.
+type legacyUpdate struct {
+	id       string
+	status   string
+	progress int
+	total    int
+	message  string
+}
+
+// legacyFakeStore implements the OpsV2Store surface by embedding the interface
+// — every method this test does not exercise is nil and would panic loudly if
+// something started calling it, which is the intent — plus the two v1 methods
+// that make it a legacyOpStore.
+type legacyFakeStore struct {
+	database.OpsV2Store
+	v2      map[string]database.OperationV2Row
+	legacy  map[string]*database.Operation
+	updates []legacyUpdate
+}
+
+func newLegacyFakeStore() *legacyFakeStore {
+	return &legacyFakeStore{
+		v2:     map[string]database.OperationV2Row{},
+		legacy: map[string]*database.Operation{},
+	}
+}
+
+func (s *legacyFakeStore) GetOperationV2(id string) (*database.OperationV2Row, error) {
+	row, ok := s.v2[id]
+	if !ok {
+		return nil, nil
+	}
+	return &row, nil
+}
+
+func (s *legacyFakeStore) GetOperationByID(id string) (*database.Operation, error) {
+	return s.legacy[id], nil
+}
+
+func (s *legacyFakeStore) UpdateOperationStatus(id, status string, progress, total int, message string) error {
+	s.updates = append(s.updates, legacyUpdate{id, status, progress, total, message})
+	if op, ok := s.legacy[id]; ok {
+		op.Status, op.Progress, op.Total, op.Message = status, progress, total, message
+	}
+	return nil
+}
+
+// v2OnlyStore has NO v1 methods. It stands in for the several registry test
+// fakes (and any future store) that implement OpsV2Store and nothing else —
+// the reason the v1 surface is discovered by type assertion rather than added
+// to OpsV2Store.
+type v2OnlyStore struct{ database.OpsV2Store }
+
+func newTestRegistryWithStore(store database.OpsV2Store) *Registry {
+	return &Registry{store: store, logger: slog.Default()}
+}
+
+// The defect: jobs dispatched via maintenance.job / the scheduler create a v1
+// operations row and enqueue a v2 op carrying its id, and nothing ever wrote
+// the v1 row again. The ops UI reads v1, so on 2026-08-14 every maintenance-job
+// row of the day sat at "pending" — including jobs that had completed with
+// journalled summaries.
+func TestPropagateLegacyOpStatus(t *testing.T) {
+	t.Run("terminal status reaches the legacy row", func(t *testing.T) {
+		s := newLegacyFakeStore()
+		s.v2["v2-1"] = database.OperationV2Row{ID: "v2-1", Params: `{"legacy_op_id":"leg-1"}`}
+		s.legacy["leg-1"] = &database.Operation{ID: "leg-1", Status: "pending", Progress: 7, Total: 9, Message: "working"}
+
+		newTestRegistryWithStore(s).propagateLegacyOpStatus("v2-1", "completed")
+
+		require.Len(t, s.updates, 1)
+		assert.Equal(t, "leg-1", s.updates[0].id)
+		assert.Equal(t, "completed", s.updates[0].status)
+		assert.Equal(t, 7, s.updates[0].progress, "existing counters must be preserved")
+		assert.Equal(t, 9, s.updates[0].total)
+	})
+
+	t.Run("a completed row with no counters is not left at zero percent", func(t *testing.T) {
+		s := newLegacyFakeStore()
+		s.v2["v2-1"] = database.OperationV2Row{ID: "v2-1", Params: `{"legacy_op_id":"leg-1"}`}
+		s.legacy["leg-1"] = &database.Operation{ID: "leg-1", Status: "pending"}
+
+		newTestRegistryWithStore(s).propagateLegacyOpStatus("v2-1", "completed")
+
+		require.Len(t, s.updates, 1)
+		assert.Equal(t, 1, s.updates[0].progress,
+			"trading 'stuck at pending' for 'finished at 0%%' would be no more honest")
+		assert.Equal(t, 1, s.updates[0].total)
+	})
+
+	t.Run("failed and canceled pass through; interrupted variants collapse", func(t *testing.T) {
+		for v2Status, want := range map[string]string{
+			"failed":              "failed",
+			"canceled":            "canceled",
+			"interrupted_ask":     "interrupted",
+			"interrupted_dropped": "interrupted",
+		} {
+			s := newLegacyFakeStore()
+			s.v2["v2-1"] = database.OperationV2Row{ID: "v2-1", Params: `{"legacy_op_id":"leg-1"}`}
+			s.legacy["leg-1"] = &database.Operation{ID: "leg-1", Status: "running"}
+
+			newTestRegistryWithStore(s).propagateLegacyOpStatus("v2-1", v2Status)
+
+			require.Len(t, s.updates, 1, "v2 status %q", v2Status)
+			assert.Equal(t, want, s.updates[0].status, "v2 status %q", v2Status)
+		}
+	})
+
+	t.Run("non-terminal statuses are not mirrored", func(t *testing.T) {
+		for _, v2Status := range []string{"queued", "running", ""} {
+			s := newLegacyFakeStore()
+			s.v2["v2-1"] = database.OperationV2Row{ID: "v2-1", Params: `{"legacy_op_id":"leg-1"}`}
+			s.legacy["leg-1"] = &database.Operation{ID: "leg-1", Status: "pending"}
+
+			newTestRegistryWithStore(s).propagateLegacyOpStatus("v2-1", v2Status)
+
+			assert.Empty(t, s.updates, "v2 status %q must not write a terminal row", v2Status)
+		}
+	})
+
+	t.Run("an op with no legacy twin writes nothing", func(t *testing.T) {
+		s := newLegacyFakeStore()
+		s.v2["v2-1"] = database.OperationV2Row{ID: "v2-1", Params: `{"some_other":"field"}`}
+
+		newTestRegistryWithStore(s).propagateLegacyOpStatus("v2-1", "completed")
+
+		assert.Empty(t, s.updates, "the vast majority of v2 ops have no legacy twin")
+	})
+
+	t.Run("unparseable or absent params write nothing", func(t *testing.T) {
+		s := newLegacyFakeStore()
+		s.v2["a"] = database.OperationV2Row{ID: "a", Params: `{not json`}
+		s.v2["b"] = database.OperationV2Row{ID: "b", Params: ``}
+		r := newTestRegistryWithStore(s)
+
+		r.propagateLegacyOpStatus("a", "completed")
+		r.propagateLegacyOpStatus("b", "completed")
+		r.propagateLegacyOpStatus("missing-entirely", "completed")
+
+		assert.Empty(t, s.updates)
+	})
+
+	t.Run("a row already at the target status is not rewritten", func(t *testing.T) {
+		s := newLegacyFakeStore()
+		s.v2["v2-1"] = database.OperationV2Row{ID: "v2-1", Params: `{"legacy_op_id":"leg-1"}`}
+		s.legacy["leg-1"] = &database.Operation{ID: "leg-1", Status: "completed", Progress: 3, Total: 3}
+
+		newTestRegistryWithStore(s).propagateLegacyOpStatus("v2-1", "completed")
+
+		assert.Empty(t, s.updates)
+	})
+
+	t.Run("a store without the v1 surface is a no-op, not a panic", func(t *testing.T) {
+		r := newTestRegistryWithStore(&v2OnlyStore{})
+		assert.NotPanics(t, func() { r.propagateLegacyOpStatus("v2-1", "completed") })
+	})
+}
+
+// TestPublishOpTerminal_PropagatesToLegacyRow is the wiring test. The cases
+// above prove propagateLegacyOpStatus is correct, not that anything CALLS it —
+// and every terminal path in the registry reaches the legacy row only by way of
+// publishOpTerminal. Deleting that one call would leave the whole block above
+// green while the defect returned intact.
+func TestPublishOpTerminal_PropagatesToLegacyRow(t *testing.T) {
+	s := newLegacyFakeStore()
+	s.v2["v2-1"] = database.OperationV2Row{ID: "v2-1", Params: `{"legacy_op_id":"leg-1"}`}
+	s.legacy["leg-1"] = &database.Operation{ID: "leg-1", Status: "pending", Progress: 4, Total: 4}
+
+	// bus is nil: publishOpTerminal returns early on that, so this also pins
+	// that the legacy write happens BEFORE the nil-bus bail-out.
+	newTestRegistryWithStore(s).publishOpTerminal("v2-1", "maintenance.job", "completed")
+
+	require.Len(t, s.updates, 1, "publishOpTerminal must mirror the terminal status onto the legacy row")
+	assert.Equal(t, "completed", s.legacy["leg-1"].Status)
+}

--- a/internal/operations/registry/registry.go
+++ b/internal/operations/registry/registry.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/registry.go
-// version: 3.10.0
+// version: 3.11.0
 // guid: f6a7b8c9-d0e1-2f3a-4b5c-6d7e8f9a0b1c
-// last-edited: 2026-08-07
+// last-edited: 2026-08-16
 
 package registry
 
@@ -809,6 +809,14 @@ func (r *Registry) publishOpCreated(row database.OperationV2Row, resumed bool) {
 // regardless of whether a bus is wired.
 func (r *Registry) publishOpTerminal(opID, defID, status string) {
 	metrics.ClearOpProgress(opID, defID)
+
+	// Mirror the terminal status onto the legacy v1 operations row, if this op
+	// has one. Done here rather than at the four call sites because every
+	// terminal path already funnels through this function, so no future
+	// terminal path can forget it — which is exactly how the scheduler's ops
+	// ended up permanently "pending" while a handful of hand-written call sites
+	// got it right.
+	r.propagateLegacyOpStatus(opID, status)
 
 	if r.bus == nil {
 		return


### PR DESCRIPTION
## What this fixes

Jobs dispatched through `maintenance.job` and the scheduler create a **v1** `operations` row:

```go
opID := ulid.Make().String()
store.CreateOperation(opID, "maintenance-window", nil)          // v1 row, status "pending"
OpRegistry.EnqueueOp(ctx, "maintenance.window", Params{LegacyOpID: opID})   // v2 op
```

…and nothing ever wrote that v1 row again. Its status was effectively **write-only after
creation**.

The operations UI reads v1. So on 2026-08-14 every maintenance-job row of the day sat at
`"pending"` — including `fix-file-modes` and `normalize-primary-flags`, both of which had
completed with journalled summaries. A composer scan showed 0% three hours into real work; a
chapters dry-run showed as an active 1.5-hour task after finishing at 17:57. It misled the owner
twice in one day.

A handful of ops already mirrored the status by hand at their own call sites —
`internal/server/itunes_ops.go:65`, `diagnostics_ops.go:68`, `folder_autoscan_op.go:186`.
Everything the scheduler dispatched did not, and — being ~20 separate enqueue sites — never
would have.

## What changed

Propagation happens once, in `publishOpTerminal`. **Every** terminal path in the registry already
funnels through it (the canceled-before-start path, the subprocess path, the abandoned path, and
the in-process path — four call sites), so a future terminal path cannot forget it. That is the
same argument as #2479 and #2481: a rule that lives in the caller is a rule every future caller
has to remember to re-derive.

Status mapping — the vocabularies overlap but are not identical:

| v2 | v1 |
|---|---|
| `completed`, `failed`, `canceled` | pass through |
| `interrupted_ask`, `interrupted_dropped` | `interrupted` (the value `server_lifecycle.go` already writes) |
| anything else (`queued`, `running`, …) | not mirrored |

### Two deliberate design choices

**The v1 surface is discovered by type assertion, not added to `OpsV2Store`.** Several registry
test fakes carry `var _ database.OpsV2Store = (*fakeStore)(nil)` and implement exactly that and
nothing more; widening the interface would break them for a concern none of them models.
`PebbleStore` — the only production implementation — satisfies it already. A test covers the
no-v1-surface case explicitly so it stays a no-op rather than a panic.

**Existing progress counters are preserved.** `UpdateOperationStatus` takes `progress, total`
positionally and overwrites both, so passing `0, 0` would leave a completed job rendering at 0% —
trading "stuck at pending" for "finished at zero", which is no more honest. A completed row that
never carried counters is reported as fully done.

## Verification

`TestPropagateLegacyOpStatus` — 8 subtests: the terminal write, counter preservation, the
zero-counter completed case, all four status mappings, non-terminal statuses being ignored, an op
with no legacy twin, unparseable/absent/missing params, an already-terminal row not being
rewritten, and a store lacking the v1 surface.

**`TestPublishOpTerminal_PropagatesToLegacyRow` is the wiring test**, and it exists because of
what happened on #2482 earlier tonight: there, the unit tests called the renderer directly and a
mutation removing its only production call site left the whole suite green. The same failure mode
applies exactly here — deleting one line from `publishOpTerminal` would leave all 8 subtests above
passing with the defect fully restored. It also pins that the legacy write happens *before* the
nil-bus early return.

**Mutation-tested** (committed first, then reverted): removing the `propagateLegacyOpStatus` call
from `publishOpTerminal` → wiring test red. Making `legacyStatusFor` treat every status as terminal
→ `non-terminal statuses are not mirrored` red.

`go build ./...` exit 0 · `go vet ./internal/operations/registry/` clean · 9/9 tests pass.

## Not in this PR

**No backfill.** Rows already stuck from before this change stay stuck; repairing them is a
separate, riskier operation that should be run deliberately rather than folded into a behaviour
fix.

Worth noting for whoever does it: this also unblocks the **C510 opstate sweep**, which treats
unknown statuses as KEEP — permanently-pending rows pin their opstate blobs forever, so this
defect was quietly defeating that retention policy too.
