### PR TITLE
fix(server): refuse to start when an operation failed to register

### DIFF
--- a/changelog.d/20260816-op-registration-fatal.md
+++ b/changelog.d/20260816-op-registration-fatal.md
@@ -1,0 +1,8 @@
+### Changed
+
+- The server now refuses to start if any background operation failed to
+  register, instead of logging a warning and carrying on. An operation that
+  fails to register doesn't degrade — it ceases to exist, while everything else
+  reports healthy, so the failure only surfaces later as an unrecognised
+  operation on a server that looks fine. Refusing to start is the louder and
+  much cheaper failure.

--- a/internal/server/op_registration_gate_test.go
+++ b/internal/server/op_registration_gate_test.go
@@ -1,0 +1,89 @@
+// file: internal/server/op_registration_gate_test.go
+// version: 1.0.0
+// guid: 7a1f4c92-3e58-4b6d-9c07-2d8ba5f1e304
+// last-edited: 2026-08-16
+
+package server
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestStart_RefusesWhenOpRegistrationFailed pins the gate added on 2026-08-16.
+//
+// NewServer's op-registrar loop used to log a failed RegisterOp at WARN and
+// continue. The result was a server that booted clean, passed every health
+// check, and was simply missing an operation -- whatever enqueued it later got
+// "unknown op" from an otherwise healthy process, which is a much harder thing
+// to diagnose than a refusal to start. This asserts the refusal happens, and
+// that the message carries enough to find the culprit.
+func TestStart_RefusesWhenOpRegistrationFailed(t *testing.T) {
+	s := &Server{
+		opRegistrationErrs: []error{
+			errors.New("registry: RegisterOp(library.scan): boom"),
+			errors.New("registry: RegisterOp(dedup.full-scan): also boom"),
+		},
+	}
+
+	err := s.Start(ServerConfig{})
+	if err == nil {
+		t.Fatal("Start returned nil with 2 registration failures pending; a server missing ops must not serve")
+	}
+
+	// The count tells an operator how bad it is; the joined causes tell them
+	// which ops to look at. A bare "registration failed" would send them to the
+	// logs to reconstruct both.
+	if !strings.Contains(err.Error(), "2 op(s)") {
+		t.Errorf("error should name how many ops failed, got: %v", err)
+	}
+	for _, want := range []string{"library.scan", "dedup.full-scan"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should name the failed op %q, got: %v", want, err)
+		}
+	}
+}
+
+// TestOpRegistrationGate_ClearWhenNothingFailed is the negative control for the
+// test above. Without it a gate that refused unconditionally would still pass
+// TestStart_RefusesWhenOpRegistrationFailed, and the gate would look tested
+// while measuring nothing.
+//
+// This exercises opRegistrationGate rather than Start on purpose: Start's later
+// stages spawn background goroutines against a fully wired Server, so a bare
+// &Server{} run through Start panics in startBackfills instead of
+// demonstrating that the gate let it through. Measured, not assumed -- that is
+// what the first draft of this test did.
+func TestOpRegistrationGate_ClearWhenNothingFailed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		errs []error
+	}{
+		{name: "nil slice", errs: nil},
+		{name: "empty slice", errs: []error{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{opRegistrationErrs: tc.errs}
+			if err := s.opRegistrationGate(); err != nil {
+				t.Errorf("gate refused a healthy registry: %v", err)
+			}
+		})
+	}
+}
+
+// TestOpRegistrationGate_OneFailureIsEnough guards the boundary. A gate written
+// as "more than a few failures" or one that only fired on a plural count would
+// let a single missing op through -- and one missing op is the whole failure
+// mode, not a lesser version of it.
+func TestOpRegistrationGate_OneFailureIsEnough(t *testing.T) {
+	s := &Server{opRegistrationErrs: []error{errors.New("registry: RegisterOp(library.scan): boom")}}
+
+	err := s.opRegistrationGate()
+	if err == nil {
+		t.Fatal("gate allowed startup with 1 failed registration")
+	}
+	if !strings.Contains(err.Error(), "1 op(s)") {
+		t.Errorf("error should report a count of 1, got: %v", err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -248,6 +248,17 @@ type Server struct {
 	// No plugins are registered until their own bot-tasks wire them in.
 	opRegistry *opsregistry.Registry
 
+	// opRegistrationErrs collects failures from the op-registrar loop in
+	// NewServer. NewServer returns *Server with no error (47 call sites, most
+	// of them tests that never Start), so there is nowhere to return these at
+	// construction time -- until 2026-08-16 they were logged at WARN and
+	// dropped, which meant a registration failure silently removed an
+	// operation from a server that then booted looking perfectly healthy.
+	// Start() refuses to come up while this is non-empty, so the error lands
+	// on the one path where a real deployment happens and stays out of the
+	// way of tests that only construct.
+	opRegistrationErrs []error
+
 	// opHub is the UOS-06 SSE event bus for operations events.
 	// Created in NewServer, wired to opRegistry via SetBus before Start().
 	opHub *opsregistry.EventHub
@@ -601,13 +612,20 @@ func NewServer(store database.Store) *Server {
 	// and the mock store has no UpsertOpDefinitionV2 expectations.
 	if config.AppConfig.RootDir != "" {
 		if err := maintenanceplugin.New(server).Register(server.opRegistry); err != nil {
-			slog.Warn("maintenance plugin register", "err", err)
+			slog.Error("maintenance plugin register", "err", err)
+			server.opRegistrationErrs = append(server.opRegistrationErrs,
+				fmt.Errorf("maintenance plugin register: %w", err))
 		}
 		// Iterate all op registrars. Each file calls addOpRegistrar in its init()
 		// so new ops never require touching this block.
+		//
+		// Every one of the ~55 RegisterOp call sites correctly returns its
+		// error; this loop was the single place that threw them away. Collect
+		// instead, and let Start() decide -- see opRegistrationErrs.
 		for _, reg := range opRegistrars {
 			if err := reg(server, server.opRegistry); err != nil {
-				slog.Warn("op registrar", "err", err)
+				slog.Error("op registrar", "err", err)
+				server.opRegistrationErrs = append(server.opRegistrationErrs, err)
 			}
 		}
 	}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -8,6 +8,7 @@ package server
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -292,7 +293,36 @@ func (s *Server) resumeLegacyOp(opID, opType string) {
 	}
 }
 
+// opRegistrationGate reports whether the operations registry came up whole.
+//
+// An op that fails to register does not degrade -- it ceases to exist,
+// silently, while every other subsystem reports healthy. Whatever enqueues it
+// later gets "unknown op" from a server that looks fine, which is a far worse
+// thing to diagnose than a refusal to start. Until 2026-08-16 these failures
+// were logged at WARN in NewServer's registrar loop and dropped, because
+// NewServer has no error return; they are collected on the Server now and
+// enforced here, on the one path where a real deployment happens.
+//
+// Split out of Start so the condition can be tested without booting a server:
+// Start's later stages spawn background goroutines that require a fully wired
+// Server, so a "no errors" control exercised through Start panics rather than
+// demonstrating anything.
+func (s *Server) opRegistrationGate() error {
+	if len(s.opRegistrationErrs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("operation registration failed for %d op(s), refusing to start: %w",
+		len(s.opRegistrationErrs), errors.Join(s.opRegistrationErrs...))
+}
+
 func (s *Server) Start(cfg ServerConfig) error {
+	// Refuse to serve with a hole in the operations registry, before touching
+	// anything else -- nothing below this line should run on a server that is
+	// about to be rejected.
+	if err := s.opRegistrationGate(); err != nil {
+		return err
+	}
+
 	s.externalURL = strings.TrimRight(cfg.ExternalURL, "/")
 
 	// SERVER-LIFECYCLE-FLIP: drive Starter services via the container.


### PR DESCRIPTION
## What

`internal/server/server.go`'s op-registrar loop logged a failed `RegisterOp` at WARN and carried on:

```go
for _, reg := range opRegistrars {
    if err := reg(server, server.opRegistry); err != nil {
        slog.Warn("op registrar", "err", err)   // swallowed
    }
}
```

All ~55 production `RegisterOp` call sites correctly return their error (zero `_ =` discards). This loop was the single place that threw them away — so a registration failure silently removed an operation from a server that then booted clean and passed every health check. Whatever enqueued that op later got "unknown op" from an otherwise healthy process.

## Approach

`NewServer` returns `*Server` with no error, and has 47 call sites — mostly tests that construct a server and never start it. Rather than change that signature, failures are collected on the `Server` and enforced in `Start`, which already returns `error` to `cmd/root.go`. The error lands on the one path where a real deployment happens, and test construction is untouched.

The gate is split into `opRegistrationGate()` so the healthy case is testable: `Start`'s later stages spawn goroutines against a fully wired `Server`, so a bare `&Server{}` run through `Start` panics in `startBackfills` rather than demonstrating the gate let it through. (The first draft of the test did exactly that.)

## Sequencing — this was blocked on #2492

Production emitted **378 `op registrar` warnings in 30 days**, 3 on every boot: `itunes.sync`, `itunes.path-reconcile`, `itunes.path-repair` were each registered twice. **Merging this before #2492 would have prevented production from starting.**

#2492 merged and deployed at 12:37 today. Verified on the running server before pushing this:

```
--- op registrar warnings since restart ---
0
```

## Tests

- `TestStart_RefusesWhenOpRegistrationFailed` — through `Start`, proving the gate is wired and returns before any side effect
- `TestOpRegistrationGate_ClearWhenNothingFailed` — negative control (nil and empty)
- `TestOpRegistrationGate_OneFailureIsEnough` — boundary; one missing op is the whole failure mode, not a lesser version of it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS