### PR TITLE
docs: overnight session wrap-up — measurement result, executive summary, open items

### DIFF
--- a/changelog.d/20260816_062000_handoff_h110_result.md
+++ b/changelog.d/20260816_062000_handoff_h110_result.md
@@ -1,0 +1,2 @@
+- Updated the 2026-08-16 overnight handoff with the `test-short` measurement result
+  (#2485) and the final completed/remaining counts.

--- a/docs/executive-summaries/2026-08-16-the-work-that-said-it-succeeded-executive-summary.md
+++ b/docs/executive-summaries/2026-08-16-the-work-that-said-it-succeeded-executive-summary.md
@@ -1,0 +1,148 @@
+<!-- file: docs/executive-summaries/2026-08-16-the-work-that-said-it-succeeded-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 24b33837-c4c8-4096-822a-83fee40f0194 -->
+<!-- last-edited: 2026-08-16 -->
+
+# The work that said it succeeded
+
+**2026-08-16 — four places the program told you it had done something it hadn't**
+
+## The common thread
+
+Every fix below is the same mistake wearing a different coat: **the program did a job,
+the job failed, and the program reported success anyway.**
+
+That is worse than an outright error. An error tells you to look. A false success tells
+you to stop looking — and everything downstream then treats the work as done.
+
+## 1. "Applied" when nothing had moved
+
+When you accept new metadata for a book, two things happen: the details are saved, and
+the files are renamed and tidied on disk to match.
+
+The renaming step had no way to report a problem. If it failed — a permissions issue, a
+disconnected drive, a file that had gone missing — it made a note in the log and returned
+as though all was well. The part above it then reported **"applied: true"** and moved on.
+
+So the screen said the change had been applied, the database agreed, and on disk nothing
+had happened. There was even a counter meant to track exactly this kind of failure; it
+could never be incremented, because nothing ever told it there had been one.
+
+The renaming step can now report failure, and the result distinguishes the two halves
+honestly: the details **were** saved (that part is real and permanent), but the file work
+did not fully land.
+
+## 2. Organising a book that had no files left
+
+When the program organises a book, it creates the destination folder first, then copies
+the files in. If a file has vanished from where it was expected, it is skipped.
+
+Skip every file, and you are left with a freshly created, completely empty folder — which
+the program handed back as the successful result, with no complaint. This did not require
+anything to be marked as broken beforehand; the files simply had to be gone.
+
+Three different parts of the program call this. **One** of them checked whether anything
+had actually been copied. The other two believed the answer:
+
+- one created a **new book record pointing at the empty folder**;
+- the other **moved the book's official location** to it.
+
+In both cases the library ends up confidently pointing at nothing.
+
+The check now lives inside the organising step itself, so all three callers get it — and
+the error names the book and says why, rather than leaving you to work it out.
+
+That last point is the real lesson, and it came up three separate times last night: **a
+safety check that lives in one caller is a check every other caller silently lacks.**
+Whoever writes the fourth caller cannot be expected to rediscover it.
+
+## 3. Activity messages that stopped mid-sentence
+
+The activity list was showing entries like *"cover art saved to"* and *"ISBN enrichment
+succeeded for"* — sentences that just stopped. Occasionally a neighbouring row showed raw
+internal text with a stray quotation mark in it.
+
+Those looked like two separate faults. They were one.
+
+The program reads its own log lines to build these summaries, and it found the end of the
+message by searching for the **last quotation mark in the entire line**. When a line
+ended with the message, that happened to be right. When anything followed — the filename,
+the book, the value that had been found — the message swallowed it, or the quotation mark
+ended up displayed as text.
+
+Lines are now read properly, once, in order. The details are put back into the sentence —
+*"cover art saved to /library/Asimov/cover.jpg"* — **and** stored alongside it, so they
+can be searched later rather than only looked at.
+
+## 4. Maintenance jobs that never stopped saying "pending"
+
+You reported that every maintenance job from 14 August was still showing as **pending**,
+including two that had definitely finished and written full summaries of what they did.
+It misled you twice in one day.
+
+The program keeps two records of a job: an older one, which is what the operations screen
+displays, and a newer one, which is what actually runs. The newer record was updated
+throughout. The older one was written once, when the job was created, **and never touched
+again.** Its status was permanently frozen at whatever it started as.
+
+A handful of jobs happened to update it by hand. Everything started on a schedule did
+not — and never would have, because each new job would have had to remember to do it.
+
+The update now happens in the single place every job passes through when it finishes, so
+it cannot be forgotten. Jobs that keep a progress count keep it; jobs that don't are
+recorded as done rather than as "finished, 0%", which would have been a different lie.
+
+**This one is confirmed working on your live system.** After the update was deployed, two
+scheduled jobs ran and both correctly reported themselves finished, while the older
+entries from before the fix are still sitting at pending — visible side by side.
+
+Those older entries stay stuck. Repairing them means rewriting past records, which is a
+deliberate operation to run while watching it, not something to slip in unattended
+overnight.
+
+## The thing that was found by accident, and matters most
+
+While confirming the deployment had worked, the startup log turned out to be reporting
+that **three scheduled jobs are switched on but can never actually run.** They have no
+schedule, and the nightly maintenance window doesn't reach them. They have been in this
+state for some time — this is not new, and not caused by any of the above.
+
+One of them is the metadata upgrade. If you believed that had been running quietly each
+night, it has not been.
+
+Another is the one that organises the library. That matters right now for a specific
+reason: a recent fix corrected a long-standing disagreement about *where books should
+live*, and the correction only takes effect the next time books are organised. It is
+therefore still waiting — and it will not start on its own.
+
+**Nothing was changed here.** Switching that job on would begin moving files across the
+entire library, unsupervised, overnight. That is a decision to make deliberately, with
+someone watching.
+
+## Also: the test suite was doing everything twice
+
+Not a fault in the program itself, but the same species of problem.
+
+The standard test run executed the **entire** suite twice — once checking for one class of
+issue, once measuring coverage — when both can be done in a single pass. Measured properly:
+16 minutes became 8, and the coverage figure came out **identical to the digit**.
+
+The second run also threw away everything it printed. If a failure had happened only in
+that run, it would have failed with nothing to read — a silent failure, in the tooling
+built to catch silent failures.
+
+## How we know
+
+Each fix has a test that drives the **real** path, not just the repaired piece in
+isolation. That distinction mattered: for the activity messages, deliberately re-breaking
+the fixed line left every test still passing, because the tests were calling the repaired
+function directly and never checking that the program used it. A test that goes through
+the actual machinery now catches it.
+
+The maintenance-job fix is verified on the live system rather than only in tests.
+
+## What has not been established
+
+The library-wide file reorganisation has not run, and cannot until the scheduling decision
+above is made. Until then, the disagreement about where books live is corrected in
+principle but not yet on disk.

--- a/docs/handoffs/2026-08-16-overnight-silent-failure-fixes.md
+++ b/docs/handoffs/2026-08-16-overnight-silent-failure-fixes.md
@@ -1,5 +1,5 @@
 <!-- file: docs/handoffs/2026-08-16-overnight-silent-failure-fixes.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 7d1a4b60-3e92-4c58-b0a7-2f6c9d81e534 -->
 <!-- last-edited: 2026-08-16 -->
 
@@ -220,20 +220,55 @@ deliberate, supervised action, not something to fold into a behaviour fix unatte
 | **Backfill for stuck legacy rows** | #2483 fixes the forward path only. The already-stuck rows need a one-off supervised pass. |
 | **Maintenance-window watchdog vs. plugin success** | Cancelled at 331s idle; plugin then logged "completed successfully (100%)". Pre-existing disagreement, newly consequential — see #4 above. |
 | **Activity summaries, second half** | Metadata-apply rows leading with the book title rather than a bare "book →" link, and `(none) → 2021` instead of a dangling arrow. Separate change in the emitters + frontend. |
-| **H110 coverage double-run** | `Makefile:196-202` — `test-short` runs `go test ./...` twice, once with `-race` and again with `-coverprofile`, the second discarding all output (`>/dev/null 2>&1`, so a failure there is invisible — itself a silent failure of exactly the species above). Measurement result below. |
+| ~~**H110 coverage double-run**~~ | ✅ **Fixed and merged — PR #2485.** See below. |
+
+## 5. `make test-short` ran the whole suite twice — PR #2485 ✅ merged
+
+Not a correctness bug, but it shares the species: the second run discarded its output with
+`>/dev/null 2>&1`, so a failure occurring *only* under the coverage run produced a silent
+non-zero exit with nothing to read.
+
+`test-short` ran `go test ./...` once with `-race`, then again with `-coverprofile`.
+Measured on an idle machine (a first attempt was **discarded as invalid** — another full
+suite was running concurrently and contending for CPU, which is the same mistake that
+would have produced a confident wrong number):
+
+| Config | Time |
+|---|---|
+| `-race` alone | 493s |
+| `-coverprofile` alone | 473s |
+| **both together** | **500s** |
+
+One combined pass is **466s cheaper per invocation (966s → 500s, −48%)** and only 7s more
+than `-race` by itself. Coverage is byte-identical either way — 47.0%, 81950 profile lines
+— so `coverage-check-short`'s floor is unaffected, and `-covermode=atomic` was already
+required by `-race`. Verified end to end before pushing: 512s, exit 0, coverage 47.0%,
+gate passes. CI then ran the new target on the PR itself.
+
+Also gitignored `.ci/coverage-last.txt`, which the gate writes as local running state and
+which was neither tracked nor ignored — so running the documented target left a dirty tree.
+I swept it into a commit with `git add -A` and had to back it out, which is the footgun
+that rule exists for.
 
 ## COMPLETED / REMAINING / BLOCKED
 
-**COMPLETED: 5** — prod deploy (main, debug build, verified healthy, zero panics/errors);
+**COMPLETED: 7** — prod deploy ×2 (debug build, verified healthy, zero real errors);
 PR #2480 (F7 file-I/O error return); PR #2481 (F6 empty organize is an error);
-PR #2482 (activity summary attrs); PR #2483 (legacy op terminal status).
-**All four PRs merged** (22/22 checks passing each, zero failures); `main` is at `5aeb02a8`,
-which is also what prod is running. Worktrees removed, branches deleted.
+PR #2482 (activity summary attrs); PR #2483 (legacy op terminal status, **verified live in
+prod**); PR #2484 (this handoff); PR #2485 (test-short single pass, −48%).
+**All six PRs merged**, each with 21–22 checks passing and zero failures. Worktrees
+removed, branches deleted. Prod runs `5aeb02a8`; `main` is at `20023a5d` (the two commits
+since prod are docs + the Makefile, neither shipping in the binary).
 
-**REMAINING: 6** — 3 scheduled tasks enabled-but-inert (needs your decision);
-F5-remainder (content hash, deliberately deferred to a waking session); backfill for
-already-stuck legacy op rows; maintenance-watchdog vs. plugin-success disagreement;
-activity summaries second half (emitters + frontend); H110 Makefile change (pending the
-measurement).
+**REMAINING: 5** — 3 scheduled tasks enabled-but-inert (`library_organize`,
+`library_size_refresh`, `metadata_upgrade` — needs your decision); F5-remainder (content
+hash, deliberately deferred to a waking session); backfill for already-stuck legacy op
+rows; maintenance-watchdog vs. plugin-success disagreement; activity summaries second half
+(emitters + frontend).
 
 **BLOCKED: 0**
+
+## If you only read one thing
+
+The relocation from #2479 has **not** run, and `library_organize` is enabled but cannot
+run, so it will not start on its own. That is the decision waiting for you.

--- a/docs/handoffs/2026-08-16-overnight-silent-failure-fixes.md
+++ b/docs/handoffs/2026-08-16-overnight-silent-failure-fixes.md
@@ -17,6 +17,10 @@ prod"), so the deploy that the previous handoff had deliberately left undone is 
 - Built with `make deploy-debug`, per the standing "prod stays on DEBUG" rule.
 - **This is the first production binary containing the target-path unification (#2479)
   and the write-back I/O fixes (#2468–#2470)**, plus all four of tonight's fixes.
+- **Prod runs `5aeb02a8`. `main` is ahead, at `20023a5d`.** The difference is docs and a
+  Makefile change only — nothing behavioural is missing from prod, so **no redeploy is
+  needed**. Stated here rather than only in the tally below, because this is where you'd
+  look before deciding.
 - The only ERROR in the logs is `"Failed to start HTTP/3 server" err="http: Server closed"`
   from the *outgoing* pid during the restart — a shutdown artifact, not a startup failure.
   Worth knowing so you don't chase it: it appears on every restart.

--- a/todo.d/20260816-august-roundup-is-stale.md
+++ b/todo.d/20260816-august-roundup-is-stale.md
@@ -1,0 +1,6 @@
+- [ ] **August executive-summary roundup is stale.** `2026-08-31-august-monthly-roundup-executive-summary.md`
+      says it consolidates "the seven dated summaries ... from 2026-08-04 to 2026-08-09"
+      and was last edited 2026-08-14, but the directory now holds individual summaries
+      through 2026-08-16. It describes itself as "month in progress — updated as work
+      lands", so it needs a consolidation pass covering 08-10 through 08-16 before the
+      month closes.

--- a/todo.d/20260816-backfill-stuck-legacy-op-rows.md
+++ b/todo.d/20260816-backfill-stuck-legacy-op-rows.md
@@ -1,0 +1,6 @@
+- [ ] **Backfill legacy operation rows stuck at `pending`.** #2483 fixed the forward path
+      (terminal status now mirrors from `publishOpTerminal`), but rows created before it
+      stay frozen at whatever status they started with. `/api/v1/operations` shows several
+      on page one alone (`archive-sweep`, `trash-cleanup`, `temp-file-cleanup`,
+      `cleanup_activity_log`, `maintenance-window`, `purge-deleted`). Needs a one-off
+      supervised pass — it rewrites historical records, so run it watching, not unattended.

--- a/todo.d/20260816-scheduled-tasks-enabled-but-inert.md
+++ b/todo.d/20260816-scheduled-tasks-enabled-but-inert.md
@@ -1,0 +1,9 @@
+- [ ] **3 scheduled tasks are ENABLED but can never run.** Startup logs
+      `Scheduled task is ENABLED but can NEVER run` for `library_organize`,
+      `library_size_refresh` and `metadata_upgrade` — all `interval=0s`,
+      `declaresMaintenanceWindow=false`, `inMaintenanceOrder=true`. Pre-existing (15
+      occurrences before the 2026-08-16 boot). Each needs either a
+      `scheduled.<task>.interval` or `declaresMaintenanceWindow=true`.
+      ⚠️ `library_organize` is the trigger for the library-wide relocation from #2479 —
+      enabling it starts moving files across the whole library, so decide deliberately.
+      See `docs/handoffs/2026-08-16-overnight-silent-failure-fixes.md`.

--- a/todo.d/20260816-watchdog-vs-plugin-success.md
+++ b/todo.d/20260816-watchdog-vs-plugin-success.md
@@ -1,0 +1,5 @@
+- [ ] **Maintenance window: watchdog cancels it, then the plugin reports success.** Prod
+      cancelled the maintenance window at 331s idle, after which the plugin logged
+      "completed successfully (100%)". Pre-existing disagreement, but newly consequential
+      after #2483: the legacy operations row is now mirrored as `canceled` while the op's
+      own log claims success, so the two records actively contradict each other.


### PR DESCRIPTION
Docs-only follow-up closing out the overnight session (#2480–#2485).

## Contents

1. **Handoff updated** with the `test-short` measurement now that #2485 is merged — 966s → 500s (−48%), coverage byte-identical at 47.0% — and the final tally: six PRs merged, five items remaining, none blocked.
2. **Executive summary** (`2026-08-16-the-work-that-said-it-succeeded`). The session meets the criteria on two counts: it fixes defects that could have silently caused data corruption (book records pointing at empty directories; applies reported as succeeded that never touched disk), and it spans six PRs.
3. **Three todo fragments** for what's left, all headerless per the fragment rule.

## The one that needs a decision, not an implementation

`library_organize`, `library_size_refresh` and `metadata_upgrade` are all **enabled but structurally unable to run** — `interval=0s`, outside the maintenance window's reach. Pre-existing (15 log occurrences before last night's boot), so not caused by any of these PRs.

It matters now because `library_organize` is what triggers the library-wide relocation from #2479. That relocation has **not** run and will not start on its own. Enabling it begins moving files across the whole library, so it was deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS