### PR TITLE
feat(web): add a Hide Multi-Book Matches toggle to metadata review

### DIFF
--- a/changelog.d/20260816_060000_hide_multi_book_matches.md
+++ b/changelog.d/20260816_060000_hide_multi_book_matches.md
@@ -1,0 +1,4 @@
+- Metadata review: added a **Hide Multi-Book Matches** toggle that hides any book sharing a
+  match with another book — the grouped cards with "Skip All" — so the unambiguous
+  one-book-one-match rows can be worked through on their own. Hidden books are also
+  deselected, so "Apply Selected" cannot apply one that was ticked beforehand.

--- a/web/src/components/audiobooks/MetadataReviewDialog.test.tsx
+++ b/web/src/components/audiobooks/MetadataReviewDialog.test.tsx
@@ -1,0 +1,154 @@
+// file: web/src/components/audiobooks/MetadataReviewDialog.test.tsx
+// version: 1.0.0
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import type { CandidateResult } from '../../services/api';
+import { MetadataReviewDialog } from './MetadataReviewDialog';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual<typeof import('../../services/api')>('../../services/api');
+  return {
+    ...actual,
+    getCachedReviewResults: vi.fn(),
+    batchApplyFromCache: vi.fn(),
+    markNoMatch: vi.fn(),
+    clearMetadataNoMatch: vi.fn(),
+    pollOperationV2: vi.fn(),
+  };
+});
+
+import * as api from '../../services/api';
+
+const mockGet = vi.mocked(api.getCachedReviewResults);
+const mockApply = vi.mocked(api.batchApplyFromCache);
+
+// Two books sharing one ASIN — this is what renders as a grouped card with
+// "Skip All" — plus one book with a candidate all to itself.
+function makeResult(
+  bookId: string,
+  title: string,
+  candidate: Partial<{ asin: string; title: string; source: string; score: number }>
+): CandidateResult {
+  return {
+    book: { id: bookId, title, author: 'Some Author', file_path: `/lib/${bookId}.m4b` },
+    status: 'matched',
+    candidate: {
+      title: candidate.title ?? title,
+      author: 'Some Author',
+      source: candidate.source ?? 'audible',
+      score: candidate.score ?? 0.95,
+      asin: candidate.asin,
+    },
+  };
+}
+
+const GROUPED_A = makeResult('dup-1', 'Long Book Part 1', { asin: 'B00SHARED', title: 'Long Book' });
+const GROUPED_B = makeResult('dup-2', 'Long Book Part 2', { asin: 'B00SHARED', title: 'Long Book' });
+const STANDALONE = makeResult('solo-1', 'A Normal Book', { asin: 'B00UNIQUE' });
+
+const noop = () => {};
+const toast = vi.fn();
+
+function renderDialog() {
+  return renderWithProviders(
+    <MetadataReviewDialog open onClose={noop} onComplete={noop} toast={toast} />
+  );
+}
+
+async function toggleHideMultiBook() {
+  const label = await screen.findByText(/Hide Multi-Book Matches/);
+  // The Switch is the input inside the same FormControlLabel as this text.
+  const control = label.closest('label') as HTMLElement;
+  fireEvent.click(within(control).getByRole('checkbox'));
+}
+
+function setResults(results: CandidateResult[]) {
+  mockGet.mockResolvedValue({
+    results,
+    matched: results.length,
+    no_match: 0,
+    errors: 0,
+    total: results.length,
+    total_count: results.length,
+  } as Awaited<ReturnType<typeof api.getCachedReviewResults>>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setResults([GROUPED_A, GROUPED_B, STANDALONE]);
+  mockApply.mockResolvedValue({ op_id: 'op-1' } as Awaited<
+    ReturnType<typeof api.batchApplyFromCache>
+  >);
+});
+
+describe('MetadataReviewDialog — Hide Multi-Book Matches', () => {
+  it('shows books that share a candidate until the toggle is turned on', async () => {
+    renderDialog();
+
+    // Both halves of the shared-ASIN book are present by default.
+    expect(await screen.findByText('Long Book Part 1')).toBeInTheDocument();
+    expect(screen.getByText('Long Book Part 2')).toBeInTheDocument();
+    expect(screen.getByText('A Normal Book')).toBeInTheDocument();
+
+    await toggleHideMultiBook();
+
+    await waitFor(() => {
+      expect(screen.queryByText('Long Book Part 1')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText('Long Book Part 2')).not.toBeInTheDocument();
+    // The unambiguous one-book-one-candidate row survives — that is the point.
+    expect(screen.getByText('A Normal Book')).toBeInTheDocument();
+  });
+
+  // The wiring test. Asserting the list shrinks proves the filter; it does NOT
+  // prove hidden books stay out of an apply, because selectedIds is a Set the
+  // user builds by hand and a Set does not shrink when a filter hides its
+  // members.
+  //
+  // Reaching that leak takes a specific arrangement, which is itself the reason
+  // the hide is computed globally rather than per page. Grouped CARDS render
+  // without per-row checkboxes, so a book cannot be selected while it is drawn
+  // as part of a group. But rendering-grouping is per-page: put the two halves
+  // of one book on different pages and each is a singleton on its own page, so
+  // each draws as a standalone row WITH a checkbox — selectable, while still
+  // globally part of a multi-book group. Page size floors at 25, so this needs
+  // 26 rows: dup-1 first, 24 fillers, dup-2 alone on page 2.
+  //
+  // Without the deselect effect, dup-1 stays in selectedIds and gets applied.
+  // The test above passes either way.
+  it('does not apply a grouped book selected while it was alone on its page', async () => {
+    const fillers = Array.from({ length: 24 }, (_, i) =>
+      makeResult(`solo-${i}`, `Filler Book ${i}`, { asin: `B00FILL${i}` })
+    );
+    setResults([GROUPED_A, ...fillers, GROUPED_B]);
+
+    renderDialog();
+    // Page 1 shows dup-1 as an ordinary standalone row. A compact row renders
+    // "<book title> → <candidate title>" inside ONE Typography, so an exact
+    // string match cannot hit it — match a substring.
+    const titleEl = await screen.findByText(/Long Book Part 1/);
+
+    // Tick dup-1's own row checkbox. getAllByRole('checkbox') also matches the
+    // filter Switches — MUI renders those as checkbox inputs — so scope to this
+    // row rather than clicking everything on the page.
+    const row = titleEl.closest('.MuiStack-root') as HTMLElement;
+    fireEvent.click(within(row).getByRole('checkbox'));
+
+    const applyButton = await screen.findByRole('button', { name: /Apply Selected \(1\)/i });
+    expect(applyButton).toBeInTheDocument();
+
+    await toggleHideMultiBook();
+
+    // dup-1 is now hidden, so it must also be deselected — the count goes to 0
+    // and the button disables rather than silently applying a hidden book.
+    await waitFor(() => {
+      expect(screen.queryByText(/Long Book Part 1/)).not.toBeInTheDocument();
+    });
+    const afterToggle = screen.getByRole('button', { name: /Apply Selected/i });
+    expect(afterToggle).toBeDisabled();
+    expect(afterToggle).toHaveTextContent('Apply Selected (0)');
+    expect(mockApply).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/audiobooks/MetadataReviewDialog.tsx
+++ b/web/src/components/audiobooks/MetadataReviewDialog.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/audiobooks/MetadataReviewDialog.tsx
-// version: 1.15.0
+// version: 1.16.0
 // guid: e7f8a9b0-c1d2-3e4f-5a6b-7c8d9e0f1a2b
-// last-edited: 2026-08-15
+// last-edited: 2026-08-16
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
@@ -172,6 +172,12 @@ export function MetadataReviewDialog({
   const [hideRejected, setHideRejected] = useState(true);
   const [hideNoMatch, setHideNoMatch] = useState(true);
   const [hideSkipped, setHideSkipped] = useState(false);
+  // Hide books that share a candidate with another book — the cards that render
+  // with "Skip All". Those are the ambiguous ones (two parts of one book, or
+  // genuine duplicates) and need a judgement call per group; this toggle gets
+  // them out of the way so the unambiguous one-book-one-candidate rows can be
+  // worked through on their own.
+  const [hideMultiBook, setHideMultiBook] = useState(false);
   const [matchLanguage, setMatchLanguage] = useState<boolean>(loadLanguageFilter);
   const [titleFilter, setTitleFilter] = useState('');
   const [onlyWithTranscription, setOnlyWithTranscription] = useState(false);
@@ -277,7 +283,7 @@ export function MetadataReviewDialog({
     try { return new RegExp(titleFilter, 'i'); } catch { return null; }
   })();
 
-  const filteredResults = results
+  const preGroupFiltered = results
     .filter((r) => !titleRegex || titleRegex.test(r.book.title || ''))
     .filter((r) => !sourceFilter || r.candidate?.source === sourceFilter)
     .filter(
@@ -308,10 +314,55 @@ export function MetadataReviewDialog({
     .filter((r) => !onlyWithTranscription || !!r.book.transcribed_title)
     .filter((r) => !onlyTranscriptionMatched || !!r.candidate?.transcription_boosted);
 
+  // Book ids that share a candidate with at least one other book.
+  //
+  // This is deliberately computed over the WHOLE filtered set rather than the
+  // current page, unlike the `multiGroups` map further down which drives
+  // rendering and is per-page by design. Two files of the same book that land on
+  // opposite sides of a page boundary would each look like a singleton to a
+  // per-page pass and would survive the hide — which is exactly the case this
+  // toggle exists to remove. `candidateKey` is a hoisted function declaration
+  // defined with the grouping code below.
+  const multiBookIds = (() => {
+    if (!hideMultiBook) return new Set<string>();
+    const byKey = new Map<string, string[]>();
+    for (const r of preGroupFiltered) {
+      if (!r.candidate || r.status !== 'matched' || ungroupedIds.has(r.book.id)) continue;
+      const key = candidateKey(r.candidate);
+      const ids = byKey.get(key);
+      if (ids) ids.push(r.book.id);
+      else byKey.set(key, [r.book.id]);
+    }
+    const out = new Set<string>();
+    for (const ids of byKey.values()) {
+      if (ids.length > 1) ids.forEach((id) => out.add(id));
+    }
+    return out;
+  })();
+
+  const filteredResults = hideMultiBook
+    ? preGroupFiltered.filter((r) => !multiBookIds.has(r.book.id))
+    : preGroupFiltered;
+
+  // Deselect anything the multi-book filter has hidden. selectedIds is a Set the
+  // user builds by hand and it does not shrink when a filter hides its members,
+  // so without this "Apply Selected" would still apply a grouped book that was
+  // ticked before the toggle went on — the precise opposite of what the toggle
+  // is for — and the button's count would disagree with what it does.
+  useEffect(() => {
+    if (!hideMultiBook || multiBookIds.size === 0) return;
+    setSelectedIds((prev) => {
+      const next = new Set([...prev].filter((id) => !multiBookIds.has(id)));
+      return next.size === prev.size ? prev : next;
+    });
+    // multiBookIds is rebuilt each render; key the effect on its contents.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hideMultiBook, [...multiBookIds].sort().join(',')]);
+
   // Reset to page 1 when filters change so the user sees the first filtered result.
   useEffect(() => {
     setServerPage(1);
-  }, [sourceFilter, confidenceThreshold, hideApplied, hideRejected, hideSkipped, hideNoMatch, matchLanguage, titleFilter, onlyWithTranscription, onlyTranscriptionMatched]);
+  }, [sourceFilter, confidenceThreshold, hideApplied, hideRejected, hideSkipped, hideNoMatch, hideMultiBook, matchLanguage, titleFilter, onlyWithTranscription, onlyTranscriptionMatched]);
 
   // Go back to page 1 on manual refresh.
   useEffect(() => {
@@ -1427,6 +1478,23 @@ export function MetadataReviewDialog({
                   }
                   label={<Typography variant="body2">Hide No Match</Typography>}
                 />
+                <Tooltip title="Hide any book that shares a match with another book — the grouped cards with 'Skip All'. Those are the ambiguous ones (two parts of the same book, or duplicates) and need a decision per group. Turning this on leaves only the straightforward one-book-one-match rows, and takes the hidden books out of Apply Selected too.">
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        size="small"
+                        checked={hideMultiBook}
+                        onChange={(e) => setHideMultiBook(e.target.checked)}
+                      />
+                    }
+                    label={
+                      <Typography variant="body2">
+                        Hide Multi-Book Matches
+                        {hideMultiBook && multiBookIds.size > 0 ? ` (${multiBookIds.size})` : ''}
+                      </Typography>
+                    }
+                  />
+                </Tooltip>
                 <Tooltip title="Hide candidates whose language doesn't match the book's current language. Books without a language set still show all candidates.">
                   <FormControlLabel
                     control={


### PR DESCRIPTION
Books that share a match render as a grouped card with **"Skip All"**. Those are the ambiguous ones — two parts of the same book, or genuine duplicates — and each needs a judgement call. This adds a toggle that hides them so the straightforward one-book-one-match rows can be applied on their own.

## Two things that make it actually work

**1. Group membership is computed over the whole filtered set, not the current page.**

The existing `multiGroups` map that drives *rendering* is per-page by design. Reusing it for the filter would have missed exactly the case being complained about: two files of one book landing on opposite sides of a page boundary each look like a singleton to a per-page pass, and would have survived the hide.

**2. Hidden books are deselected.**

`selectedIds` is a `Set` the user builds by hand, and a Set doesn't shrink when a filter hides its members. Without this, ticking a book and then turning the toggle on would still apply it via **Apply Selected** — the opposite of the intent — with the button's count disagreeing with what it did.

That path is reachable precisely *because* rendering-grouping is per-page: grouped cards render without per-row checkboxes, but a book alone on its page draws as a standalone row **with** a checkbox while still being globally grouped.

## Tests

Two cases, and the second is the wiring test:

- rows disappear when the toggle goes on, the standalone row survives
- a book selected while alone on its page is **not** applied afterwards

Verified by mutation: removing the deselect effect **fails the second test while the first stays green**. Full frontend suite 478/478, `tsc` clean, eslint clean.

Default off, no persistence — matches `hideRejected`/`hideSkipped`/`hideNoMatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS