### PR TITLE
fix(itunes): stop stub ops from shadowing their real implementations

### DIFF
--- a/changelog.d/20260816-itunes-stubs-shadow-real-ops.md
+++ b/changelog.d/20260816-itunes-stubs-shadow-real-ops.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- Three iTunes operations — **Sync**, **Path Reconcile** and **Path Repair** —
+  have been reporting success without doing anything since 2026-07-17. A
+  half-finished refactor left placeholder versions of them in the iTunes plugin,
+  and because plugins load before the rest of the server, the placeholders took
+  over from the working versions. Running any of the three produced a green
+  "completed" row and no work. All three now run their real implementations
+  again. A fourth, **Position Sync**, had no working version to fall back on and
+  now reports an honest failure instead of a false success.
+
+### Changed
+
+- A placeholder operation that has not been implemented yet now fails when run
+  instead of quietly reporting success. Reporting success for work that did not
+  happen is the more expensive failure: nothing looks wrong, so nobody looks.

--- a/internal/plugins/itunes/import.go
+++ b/internal/plugins/itunes/import.go
@@ -8,7 +8,6 @@ package itunes
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
@@ -39,8 +38,7 @@ func (p *Plugin) runImport(ctx context.Context, _ json.RawMessage, reporter sdk.
 	// NOTE: the canonical itunes.import op is registered by
 	// server.RegisterITunesImportOp (itunes_ops.go); this stub is
 	// intentionally unregistered (see Register in plugin.go).
-	_ = reporter.Log(slog.LevelWarn, "op not implemented — no-op", slog.String("def_id", "itunes.import"))
-	return nil
+	return errNotImplemented("itunes.import")
 }
 
 // Ensure methods are referenced so staticcheck doesn't flag them as unused (U1000).

--- a/internal/plugins/itunes/path_reconcile.go
+++ b/internal/plugins/itunes/path_reconcile.go
@@ -8,7 +8,6 @@ package itunes
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
@@ -37,6 +36,5 @@ func (p *Plugin) pathReconciledDef() sdk.OperationDef {
 func (p *Plugin) runPathReconcile(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	// TODO: Implement iTunes path reconciliation operation.
 	// This should call p.svc.Paths.Reconcile(ctx, opID, progress).
-	_ = reporter.Log(slog.LevelWarn, "op not implemented — no-op", slog.String("def_id", "itunes.path-reconcile"))
-	return nil
+	return errNotImplemented("itunes.path-reconcile")
 }

--- a/internal/plugins/itunes/path_repair.go
+++ b/internal/plugins/itunes/path_repair.go
@@ -8,7 +8,6 @@ package itunes
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
@@ -34,6 +33,5 @@ func (p *Plugin) pathRepairDef() sdk.OperationDef {
 func (p *Plugin) runPathRepair(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	// TODO: Implement iTunes path repair operation.
 	// This should call p.svc.Repair.Repair(ctx, opID, dryRun, progress).
-	_ = reporter.Log(slog.LevelWarn, "op not implemented — no-op", slog.String("def_id", "itunes.path-repair"))
-	return nil
+	return errNotImplemented("itunes.path-repair")
 }

--- a/internal/plugins/itunes/plugin.go
+++ b/internal/plugins/itunes/plugin.go
@@ -38,6 +38,46 @@ func (p *Plugin) Name() string { return "iTunes/Music Library" }
 // Version implements sdk.Plugin.
 func (p *Plugin) Version() string { return "1.0.0" }
 
+// registeredDefs is the whitelist of OperationDefs this plugin puts into the
+// registry.
+//
+// It is a whitelist, not "everything in this package", because registering a
+// def does not ADD an operation -- it REPLACES whatever else claims that ID.
+// Container.PostInit runs before NewServer's opRegistrars loop (server.go:567
+// vs :625), so a plugin def always wins a collision and the server's
+// registration is the one rejected.
+//
+// From 2026-07-17 until 2026-08-16 this package registered four stubs. Three of
+// them -- itunes.sync, itunes.path-reconcile, itunes.path-repair -- shadowed
+// the working implementations in internal/server/itunes_ops.go and
+// itunes_path_ops.go, which wire Importer.Sync, Paths.Reconcile and
+// Repair.Repair. Each stub returned nil, so all three operations reported
+// "completed" in production without doing anything. The only evidence was one
+// WARN per boot from the registrar loop, and that WARN was swallowed.
+//
+// The importDef exclusion below already described this exact hazard in a
+// comment; it was simply never applied to its siblings.
+//
+// Split out of Register so the whitelist can be asserted in a test without an
+// enabled Service (Enabled() reads an unexported deps.Config).
+func (p *Plugin) registeredDefs() []sdk.OperationDef {
+	return []sdk.OperationDef{
+		// EXCLUDED, all stubs whose real implementation lives in internal/server:
+		//   syncDef           -> server.RegisterITunesSyncOp (Importer.Sync)
+		//   importDef         -> server.RegisterITunesImportOp (Importer.Execute)
+		//   pathReconciledDef -> server.RegisterITunesPathReconcileOp (Paths.Reconcile)
+		//   pathRepairDef     -> server.RegisterITunesPathRepairOp (Repair.Repair)
+		//
+		// positionSyncDef is a stub too, but it has no server-side counterpart,
+		// so it stays registered: dropping it would make the op vanish rather
+		// than fail, and "unknown op" is a worse error than an honest one. Its
+		// Run returns an error instead of nil -- see runPositionSync. The real
+		// implementation it should call, svc.Positions.Sync, exists and has
+		// never been wired to anything.
+		p.positionSyncDef(),
+	}
+}
+
 // Register registers all iTunes OperationDefs with the UOS registry.
 // Returns nil if the service is nil or disabled (nil-guard pattern).
 func (p *Plugin) Register(r sdk.Registry) error {
@@ -46,18 +86,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		return nil
 	}
 
-	defs := []sdk.OperationDef{
-		p.syncDef(),
-		// importDef is a stub — the canonical itunes.import op is
-		// registered by server.RegisterITunesImportOp (itunes_ops.go),
-		// which wires Importer.Execute. Registering the stub here would
-		// collide with the real one and route through a no-op subprocess.
-		p.pathReconciledDef(),
-		p.pathRepairDef(),
-		p.positionSyncDef(),
-	}
-
-	for _, def := range defs {
+	for _, def := range p.registeredDefs() {
 		if err := r.RegisterOp(def); err != nil {
 			return fmt.Errorf("register %s: %w", def.ID, err)
 		}

--- a/internal/plugins/itunes/plugin_test.go
+++ b/internal/plugins/itunes/plugin_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/itunes/plugin_test.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: a7b8c9d0-e1f2-3456-ghij-567890123456
-// last-edited: 2026-07-17
+// last-edited: 2026-08-16
 
 package itunes
 
@@ -69,29 +69,85 @@ func (r *stubWarnReporter) Trigger(ctx context.Context, eventName string, payloa
 }
 func (r *stubWarnReporter) SetCurrentItem(label string) {}
 
-// TestStubRuns_LogNotImplementedWarn proves every stub Run emits an honest
-// "op not implemented" warning instead of silently returning nil.
-func TestStubRuns_LogNotImplementedWarn(t *testing.T) {
+// TestStubRuns_FailInsteadOfReportingSuccess requires every stub Run to return
+// an error naming its def.
+//
+// This test previously asserted the exact opposite -- `if err != nil {
+// t.Fatalf(...) }` -- and so locked in the defect it looked like it was
+// guarding. A WARN log plus `return nil` is not an honest stub: the registry
+// keys operation status off the returned error, so the op was recorded
+// "completed" and the UI showed a green row while nothing ran. Between
+// 2026-07-17 and 2026-08-16 that applied to itunes.sync,
+// itunes.path-reconcile and itunes.path-repair in production, all three of
+// which were also shadowing working implementations in internal/server.
+//
+// The log line is gone because the returned error carries the same
+// information to the same place, and cannot be mistaken for success.
+func TestStubRuns_FailInsteadOfReportingSuccess(t *testing.T) {
 	p := New(nil, nil)
-	runs := map[string]func(context.Context) error{}
 	rep := &stubWarnReporter{}
-	runs["itunes.sync"] = func(ctx context.Context) error { return p.runSync(ctx, nil, rep) }
-	runs["itunes.position-sync"] = func(ctx context.Context) error { return p.runPositionSync(ctx, nil, rep) }
-	runs["itunes.import"] = func(ctx context.Context) error { return p.runImport(ctx, nil, rep) }
-	runs["itunes.path-reconcile"] = func(ctx context.Context) error { return p.runPathReconcile(ctx, nil, rep) }
-	runs["itunes.path-repair"] = func(ctx context.Context) error { return p.runPathRepair(ctx, nil, rep) }
+	runs := map[string]func(context.Context) error{
+		"itunes.sync":           func(ctx context.Context) error { return p.runSync(ctx, nil, rep) },
+		"itunes.position-sync":  func(ctx context.Context) error { return p.runPositionSync(ctx, nil, rep) },
+		"itunes.import":         func(ctx context.Context) error { return p.runImport(ctx, nil, rep) },
+		"itunes.path-reconcile": func(ctx context.Context) error { return p.runPathReconcile(ctx, nil, rep) },
+		"itunes.path-repair":    func(ctx context.Context) error { return p.runPathRepair(ctx, nil, rep) },
+	}
 
 	for id, run := range runs {
-		rep.logged.Reset()
-		if err := run(context.Background()); err != nil {
-			t.Fatalf("%s: stub run returned error: %v", id, err)
+		err := run(context.Background())
+		if err == nil {
+			t.Errorf("%s: stub Run returned nil — the registry will record this op as completed", id)
+			continue
 		}
-		out := rep.logged.String()
-		if !strings.Contains(out, "op not implemented") {
-			t.Errorf("%s: stub run did not log a not-implemented warning; got %q", id, out)
+		if !strings.Contains(err.Error(), id) {
+			t.Errorf("%s: error does not name the def id, so the op history will not say which op lied; got %q", id, err)
 		}
-		if !strings.Contains(out, id) {
-			t.Errorf("%s: warning does not name the def id; got %q", id, out)
+	}
+}
+
+// TestRegister_OnlyRegistersDefsWithARealRun pins which of this package's defs
+// reach the registry.
+//
+// Registering a stub does not add an operation, it REPLACES whichever
+// registration would otherwise claim that ID. Container.PostInit runs before
+// NewServer's opRegistrars loop (server.go:567 vs :625), so a plugin def always
+// wins and the server's real implementation is the one rejected -- with a
+// single swallowed WARN as the only evidence.
+//
+// This is a whitelist on purpose. Adding a def here must be a deliberate edit
+// with a real Run behind it, not something that happens by appending a line to
+// the defs slice.
+func TestRegister_OnlyRegistersDefsWithARealRun(t *testing.T) {
+	// These IDs have working implementations registered from internal/server.
+	// A plugin stub claiming any of them silently disables the real op.
+	shadowed := map[string]string{
+		"itunes.sync":           "server.RegisterITunesSyncOp (Importer.Sync)",
+		"itunes.import":         "server.RegisterITunesImportOp (Importer.Execute)",
+		"itunes.path-reconcile": "server.RegisterITunesPathReconcileOp (Paths.Reconcile)",
+		"itunes.path-repair":    "server.RegisterITunesPathRepairOp (Repair.Repair)",
+	}
+
+	p := New(nil, nil)
+	var got []string
+	for _, def := range p.registeredDefs() {
+		got = append(got, def.ID)
+	}
+
+	for _, id := range got {
+		if owner, bad := shadowed[id]; bad {
+			t.Errorf("plugin registered %q, which shadows the real implementation in %s; "+
+				"the plugin def wins the collision and the working op becomes unreachable", id, owner)
+		}
+	}
+
+	want := []string{"itunes.position-sync"}
+	if len(got) != len(want) {
+		t.Fatalf("registered ops = %v, want %v", got, want)
+	}
+	for i, id := range want {
+		if got[i] != id {
+			t.Errorf("registered op %d = %q, want %q", i, got[i], id)
 		}
 	}
 }

--- a/internal/plugins/itunes/position_sync.go
+++ b/internal/plugins/itunes/position_sync.go
@@ -8,7 +8,6 @@ package itunes
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
@@ -37,6 +36,5 @@ func (p *Plugin) positionSyncDef() sdk.OperationDef {
 func (p *Plugin) runPositionSync(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	// TODO: Implement iTunes position sync operation.
 	// This should call p.svc.Positions.Sync().
-	_ = reporter.Log(slog.LevelWarn, "op not implemented — no-op", slog.String("def_id", "itunes.position-sync"))
-	return nil
+	return errNotImplemented("itunes.position-sync")
 }

--- a/internal/plugins/itunes/stub.go
+++ b/internal/plugins/itunes/stub.go
@@ -1,0 +1,28 @@
+// file: internal/plugins/itunes/stub.go
+// version: 1.0.0
+// guid: 3d81f0a7-6c94-4e2b-b5d3-9f7a1c60e482
+// last-edited: 2026-08-16
+
+package itunes
+
+import "fmt"
+
+// errNotImplemented is what an unfinished op Run must return.
+//
+// Returning nil from a stub is not a placeholder, it is a false report: the
+// registry marks the op "completed", the UI shows a green row, and the work
+// silently did not happen. Three iTunes ops did exactly that between
+// 2026-07-17 and 2026-08-16, and the only reason it was ever noticed is that
+// they also collided with a real registration and logged a WARN. A stub with
+// no collision -- itunes.position-sync -- produced no evidence at all.
+//
+// The 2026-07-17 response to the same symptom was to remove the cron schedules
+// from itunes.sync and itunes.position-sync so they would stop burning green
+// no-op rows every 10 and 30 minutes. That stopped the rows; it left the lie
+// intact for anyone who triggered the op by hand.
+//
+// An op that cannot do its work must fail. Failing is recoverable -- someone
+// sees it and fixes it. Succeeding falsely is not.
+func errNotImplemented(defID string) error {
+	return fmt.Errorf("%s: operation is not implemented — refusing to report success for work that did not happen", defID)
+}

--- a/internal/plugins/itunes/sync.go
+++ b/internal/plugins/itunes/sync.go
@@ -8,7 +8,6 @@ package itunes
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
@@ -37,6 +36,5 @@ func (p *Plugin) syncDef() sdk.OperationDef {
 func (p *Plugin) runSync(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	// TODO: Implement iTunes sync operation.
 	// This should call p.svc.Importer.Sync with appropriate path mappings.
-	_ = reporter.Log(slog.LevelWarn, "op not implemented — no-op", slog.String("def_id", "itunes.sync"))
-	return nil
+	return errNotImplemented("itunes.sync")
 }

--- a/todo.d/20260816-finish-itunes-plugin-migration.md
+++ b/todo.d/20260816-finish-itunes-plugin-migration.md
@@ -1,0 +1,14 @@
+- [ ] **Finish (or delete) the iTunes plugin op migration.** `internal/plugins/itunes/`
+      holds five stub `Run` bodies. Four are excluded from `registeredDefs()` because
+      the real implementations live in `internal/server/itunes_ops.go` and
+      `itunes_path_ops.go`; the package is now half a migration that does nothing.
+      Either port the real bodies in (`itunes.sync` additionally needs
+      `s.activityWriter` + `s.itunesActivityFn` threaded into `Plugin`, which is a
+      design decision, not a move) or delete the stub files and their defs. Leaving
+      them is what caused #2490's sibling bug: a stub that looks registrable.
+- [ ] **Wire `itunes.position-sync` or drop it.** `internal/itunes/service/position_sync.go`
+      implements a full bidirectional bookmark/play-count sync (`PositionSync.Sync()
+      (pulled, pushed int)`) and **nothing in the codebase calls it** — the only
+      reference is the TODO comment in the plugin stub. Wiring it turns on real writes
+      to user positions across two systems on a 63k-book library, so it needs an
+      explicit decision and a dry-run, not a one-line hookup.


### PR DESCRIPTION
## What

Three iTunes operations have been reporting `completed` in production while doing nothing since 2026-07-17.

`Container.PostInit` runs before `NewServer`'s `opRegistrars` loop (`internal/server/server.go:567` vs `:625`), so an `OperationDef` registered by a plugin always wins an ID collision and the **server's** registration is the one rejected.

`internal/plugins/itunes` registered four stubs. Three collided with working implementations:

| Op | Stub (winner) | Real implementation (rejected) |
|---|---|---|
| `itunes.sync` | `sync.go` → `return nil` | `server.RegisterITunesSyncOp` → `Importer.Sync` |
| `itunes.path-reconcile` | `path_reconcile.go` → `return nil` | `server.RegisterITunesPathReconcileOp` → `Paths.Reconcile` |
| `itunes.path-repair` | `path_repair.go` → `return nil` | `server.RegisterITunesPathRepairOp` → `Repair.Repair` |
| `itunes.position-sync` | `position_sync.go` → `return nil` | *(none — sole registrant)* |

The only evidence was one `WARN msg="op registrar" err="OperationDef already registered"` per boot — **378 lines in 30 days** of production journal — and the registrar loop swallowed it.

`importDef` was already excluded, with a comment describing this exact hazard. It was never applied to its four siblings.

## Changes

- `registeredDefs()` is now an explicit whitelist, split out of `Register` so it can be asserted without an enabled `Service` (`Enabled()` reads an unexported `deps.Config`).
- Every stub `Run` returns an error instead of `nil`. An unimplemented op that returns `nil` is recorded `completed` — a false report, not a placeholder.
- `itunes.position-sync` stays registered: it has no counterpart, and dropping it would make the op vanish rather than fail.

## Tests

`TestStubRuns` previously asserted `if err != nil { t.Fatalf }` — it **locked in the false success it appeared to guard**. Inverted.

Both new guards mutation-tested:
- re-adding the 3 shadowing defs → `TestRegister_OnlyRegistersDefsWithARealRun` fails naming all 3
- reverting one stub to `return nil` → `TestStubRuns_FailInsteadOfReportingSuccess` fails naming it

4/4 pass; `go vet` clean.

## Note on sequencing

`fix/op-registrar-failure-is-fatal` (makes a failed registration refuse to boot) **must merge after this one is deployed** — with the duplicate present it would prevent production from starting.

## Not in scope

`todo.d/20260816-finish-itunes-plugin-migration.md` — finishing or deleting the migration, and wiring `svc.Positions.Sync` (fully implemented, never called by anything; turning it on means real bidirectional writes to user positions on a 63k-book library).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS