### PR TITLE
fix(operations): carry progress to the registry instead of dropping it

### DIFF
--- a/changelog.d/20260816-operation-progress-bridge.md
+++ b/changelog.d/20260816-operation-progress-bridge.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- Long-running operations no longer get cancelled after five minutes while they
+  are working normally. `LoggerFromReporter` — the adapter between an operation's
+  work and the operations registry — discarded the progress reporter it was
+  given and returned a logger whose progress method did nothing, so every
+  progress update from a library scan, import, organize, iTunes sync, reconcile
+  or folder autoscan was thrown away. The registry's stall detector, seeing an
+  operation that had never once reported progress, cancelled it at the
+  five-minute mark no matter how healthy it was; the operation's real time limit
+  (four hours for a library scan) never applied. Progress now reaches the
+  registry, so these operations run to completion and report live progress in the
+  UI instead of stopping partway with a "stuck" error.

--- a/internal/operations/progress.go
+++ b/internal/operations/progress.go
@@ -1,7 +1,7 @@
 // file: internal/operations/progress.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c3d4e5f6-a7b8-9012-cdef-012345678901
-// last-edited: 2026-05-11
+// last-edited: 2026-08-16
 
 // Package operations provides shared types for async operation execution.
 // This file holds ProgressReporter, OperationFunc, and LoggerFromReporter —
@@ -25,9 +25,90 @@ type ProgressReporter interface {
 	IsCanceled() bool
 }
 
-// LoggerFromReporter returns a logger.Logger from a ProgressReporter.
-// The v2 registry wraps reporters differently; this always returns a new
-// standard logger now that the v1 queue's loggerProgressReporter is gone.
-func LoggerFromReporter(_ ProgressReporter) logger.Logger {
-	return logger.New("operation")
+// LoggerFromReporter adapts a ProgressReporter to the logger.Logger interface
+// that the long-running services (scanner, organizer, reconcile, iTunes import)
+// take, so their UpdateProgress calls reach the operations registry.
+//
+// This carries the ops registry's liveness signal. The watchdog
+// (internal/operations/registry/watchdog.go) cancels any op that goes
+// ProgressTimeout — 5 minutes by default — without a progress stamp, and when an
+// op has NEVER stamped one it measures from StartedAt instead. An operation that
+// cannot report progress is therefore not merely un-observable: it is killed at
+// the five-minute mark however healthy it is, and its own Timeout (4h for
+// library.scan) never gets to apply.
+//
+// From the BridgeQueue elimination (2026-05-11) until 2026-08-16 this function
+// was a stub that discarded its argument:
+//
+//	func LoggerFromReporter(_ ProgressReporter) logger.Logger {
+//	    return logger.New("operation")
+//	}
+//
+// The signature still satisfied every caller, so nothing failed to compile and
+// nothing failed loudly. StandardLogger.UpdateProgress has an empty body, so the
+// scanner's three progress calls (internal/scanner/service.go:324, :366, :465)
+// ran, cost nothing and reported nothing. All eight ops built on this helper —
+// library.scan, library.import, library.organize, itunes.import, itunes.sync,
+// reconcile preview, folder autoscan and maintenance reconcile — were blind, and
+// each one that ran longer than five minutes was cancelled mid-flight. Two were
+// diagnosed as problems with the op itself and worked around locally
+// (internal/plugins/maintenance/dedupe_book_file_rows.go raised ProgressTimeout
+// to 30m; internal/organizer/service.go stopped re-taking a 20-minute backup);
+// both comments describe an operation that was, in their words, "in fact working
+// the whole time". Those workarounds stay — they are independently worthwhile —
+// but they are now belt-and-braces rather than load-bearing.
+//
+// A nil reporter yields a plain logger, so callers that log before they have a
+// reporter keep working.
+func LoggerFromReporter(r ProgressReporter) logger.Logger {
+	return &reporterLogger{Logger: logger.New("operation"), reporter: r}
 }
+
+// reporterLogger is a logger.Logger that forwards progress to a
+// ProgressReporter and delegates everything else to the logger it wraps.
+//
+// It embeds the logger.Logger INTERFACE rather than *logger.StandardLogger so
+// that With delegates to the wrapped logger's own implementation, preserving its
+// subsystem prefix, minimum stdout level and activity-log writer instead of
+// reconstructing them here.
+type reporterLogger struct {
+	logger.Logger
+	reporter ProgressReporter
+}
+
+// UpdateProgress forwards to the reporter, which stamps the registry's liveness
+// clock. A reporter error is logged rather than returned: logger.Logger's
+// UpdateProgress has no error result, and a failed progress write must never
+// abort the work whose progress it describes.
+func (l *reporterLogger) UpdateProgress(current, total int, message string) {
+	if l.reporter == nil {
+		return
+	}
+	if err := l.reporter.UpdateProgress(current, total, message); err != nil {
+		l.Logger.Warn("progress update failed: %v", err)
+	}
+}
+
+// With returns a child logger that KEEPS the reporter.
+//
+// Without this override the promoted method would return the wrapped logger's
+// child — a plain logger with no reporter — and progress would silently stop at
+// the first .With() call. That is not a theoretical concern: the scanner hands
+// log.With("scanner") to ScanDirectoryParallel and ProcessBooksParallel
+// (internal/scanner/service.go:338, :389), which is the longest-running stretch
+// of a scan and exactly the window in which the watchdog fires.
+func (l *reporterLogger) With(subsystem string) logger.Logger {
+	return &reporterLogger{Logger: l.Logger.With(subsystem), reporter: l.reporter}
+}
+
+// IsCanceled deliberately still delegates to the wrapped logger, which answers
+// false, rather than to the reporter.
+//
+// Forwarding it is a separate behavioural change from restoring progress:
+// internal/scanner/service.go:190, internal/organizer/service.go:897 and :1082
+// and internal/reconcile/reconcile.go:597 all guard on it, and those branches
+// have been unreachable for three months. Cancellation already works through
+// ctx, which every one of these services honours, so nothing is broken by
+// leaving this alone — but turning four never-exercised early-return paths on in
+// the same change that unblocks production scanning would make a bad first run
+// impossible to bisect. Tracked in todo.d/20260816-logger-iscanceled-forwarding.md.

--- a/internal/operations/progress_bridge_test.go
+++ b/internal/operations/progress_bridge_test.go
@@ -1,0 +1,131 @@
+// file: internal/operations/progress_bridge_test.go
+// version: 1.0.0
+// guid: 6b1f0a72-3c9d-4e58-9a41-77c2e5d8b430
+// last-edited: 2026-08-16
+
+// LoggerFromReporter is the seam between an operation's work and the ops
+// registry's liveness watchdog. It shipped as a stub that took the reporter and
+// discarded it (`func LoggerFromReporter(_ ProgressReporter)`), returning a
+// StandardLogger whose UpdateProgress has an empty body. The compiler was
+// satisfied and every progress call in every op vanished.
+//
+// The registry watchdog cancels an op that goes ProgressTimeout (default 5m)
+// without a progress stamp, falling back to StartedAt when progress was NEVER
+// reported. An op that CANNOT report therefore accrues stuck time from birth and
+// is killed at exactly five minutes no matter how healthy it is -- which is what
+// happened to the 2026-08-16 library.scan, and to two earlier ops whose comments
+// (internal/plugins/maintenance/dedupe_book_file_rows.go, internal/organizer/
+// service.go) both describe "an operation that was in fact working the whole
+// time".
+//
+// These tests assert the bridge carries the call. Verify them by reverting the
+// bridge: they must go red.
+
+package operations
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/logger"
+)
+
+// recordingReporter captures what actually arrives at the ProgressReporter.
+type recordingReporter struct {
+	mu       sync.Mutex
+	progress []progressCall
+	canceled bool
+}
+
+type progressCall struct {
+	current int
+	total   int
+	message string
+}
+
+func (r *recordingReporter) UpdateProgress(current, total int, message string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.progress = append(r.progress, progressCall{current, total, message})
+	return nil
+}
+
+func (r *recordingReporter) Log(_, _ string, _ *string) error { return nil }
+
+func (r *recordingReporter) IsCanceled() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.canceled
+}
+
+func (r *recordingReporter) calls() []progressCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]progressCall(nil), r.progress...)
+}
+
+// TestLoggerFromReporter_ForwardsProgress is the whole bug in one assertion.
+func TestLoggerFromReporter_ForwardsProgress(t *testing.T) {
+	rep := &recordingReporter{}
+	log := LoggerFromReporter(rep)
+
+	log.UpdateProgress(7, 100, "Scanning folder 1/3")
+
+	calls := rep.calls()
+	if len(calls) != 1 {
+		t.Fatalf("reporter received %d progress calls, want 1 -- the logger is not wired to the reporter", len(calls))
+	}
+	if calls[0] != (progressCall{7, 100, "Scanning folder 1/3"}) {
+		t.Errorf("reporter got %+v, want {7 100 \"Scanning folder 1/3\"}", calls[0])
+	}
+}
+
+// TestLoggerFromReporter_WithPreservesTheBridge guards a trap specific to
+// implementing this by embedding *logger.StandardLogger: the promoted With()
+// returns a bare StandardLogger, silently dropping the reporter again.
+//
+// This is not hypothetical. internal/scanner/service.go:338 and :389 hand
+// log.With("scanner") to ScanDirectoryParallel and ProcessBooksParallel -- the
+// deepest, slowest part of a scan, and precisely the stretch during which the
+// watchdog fires. A bridge that forgets to override With fixes the shallow calls
+// and leaves the ones that matter broken.
+func TestLoggerFromReporter_WithPreservesTheBridge(t *testing.T) {
+	rep := &recordingReporter{}
+	child := LoggerFromReporter(rep).With("scanner")
+
+	child.UpdateProgress(42, 100, "from a child logger")
+
+	calls := rep.calls()
+	if len(calls) != 1 {
+		t.Fatalf("child logger delivered %d progress calls, want 1 -- With() dropped the reporter", len(calls))
+	}
+	if calls[0].current != 42 || calls[0].message != "from a child logger" {
+		t.Errorf("child logger delivered %+v", calls[0])
+	}
+}
+
+// TestLoggerFromReporter_NilReporter keeps the no-reporter path a no-op rather
+// than a panic: several callers build a logger before they have a reporter.
+func TestLoggerFromReporter_NilReporter(t *testing.T) {
+	log := LoggerFromReporter(nil)
+	log.UpdateProgress(1, 10, "no reporter")     // must not panic
+	log.With("child").UpdateProgress(1, 10, "x") // must not panic
+	log.Info("still logs")
+	if log.IsCanceled() {
+		t.Error("a nil reporter reported cancellation")
+	}
+}
+
+// TestLoggerFromReporter_PlainLoggingStillWorks confirms the bridge did not lose
+// the ordinary Logger behaviour it wraps.
+func TestLoggerFromReporter_PlainLoggingStillWorks(t *testing.T) {
+	log := LoggerFromReporter(&recordingReporter{})
+	log.Trace("trace")
+	log.Debug("debug")
+	log.Info("info")
+	log.Warn("warn")
+	log.Error("error")
+	// ProgressReporter has no change-tracking method, so RecordChange keeps
+	// StandardLogger's no-op behaviour. Asserted only to prove it does not panic.
+	log.RecordChange(logger.Change{BookID: "1", ChangeType: "book_update", Summary: "s"})
+}

--- a/todo.d/20260816-logger-iscanceled-forwarding.md
+++ b/todo.d/20260816-logger-iscanceled-forwarding.md
@@ -1,0 +1,26 @@
+- [ ] **Forward `IsCanceled()` through `reporterLogger` and exercise the four guards it wakes up.**
+      `LoggerFromReporter` now bridges `UpdateProgress` to the ops registry
+      reporter, but `IsCanceled()` still delegates to the wrapped logger, which
+      answers `false` unconditionally. That leaves four cancellation guards
+      unreachable, as they have been since the 2026-05-11 BridgeQueue removal:
+      `internal/scanner/service.go:190`, `internal/organizer/service.go:897` and
+      `:1082`, `internal/reconcile/reconcile.go:597`.
+      Cancellation itself is not broken — every one of these services also
+      honours `ctx`, which is what the watchdog cancels — so this is a
+      responsiveness and correctness-of-intent item, not an outage. It was held
+      back from the progress fix deliberately: switching on four branches that
+      have not run in three months, in the same change that unblocks production
+      scanning, would make a bad first run impossible to bisect.
+      Before flipping it: read each guard for what it does on the way out
+      (partial state, half-written aggregates, skipped cleanup), and check
+      whether `scanner/service.go:177`'s "both cancellation channels have to be
+      checked here" comment still describes the intended behaviour once the
+      logger channel is live.
+
+- [ ] **Audit the other two silently-stubbed `StandardLogger` methods.**
+      `RecordChange` and `ChangeCounters` (`internal/logger/standard.go:62-63`)
+      are also empty/nil, so any operation running through
+      `LoggerFromReporter` that records changes is discarding them the same way
+      progress was being discarded. Determine whether the scanner/organizer
+      change-tracking counters are consumed anywhere (activity feed, op summary)
+      and, if so, whether they have been empty since 2026-05-11.


### PR DESCRIPTION
## What happened

Today's library rescan — the one that has to run so the database picks up the
41,582 files relocated by the recovery in #2489 — was cancelled after five
minutes:

```
registry: strike recorded  kind=stuck  message="no progress for 5m13s (timeout=5m0s)"
registry: canceling stuck op
library scan failed  err="scan canceled: context canceled"
```

Its own log showed it detecting multi-file groups continuously right up to the
cancellation. It was not stuck. **It had no way to say so.**

## Root cause

`LoggerFromReporter` is the seam between an operation's work and the operations
registry. Since the BridgeQueue elimination (2026-05-11) it has been a stub that
takes the reporter and throws it away:

```go
func LoggerFromReporter(_ ProgressReporter) logger.Logger {
    return logger.New("operation")
}
```

The `_` is the whole bug. The signature satisfied every caller, so nothing failed
to compile and nothing failed loudly. What it returns is a `StandardLogger`,
whose `UpdateProgress` has an empty body — so the scanner's three progress calls
(`internal/scanner/service.go:324`, `:366`, `:465`) execute, cost nothing, and
report nothing.

The watchdog then converts that silence into a kill. It cancels an op that goes
`ProgressTimeout` without a stamp, and when an op has **never** stamped one it
measures from `StartedAt` instead (`watchdog.go:105-112`). That fallback is a
sound rule for catching an op that hangs before its first report — but against an
op that *cannot* report, elapsed-since-start grows without bound, so it is
cancelled at exactly five minutes however healthy it is. The op's real `Timeout`
(4 hours for `library.scan`) never gets to apply.

## Blast radius: 8 ops, not 1

`library.scan`, `library.import`, `library.organize`, `itunes.import`,
`itunes.sync`, reconcile preview, folder autoscan, maintenance reconcile — every
one progress-blind, every one killable at the five-minute mark.

## This is the third encounter with the symptom, and the first with the cause

Two earlier hits were diagnosed as problems with the operation itself and worked
around locally:

- `internal/plugins/maintenance/dedupe_book_file_rows.go` raised its
  `ProgressTimeout` to 30m after a run died at book 19/194.
- `internal/organizer/service.go` stopped re-taking a 20-minute pre-organize
  backup, noting the registry struck an operation "that was in fact working the
  whole time."

**Both workarounds stay.** They are independently worthwhile — but they are now
belt-and-braces rather than load-bearing.

## The fix

Return a logger that actually forwards `UpdateProgress` to the reporter. Two
details worth calling out:

- It embeds the `logger.Logger` **interface**, not `*StandardLogger`, so `With`
  delegates to the wrapped logger and preserves its subsystem prefix, minimum
  level and activity writer instead of reconstructing them.
- **`With` is overridden to re-wrap.** A promoted `With` would return a plain
  child logger with no reporter, and progress would stop dead at the first
  `.With()` call — and `internal/scanner/service.go:338`/`:389` hand
  `log.With("scanner")` to `ScanDirectoryParallel` and `ProcessBooksParallel`,
  the longest stretch of a scan and precisely the window in which the watchdog
  fires. Fixing the shallow calls and leaving the deep ones broken would have
  looked like a fix and changed nothing. There is a dedicated test for this trap.

## Verification

- Both new tests confirmed **red against the stub** before the bridge existed
  (`reporter received 0 progress calls, want 1`).
- **Mutation-tested:** removing only the `With` override turns the `With` test
  red while `ForwardsProgress` stays green — so that test measures the specific
  trap, not the general fix.
- Traced the full path rather than just the seam: `dbReporter.UpdateProgress`
  stamps the watchdog's atomic **first, before any lock or Pebble write**
  (`reporter_db.go:312-317`), so a restored progress call reaches the watchdog
  synchronously and does not race L0 compaction.
- `go build ./...`, `go vet`, and 7 test packages green — including
  `internal/operations/registry` (43.0s) and `internal/scanner` (13.2s).

## Deliberately not in this PR

`IsCanceled` is still **not** forwarded. Four guards depend on it
(`scanner:190`, `organizer:897` and `:1082`, `reconcile:597`) and have been
unreachable for three months. Cancellation already works through `ctx`, which all
of these services honour, so nothing is broken by leaving them — but waking four
never-exercised early-return paths in the same change that unblocks production
scanning would make a bad first run impossible to bisect. Tracked in
`todo.d/20260816-logger-iscanceled-forwarding.md`, along with an audit of
`RecordChange`/`ChangeCounters`, which are stubbed the same way.

Separate from #2489 (path sanitization) — different defect, different packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS
