### PR TITLE
feat(operations): tell "never reported" apart from "stuck"

### DIFF
--- a/changelog.d/20260816-ops-liveness-enforcement.md
+++ b/changelog.d/20260816-ops-liveness-enforcement.md
@@ -1,0 +1,18 @@
+### Changed
+
+- Operations that are cancelled for inactivity now say **why** in two distinct
+  ways instead of one ambiguous one. Previously an operation that stalled and an
+  operation that was never connected to the progress system produced an identical
+  "stuck" message, which is how a broken connection went unnoticed for three
+  months and got worked around three separate times as if it were a slow
+  operation. Being cancelled after never once reporting is now recorded as
+  `never_reported` and logged as an error that names the likely cause, while a
+  genuine stall keeps the existing `stuck` label.
+
+### Added
+
+- An operation that runs for more than a minute and finishes successfully without
+  ever reporting progress now logs an error. This catches the problem while the
+  operation still works — before it grows slow enough to start being cancelled —
+  which is the point at which the library-scan fault could have been caught in
+  May rather than August.

--- a/internal/database/iface_ops_v2.go
+++ b/internal/database/iface_ops_v2.go
@@ -72,7 +72,7 @@ type OperationV2Row struct {
 type OpStrikeV2Row struct {
 	DefID       string
 	OperationID string
-	Kind        string // "uncheckpointed" | "stuck" | "infinite_restart"
+	Kind        string // "uncheckpointed" | "stuck" | "never_reported" | "infinite_restart"
 	Details     string // JSON object with plugin, message, etc.
 	OccurredAt  time.Time
 }

--- a/internal/operations/registry/liveness_internal_test.go
+++ b/internal/operations/registry/liveness_internal_test.go
@@ -1,0 +1,67 @@
+// file: internal/operations/registry/liveness_internal_test.go
+// version: 1.0.0
+// guid: 5e70b3c8-91a4-42d6-8f13-c07e5a9bd248
+// last-edited: 2026-08-16
+
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// TestShouldWarnNeverReported pins the policy for flagging an op that finished
+// successfully without ever reporting.
+//
+// The watchdog cannot catch this case: the op completed inside its
+// ProgressTimeout, so nothing was ever struck. That is exactly how library.scan
+// stayed broken from 2026-05-11 -- it finished quietly while the library was
+// small enough to scan in under five minutes, and only surfaced once it grew
+// past that. The warning has to fire on success or it does not fire in time.
+func TestShouldWarnNeverReported(t *testing.T) {
+	cases := []struct {
+		name         string
+		duration     time.Duration
+		everReported bool
+		want         bool
+	}{
+		{
+			name:     "long run that never reported is the defect we are hunting",
+			duration: 5 * time.Minute,
+			want:     true,
+		},
+		{
+			name:     "exactly at the grace boundary warns",
+			duration: neverReportedGrace,
+			want:     true,
+		},
+		{
+			// Most ops are sub-second and have nothing worth reporting. Warning
+			// on those would bury the real signal on the first day.
+			name:     "short run that never reported is ordinary brevity",
+			duration: time.Second,
+			want:     false,
+		},
+		{
+			name:         "long run that reported is healthy, however long it took",
+			duration:     4 * time.Hour,
+			everReported: true,
+			want:         false,
+		},
+		{
+			name:         "short run that reported is healthy",
+			duration:     time.Second,
+			everReported: true,
+			want:         false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldWarnNeverReported(tc.duration, tc.everReported); got != tc.want {
+				t.Errorf("shouldWarnNeverReported(%s, everReported=%v) = %v, want %v",
+					tc.duration, tc.everReported, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/operations/registry/liveness_test.go
+++ b/internal/operations/registry/liveness_test.go
@@ -1,0 +1,119 @@
+// file: internal/operations/registry/liveness_test.go
+// version: 1.0.0
+// guid: 8c41f7a2-6e05-4d93-b7a8-3f9d20c15e64
+// last-edited: 2026-08-16
+
+// Telling "never reported once" apart from "reported, then stopped".
+//
+// Both states used to produce the same strike -- kind "stuck", message "no
+// progress for 5m...". That ambiguity is why a broken wire survived from
+// 2026-05-11 to 2026-08-16: LoggerFromReporter discarded the reporter it was
+// handed, so eight ops could not report at all, and every symptom they produced
+// read as "this operation is slow" rather than "this operation is not
+// connected". It was diagnosed as a property of the op and worked around
+// locally three separate times.
+//
+// The two states want opposite responses. A stuck op is a bug in the work: go
+// look at what it is blocked on. A never-reported op is a bug in the wiring: the
+// op is probably fine and the plumbing is missing. Only one of them is fixed by
+// raising ProgressTimeout, which is what all three earlier workarounds did.
+
+package registry_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+)
+
+// TestWatchdog_NeverReportedGetsItsOwnStrike covers the op that cannot report:
+// it never calls UpdateProgress and no last_progress_at is ever written, so the
+// watchdog measures from StartedAt. That is the LoggerFromReporter shape.
+func TestWatchdog_NeverReportedGetsItsOwnStrike(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	r := registry.NewWithOptions(store, slog.Default(), 2, registry.Options{
+		WatchdogInterval: 50 * time.Millisecond,
+	})
+
+	canceled := make(chan struct{})
+	def := makeValidDef("test.never-reported")
+	def.ResumePolicy = registry.ResumeDrop
+	def.ProgressTimeout = 100 * time.Millisecond
+	def.Run = func(runCtx context.Context, _ json.RawMessage, _ registry.Reporter) error {
+		// Never touches the reporter -- exactly what the eight LoggerFromReporter
+		// ops did for three months.
+		<-runCtx.Done()
+		close(canceled)
+		return runCtx.Err()
+	}
+	_ = r.RegisterOp(def)
+	r.Start(ctx)
+
+	opID, _ := r.EnqueueOp(ctx, "test.never-reported", nil)
+	awaitStatus(t, store, opID, "running", 3*time.Second)
+
+	select {
+	case <-canceled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("never-reporting op was not canceled within 3s")
+	}
+	awaitStatus(t, store, opID, "canceled", 3*time.Second)
+
+	if n := len(store.strikesOfKind(opID, "never_reported")); n == 0 {
+		t.Error("an op that never called UpdateProgress did not get a never_reported strike")
+	}
+	if n := len(store.strikesOfKind(opID, "stuck")); n != 0 {
+		t.Errorf("an op that never reported was also filed as %d stuck strike(s); the two kinds must be exclusive", n)
+	}
+}
+
+// TestWatchdog_ReportedThenStalledIsStillStuck is the control. Without it the
+// first test would pass just as well if EVERY strike were relabelled
+// never_reported, which would destroy the distinction rather than draw it.
+func TestWatchdog_ReportedThenStalledIsStillStuck(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	r := registry.NewWithOptions(store, slog.Default(), 2, registry.Options{
+		WatchdogInterval: 50 * time.Millisecond,
+	})
+
+	canceled := make(chan struct{})
+	def := makeValidDef("test.reported-then-stalled")
+	def.ResumePolicy = registry.ResumeDrop
+	def.ProgressTimeout = 100 * time.Millisecond
+	def.Run = func(runCtx context.Context, _ json.RawMessage, rep registry.Reporter) error {
+		// Report once -- the op IS wired -- then wedge. This is a genuine stall.
+		_ = rep.UpdateProgress(1, 10, "working")
+		<-runCtx.Done()
+		close(canceled)
+		return runCtx.Err()
+	}
+	_ = r.RegisterOp(def)
+	r.Start(ctx)
+
+	opID, _ := r.EnqueueOp(ctx, "test.reported-then-stalled", nil)
+	awaitStatus(t, store, opID, "running", 3*time.Second)
+
+	select {
+	case <-canceled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("stalled op was not canceled within 3s")
+	}
+	awaitStatus(t, store, opID, "canceled", 3*time.Second)
+
+	if n := len(store.strikesOfKind(opID, "stuck")); n == 0 {
+		t.Error("an op that reported and then stalled did not get a stuck strike")
+	}
+	if n := len(store.strikesOfKind(opID, "never_reported")); n != 0 {
+		t.Errorf("an op that DID report was filed as never_reported (%d strikes)", n)
+	}
+}

--- a/internal/operations/registry/reliability_fixes_test.go
+++ b/internal/operations/registry/reliability_fixes_test.go
@@ -67,8 +67,15 @@ func TestWatchdog_StuckBeforeFirstProgress(t *testing.T) {
 	}
 	awaitStatus(t, store, opID, "canceled", 3*time.Second)
 
-	if n := len(store.strikesOfKind(opID, "stuck")); n == 0 {
-		t.Error("expected at least 1 stuck strike, got 0")
+	// Reclassified 2026-08-16: this op never calls UpdateProgress, which is now
+	// its own strike kind. R-2's guarantee is unchanged and still asserted --
+	// an op that hangs before its first report is detected and canceled rather
+	// than being invisible forever -- but the strike now says which of the two
+	// causes it was, because "never reported once" usually means the op is not
+	// wired to its reporter rather than that its work is wedged. See
+	// liveness_test.go and internal/operations/progress.go.
+	if n := len(store.strikesOfKind(opID, "never_reported")); n == 0 {
+		t.Error("expected at least 1 never_reported strike, got 0")
 	}
 }
 

--- a/internal/operations/registry/watchdog.go
+++ b/internal/operations/registry/watchdog.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/watchdog.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 2b3c4d5e-6f7a-8901-bcde-f01234567890
-// last-edited: 2026-07-17
+// last-edited: 2026-08-16
 
 package registry
 
@@ -23,8 +23,12 @@ const (
 //
 //   - uncheckpointed: ResumeRestart ops that haven't checkpointed in
 //     ≥5 consecutive minutes (and whose def sets MinCheckpointInterval).
-//   - stuck: ops whose last_progress_at is older than def.ProgressTimeout.
-//     The run's context is canceled; the worker will set terminal status.
+//   - stuck: ops that reported progress at least once and then went quiet for
+//     longer than def.ProgressTimeout. The run's context is canceled; the
+//     worker will set terminal status.
+//   - never_reported: ops that have not reported progress even once since
+//     StartedAt. Same cancellation, different diagnosis: this usually means the
+//     op is not wired to its reporter, not that its work is wedged.
 //
 // Infinite-restart detection happens in worker.go at run start time, not
 // here, because it needs to be enforced before the run begins.
@@ -98,10 +102,22 @@ func (r *Registry) watchdogCycle() {
 		// cancellations when UpdateOpProgressV2 is queued behind PebbleDB L0
 		// compaction. Fall back to the DB row only when the atomic is unset (zero).
 		var lastProgress time.Time
+		// everReported separates two states that produced an identical strike
+		// until 2026-08-16, and which call for opposite responses. An op that
+		// reported and then went quiet is stuck: go and see what it is blocked
+		// on. An op that has never reported once is, far more often, not wired
+		// to its reporter at all — the work may be perfectly healthy while the
+		// only channel that could say so is missing. Raising ProgressTimeout
+		// "fixes" the first and merely hides the second, which is precisely what
+		// three separate workarounds did before the LoggerFromReporter stub was
+		// found (see internal/operations/progress.go).
+		everReported := false
 		if ts := h.lastProgressAt.Load(); ts != 0 {
 			lastProgress = time.Unix(0, ts).UTC()
+			everReported = true
 		} else if row.LastProgressAt != nil {
 			lastProgress = *row.LastProgressAt
+			everReported = true
 		} else if row.StartedAt != nil {
 			// R-2: no progress has EVER been reported (atomic unset, DB row nil).
 			// Marking an op running stamps StartedAt but never LastProgressAt, so
@@ -112,10 +128,24 @@ func (r *Registry) watchdogCycle() {
 			lastProgress = *row.StartedAt
 		}
 		if !lastProgress.IsZero() && now.Sub(lastProgress) > progressTimeout {
-			r.writeStrike(h.id, def.ID, def.Plugin, "stuck",
-				fmt.Sprintf("no progress for %s (timeout=%s)", now.Sub(lastProgress).Round(time.Second), progressTimeout))
-			r.logger.Warn("registry: canceling stuck op", "op_id", h.id, "def_id", def.ID,
-				"idle_since", lastProgress)
+			idle := now.Sub(lastProgress).Round(time.Second)
+			if everReported {
+				r.writeStrike(h.id, def.ID, def.Plugin, "stuck",
+					fmt.Sprintf("no progress for %s (timeout=%s)", idle, progressTimeout))
+				r.logger.Warn("registry: canceling stuck op", "op_id", h.id, "def_id", def.ID,
+					"idle_since", lastProgress)
+			} else {
+				// ERROR, not WARN: a healthy op being killed because nothing
+				// can hear it is a defect in the operation's plumbing, and it
+				// will recur on every single run until someone changes code.
+				r.writeStrike(h.id, def.ID, def.Plugin, "never_reported",
+					fmt.Sprintf("never reported progress in the %s since it started (timeout=%s); "+
+						"the op is most likely not wired to its reporter", idle, progressTimeout))
+				r.logger.Error("registry: canceling op that never reported progress",
+					"op_id", h.id, "def_id", def.ID, "started_at", lastProgress, "ran_for", idle,
+					"hint", "Run never called reporter.UpdateProgress — run the work through "+
+						"registry.RunItems, or report directly; raising ProgressTimeout only hides this")
+			}
 			h.cancelIfActive()
 			continue // don't also check uncheckpointed for the same op
 		}

--- a/internal/operations/registry/worker.go
+++ b/internal/operations/registry/worker.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/worker.go
-// version: 2.13.0
+// version: 2.14.0
 // guid: b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e
-// last-edited: 2026-08-07
+// last-edited: 2026-08-16
 
 package registry
 
@@ -282,7 +282,7 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 		// C-5: notify the dep scheduler on ALL terminal transitions (the
 		// subprocess path previously notified on none of them).
 		r.notifyDepTerminal(finalStatus, qr)
-		emitOpFinishedLog(runCtx, reporter, runStartedAt, finalStatus, runErr, true)
+		emitOpFinishedLog(runCtx, reporter, runStartedAt, finalStatus, runErr, true, h.lastProgressAt.Load() != 0)
 		r.logger.Info("registry: subprocess run finished", "op_id", qr.opID, "status", finalStatus)
 		return false
 	}
@@ -440,7 +440,7 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 	// for the same subject can be re-evaluated or failed as appropriate.
 	r.notifyDepTerminal(finalStatus, qr)
 
-	emitOpFinishedLog(runCtx, reporter, runStartedAt, finalStatus, runErr, false)
+	emitOpFinishedLog(runCtx, reporter, runStartedAt, finalStatus, runErr, false, h.lastProgressAt.Load() != 0)
 	r.logger.Info("registry: run finished", "op_id", qr.opID, "status", finalStatus)
 	return false
 }
@@ -462,17 +462,49 @@ func (r *Registry) notifyDepTerminal(finalStatus string, qr *queuedRun) {
 	}
 }
 
+// neverReportedGrace is how long an op may run without reporting before its
+// silence is treated as a wiring defect rather than ordinary brevity. Most ops
+// are legitimately sub-second and have nothing to report; the threshold sits
+// well below the 5m ProgressTimeout so the warning arrives while the op is
+// still succeeding, not after it starts being killed.
+const neverReportedGrace = 60 * time.Second
+
+// shouldWarnNeverReported is split out as a pure function so the policy can be
+// tested without standing up a registry, a store and a worker pool.
+func shouldWarnNeverReported(runDuration time.Duration, everReported bool) bool {
+	return !everReported && runDuration >= neverReportedGrace
+}
+
 // emitOpFinishedLog emits the canonical "operation finished" line through
 // the reporter's tagged logger. Every op gets this line regardless of
 // whether its Run emitted one. Downstream readers can rely on a
 // phase=end tag + structured outcome instead of parsing the message.
-func emitOpFinishedLog(ctx context.Context, rep Reporter, startedAt time.Time, outcome string, runErr error, subprocess bool) {
-	durMs := time.Since(startedAt).Milliseconds()
+func emitOpFinishedLog(ctx context.Context, rep Reporter, startedAt time.Time, outcome string, runErr error, subprocess bool, everReported bool) {
+	runDuration := time.Since(startedAt)
+	durMs := runDuration.Milliseconds()
 	attrs := []slog.Attr{
 		slog.String("phase", "end"),
 		slog.String("outcome", outcome),
 		slog.Int64("duration_ms", durMs),
 		slog.Bool("subprocess", subprocess),
+	}
+
+	// An op that did real work without ever reporting is one slow run away from
+	// being killed by the watchdog, and says nothing about itself until then.
+	// Flagging it on a SUCCESSFUL run is what turns a latent outage into a bug
+	// report: library.scan was in this state from 2026-05-11, completing
+	// quietly on a small library, and only became visible once the library grew
+	// past five minutes of scanning. The watchdog cannot catch this case --
+	// by definition the op finished in time.
+	if shouldWarnNeverReported(runDuration, everReported) {
+		rep.Logger().LogAttrs(ctx, slog.LevelError, "operation never reported progress",
+			slog.String("phase", "end"),
+			slog.String("outcome", outcome),
+			slog.Int64("duration_ms", durMs),
+			slog.String("hint", "this op ran for "+runDuration.Round(time.Second).String()+
+				" without a single reporter.UpdateProgress call; it will be canceled as stuck once it "+
+				"exceeds ProgressTimeout. Run the work through registry.RunItems, or report directly."),
+		)
 	}
 	if runErr != nil {
 		attrs = append(attrs, slog.String("error", runErr.Error()))


### PR DESCRIPTION
## Why

`stuck` and `never reported once` produced an identical strike, and they call for opposite responses:

- **stuck** — the op reported, then went quiet. Go and see what its work is blocked on.
- **never reported** — the op has not reported a single time. Far more often this means it is *not wired to its reporter at all*; the work may be perfectly healthy while the only channel that could say so is missing.

Conflating them is why the `LoggerFromReporter` stub (#2490) survived from 2026-05-11 to 2026-08-16. Every symptom it produced read as *"this operation is slow"*, so it was diagnosed as a property of the op and worked around **three separate times** — `dedupe_book_file_rows` raised its `ProgressTimeout` to 30m, `organizer` stopped re-taking a 20-minute backup, and today's `library.scan` was simply re-run. Raising `ProgressTimeout` fixes a genuine stall and merely *hides* a missing wire.

Measured on production — **44 stuck-op cancellations in 30 days**:

| def_id | strikes | mechanism |
|---|---|---|
| `maintenance.window` | 28 | stamps once at start, then only `Log()` |
| `library.scan` | 8 | reporter discarded — fixed by #2490 |
| `library.organize` | 3 | reporter discarded — fixed by #2490 |
| `scheduler.isbn-enrichment` | 2 | unclassified |
| `maintenance.job` | 1 | unclassified |
| `maintenance.dedupe-book-file-rows` | 1 | struck despite its 30m override |
| `itunes.import` | 1 | reporter discarded — fixed by #2490 |

## What changed

**1. The watchdog splits the strike.** Reported-then-quiet keeps kind `stuck` at WARN. Never-reported gets kind `never_reported` at ERROR with a hint naming `RunItems`. **Cancellation behaviour is unchanged** — an op cancelled before this commit is cancelled identically now. Only the label, level and message differ.

**2. A successful run that never reported is flagged.** If an op runs over a minute and completes without a single `UpdateProgress` call, it logs an error. The watchdog structurally cannot catch this case — the op finished inside its timeout. That is exactly how `library.scan` hid: it completed quietly while the library was small enough to scan in under five minutes, and only surfaced once it outgrew that. **Flagging on success is what would have caught this in May instead of August.**

## Deliberately not done

**Making `Log()` stamp the liveness clock.** It would clear 28 of the 44 strikes in about three lines — and would blind the watchdog to exactly what it exists for: a retry loop emitting `"connection failed, retrying"` forever is *stuck*, and would become permanently and silently healthy. Liveness must stay a deliberate assertion of forward progress, never a side effect of being noisy. `maintenance.window` gets fixed by making it report (follow-up), not by lowering the bar.

## Verification

- Both new watchdog tests confirmed **red first**.
- The **`reported-then-stalled` control passed before the change** — that is what proves the split *discriminates* rather than relabelling everything as never-reported.
- `shouldWarnNeverReported` is split out as a pure function and table-tested, including the grace boundary, so the policy is testable without standing up a registry, store and worker pool.
- `TestWatchdog_StuckBeforeFirstProgress` is **reclassified, not broken**: its op never calls `UpdateProgress`, so it now asserts the more specific kind. R-2's guarantee — a hang-from-birth op is detected rather than invisible forever — is unchanged and still asserted.
- Full `internal/operations/registry` suite green (44.9s). `go build ./...` and `go vet` clean.

Strike kinds are documented in `internal/database/iface_ops_v2.go`; `never_reported` is added there. No UI or alerting consumer reads strike kinds today (grepped), so adding one breaks nothing.

Follows #2490, which fixed the wire itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS
