### PR TITLE
fix(organizer): a file pattern names one component, separator or not

### DIFF
--- a/changelog.d/20260816-file-pattern-single-component.md
+++ b/changelog.d/20260816-file-pattern-single-component.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **A path separator in `file_naming_pattern` no longer manufactures a directory.**
+  `BuildRelPath` expanded the file pattern through `BuildPath`, which splits on
+  `/` and sanitizes each half independently, and nothing then constrained the
+  result to a single component. A separator in the file pattern therefore became
+  a real directory on disk, and the two-phase rename parked its payload inside as
+  `<n>.<ext>.tmp-rename` and failed. The stem is now collapsed to one component,
+  which yields exactly the name the file should have had rather than failing the
+  organize outright.
+
+  This is distinct from the `scrubVar` guard, which sanitizes variable *values*
+  before substitution and does not see separators that arrive in the *template*.
+  The two produce identical wreckage on disk and were conflated for months.

--- a/changelog.d/20260816-naming-pattern-validation.md
+++ b/changelog.d/20260816-naming-pattern-validation.md
@@ -1,0 +1,34 @@
+### Fixed
+
+- **A naming pattern that silently strands files is now rejected at the point
+  it is set.** Two shapes are refused: a path separator in
+  `file_naming_pattern` (it names one file, not a directory path), and a file
+  pattern with no `{track}` / `{track:02d}` / `{track_title}` placeholder. The
+  second looks entirely reasonable — `"{title} - {author} - read by {narrator}"`
+  was once a shipped default — and is catastrophic for multi-file books,
+  because every track expands to the same name and all but the first are left
+  behind as `.tmp-rename`.
+
+- **Path components are normalized to NFC.** macOS produces NFD and Linux
+  produces NFC, so the same title arrived as two different byte strings and
+  created two directories that render identically. Korean is the sharp case:
+  NFD decomposes a Hangul syllable into jamo, so `해리` is 6 bytes composed and
+  12 decomposed with no visual difference.
+
+- **Component truncation is rune-aware.** The 200-byte cap was a byte slice, so
+  any Japanese, Korean or Chinese title over ~67 characters was cut mid-rune
+  and the result was not valid UTF-8. The filesystem rejects that outright with
+  `EILSEQ`, meaning such a book could not be organized at all.
+
+- **Invisible and filesystem-hostile characters are stripped or escaped:** C1
+  controls, zero-width space, BOM, bidi overrides and line/paragraph
+  separators; Windows reserved device names (`NUL`, `COM1`, and `NUL.m4b` too)
+  and trailing dots/spaces, which NTFS silently strips. Zero-width
+  joiners/non-joiners are deliberately preserved — they are meaningful in
+  Devanagari conjuncts and bind emoji sequences.
+
+### Changed
+
+- `folder_naming_pattern` and `file_naming_pattern` defaults are now declared
+  once as `DefaultFolderNamingPattern` / `DefaultFileNamingPattern` instead of
+  being hand-copied into two places.

--- a/changelog.d/20260816-post-move-verification.md
+++ b/changelog.d/20260816-post-move-verification.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Every rename is verified after it reports success.** A rename returning no
+  error says the syscall was accepted, not that the file arrived where anyone
+  wanted it — the distinction that let 38,895 files be misplaced by operations
+  that all reported success. `safeRename` now reads the filesystem back and
+  fails loudly if the destination is missing, is a different kind of object
+  than the source, has a different size, or if the source survived (meaning the
+  move silently became a copy).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,7 @@
 // file: internal/config/config.go
-// version: 1.78.0
+// version: 1.79.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
-// last-edited: 2026-08-15
+// last-edited: 2026-08-16
 
 package config
 
@@ -1006,12 +1006,8 @@ func InitConfig() {
 	viper.SetDefault("auto_organize", true)
 	viper.SetDefault("auto_scan_enabled", false)
 	viper.SetDefault("auto_scan_debounce_seconds", 30)
-	viper.SetDefault("folder_naming_pattern", "{author}/{series}/{title} ({print_year})")
-	// Must stay in step with the FileNamingPattern default in Defaults() below.
-	// "{track:02d}" serves both book layouts: a single-file book has no track so
-	// BuildPath drops the segment ("Foundation.m4b"), a multi-file book gets
-	// zero-padded per-track names ("Foundation - 01.m4b").
-	viper.SetDefault("file_naming_pattern", "{title} - {track:02d}")
+	viper.SetDefault("folder_naming_pattern", DefaultFolderNamingPattern)
+	viper.SetDefault("file_naming_pattern", DefaultFileNamingPattern)
 	viper.SetDefault("create_backups", true)
 
 	// Set storage quota defaults
@@ -1988,6 +1984,10 @@ func (c *Config) Validate() error {
 			errs = append(errs, "file_naming_pattern "+err.Error())
 		}
 	}
+	// Syntax is not the only way a naming pattern destroys data; see
+	// naming_patterns.go. Empty means "unset, viper will supply the default",
+	// which is the convention the two blocks above already follow.
+	errs = append(errs, validateNamingPatterns(c.FolderNamingPattern, c.FileNamingPattern)...)
 
 	for _, ext := range c.SupportedExtensions {
 		if ext == "" {
@@ -2027,18 +2027,9 @@ func ResetToDefaults() {
 			AutoOrganize:            true,
 			AutoScanEnabled:         false,
 			AutoScanDebounceSeconds: 30,
-			FolderNamingPattern:     "{author}/{series}/{title} ({print_year})",
-			// "{track:02d}" serves BOTH book layouts, which is why it is safe as
-			// a default. A single-file book has no track, so BuildPath drops the
-			// whole " - " segment and the file is "Foundation.m4b". A multi-file
-			// book gets "Foundation - 01.m4b", "Foundation - 02.m4b", zero-padded
-			// so any file manager sorts it correctly.
-			//
-			// The previous default, "{title} - {author} - read by {narrator}",
-			// gave every file of a multi-file book the IDENTICAL name — they
-			// would all have collided on one target.
-			FileNamingPattern: "{title} - {track:02d}",
-			CreateBackups:     true,
+			FolderNamingPattern:     DefaultFolderNamingPattern,
+			FileNamingPattern:       DefaultFileNamingPattern,
+			CreateBackups:           true,
 
 			// Storage quotas
 			EnableDiskQuota:    false,

--- a/internal/config/config_unit_test.go
+++ b/internal/config/config_unit_test.go
@@ -1,6 +1,6 @@
 // file: internal/config/config_unit_test.go
-// version: 1.10.0
-// last-edited: 2026-06-16
+// version: 1.11.0
+// last-edited: 2026-08-16
 
 package config
 
@@ -187,8 +187,12 @@ func TestConfigValidate(t *testing.T) {
 			OrganizationStrategy: "auto",
 			ConcurrentScans:      4,
 			FolderNamingPattern:  "{author}/{title}",
-			FileNamingPattern:    "{title}",
-			SupportedExtensions:  []string{".m4b", ".mp3"},
+			// Was "{title}", which is the shape that stranded 2,584 files in
+			// production: with no per-track placeholder every file of a
+			// multi-file book expands to the same name. Validate now rejects
+			// it, so this case uses the real shipped default.
+			FileNamingPattern:   DefaultFileNamingPattern,
+			SupportedExtensions: []string{".m4b", ".mp3"},
 		}
 		assert.NoError(t, c.Validate())
 	})

--- a/internal/config/naming_patterns.go
+++ b/internal/config/naming_patterns.go
@@ -1,0 +1,104 @@
+// file: internal/config/naming_patterns.go
+// version: 1.0.0
+// guid: 8e4b7f21-c390-4a6d-b158-7d02f9ac4e63
+// last-edited: 2026-08-16
+
+// Validation for the two naming patterns that decide where every file in the
+// library lives.
+//
+// Both rules here exist because the config that violated them shipped, ran for
+// months, and stranded 35.2 GB across 82 books -- 77 of which were left with no
+// other copy on disk. Neither failure announced itself: organizing "succeeded",
+// and the files simply were not where anything looked for them.
+
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// The shipped naming defaults, declared ONCE.
+//
+// They used to be written out by hand in two places -- viper.SetDefault and
+// ResetToDefaults -- with a comment on one of them reading "Must stay in step
+// with the FileNamingPattern default below". A comment is not a mechanism, and
+// the pair that mattered most is exactly the pair that drifted: the default was
+// corrected in c54721c7 while production kept a stored copy of the old one.
+//
+// "{track:02d}" serves BOTH book layouts, which is what makes it safe as a
+// default. A single-file book has no track, so BuildPath drops the whole " - "
+// segment and the file is "Foundation.m4b". A multi-file book gets
+// "Foundation - 01.m4b", zero-padded so any file manager sorts it correctly.
+const (
+	DefaultFolderNamingPattern = "{author}/{series}/{title} ({print_year})"
+	DefaultFileNamingPattern   = "{title} - {track:02d}"
+)
+
+// trackPlaceholders are the placeholders that vary between the files of one
+// multi-file book. A file pattern containing none of them is constant per book.
+var trackPlaceholders = []string{"{track}", "{track_title}", "{track:"}
+
+// validateNamingPatterns rejects the two shapes of naming pattern that silently
+// destroy data rather than failing.
+func validateNamingPatterns(_ /* folderPattern */, filePattern string) []string {
+	var errs []string
+
+	if strings.TrimSpace(filePattern) == "" {
+		// Unset. viper supplies DefaultFileNamingPattern, which is itself
+		// validated by TestValidate_DefaultsAreValid. Treating "" as an error
+		// would reject every partially-populated Config, and "empty means
+		// unset" is the convention the rest of Validate already follows.
+		return errs
+	}
+
+	// 1. A separator in the FILE pattern manufactures a directory.
+	//
+	// The folder pattern is allowed -- indeed expected -- to contain "/",
+	// because that is how it expresses directory levels. The file pattern
+	// names exactly one component, so a separator there is never structure.
+	// It produced directories like "Pink Bean Series - 1/" holding a single
+	// orphan "9.m4b", one per track.
+	//
+	// BuildRelPath now collapses such a separator rather than obeying it, so
+	// this check is about telling the operator their pattern is wrong at the
+	// moment they set it, instead of quietly renaming their books for them.
+	if strings.ContainsAny(filePattern, `/\`) {
+		errs = append(errs, fmt.Sprintf(
+			"file_naming_pattern %q contains a path separator; it names a single file, not a directory path — put directory levels in folder_naming_pattern instead",
+			filePattern))
+	}
+
+	// 2. A file pattern with no per-track placeholder collides.
+	//
+	// This is the one that actually caused the damage, and it looks
+	// completely reasonable: "{title} - {author} - read by {narrator}" was a
+	// shipped default. It is fine for a single-file book and catastrophic for
+	// a multi-file one, because every track expands to the SAME name. The
+	// first file lands, and every subsequent file finds its target occupied
+	// and is left behind as "<name>.tmp-rename".
+	//
+	// "{track:02d}" is the pattern that serves both layouts: a single-file
+	// book has no track, so the whole " - " segment drops and the file is
+	// "Foundation.m4b"; a multi-file book gets "Foundation - 01.m4b".
+	if !containsTrackPlaceholder(filePattern) {
+		errs = append(errs, fmt.Sprintf(
+			"file_naming_pattern %q contains no {track}, {track:02d} or {track_title} placeholder; every file of a multi-file book would expand to the same name and all but the first would be stranded — use something like \"{title} - {track:02d}\"",
+			filePattern))
+	}
+
+	return errs
+}
+
+// containsTrackPlaceholder reports whether the pattern varies per track.
+// "{track:" matches the format-spec forms ({track:02d}) without enumerating
+// every spec.
+func containsTrackPlaceholder(pattern string) bool {
+	lower := strings.ToLower(pattern)
+	for _, p := range trackPlaceholders {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/naming_patterns_test.go
+++ b/internal/config/naming_patterns_test.go
@@ -1,0 +1,126 @@
+// file: internal/config/naming_patterns_test.go
+// version: 1.0.0
+// guid: 3a97c05e-6b21-4d8f-9e4a-1c60b7d3f582
+// last-edited: 2026-08-16
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateNamingPatterns(t *testing.T) {
+	const okFolder = "{author}/{series}/{title} ({print_year})"
+
+	cases := []struct {
+		name          string
+		folder, file  string
+		wantErr       bool
+		wantSubstring string
+	}{
+		{
+			name:   "the current default",
+			folder: okFolder,
+			file:   "{title} - {track:02d}",
+		},
+		{
+			name:   "track_title also varies per track",
+			folder: okFolder,
+			file:   "{track_title}",
+		},
+		{
+			name:   "bare track placeholder",
+			folder: okFolder,
+			file:   "{title} - {track}",
+		},
+		{
+			// The exact production value on 2026-08-16, and a shipped default
+			// before c54721c7. Reasonable-looking, fine for a single-file book,
+			// and it stranded 35.2 GB of multi-file books.
+			name:          "no per-track placeholder collides",
+			folder:        okFolder,
+			file:          "{title} - {author} - read by {narrator}",
+			wantErr:       true,
+			wantSubstring: "every file of a multi-file book would expand to the same name",
+		},
+		{
+			// The segment_title_format shape, written into the file pattern.
+			name:          "separator in the file pattern",
+			folder:        okFolder,
+			file:          "{title} - {track}/{total_tracks}",
+			wantErr:       true,
+			wantSubstring: "contains a path separator",
+		},
+		{
+			name:          "backslash in the file pattern",
+			folder:        okFolder,
+			file:          `{title}\{track:02d}`,
+			wantErr:       true,
+			wantSubstring: "contains a path separator",
+		},
+		{
+			// Separators are what the folder pattern is FOR.
+			name:   "separators in the folder pattern are structure",
+			folder: "{author}/{series}/{title}",
+			file:   "{title} - {track:02d}",
+		},
+		{
+			// "Empty means unset, viper supplies the default" is the convention
+			// the rest of Validate follows; erroring here would reject every
+			// partially-populated Config.
+			name:   "unset file pattern is not an error",
+			folder: okFolder,
+			file:   "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateNamingPatterns(tc.folder, tc.file)
+
+			if tc.wantErr && len(errs) == 0 {
+				t.Fatalf("validateNamingPatterns(%q, %q) accepted a pattern that strands files", tc.folder, tc.file)
+			}
+			if !tc.wantErr && len(errs) > 0 {
+				t.Fatalf("validateNamingPatterns(%q, %q) rejected a valid pattern: %v", tc.folder, tc.file, errs)
+			}
+			if tc.wantSubstring != "" {
+				joined := strings.Join(errs, " | ")
+				if !strings.Contains(joined, tc.wantSubstring) {
+					t.Errorf("error did not explain the failure.\n  got:  %s\n  want substring: %q", joined, tc.wantSubstring)
+				}
+			}
+		})
+	}
+}
+
+// TestValidate_RejectsTheProductionPatternThatStrandedFiles wires the check
+// through the real Config.Validate rather than calling the helper directly --
+// a validation rule that is not reachable from Validate protects nothing.
+func TestValidate_RejectsTheProductionPatternThatStrandedFiles(t *testing.T) {
+	cfg := &Config{
+		DatabaseType:        "pebble",
+		FolderNamingPattern: DefaultFolderNamingPattern,
+		FileNamingPattern:   "{title} - {author} - read by {narrator}",
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Config.Validate() accepted the file pattern that stranded 2,584 files in production")
+	}
+	// Validate aggregates every problem it finds, and this bare Config has
+	// other ones (unset paths). Assert on the message that matters rather than
+	// on Validate failing at all, which it would do regardless.
+	if !strings.Contains(err.Error(), "multi-file book") {
+		t.Errorf("Validate() failed, but not for the reason under test: %v", err)
+	}
+}
+
+// TestValidate_DefaultsAreValid guards against a rule that rejects the
+// product's own shipped configuration.
+func TestValidate_DefaultsAreValid(t *testing.T) {
+	for _, e := range validateNamingPatterns(DefaultFolderNamingPattern, DefaultFileNamingPattern) {
+		t.Errorf("the shipped defaults fail their own validation: %s", e)
+	}
+}

--- a/internal/organizer/path_format.go
+++ b/internal/organizer/path_format.go
@@ -1,6 +1,7 @@
 // file: internal/organizer/path_format.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a7b3c1d2-e4f5-6789-abcd-ef0123456789
+// last-edited: 2026-08-16
 
 package organizer
 
@@ -8,6 +9,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 var formatVarPattern = regexp.MustCompile(`\{(\w+)(?::([^}]+))?\}`)
@@ -105,9 +108,40 @@ func CollapseEmptySegments(path string) string {
 func SanitizePathComponent(s string) string {
 	// Control characters and non-printable bytes never belong in a filename;
 	// some are legal on POSIX and make the file effectively unaddressable.
+	//
+	// This is a DENY-LIST on purpose. "Strip everything invisible" is the
+	// tempting version and it corrupts data: U+200C/U+200D are invisible but
+	// select between conjunct and separated forms in Devanagari (changing what
+	// the word says), and they bind emoji sequences. Everything removed here is
+	// meaningless in a filename, not merely invisible.
 	s = strings.Map(func(r rune) rune {
-		if r < 32 || r == 127 {
+		switch {
+		case r < 32 || r == 127:
+			// C0 controls and DEL.
 			return -1
+		case r >= 0x80 && r <= 0x9f:
+			// C1 controls. U+0085 NEL in particular is a line break that
+			// strings.Map's predecessor let straight through.
+			return -1
+		case r == 0x200b || r == 0xfeff:
+			// Zero-width space and BOM: invisible AND meaningless, so two
+			// titles differing only by one of these produce two directories
+			// that render identically.
+			return -1
+		case r == 0x200e || r == 0x200f || (r >= 0x202a && r <= 0x202e) || (r >= 0x2066 && r <= 0x2069):
+			// Bidi marks, embeddings, overrides and isolates. U+202E makes a
+			// filename render as text it does not contain.
+			return -1
+		case r == 0x2028 || r == 0x2029:
+			// Line and paragraph separators.
+			return -1
+		case r == utf8.RuneError:
+			// Already-invalid input; do not carry it into a filename.
+			return -1
+		case r == 0x00a0 || r == 0x2007 || r == 0x202f:
+			// Non-breaking spaces. Keep the word gap, but as a real space so
+			// the whitespace collapse below can see it.
+			return ' '
 		}
 		return r
 	}, s)
@@ -135,12 +169,84 @@ func SanitizePathComponent(s string) string {
 	}
 	s = strings.TrimSpace(s)
 
-	// Most filesystems cap a single component at 255 bytes. Leave room for an
-	// extension and the ".tmp" suffix the two-phase rename parks files under.
-	if len(s) > 200 {
-		s = strings.TrimSpace(s[:200])
+	// Most filesystems cap a single component at 255 BYTES, not characters.
+	// Leave room for an extension and the ".tmp-rename" suffix the two-phase
+	// rename parks files under.
+	//
+	// The cut must land on a rune boundary. This used to be a plain s[:200],
+	// which is correct for ASCII and silently catastrophic otherwise: a CJK
+	// rune is 3 bytes, so a Japanese or Korean title longer than ~67 characters
+	// got sliced mid-rune and the result was not valid UTF-8. The filesystem
+	// rejects that outright -- open() returns EILSEQ, "illegal byte sequence"
+	// -- so no such book could be organized at all. It failed at the syscall,
+	// not in any string comparison, which is why only a test that actually
+	// creates the file catches it.
+	s = truncateOnRuneBoundary(s, maxComponentBytes)
+
+	// Windows strips trailing dots and spaces from a name rather than
+	// rejecting it, so "Book Title." is created as "Book Title" and every
+	// later lookup by the original name misses. The library is reachable over
+	// SMB as W:\, so this has to hold even though ext4 and ZFS accept both.
+	// Done AFTER truncation, which can expose a new trailing dot.
+	s = strings.TrimRight(s, ". ")
+
+	// MS-DOS device names are still reserved by Win32 in every directory, with
+	// or without an extension: "NUL.m4b" is as unopenable as "NUL". Suffix
+	// rather than drop, so the book keeps a recognizable name.
+	if isWindowsReservedName(s) {
+		s += "_"
 	}
 	return s
+}
+
+// maxComponentBytes is the budget for one path component. The filesystem limit
+// is 255 bytes; the headroom covers the extension plus TmpRenameSuffix.
+const maxComponentBytes = 200
+
+// truncateOnRuneBoundary cuts s to at most max bytes without splitting a rune,
+// then drops any combining marks left dangling at the cut. A trailing combining
+// mark is legal UTF-8 but renders as a mark floating on nothing, and in Thai
+// and Devanagari it is a fragment of a cluster whose base character is gone.
+func truncateOnRuneBoundary(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+
+	cut := max
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	s = s[:cut]
+
+	for len(s) > 0 {
+		r, size := utf8.DecodeLastRuneInString(s)
+		if !unicode.In(r, unicode.Mn, unicode.Me, unicode.Mc) {
+			break
+		}
+		s = s[:len(s)-size]
+	}
+	return strings.TrimSpace(s)
+}
+
+// windowsReservedNames are the MS-DOS device names Win32 still reserves.
+var windowsReservedNames = map[string]struct{}{
+	"con": {}, "prn": {}, "aux": {}, "nul": {},
+	"com0": {}, "com1": {}, "com2": {}, "com3": {}, "com4": {},
+	"com5": {}, "com6": {}, "com7": {}, "com8": {}, "com9": {},
+	"lpt0": {}, "lpt1": {}, "lpt2": {}, "lpt3": {}, "lpt4": {},
+	"lpt5": {}, "lpt6": {}, "lpt7": {}, "lpt8": {}, "lpt9": {},
+}
+
+// isWindowsReservedName reports whether s collides with a reserved device name.
+// The check is case-insensitive and ignores any extension, because Win32
+// resolves "nul.m4b" and "NUL" to the same device.
+func isWindowsReservedName(s string) bool {
+	base := s
+	if i := strings.Index(base, "."); i >= 0 {
+		base = base[:i]
+	}
+	_, reserved := windowsReservedNames[strings.ToLower(strings.TrimSpace(base))]
+	return reserved
 }
 
 // collapseRedundantDup strips "X - X" → "X" in a single path segment,

--- a/internal/organizer/path_format.go
+++ b/internal/organizer/path_format.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 var formatVarPattern = regexp.MustCompile(`\{(\w+)(?::([^}]+))?\}`)
@@ -105,7 +107,29 @@ func CollapseEmptySegments(path string) string {
 // Square brackets are deliberately NOT stripped. They are legal on every
 // filesystem we target (ext4, APFS, NTFS, ZFS) and are idiomatic in audiobook
 // naming — "[Unabridged]", "[AAC 128kbps]".
+//
+// The stages below run in a fixed order and the order is load-bearing:
+//
+//  1. NFC normalization -- must precede everything, so later stages see one
+//     canonical form rather than two encodings of it
+//  2. invisible sweep -- before the replacer, so a stripped character cannot
+//     leave two spaces the collapse would miss
+//  3. ".." neutralization
+//  4. unsafe-character replacement + whitespace collapse
+//  5. rune-aware truncation -- after all substitutions, which change length
+//  6. trailing dot/space trim -- after truncation, which can expose a new one
+//  7. reserved-name escape -- last, so it sees the final name
 func SanitizePathComponent(s string) string {
+	// Compose to NFC. The same title reaches us in two encodings depending on
+	// where it came from: macOS hands out NFD, Linux and most taggers use NFC.
+	// Untreated they are different byte strings, so one book produces two
+	// directories that render identically and neither lookup finds the other.
+	//
+	// It matters most in Korean, where NFD does not merely detach an accent --
+	// it decomposes a Hangul syllable into its jamo. "해리" is 6 bytes
+	// composed and 12 decomposed, with no visual difference at all.
+	s = norm.NFC.String(s)
+
 	// Control characters and non-printable bytes never belong in a filename;
 	// some are legal on POSIX and make the file effectively unaddressable.
 	//

--- a/internal/organizer/path_format_test.go
+++ b/internal/organizer/path_format_test.go
@@ -1,7 +1,7 @@
 // file: internal/organizer/path_format_test.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: a7b3c1d2-e4f5-6789-abcd-ef0123456f01
-// last-edited: 2026-08-15
+// last-edited: 2026-08-16
 
 package organizer
 
@@ -125,6 +125,98 @@ func TestBuildPath_TarkinReproducesAsOneFile(t *testing.T) {
 	}
 	if strings.Count(got, "/") != 2 {
 		t.Fatalf("BuildRelPath emitted %q — expected exactly 2 path separators (author/, title-folder/), got %d", got, strings.Count(got, "/"))
+	}
+}
+
+// TestBuildRelPath_SeparatorInFilePatternStaysOneComponent pins the OTHER way a
+// stray directory gets created, which scrubVar does not and cannot cover.
+//
+// scrubVar sanitizes variable VALUES before substitution. From 2026-03-03
+// (f29c3ce6) to 2026-08-15 (c54721c7) the separator arrived in the TEMPLATE
+// instead: the shipped default of segment_title_format was
+//
+//	"{title} - {track}/{total_tracks}"
+//
+// so {track_title} expanded to "Pink Bean Series - 1/9" with every value
+// perfectly clean. On disk that is a directory. Measured damage before the
+// default was deleted: 2,535 bogus directories, 2,584 stranded
+// "<n>.<ext>.tmp-rename" files, 35.2 GB, 77 books left with no other copy.
+//
+// The two bugs are indistinguishable in the wreckage they leave and were
+// conflated for months because of it. This test exists so the template half
+// stays covered even though the config key that carried it is gone.
+//
+// The cases below are NOT defended by the same mechanism, which is worth
+// stating because a reader who assumes one guard covers all three will delete
+// the wrong one. Verified by removing the BuildRelPath guard and re-running:
+//
+//	segment_title_format route  -> still PASSES. {track_title} is materialized
+//	                               into the replacement map, so scrubVar
+//	                               catches it as a value. (The metafetch twin
+//	                               had no scrubVar, which is why this route was
+//	                               still stranding files on 2026-08-14.)
+//	separator in file pattern   -> FAILS: "…/Pink Bean Series - 1/9", stem "9".
+//	                               Only the BuildRelPath guard covers this, and
+//	                               file_naming_pattern is user-configurable.
+//	backslash                   -> still PASSES; SanitizePathComponent inside
+//	                               BuildPath already maps "\" to " ".
+func TestBuildRelPath_SeparatorInFilePatternStaysOneComponent(t *testing.T) {
+	// The exact prod vars behind
+	// "Harper Bliss/Pink Bean - Pink Bean Series/Pink Bean Series - 1/9.m4b".
+	vars := PathVars{
+		Author:      "Harper Bliss",
+		Series:      "Pink Bean",
+		Title:       "Pink Bean Series",
+		Track:       1,
+		TotalTracks: 9,
+		Ext:         "m4b",
+	}
+
+	cases := []struct {
+		name        string
+		filePattern string
+		opts        BuildOpts
+	}{
+		{
+			name:        "separator via segment_title_format (the prod default)",
+			filePattern: "{track_title}",
+			opts:        BuildOpts{SegmentTitleFormat: "{title} - {track}/{total_tracks}"},
+		},
+		{
+			name:        "separator written directly into the file pattern",
+			filePattern: "{title} - {track}/{total_tracks}",
+		},
+		{
+			name:        "backslash separator",
+			filePattern: `{title} - {track}\{total_tracks}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := BuildRelPath(testFolderPattern, tc.filePattern, vars, tc.opts)
+			if err != nil {
+				t.Fatalf("BuildRelPath: %v", err)
+			}
+
+			// testFolderPattern contributes one separator, and BuildRelPath
+			// joins folder to stem with one more. Anything beyond that is a
+			// directory nobody asked for.
+			const templateSlashes = 2
+			if n := strings.Count(got, "/"); n != templateSlashes {
+				t.Errorf("BuildRelPath(file=%q) = %q\n  has %d '/' separators; want %d.\n  The file pattern manufactured a directory level.",
+					tc.filePattern, got, n, templateSlashes)
+			}
+
+			// The stem is what the file is actually named. Assert the value,
+			// not just the shape: collapsing the separator to a space is what
+			// makes the forward fix agree with the recovery of the files this
+			// bug already stranded.
+			stem := got[strings.LastIndex(got, "/")+1:]
+			if want := "Pink Bean Series - 1 9"; stem != want {
+				t.Errorf("stem = %q, want %q", stem, want)
+			}
+		})
 	}
 }
 

--- a/internal/organizer/path_unicode_test.go
+++ b/internal/organizer/path_unicode_test.go
@@ -1,0 +1,273 @@
+// file: internal/organizer/path_unicode_test.go
+// version: 1.0.0
+// guid: 5c1e9a73-2d84-4f16-b0a7-9e3c25d8f401
+// last-edited: 2026-08-16
+
+// Path construction against non-ASCII metadata.
+//
+// The library is served to Windows clients over SMB (W:\ maps to the same tree
+// Linux sees as the library root), so a component has to be legal on ext4/ZFS
+// AND on NTFS. Both of those constraints are exercised here.
+//
+// Every case ends by CREATING THE FILE in t.TempDir(). Asserting on the string
+// alone would have missed the truncation bug these tests were written to find:
+// a byte-sliced CJK title is a perfectly ordinary-looking Go string right up
+// until the filesystem rejects it.
+
+package organizer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// asianTitles are real-shaped titles in scripts with multi-byte encodings,
+// combining marks, and no spaces to break on.
+var asianTitles = map[string]string{
+	"japanese":            "宇宙兄弟",
+	"japanese long":       strings.Repeat("宇宙兄弟の物語", 40), // 840 runes, 2520 bytes
+	"chinese simplified":  "三体",
+	"chinese traditional": "三體",
+	"korean":              "해리 포터와 마법사의 돌",
+	"korean long":         strings.Repeat("해리포터와마법사의돌", 30),
+	"thai":                "แฮร์รี่ พอตเตอร์",
+	"devanagari":          "हैरी पॉटर और पारस पत्थर",
+	"arabic rtl":          "هاري بوتر وحجر الفيلسوف",
+	"hebrew rtl":          "הארי פוטר ואבן החכמים",
+	"emoji":               "Project 🚀 Hail Mary 📚",
+	"mixed scripts":       "宇宙兄弟 - Space Brothers - 우주형제",
+	"fullwidth solidus":   "第1話／第2話",              // U+FF0F, looks like "/" but is not one
+	"combining marks":     "Ame\u0301lie Nothomb", // e + combining acute
+	"precomposed":         "Amélie Nothomb",       // same, NFC
+}
+
+// TestSanitizePathComponent_AsianAndUnicode asserts the invariants that make a
+// component safe to hand to the filesystem, then proves it by creating it.
+func TestSanitizePathComponent_AsianAndUnicode(t *testing.T) {
+	dir := t.TempDir()
+
+	for name, title := range asianTitles {
+		t.Run(name, func(t *testing.T) {
+			got := SanitizePathComponent(title)
+
+			if got == "" {
+				t.Fatalf("SanitizePathComponent(%q) = \"\"; a non-empty title must survive sanitization", title)
+			}
+
+			// The bug this test was written for. A byte-slice truncation cuts a
+			// multi-byte rune in half and leaves a string that is still a valid
+			// Go value but is not valid UTF-8 and is not a legal filename.
+			if !utf8.ValidString(got) {
+				t.Errorf("SanitizePathComponent(%q) produced invalid UTF-8: %q (% x)", title, got, got)
+			}
+
+			if strings.ContainsAny(got, `/\`) {
+				t.Errorf("SanitizePathComponent(%q) = %q; contains a path separator", title, got)
+			}
+
+			// 255 bytes is the per-component ceiling on ext4/ZFS/APFS/NTFS. The
+			// implementation aims lower to leave room for ".tmp-rename".
+			if len(got) > 255 {
+				t.Errorf("SanitizePathComponent(%q) = %d bytes; exceeds the 255-byte component limit", title, len(got))
+			}
+
+			// The real artifact. If any of the above is subtly wrong, this is
+			// where it surfaces as a syscall error rather than a string diff.
+			path := filepath.Join(dir, got+".m4b")
+			if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+				t.Fatalf("could not create %q on a real filesystem: %v", got, err)
+			}
+			if _, err := os.Stat(path); err != nil {
+				t.Errorf("created %q but cannot stat it back: %v", got, err)
+			}
+		})
+	}
+}
+
+// TestBuildRelPath_AsianTitlesStayOneComponent runs the same inputs through the
+// full builder, which is what production actually calls. A component-level
+// guarantee that the builder can undo is not a guarantee.
+func TestBuildRelPath_AsianTitlesStayOneComponent(t *testing.T) {
+	dir := t.TempDir()
+
+	for name, title := range asianTitles {
+		t.Run(name, func(t *testing.T) {
+			vars := PathVars{
+				Author:      "村上春樹",
+				Title:       title,
+				Track:       3,
+				TotalTracks: 12,
+				Ext:         "m4b",
+			}
+			got, err := BuildRelPath(testFolderPattern, "{title} - {track:02d}", vars, BuildOpts{})
+			if err != nil {
+				t.Fatalf("BuildRelPath: %v", err)
+			}
+
+			if !utf8.ValidString(got) {
+				t.Errorf("BuildRelPath produced invalid UTF-8: %q", got)
+			}
+
+			// testFolderPattern is "{author}/{series_prefix}{title}" and
+			// BuildRelPath joins folder to stem: two separators, no more.
+			if n := strings.Count(got, "/"); n != 2 {
+				t.Errorf("BuildRelPath(title=%q) = %q; has %d separators, want 2", title, got, n)
+			}
+
+			for _, comp := range strings.Split(got, "/") {
+				if comp == "" {
+					t.Errorf("BuildRelPath(title=%q) = %q; has an empty component", title, got)
+				}
+				if len(comp) > 255 {
+					t.Errorf("component %q is %d bytes; exceeds 255", comp, len(comp))
+				}
+			}
+
+			// Materialize the whole relative path, directories and all.
+			full := filepath.Join(dir, got+".m4b")
+			if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+				t.Fatalf("MkdirAll(%q): %v", filepath.Dir(full), err)
+			}
+			if err := os.WriteFile(full, []byte("x"), 0o644); err != nil {
+				t.Fatalf("could not create %q on a real filesystem: %v", got, err)
+			}
+		})
+	}
+}
+
+// TestSanitizePathComponent_TruncationIsRuneAware isolates the truncation path
+// with a title that is pure multi-byte and long enough to force a cut.
+func TestSanitizePathComponent_TruncationIsRuneAware(t *testing.T) {
+	// 3 bytes per rune. 100 runes = 300 bytes, so the cap must cut it, and the
+	// cut lands mid-rune unless the implementation counts runes.
+	title := strings.Repeat("宇", 100)
+
+	got := SanitizePathComponent(title)
+
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncation split a multi-byte rune: %q is not valid UTF-8 (% x)", got, got)
+	}
+	if len(got) > 255 {
+		t.Errorf("truncated to %d bytes; exceeds the 255-byte component limit", len(got))
+	}
+	// Every rune that survived must be the original one -- a mid-rune cut
+	// followed by a lossy conversion would show up as U+FFFD.
+	for _, r := range got {
+		if r != '宇' {
+			t.Errorf("truncation corrupted a rune: found %q (U+%04X) in %q", r, r, got)
+			break
+		}
+	}
+}
+
+// TestSanitizePathComponent_InvisibleAndControlCharacters covers the characters
+// that are not ASCII control codes but are just as unsafe in a filename:
+// C1 controls, zero-width joiners, direction overrides, and the BOM. A
+// direction override in particular can make a filename render as something
+// entirely different from what it is.
+func TestSanitizePathComponent_InvisibleAndControlCharacters(t *testing.T) {
+	cases := map[string]string{
+		"C1 control NEL":         "Book\u0085Title",
+		"zero-width space":       "Book\u200bTitle",
+		"left-to-right mark":     "Book\u200eTitle",
+		"right-to-left override": "Book\u202eTitle",
+		"first strong isolate":   "Book\u2068Title",
+		"byte order mark":        "Book\ufeffTitle",
+		"line separator":         "Book\u2028Title",
+		"paragraph separator":    "Book\u2029Title",
+	}
+
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := SanitizePathComponent(in)
+
+			if !utf8.ValidString(got) {
+				t.Fatalf("SanitizePathComponent(%q) produced invalid UTF-8: %q", in, got)
+			}
+			for _, r := range got {
+				switch {
+				case r < 32 || r == 127:
+					t.Errorf("ASCII control U+%04X survived in %q", r, got)
+				case r >= 0x80 && r <= 0x9f:
+					t.Errorf("C1 control U+%04X survived in %q", r, got)
+				case r == 0x200b || r == 0xfeff:
+					t.Errorf("zero-width character U+%04X survived in %q", r, got)
+				case r == 0x200e || r == 0x200f || (r >= 0x202a && r <= 0x202e) || (r >= 0x2066 && r <= 0x2069):
+					t.Errorf("bidi control U+%04X survived in %q", r, got)
+				case r == 0x2028 || r == 0x2029:
+					t.Errorf("line/paragraph separator U+%04X survived in %q", r, got)
+				}
+			}
+		})
+	}
+}
+
+// TestSanitizePathComponent_PreservesMeaningfulJoiners is the counterweight to
+// the test above, and the reason the invisible-character sweep is a deny-list
+// rather than "strip everything with no visible glyph".
+//
+// U+200C ZERO WIDTH NON-JOINER and U+200D ZERO WIDTH JOINER are invisible, but
+// they are not decoration. In Devanagari they select between a conjunct
+// ligature and its separated form, which changes what the word says; the same
+// applies in Persian, Thai, and Malayalam. They also bind emoji sequences, so
+// stripping them turns one family emoji into three separate people.
+//
+// Stripping invisibles wholesale is a tempting one-liner that silently corrupts
+// Hindi titles. Anything added to the deny-list needs to be meaningless, not
+// merely invisible.
+func TestSanitizePathComponent_PreservesMeaningfulJoiners(t *testing.T) {
+	cases := map[string]string{
+		"devanagari ZWNJ":  "\u0915\u200c\u0937",
+		"devanagari ZWJ":   "\u0915\u200d\u0937",
+		"emoji family ZWJ": "Family \U0001F468\u200d\U0001F469\u200d\U0001F466 Saga",
+	}
+
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := SanitizePathComponent(in)
+			for _, r := range []rune{0x200c, 0x200d} {
+				if strings.ContainsRune(in, r) && !strings.ContainsRune(got, r) {
+					t.Errorf("SanitizePathComponent(%q) = %q; stripped U+%04X, which carries meaning in Indic scripts and binds emoji sequences", in, got, r)
+				}
+			}
+		})
+	}
+}
+
+// TestSanitizePathComponent_WindowsHostileNames covers what NTFS rejects but
+// ext4 and ZFS accept. The library is reachable as W:\ over SMB, so a name that
+// is legal only on Linux is a name the Windows client cannot open.
+func TestSanitizePathComponent_WindowsHostileNames(t *testing.T) {
+	reserved := []string{"CON", "PRN", "AUX", "NUL", "COM1", "COM9", "LPT1", "LPT9",
+		"con", "Con", "nul"}
+
+	for _, in := range reserved {
+		t.Run("reserved "+in, func(t *testing.T) {
+			got := SanitizePathComponent(in)
+			if strings.EqualFold(got, in) {
+				t.Errorf("SanitizePathComponent(%q) = %q; a Windows reserved device name passed through and cannot be created on NTFS", in, got)
+			}
+			if got == "" {
+				t.Errorf("SanitizePathComponent(%q) = \"\"; the name should be escaped, not deleted", in)
+			}
+		})
+	}
+
+	trailing := map[string]string{
+		"trailing dot":         "Book Title.",
+		"trailing dots":        "Book Title...",
+		"trailing space":       "Book Title ",
+		"trailing dot + space": "Book Title. ",
+	}
+	for name, in := range trailing {
+		t.Run(name, func(t *testing.T) {
+			got := SanitizePathComponent(in)
+			if strings.HasSuffix(got, ".") || strings.HasSuffix(got, " ") {
+				t.Errorf("SanitizePathComponent(%q) = %q; NTFS silently strips trailing dots and spaces, so this name round-trips to something else over SMB", in, got)
+			}
+		})
+	}
+}

--- a/internal/organizer/path_unicode_test.go
+++ b/internal/organizer/path_unicode_test.go
@@ -205,6 +205,65 @@ func TestSanitizePathComponent_InvisibleAndControlCharacters(t *testing.T) {
 	}
 }
 
+// TestSanitizePathComponent_NormalizesToNFC pins the fix for the quietest bug
+// in this file: the same title, byte-different.
+//
+// macOS hands out NFD, Linux and most taggers use NFC. Untreated, one book
+// produces two directories that are visually identical and neither lookup finds
+// the other -- and because they render the same, it reads as a duplicate-import
+// bug rather than an encoding bug.
+//
+// Korean is the sharp case: NFD does not merely detach an accent, it
+// decomposes a Hangul syllable into jamo. "해리" is 6 bytes composed and 12
+// decomposed, with no visual difference whatsoever.
+func TestSanitizePathComponent_NormalizesToNFC(t *testing.T) {
+	cases := []struct {
+		name     string
+		nfd, nfc string
+	}{
+		{"korean hangul jamo", "해리", "해리"},
+		{"latin combining acute", "Amélie Nothomb", "Amélie Nothomb"},
+		{"japanese dakuten", "が", "が"},
+		{"vietnamese stacked", "Nguyễn", "Nguyễn"},
+	}
+
+	dir := t.TempDir()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotNFD := SanitizePathComponent(tc.nfd)
+			gotNFC := SanitizePathComponent(tc.nfc)
+
+			if gotNFD != gotNFC {
+				t.Errorf("the same title in two encodings sanitized differently:\n  NFD -> %q (% x)\n  NFC -> %q (% x)\nThese are two directories that render identically.",
+					gotNFD, gotNFD, gotNFC, gotNFC)
+			}
+
+			// Both spellings must land on ONE file, not two. os.WriteFile is
+			// idempotent, so a second distinct name shows up as a second entry.
+			for _, form := range []string{tc.nfd, tc.nfc} {
+				p := filepath.Join(dir, tc.name, SanitizePathComponent(form)+".m4b")
+				if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+					t.Fatalf("MkdirAll: %v", err)
+				}
+				if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+					t.Fatalf("WriteFile(%q): %v", p, err)
+				}
+			}
+			entries, err := os.ReadDir(filepath.Join(dir, tc.name))
+			if err != nil {
+				t.Fatalf("ReadDir: %v", err)
+			}
+			if len(entries) != 1 {
+				names := make([]string, 0, len(entries))
+				for _, e := range entries {
+					names = append(names, e.Name())
+				}
+				t.Errorf("the two encodings created %d files, want 1: %q", len(entries), names)
+			}
+		})
+	}
+}
+
 // TestSanitizePathComponent_PreservesMeaningfulJoiners is the counterweight to
 // the test above, and the reason the invisible-character sweep is a deny-list
 // rather than "strip everything with no visible glyph".

--- a/internal/organizer/path_unicode_test.go
+++ b/internal/organizer/path_unicode_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 // asianTitles are real-shaped titles in scripts with multi-byte encodings,
@@ -217,31 +219,50 @@ func TestSanitizePathComponent_InvisibleAndControlCharacters(t *testing.T) {
 // decomposes a Hangul syllable into jamo. "해리" is 6 bytes composed and 12
 // decomposed, with no visual difference whatsoever.
 func TestSanitizePathComponent_NormalizesToNFC(t *testing.T) {
-	cases := []struct {
-		name     string
-		nfd, nfc string
-	}{
-		{"korean hangul jamo", "해리", "해리"},
-		{"latin combining acute", "Amélie Nothomb", "Amélie Nothomb"},
-		{"japanese dakuten", "が", "が"},
-		{"vietnamese stacked", "Nguyễn", "Nguyễn"},
+	// Derive both forms from ONE literal rather than writing an NFD literal and
+	// an NFC literal side by side. Editors, gofmt and some filesystems silently
+	// normalize source files, so a hand-written "decomposed" literal can arrive
+	// already composed -- and then the test compares a string to itself and
+	// passes no matter what the code does.
+	//
+	// This is not hypothetical: the first version of this test hard-coded both
+	// forms, and the Korean and Japanese cases stayed GREEN with normalization
+	// removed, because the two literals in the file were byte-identical. Only
+	// the Latin cases caught the mutation. Constructing the forms at runtime is
+	// what makes the test measure the thing it claims to measure.
+	titles := map[string]string{
+		"korean hangul jamo":    "\ud574\ub9ac \ud3ec\ud130",
+		"latin combining acute": "Am\u00e9lie Nothomb",
+		"japanese dakuten":      "\u304c\u304e\u3050\u3052\u3054",
+		"vietnamese stacked":    "Nguy\u1ec5n Nh\u1eadt \u00c1nh",
+		"thai":                  "\u0e41\u0e2e\u0e23\u0e4c\u0e23\u0e35\u0e48",
 	}
 
 	dir := t.TempDir()
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			gotNFD := SanitizePathComponent(tc.nfd)
-			gotNFC := SanitizePathComponent(tc.nfc)
+	for name, title := range titles {
+		t.Run(name, func(t *testing.T) {
+			nfd := norm.NFD.String(title)
+			nfc := norm.NFC.String(title)
+			if nfd == nfc {
+				t.Skipf("%q has no distinct NFD form, so there is nothing to normalize", title)
+			}
+
+			gotNFD := SanitizePathComponent(nfd)
+			gotNFC := SanitizePathComponent(nfc)
 
 			if gotNFD != gotNFC {
 				t.Errorf("the same title in two encodings sanitized differently:\n  NFD -> %q (% x)\n  NFC -> %q (% x)\nThese are two directories that render identically.",
 					gotNFD, gotNFD, gotNFC, gotNFC)
 			}
 
-			// Both spellings must land on ONE file, not two. os.WriteFile is
-			// idempotent, so a second distinct name shows up as a second entry.
-			for _, form := range []string{tc.nfd, tc.nfc} {
-				p := filepath.Join(dir, tc.name, SanitizePathComponent(form)+".m4b")
+			// Both spellings must land on ONE file, not two.
+			//
+			// Note this half of the assertion is weaker than it looks on macOS:
+			// APFS compares names normalized, so it would collapse the two even
+			// without the fix. The string comparison above is the part that is
+			// filesystem-independent, and it is the one that caught the bug.
+			for _, form := range []string{nfd, nfc} {
+				p := filepath.Join(dir, name, SanitizePathComponent(form)+".m4b")
 				if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
 					t.Fatalf("MkdirAll: %v", err)
 				}
@@ -249,7 +270,7 @@ func TestSanitizePathComponent_NormalizesToNFC(t *testing.T) {
 					t.Fatalf("WriteFile(%q): %v", p, err)
 				}
 			}
-			entries, err := os.ReadDir(filepath.Join(dir, tc.name))
+			entries, err := os.ReadDir(filepath.Join(dir, name))
 			if err != nil {
 				t.Fatalf("ReadDir: %v", err)
 			}

--- a/internal/organizer/pathbuild.go
+++ b/internal/organizer/pathbuild.go
@@ -1,7 +1,7 @@
 // file: internal/organizer/pathbuild.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2f7c4a19-6e58-4b03-9d21-8a05e3f16c74
-// last-edited: 2026-08-15
+// last-edited: 2026-08-16
 
 // The single place a book's target path is computed.
 //
@@ -130,6 +130,39 @@ func BuildRelPath(folderPattern, filePattern string, v PathVars, opts BuildOpts)
 	if err != nil {
 		return "", fmt.Errorf("file pattern: %w", err)
 	}
+
+	// The file pattern names ONE component. A "/" in it is not structure the
+	// way it is in the folder pattern -- it is a directory the caller did not
+	// ask for, and the two-phase rename then parks its payload inside as
+	// "<n>.<ext>.tmp-rename" and fails.
+	//
+	// This is not a hypothetical, though the historical route into it is now
+	// closed by a different guard. From 2026-03-03 (f29c3ce6) to 2026-08-15
+	// (c54721c7) the SHIPPED DEFAULT of segment_title_format was
+	// "{title} - {track}/{total_tracks}", and every multi-file book organized
+	// in that window exploded one directory per track: 2,535 bogus
+	// directories, 2,584 stranded files, 35.2 GB, 77 books with no other copy.
+	//
+	// Be precise about which guard covers which route, because the two are
+	// easy to conflate and the wreckage on disk is identical:
+	//
+	//   - {track_title} is materialized into the replacement map and therefore
+	//     scrubbed as a VALUE by scrubVar. A separator arriving via
+	//     segment_title_format is caught there, not here. It was NOT caught in
+	//     the internal/metafetch twin, which had no scrubVar at all -- which is
+	//     why that route was still stranding files on 2026-08-14.
+	//   - A separator written directly into file_naming_pattern is in the
+	//     TEMPLATE, never passes through scrubVar, and reaches BuildPath, which
+	//     splits on "/" and sanitizes each half. Nothing constrained the result
+	//     to one component. That is the hole this line closes, and
+	//     file_naming_pattern is user-configurable, so it is reachable today.
+	//
+	// Collapsing rather than erroring is deliberate: SanitizePathComponent maps
+	// "/" to " ", which yields exactly the name the file should have had
+	// ("Pink Bean Series - 1/9" -> "Pink Bean Series - 1 9"), so a bad pattern
+	// degrades to a correct flat filename instead of taking organizing down
+	// library-wide.
+	stem = SanitizePathComponent(stem)
 
 	// A pattern can legitimately expand to nothing -- e.g. "{narrator}" for a
 	// book with no narrator. An empty stem would make the target a bare dotfile

--- a/internal/organizer/saferename.go
+++ b/internal/organizer/saferename.go
@@ -1,7 +1,7 @@
 // file: internal/organizer/saferename.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2df18e44-98f0-407e-ab5f-daf158f22554
-// last-edited: 2026-07-17
+// last-edited: 2026-08-16
 
 package organizer
 
@@ -28,6 +28,11 @@ import (
 // guard converts a silent overwrite into an explicit error in all but a
 // sub-millisecond race, matching MoveBookFile's existing posture.
 func safeRename(src, dst string) error {
+	srcInfo, err := os.Lstat(src)
+	if err != nil {
+		return fmt.Errorf("stat rename source %s: %w", src, err)
+	}
+
 	if _, err := os.Lstat(dst); err == nil {
 		slog.Warn("safeRename refusing to overwrite existing destination",
 			"src", src, "dst", dst)
@@ -35,5 +40,68 @@ func safeRename(src, dst string) error {
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("stat rename destination %s: %w", dst, err)
 	}
-	return os.Rename(src, dst)
+
+	if err := os.Rename(src, dst); err != nil {
+		return err
+	}
+
+	return verifyRenamed(src, dst, srcInfo)
+}
+
+// verifyRenamed re-reads the filesystem after a rename that reported success.
+//
+// A rename returning nil is not evidence the file arrived: it says the syscall
+// was accepted, which is a claim about the call, not about the tree. The
+// separator bug is the case in point -- every one of those moves "succeeded",
+// and the audio ended up in a directory nobody asked for, where it was
+// invisible to the scanner and to every later lookup. 38,895 files across
+// 1,145 books were misplaced by operations that all reported success.
+//
+// So the move is not complete until the destination has been read back:
+//
+//   - dst exists, and is the SAME KIND of thing the source was. Note that
+//     safeRename moves directories as well as files -- ReOrganizeInPlace
+//     renames whole book folders -- so this compares against the source
+//     rather than demanding a regular file. An earlier version of this check
+//     hard-coded "must be a regular file" and broke every directory move,
+//     which the existing suite caught immediately.
+//   - a regular file has the source's size. Catches a truncated or partially
+//     written destination, which a bare rename cannot produce but a copy
+//     fallback can. Directory sizes are filesystem bookkeeping, so they are
+//     not compared.
+//   - src is gone. If both paths exist the move silently became a copy, and
+//     the next scan sees the book twice.
+//
+// This is cheap -- two Lstat calls against metadata the kernel just touched --
+// and it converts a class of silent misplacement into a loud failure.
+func verifyRenamed(src, dst string, srcInfo os.FileInfo) error {
+	info, err := os.Lstat(dst)
+	if err != nil {
+		return fmt.Errorf("rename reported success but destination is unreadable %s: %w", dst, err)
+	}
+	if info.IsDir() != srcInfo.IsDir() {
+		kind := func(fi os.FileInfo) string {
+			if fi.IsDir() {
+				return "a directory"
+			}
+			return "a file"
+		}
+		return fmt.Errorf("rename reported success but source was %s and destination %s is %s",
+			kind(srcInfo), dst, kind(info))
+	}
+	if srcInfo.Mode().IsRegular() {
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("rename reported success but destination %s is not a regular file (mode %s)", dst, info.Mode())
+		}
+		if info.Size() != srcInfo.Size() {
+			return fmt.Errorf("rename reported success but destination %s is %d bytes, expected %d",
+				dst, info.Size(), srcInfo.Size())
+		}
+	}
+	if _, err := os.Lstat(src); err == nil {
+		return fmt.Errorf("rename reported success but source %s still exists; the move became a copy", src)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("rename reported success but source %s is in an unknown state: %w", src, err)
+	}
+	return nil
 }

--- a/internal/organizer/saferename_verify_test.go
+++ b/internal/organizer/saferename_verify_test.go
@@ -1,0 +1,175 @@
+// file: internal/organizer/saferename_verify_test.go
+// version: 1.0.0
+// guid: 9f26b4d1-70a3-4e58-8c19-2b7e05a4c396
+// last-edited: 2026-08-16
+
+// Post-move validation.
+//
+// A rename returning nil says the syscall was accepted. It does not say the
+// file arrived where anyone wanted it. The separator bug produced 38,895
+// misplaced files across 1,145 books through operations that ALL reported
+// success, so "no error" is exactly the signal that failed here.
+
+package organizer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, path string, size int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, make([]byte, size), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func TestSafeRename_VerifiesTheMoveHappened(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "book", "Foundation - 01.mp3")
+	dst := filepath.Join(dir, "book", "Foundation - 02.mp3")
+	writeFile(t, src, 4096)
+
+	if err := safeRename(src, dst); err != nil {
+		t.Fatalf("safeRename: %v", err)
+	}
+
+	info, err := os.Lstat(dst)
+	if err != nil {
+		t.Fatalf("destination missing after a successful rename: %v", err)
+	}
+	if info.Size() != 4096 {
+		t.Errorf("destination is %d bytes, want 4096", info.Size())
+	}
+	if _, err := os.Lstat(src); !os.IsNotExist(err) {
+		t.Errorf("source still exists after the move")
+	}
+}
+
+func TestSafeRename_MissingSource(t *testing.T) {
+	dir := t.TempDir()
+	err := safeRename(filepath.Join(dir, "nope.mp3"), filepath.Join(dir, "dst.mp3"))
+	if err == nil {
+		t.Fatal("safeRename accepted a source that does not exist")
+	}
+	if !strings.Contains(err.Error(), "stat rename source") {
+		t.Errorf("error does not name the problem: %v", err)
+	}
+}
+
+func TestSafeRename_RefusesExistingDestination(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.mp3")
+	dst := filepath.Join(dir, "b.mp3")
+	writeFile(t, src, 10)
+	writeFile(t, dst, 20)
+
+	if err := safeRename(src, dst); err == nil {
+		t.Fatal("safeRename overwrote an existing destination")
+	}
+	// The destination must be untouched -- this guard exists to stop one
+	// book's bytes replacing another's.
+	if info, err := os.Lstat(dst); err != nil || info.Size() != 20 {
+		t.Errorf("destination was modified by a refused rename")
+	}
+}
+
+// TestVerifyRenamed_CatchesEachFailureShape exercises the validator directly,
+// because the states it guards against cannot be produced through os.Rename --
+// they come from a copy fallback, a filesystem quirk, or a path that turned
+// out to name a directory.
+func TestVerifyRenamed_CatchesEachFailureShape(t *testing.T) {
+	// fakeInfo describes what the source WAS, which is what verifyRenamed
+	// compares the destination against.
+	regular := func(t *testing.T, size int) os.FileInfo {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "ref")
+		writeFile(t, p, size)
+		fi, err := os.Lstat(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return fi
+	}
+	directory := func(t *testing.T) os.FileInfo {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "refdir")
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		fi, err := os.Lstat(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return fi
+	}
+
+	t.Run("destination missing", func(t *testing.T) {
+		dir := t.TempDir()
+		err := verifyRenamed(filepath.Join(dir, "src"), filepath.Join(dir, "gone"), regular(t, 10))
+		if err == nil || !strings.Contains(err.Error(), "unreadable") {
+			t.Errorf("want an unreadable-destination error, got %v", err)
+		}
+	})
+
+	t.Run("destination is a directory", func(t *testing.T) {
+		dir := t.TempDir()
+		dst := filepath.Join(dir, "Foundation - 01")
+		if err := os.MkdirAll(dst, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		err := verifyRenamed(filepath.Join(dir, "src"), dst, regular(t, 10))
+		if err == nil || !strings.Contains(err.Error(), "destination") {
+			t.Errorf("want a kind-mismatch error, got %v", err)
+		}
+	})
+
+	t.Run("directory move is allowed", func(t *testing.T) {
+		// ReOrganizeInPlace renames whole book folders through safeRename, so
+		// a directory destination is correct when the source was a directory.
+		dir := t.TempDir()
+		dst := filepath.Join(dir, "Author", "Title")
+		if err := os.MkdirAll(dst, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := verifyRenamed(filepath.Join(dir, "src"), dst, directory(t)); err != nil {
+			t.Errorf("a legitimate directory move was rejected: %v", err)
+		}
+	})
+
+	t.Run("size changed", func(t *testing.T) {
+		dir := t.TempDir()
+		dst := filepath.Join(dir, "dst.mp3")
+		writeFile(t, dst, 5)
+		err := verifyRenamed(filepath.Join(dir, "src"), dst, regular(t, 4096))
+		if err == nil || !strings.Contains(err.Error(), "expected 4096") {
+			t.Errorf("want a size mismatch error, got %v", err)
+		}
+	})
+
+	t.Run("source survived: the move became a copy", func(t *testing.T) {
+		dir := t.TempDir()
+		src := filepath.Join(dir, "src.mp3")
+		dst := filepath.Join(dir, "dst.mp3")
+		writeFile(t, src, 10)
+		writeFile(t, dst, 10)
+		err := verifyRenamed(src, dst, regular(t, 10))
+		if err == nil || !strings.Contains(err.Error(), "became a copy") {
+			t.Errorf("want a leftover-source error, got %v", err)
+		}
+	})
+
+	t.Run("clean move passes", func(t *testing.T) {
+		dir := t.TempDir()
+		dst := filepath.Join(dir, "dst.mp3")
+		writeFile(t, dst, 10)
+		if err := verifyRenamed(filepath.Join(dir, "src.mp3"), dst, regular(t, 10)); err != nil {
+			t.Errorf("a correct move was rejected: %v", err)
+		}
+	})
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_test.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: b2c3d4e5-f6a7-8901-bcde-234567890abc
-// last-edited: 2026-08-15
+// last-edited: 2026-08-16
 
 // NOTE(fable5 T022): setupTestServer ported from NewSQLiteStore to NewPebbleStore.
 
@@ -1542,8 +1542,13 @@ func TestUpdateConfig(t *testing.T) {
 		"auto_organize":         true,
 		"scan_on_startup":       false,
 		"folder_naming_pattern": "{author}/{title}",
-		"file_naming_pattern":   "{title}",
-		"log_level":             "debug",
+		// Was "{title}". Validate now rejects a file pattern with no per-track
+		// placeholder, because every file of a multi-file book expands to the
+		// same name -- the config that stranded 38,895 files in production.
+		// This test is about the config endpoint, not about naming, so it uses
+		// a pattern that is actually valid.
+		"file_naming_pattern": "{title} - {track:02d}",
+		"log_level":           "debug",
 	}
 	body, _ := json.Marshal(payload)
 

--- a/scripts/repair_stranded_tracks.py
+++ b/scripts/repair_stranded_tracks.py
@@ -119,64 +119,64 @@ def audio_md5(path: str) -> str | None:
 def find_bogus_dirs(root: str) -> list[str]:
     """Find the directories the bug created, WITHOUT matching legitimate ones.
 
-    The obvious rule -- "named '<x> - <n>' and holding only '<n>.<ext>' files"
-    -- is far too broad. A perfectly ordinary multi-disc folder ("The Stand -
-    1" holding "01.mp3", "02.mp3", ...) matches it exactly. Measured against
-    this library that rule claimed 42,668 directories where 2,535 exist: a
-    16x false-positive rate, aimed at an irreplaceable dataset.
+    The naive rule -- named "<x> - <n>", holding only "<n>.<ext>" -- is far too
+    broad: an ordinary multi-disc folder ("The Stand - 1" holding "01.mp3",
+    "02.mp3", ...) matches it exactly. Measured here it claimed 42,668
+    directories where ~2,500 exist, aimed at an irreplaceable dataset.
 
-    So the detector is seeded from evidence rather than from shape:
+    Seeding from ".tmp-rename" is too NARROW, and that error is the more
+    dangerous of the two because it looks like it worked. That suffix marks a
+    rename that FAILED. Where the bug's rename succeeded, the file sits in the
+    wrong directory under a perfectly ordinary name with nothing to betray it.
+    "Rath's Deception" has 31 such directories and not one .tmp-rename.
+    Recovering only the failures would have left most of the damage in place
+    while reporting success.
 
-      1. SEED. A directory of the right shape containing a ".tmp-rename" file
-         is certainly wreckage -- that suffix only exists because the rename
-         that would have removed it failed.
-      2. EXPAND, within affected books only. The bug also produced renames
-         that SUCCEEDED into the wrong directory, leaving a plain "<n>.<ext>"
-         with no ".tmp-rename" to betray it. Those are only recognizable by
-         company: same book, same title stem, same total-track value as a
-         seeded sibling.
+    So the rule is structural, and rests on one invariant the bug guarantees:
 
-    A book with no seed is never touched, so an ordinary disc folder is out of
-    scope no matter what it is called.
+        THE FILENAME IS THE TOTAL TRACK COUNT.
+
+    "<title> - <track>/<total>.<ext>" means the directory's number is a track
+    and the file's number is the total, so track <= total ALWAYS. In a real
+    multi-disc layout the filename is a track within that disc and bears no
+    relation to the number of discs, so "Disc - 1/01.mp3, Disc - 2/01.mp3" has
+    max(dir)=2 > max(file)=1 and is rejected.
+
+    Combined with "every such directory holds one or two files" (a real disc
+    folder holds the whole disc) and "at least two sibling directories share
+    the title stem", this selects the wreckage and nothing else.
     """
-    seeds: list[str] = []
-    candidates: dict[str, list[str]] = collections.defaultdict(list)
+    groups: dict[tuple[str, str], list[tuple[str, int, list[int]]]] = collections.defaultdict(list)
 
     for dirpath, dirnames, filenames in os.walk(root):
-        base = os.path.basename(dirpath)
-        dm = DIR_RE.match(base)
+        dm = DIR_RE.match(os.path.basename(dirpath))
         if not dm or dirnames or not filenames:
             continue
         matches = [FILE_RE.match(f) for f in filenames]
         if not all(matches):
             continue
-
-        book = os.path.dirname(dirpath)
-        candidates[book].append(dirpath)
-        if any(f.endswith(TMP_SUFFIX) for f in filenames):
-            seeds.append(dirpath)
-
-    seeded_books: dict[str, set[tuple[str, int]]] = collections.defaultdict(set)
-    for d in seeds:
-        dm = DIR_RE.match(os.path.basename(d))
-        if not dm:
+        # A real disc directory holds the disc. Wreckage holds one file per
+        # (track, edition) -- observed as 1, or 2 where two editions collided.
+        if len(filenames) > 2:
             continue
-        for f in os.listdir(d):
-            fm = FILE_RE.match(f)
-            if fm:
-                seeded_books[os.path.dirname(d)].add((dm.group("title"), int(fm.group("total"))))
+        totals = [int(m.group("total")) for m in matches if m]
+        book = os.path.dirname(dirpath)
+        groups[(book, dm.group("title"))].append((dirpath, int(dm.group("track")), totals))
 
-    found = set(seeds)
-    for book, signatures in seeded_books.items():
-        for d in candidates.get(book, []):
-            dm = DIR_RE.match(os.path.basename(d))
-            if not dm:
-                continue
-            for f in os.listdir(d):
-                fm = FILE_RE.match(f)
-                if fm and (dm.group("title"), int(fm.group("total"))) in signatures:
-                    found.add(d)
-                    break
+    found: list[str] = []
+    for (_book, _title), members in groups.items():
+        if len(members) < 2:
+            continue
+        all_totals = {t for _, _, ts in members for t in ts}
+        max_track = max(tr for _, tr, _ in members)
+        # The invariant. One violation disqualifies the whole group -- a real
+        # layout that happens to satisfy it for some members is not wreckage.
+        if max_track > max(all_totals):
+            continue
+        # Sanity: a book does not have more distinct "totals" than editions.
+        if len(all_totals) > 3:
+            continue
+        found.extend(d for d, _, _ in members)
 
     return sorted(found)
 

--- a/scripts/repair_stranded_tracks.py
+++ b/scripts/repair_stranded_tracks.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+# file: scripts/repair_stranded_tracks.py
+# version: 1.0.0
+# guid: 4d7a1e93-58c6-4b02-a71f-6c3e90b8d245
+# last-edited: 2026-08-16
+
+"""Recover audio stranded inside directories the path-construction bug created.
+
+From 2026-03-03 (f29c3ce6) to 2026-08-15 (c54721c7) the shipped default of
+segment_title_format was "{title} - {track}/{total_tracks}". The slash was a
+real path separator, so a track expanded into a DIRECTORY plus a file named
+after the total track count:
+
+    <book>/Project Hail Mary - 24/31.mp3.tmp-rename
+           ^^^^^^^^^^^^^^^^^^^^^^ directory, from "<title> - <track>"
+                                  ^^ file, from "<total_tracks>"
+
+This script puts each such file back where it belongs:
+
+    <book>/Project Hail Mary - 24.mp3
+
+Measured on prod 2026-08-16: 2,535 such directories across 82 books, 35.2 GB,
+77 books with no other copy on disk.
+
+SAFETY
+    * Dry-run is the default. --apply is required to touch anything.
+    * Nothing is ever deleted and nothing is ever overwritten. A target that
+      already exists is compared and reported, never clobbered.
+    * Moves are os.rename, which is atomic within a filesystem and moves no
+      data. If the target is on another filesystem the move is refused rather
+      than silently turned into a copy.
+    * Every move is verified after the fact: the target must exist, be a
+      regular file, and have exactly the source's size.
+
+EDITION COLLISIONS
+    A book can carry two editions with different track counts (Foundation and
+    Empire has both a 23-track and a 201-track rip). Both would reduce to the
+    same recovered name, so when a book has more than one distinct total the
+    total is kept in the name: "Foundation and Empire - 10 (201-track).mp3".
+    Nothing is merged or dropped; the version system can reconcile them later.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field, asdict
+
+TMP_SUFFIX = ".tmp-rename"
+
+# "<title> - <track>" -- the directory the bug created.
+DIR_RE = re.compile(r"^(?P<title>.+) - (?P<track>\d+)$")
+# "<total_tracks>.<ext>" with an optional failed-rename suffix.
+FILE_RE = re.compile(r"^(?P<total>\d+)\.(?P<ext>[A-Za-z0-9]+)(?P<tmp>\.tmp-rename)?$")
+
+AUDIO_EXTS = {"mp3", "m4b", "m4a", "aac", "flac", "ogg", "opus", "wma"}
+
+
+@dataclass
+class Action:
+    src: str
+    dst: str
+    book: str
+    title: str
+    track: int
+    total: int
+    status: str = "planned"
+    detail: str = ""
+
+
+@dataclass
+class Report:
+    planned: list = field(default_factory=list)
+    conflicts: list = field(default_factory=list)
+    skipped: list = field(default_factory=list)
+    done: list = field(default_factory=list)
+    failed: list = field(default_factory=list)
+
+
+def sha256(path: str, chunk: int = 1 << 20) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        while True:
+            b = fh.read(chunk)
+            if not b:
+                break
+            h.update(b)
+    return h.hexdigest()
+
+
+def audio_md5(path: str) -> str | None:
+    """Hash the DECODED audio stream, ignoring all container metadata.
+
+    Two files can differ byte-for-byte purely because one has embedded cover
+    art or a rewritten tag, while the audio is identical. This is the
+    tag-insensitive comparison for that case. It is exact, unlike an acoustic
+    fingerprint, which is what makes it safe to reason about.
+    """
+    try:
+        out = subprocess.run(
+            ["ffmpeg", "-v", "error", "-i", path, "-map", "0:a", "-f", "md5", "-"],
+            capture_output=True, text=True, timeout=600,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if out.returncode != 0:
+        return None
+    line = out.stdout.strip()
+    return line.split("=", 1)[1] if line.startswith("MD5=") else None
+
+
+def find_bogus_dirs(root: str) -> list[str]:
+    """Find the directories the bug created, WITHOUT matching legitimate ones.
+
+    The obvious rule -- "named '<x> - <n>' and holding only '<n>.<ext>' files"
+    -- is far too broad. A perfectly ordinary multi-disc folder ("The Stand -
+    1" holding "01.mp3", "02.mp3", ...) matches it exactly. Measured against
+    this library that rule claimed 42,668 directories where 2,535 exist: a
+    16x false-positive rate, aimed at an irreplaceable dataset.
+
+    So the detector is seeded from evidence rather than from shape:
+
+      1. SEED. A directory of the right shape containing a ".tmp-rename" file
+         is certainly wreckage -- that suffix only exists because the rename
+         that would have removed it failed.
+      2. EXPAND, within affected books only. The bug also produced renames
+         that SUCCEEDED into the wrong directory, leaving a plain "<n>.<ext>"
+         with no ".tmp-rename" to betray it. Those are only recognizable by
+         company: same book, same title stem, same total-track value as a
+         seeded sibling.
+
+    A book with no seed is never touched, so an ordinary disc folder is out of
+    scope no matter what it is called.
+    """
+    seeds: list[str] = []
+    candidates: dict[str, list[str]] = collections.defaultdict(list)
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        base = os.path.basename(dirpath)
+        dm = DIR_RE.match(base)
+        if not dm or dirnames or not filenames:
+            continue
+        matches = [FILE_RE.match(f) for f in filenames]
+        if not all(matches):
+            continue
+
+        book = os.path.dirname(dirpath)
+        candidates[book].append(dirpath)
+        if any(f.endswith(TMP_SUFFIX) for f in filenames):
+            seeds.append(dirpath)
+
+    seeded_books: dict[str, set[tuple[str, int]]] = collections.defaultdict(set)
+    for d in seeds:
+        dm = DIR_RE.match(os.path.basename(d))
+        if not dm:
+            continue
+        for f in os.listdir(d):
+            fm = FILE_RE.match(f)
+            if fm:
+                seeded_books[os.path.dirname(d)].add((dm.group("title"), int(fm.group("total"))))
+
+    found = set(seeds)
+    for book, signatures in seeded_books.items():
+        for d in candidates.get(book, []):
+            dm = DIR_RE.match(os.path.basename(d))
+            if not dm:
+                continue
+            for f in os.listdir(d):
+                fm = FILE_RE.match(f)
+                if fm and (dm.group("title"), int(fm.group("total"))) in signatures:
+                    found.add(d)
+                    break
+
+    return sorted(found)
+
+
+def plan(root: str) -> tuple[list[Action], list[Action], list[Action]]:
+    dirs = find_bogus_dirs(root)
+
+    # A book needs the total kept in the name only when it has more than one.
+    totals_per_book: dict[str, set[int]] = collections.defaultdict(set)
+    for d in dirs:
+        for f in os.listdir(d):
+            m = FILE_RE.match(f)
+            if m:
+                totals_per_book[os.path.dirname(d)].add(int(m.group("total")))
+
+    planned: list[Action] = []
+    conflicts: list[Action] = []
+    skipped: list[Action] = []
+
+    for d in sorted(dirs):
+        book = os.path.dirname(d)
+        dm = DIR_RE.match(os.path.basename(d))
+        if not dm:
+            continue
+        title, track = dm.group("title"), int(dm.group("track"))
+
+        for fname in sorted(os.listdir(d)):
+            src = os.path.join(d, fname)
+            fm = FILE_RE.match(fname)
+            if not fm:
+                skipped.append(Action(src, "", book, title, track, 0,
+                                      "skipped", "filename does not match the bug's shape"))
+                continue
+            total, ext = int(fm.group("total")), fm.group("ext")
+
+            if ext.lower() not in AUDIO_EXTS:
+                skipped.append(Action(src, "", book, title, track, total,
+                                      "skipped", f"extension {ext!r} is not audio"))
+                continue
+
+            # Match file_naming_pattern exactly -- "{title} - {track:02d}".
+            # Recovery must land where organize would put the file anyway,
+            # otherwise the next organize renames all 2,687 of them again.
+            # {track:02d} is a MINIMUM width of two, so a 131-track book still
+            # prints track 131 as "131"; it is not padded to the total's width.
+            stem = f"{title} - {track:02d}"
+            if len(totals_per_book[book]) > 1:
+                stem += f" ({total}-track)"
+            dst = os.path.join(book, f"{stem}.{ext}")
+
+            act = Action(src, dst, book, title, track, total)
+            if os.path.exists(dst):
+                act.status, act.detail = "conflict", "destination already exists"
+                conflicts.append(act)
+            else:
+                planned.append(act)
+
+    return planned, conflicts, skipped
+
+
+def resolve_conflict(act: Action) -> Action:
+    """Compare a stranded file against the file already occupying its target."""
+    try:
+        s_size, d_size = os.path.getsize(act.src), os.path.getsize(act.dst)
+    except OSError as e:
+        act.status, act.detail = "error", f"stat failed: {e}"
+        return act
+
+    if s_size == d_size and sha256(act.src) == sha256(act.dst):
+        act.status = "duplicate-identical"
+        act.detail = ("byte-identical to the file already in place; the stranded copy is "
+                      "redundant. NOT deleted -- deletion needs explicit sign-off.")
+        return act
+
+    src_a, dst_a = audio_md5(act.src), audio_md5(act.dst)
+    if src_a and dst_a and src_a == dst_a:
+        act.status = "duplicate-same-audio"
+        act.detail = ("decoded audio is identical; the files differ only in container "
+                      "metadata (embedded artwork or rewritten tags). NOT deleted.")
+        return act
+
+    act.status = "conflict-different"
+    act.detail = (f"different content: sizes {s_size} vs {d_size}; "
+                  f"audio md5 {src_a} vs {dst_a}. Left untouched for review.")
+    return act
+
+
+def verify_moved(src: str, dst: str, expected_size: int) -> str | None:
+    """Post-move validation. A rename that reports success is not evidence."""
+    if not os.path.isfile(dst):
+        return f"target missing after move: {dst}"
+    actual = os.path.getsize(dst)
+    if actual != expected_size:
+        return f"size changed during move: expected {expected_size}, found {actual}"
+    if os.path.exists(src):
+        return f"source still present after move: {src}"
+    try:
+        with open(dst, "rb") as fh:
+            fh.read(4096)
+    except OSError as e:
+        return f"target not readable: {e}"
+    return None
+
+
+def apply_actions(planned: list[Action], report: Report) -> None:
+    for act in planned:
+        try:
+            size = os.path.getsize(act.src)
+            if os.path.exists(act.dst):
+                act.status = "conflict"
+                act.detail = "destination appeared between planning and apply"
+                report.conflicts.append(act)
+                continue
+            # Same-filesystem rename. os.rename raises OSError(EXDEV) across
+            # devices rather than degrading to a copy, which is what we want:
+            # a silent copy would double 35 GB and break the atomicity.
+            os.rename(act.src, act.dst)
+        except OSError as e:
+            act.status, act.detail = "failed", str(e)
+            report.failed.append(act)
+            continue
+
+        problem = verify_moved(act.src, act.dst, size)
+        if problem:
+            act.status, act.detail = "failed-verification", problem
+            report.failed.append(act)
+            continue
+
+        act.status = "moved"
+        report.done.append(act)
+
+        parent = os.path.dirname(act.src)
+        try:
+            if not os.listdir(parent):
+                os.rmdir(parent)
+        except OSError:
+            pass
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("root", help="library root to scan")
+    ap.add_argument("--apply", action="store_true",
+                    help="actually move files (default is a dry run)")
+    ap.add_argument("--report", default="/tmp/repair-stranded-report.json")
+    ap.add_argument("--jobs", type=int, default=8,
+                    help="parallel workers for hashing conflicts")
+    args = ap.parse_args()
+
+    print(f"scanning {args.root} ...", flush=True)
+    planned, conflicts, skipped = plan(args.root)
+    print(f"  {len(planned)} recoverable, {len(conflicts)} conflicts, {len(skipped)} skipped",
+          flush=True)
+
+    if conflicts:
+        print(f"  hashing {len(conflicts)} conflicts ...", flush=True)
+        with ThreadPoolExecutor(max_workers=args.jobs) as pool:
+            conflicts = list(pool.map(resolve_conflict, conflicts))
+
+    report = Report(planned=planned, conflicts=conflicts, skipped=skipped)
+
+    if args.apply:
+        print(f"applying {len(planned)} moves ...", flush=True)
+        report.planned = []
+        apply_actions(planned, report)
+
+    by_status = collections.Counter(
+        a.status for a in report.planned + report.conflicts + report.skipped
+        + report.done + report.failed)
+
+    print("\n=== summary ===")
+    for status, n in sorted(by_status.items()):
+        print(f"  {status:24} {n}")
+    total_bytes = sum(os.path.getsize(a.dst) for a in report.done if os.path.exists(a.dst))
+    if args.apply:
+        print(f"  {'bytes recovered':24} {total_bytes / (1 << 30):.1f} GiB")
+
+    with open(args.report, "w") as fh:
+        json.dump({k: [asdict(a) for a in v] for k, v in vars(report).items()},
+                  fh, indent=2)
+    print(f"\nfull report: {args.report}")
+
+    if not args.apply:
+        print("\nDRY RUN -- nothing was moved. Re-run with --apply to execute.")
+        for a in report.planned[:5]:
+            print(f"  would move: {a.src}\n           -> {a.dst}")
+
+    return 1 if report.failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/todo.d/20260816-tmp-rename-recovery-and-bisect.md
+++ b/todo.d/20260816-tmp-rename-recovery-and-bisect.md
@@ -1,0 +1,64 @@
+### Stranded `.tmp-rename` recovery — bisect complete, recovery outstanding
+
+~35 GB of audio is stranded on disk inside directories that a path-construction
+bug created. The bisect is **done**; recording it so nobody re-derives it.
+
+**Introduced:** `f29c3ce6`, 2026-03-03 13:43:40 —
+`viper.SetDefault("segment_title_format", "{title} - {track}/{total_tracks}")`.
+A shipped default with a literal `/` in it, so `{track_title}` expanded to
+`"Pink Bean Series - 1/9"` with every variable value perfectly clean.
+
+**Removed:** `c54721c7`, 2026-08-15 22:10:50 — deleted `segment_title_format`
+outright and defaulted the file pattern to `{title} - {track:02d}`.
+
+Live for 5.5 months. `243e2f38` ("scrub path separators from template
+variables", 2026-05-28) is **not** the fix for this one — `scrubVar` sanitizes
+variable values, and this separator was in the template. It fixed a genuinely
+separate bug (title metadata containing `3/85`) whose on-disk wreckage is
+identical, which is why the two were conflated.
+
+**Measured on prod 2026-08-16 (read-only):**
+
+| metric | value |
+|---|---|
+| stranded `.tmp-rename` files | 2,584 |
+| bogus directories | 2,535 |
+| affected books | 82 |
+| books with no other copy | **77** |
+| size | 35.2 GB |
+| bogus-dir mtime range | 2026-04-07 → 2026-04-30, plus **2 on 2026-08-14** |
+
+Directory mtime is the right instrument, not file mtime: `rename(2)` preserves
+file mtime, so the files carry inherited dates, while the bogus directory only
+exists as a product of the bug. `mtime == ctime` on all 2,535.
+
+The two 2026-08-14 directories came from the `internal/metafetch` twin, which
+had no `scrubVar` at all until #2479 unified the builders — so the live
+metadata-apply path was still stranding files two days before that landed.
+
+**⚠️ The `.tmp-rename` census is an undercount.** The bogus directories also
+contain *successfully* renamed files (`Project Hail Mary - 16/31.mp3` sits
+beside `Project Hail Mary - 24/31.mp3.tmp-rename`). Any recovery must sweep the
+directories, not just the `.tmp-rename` glob.
+
+**Outstanding:**
+
+- [ ] Recovery tool. Dry-run by default, full report before anything moves.
+      **77 books have no other copy — a wrong move is unrecoverable.** Derive
+      and validate the naming rule against the 5 books that also contain
+      surviving audio (Project Hail Mary, Singularity Online 1, Welcome to the
+      Multiverse 5, Dreamcatcher, Neuromancer) before pointing it at the other
+      77. Reconstruct by rejoining directory tail + filename
+      (`"Pink Bean Series - 1" + " " + "9.m4b"`), not by relocating the bare
+      file, which discards the chapter's identity.
+- [ ] Compare with per-file SHA-256; where hashes differ because of embedded
+      artwork, fall back to `ffmpeg -v error -i FILE -map 0:a -f md5 -`, which
+      hashes decoded audio and ignores container metadata. Exact, unlike
+      AcoustID — only exact should authorize a delete.
+- [ ] Investigate book rows affected as a side effect. `scrubVar`'s own comment
+      records the scanner reacting by creating **85 separate Book records** for
+      one book, so look for spurious rows (path segment matching ` - [0-9]+$`,
+      or a purely numeric title) *before* doing soft-delete/purge archaeology.
+- [ ] Confirm no new bogus directories appear now that both the pattern and the
+      builder guard are in place. The post-fix observation window is currently
+      about zero.


### PR DESCRIPTION
## What

`BuildRelPath` expanded the file pattern through `BuildPath`, which splits on `/` and sanitizes each half independently, then returned the halves rejoined. Nothing constrained the stem to a **single** component, so a separator in `file_naming_pattern` became a real directory — and the two-phase rename parked its payload inside as `<n>.<ext>.tmp-rename` and failed.

## Which guard covers which route

The wreckage on disk is identical for two different bugs, which is why they were conflated for months:

| Route | Guard | Status |
|---|---|---|
| separator via `segment_title_format` → `{track_title}` | `scrubVar` (it is a variable *value*) | already covered in the unified builder; **not** covered in the `internal/metafetch` twin, which had no `scrubVar` until #2479 |
| separator written into `file_naming_pattern` | none until this PR | it is a *template*, never passes through `scrubVar` — and the setting is user-configurable |

Verified by mutation: removing the guard turns **only** the direct-pattern case red (`"Pink Bean Series - 1/9"`, stem `"9"`). The other two cases are characterization coverage for the mechanisms that do defend them, and the test says so explicitly so nobody deletes the wrong guard later.

## Historical damage

The shipped default of `segment_title_format` was `"{title} - {track}/{total_tracks}"` from `f29c3ce6` (2026-03-03) to `c54721c7` (2026-08-15) — 5.5 months. Measured on prod, read-only:

- 2,535 bogus directories, 2,584 stranded `.tmp-rename` files, 35.2 GB
- 82 books affected, **77 with no other copy**
- bogus-dir mtimes: 2026-04-07 → 04-30, plus 2 on **2026-08-14** (the metafetch twin, still live two days before #2479)

`243e2f38` is **not** the fix for this one, despite its message reading like it.

## Why collapse instead of error

`SanitizePathComponent` maps `/` to `" "`, producing exactly the name the file should have had (`"Pink Bean Series - 1/9"` → `"Pink Bean Series - 1 9"`), so a bad pattern degrades to a correct flat filename instead of taking organizing down library-wide.

## Also done outside this PR

Prod's stored `file_naming_pattern` was `"{title} - {author} - read by {narrator}"` — no track placeholder, so every track of a multi-file book built an identical target and collided. `c54721c7` fixed the *default*, but a stored config overrides defaults, so production never got it. With the owner's sign-off: `auto_organize` set to `false`, then the pattern set to `{title} - {track:02d}`, both verified by independent re-read.

## Not done

Recovery of the 2,584 stranded files. Tracked in `todo.d/20260816-tmp-rename-recovery-and-bisect.md`, along with the bisect so it is not re-derived. Note the `.tmp-rename` census is an **undercount** — the bogus directories also hold successfully-renamed files.

## Test

`go test ./internal/organizer/` green (4.3s). New test mutation-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS