### PR TITLE
fix(scanner): check in during directory walk and honor the configured LLM backend

### DIFF
--- a/changelog.d/20260816-scanner-walk-progress.md
+++ b/changelog.d/20260816-scanner-walk-progress.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **Library scans no longer get killed while they are still working.** The
+  directory-discovery and directory-scanning phases of a scan reported no
+  progress at all, so on a large import folder the scan looked identical to a
+  hung process and the stuck-operation watchdog killed it after five minutes.
+  The 2026-08-16 rescan died this way mid-walk of a folder holding 17,469
+  books. Both phases now check in every 20 directories.
+
+- **The scanner honors the configured LLM backend.** It previously built the
+  cloud OpenAI parser whenever AI parsing was enabled, ignoring
+  `ai_backend.llm_mode` entirely — so a deployment configured for a local
+  Ollama endpoint, or for no LLM at all, still sent every scan batch to
+  `api.openai.com`. Local, OpenAI, and disabled modes are now all respected,
+  matching the `llmparser` service registration.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.78.0
+// version: 1.79.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-08-15
 
@@ -564,6 +564,14 @@ type Config struct {
 
 	// Performance
 	ConcurrentScans int `json:"concurrent_scans"`
+
+	// ScanProgressEvery is how many directories/files a library scan processes
+	// between progress checkpoints. It exists because the stuck-op watchdog
+	// kills an operation after ProgressTimeout without one, and how long a
+	// batch of N items takes depends entirely on the storage underneath: a
+	// library on slow or high-latency storage may need a smaller interval than
+	// the default of 20. 0 means use the default.
+	ScanProgressEvery int `json:"scan_progress_every" mapstructure:"scan_progress_every"`
 	// ChapterConsolidationThresholdMin is the per-file duration threshold (minutes)
 	// used during scanning to detect chapter-named files. If a group of ≥ 3 files
 	// sharing the same base title (e.g. "01 - My Book", "02 - My Book") each
@@ -1450,6 +1458,7 @@ func InitConfig() {
 
 			// Performance
 			ConcurrentScans:                  viper.GetInt("concurrent_scans"),
+			ScanProgressEvery:                viper.GetInt("scan_progress_every"),
 			ChapterConsolidationThresholdMin: viper.GetInt("chapter_consolidation_threshold_min"),
 			CoalesceShatteredSiblings:        viper.GetBool("coalesce_shattered_siblings"),
 			OperationTimeoutMinutes:          viper.GetInt("operation_timeout_minutes"),
@@ -2065,6 +2074,7 @@ func ResetToDefaults() {
 
 			// Performance
 			ConcurrentScans:         max(runtime.NumCPU(), 4),
+			ScanProgressEvery:       20,
 			OperationTimeoutMinutes: 30,
 			MinBookSizeBytes:        5 * 1024 * 1024,
 			APIRateLimitPerMinute:   100,

--- a/internal/scanner/scan_progress_test.go
+++ b/internal/scanner/scan_progress_test.go
@@ -1,0 +1,111 @@
+// file: internal/scanner/scan_progress_test.go
+// version: 1.0.0
+// guid: 5f2a9c14-8e63-4b07-a5d9-1c4e7b0f6a38
+// last-edited: 2026-08-16
+
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/logger"
+)
+
+// progressSpy records UpdateProgress calls. It embeds logger.Logger so the
+// rest of the (large) interface comes from a real logger, and overrides With
+// to return itself -- callers wrap the logger before handing it down, and a
+// spy that lost its identity on With would silently observe nothing.
+type progressSpy struct {
+	logger.Logger
+	mu    sync.Mutex
+	calls []string
+}
+
+func (p *progressSpy) UpdateProgress(current, total int, message string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, fmt.Sprintf("%d/%d %s", current, total, message))
+}
+
+func (p *progressSpy) With(string) logger.Logger { return p }
+
+func (p *progressSpy) count() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.calls)
+}
+
+// TestScanDirectoryParallel_ChecksInLongEnoughToSurviveTheWatchdog pins the
+// 2026-08-16 fix.
+//
+// Both phases of ScanDirectoryParallel -- the WalkDir that discovers
+// directories and the parallel pass that reads each one -- used to run without
+// a single UpdateProgress call. The stuck-op watchdog kills an operation after
+// 5 minutes of silence, so on a large import root the scan was killed while
+// the process was demonstrably busy. That is precisely how the 2026-08-16
+// rescan died, mid-walk of a folder holding 17,469 books.
+//
+// The assertion is deliberately about the COUNT of checkpoints, not merely
+// that one happened: a single call at the start or the end would satisfy
+// "reports progress" while leaving an arbitrarily long silent stretch in the
+// middle, which is the actual defect.
+func TestScanDirectoryParallel_ChecksInLongEnoughToSurviveTheWatchdog(t *testing.T) {
+	root := t.TempDir()
+
+	// scanProgressEvery*3 directories, so a correct implementation must check
+	// in several times in each phase rather than once at a boundary.
+	const dirCount = scanProgressEvery * 3
+	for i := range dirCount {
+		d := filepath.Join(root, fmt.Sprintf("book-%03d", i))
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		// A supported audio file so the directory is real work, not skipped.
+		if err := os.WriteFile(filepath.Join(d, "track.mp3"), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	prev := config.AppConfig.SupportedExtensions
+	config.AppConfig.SupportedExtensions = []string{".mp3"}
+	t.Cleanup(func() { config.AppConfig.SupportedExtensions = prev })
+
+	spy := &progressSpy{Logger: logger.New("test")}
+
+	if _, err := ScanDirectoryParallel(context.Background(), root, 4, spy); err != nil {
+		t.Fatalf("ScanDirectoryParallel: %v", err)
+	}
+
+	got := spy.count()
+	// dirCount directories in the scan phase alone yields dirCount/every
+	// checkpoints; the discovery walk adds its own. Require at least the scan
+	// phase's share so the test fails if either phase goes silent.
+	want := dirCount / scanProgressEvery
+	if got < want {
+		t.Errorf("got %d progress checkpoints for %d directories, want >= %d — "+
+			"a phase is running silently and the stuck-op watchdog will kill long scans",
+			got, dirCount, want)
+	}
+}
+
+// TestScanProgressEveryIsATightEnoughBound guards the constant itself. It is
+// the only thing standing between a directory-heavy scan and a watchdog kill,
+// so a well-meaning bump to a large value would silently reintroduce the bug.
+func TestScanProgressEveryIsATightEnoughBound(t *testing.T) {
+	if scanProgressEvery <= 0 {
+		t.Fatalf("scanProgressEvery must be positive, got %d", scanProgressEvery)
+	}
+	// 5m watchdog budget; even a pathologically slow directory (1s) must leave
+	// a wide margin.
+	if scanProgressEvery > 100 {
+		t.Errorf("scanProgressEvery=%d is too coarse: at ~1s per slow directory "+
+			"that is %ds between checkpoints against a 5m ProgressTimeout",
+			scanProgressEvery, scanProgressEvery)
+	}
+}

--- a/internal/scanner/scan_progress_test.go
+++ b/internal/scanner/scan_progress_test.go
@@ -1,5 +1,5 @@
 // file: internal/scanner/scan_progress_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5f2a9c14-8e63-4b07-a5d9-1c4e7b0f6a38
 // last-edited: 2026-08-16
 
@@ -91,6 +91,48 @@ func TestScanDirectoryParallel_ChecksInLongEnoughToSurviveTheWatchdog(t *testing
 		t.Errorf("got %d progress checkpoints for %d directories, want >= %d — "+
 			"a phase is running silently and the stuck-op watchdog will kill long scans",
 			got, dirCount, want)
+	}
+}
+
+// TestScanDirectoryParallel_ReportsInsideOneHugeDirectory covers the shape
+// that per-directory checkpoints cannot see.
+//
+// The first version of this fix counted directories only. That is fine for a
+// library organized as a folder per book, but a library kept as ONE flat
+// folder of tens of thousands of files has exactly one directory: the
+// discovery walk reports nothing (1 % 20 != 0) and the scan phase reports once,
+// after all the work is already done. The whole scan is a single silent stretch
+// and the watchdog kills it -- the same failure, just reached differently.
+//
+// So this asserts checkpoints happen with dirCount == 1, which is false for
+// any directory-counting implementation no matter how small its interval.
+func TestScanDirectoryParallel_ReportsInsideOneHugeDirectory(t *testing.T) {
+	root := t.TempDir()
+
+	const fileCount = scanProgressEvery * 3
+	for i := range fileCount {
+		f := filepath.Join(root, fmt.Sprintf("track-%03d.mp3", i))
+		if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	prev := config.AppConfig.SupportedExtensions
+	config.AppConfig.SupportedExtensions = []string{".mp3"}
+	t.Cleanup(func() { config.AppConfig.SupportedExtensions = prev })
+
+	spy := &progressSpy{Logger: logger.New("test")}
+
+	if _, err := ScanDirectoryParallel(context.Background(), root, 4, spy); err != nil {
+		t.Fatalf("ScanDirectoryParallel: %v", err)
+	}
+
+	got := spy.count()
+	want := fileCount / scanProgressEvery
+	if got < want {
+		t.Errorf("got %d checkpoints scanning %d files in a SINGLE directory, want >= %d — "+
+			"a flat library reports only per-directory and will be killed mid-scan",
+			got, fileCount, want)
 	}
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,5 +1,5 @@
 // file: internal/scanner/scanner.go
-// version: 1.53.0
+// version: 1.54.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
 // last-edited: 2026-08-16
 
@@ -516,11 +516,25 @@ func ScanDirectoryParallel(ctx context.Context, rootDir string, workers int, sca
 	// (audit 2026-07-17 R-5/M8). Atomic: ReadDir failures occur in workers.
 	var walkErrCount atomic.Int64
 
-	// dirsFound / dirsScanned drive the liveness checkpoints below. Both
-	// phases of this function used to run silently; see the comments at each
-	// UpdateProgress call for why that killed the 2026-08-16 rescan.
+	// dirsFound / dirsScanned / filesScanned drive the liveness checkpoints
+	// below. Every phase of this function used to run silently; see the
+	// comments at each UpdateProgress call for why that killed the 2026-08-16
+	// rescan.
+	//
+	// Directory counters alone are not sufficient: a library kept as one flat
+	// folder of tens of thousands of files has exactly one directory, so the
+	// per-directory checkpoints fire once, at the end. filesScanned is what
+	// covers that shape.
 	var dirsFound atomic.Int64
 	var dirsScanned atomic.Int64
+	var filesScanned atomic.Int64
+
+	// Operators with unusually slow storage can widen the interval; 0 or unset
+	// means the default.
+	every := config.AppConfig.ScanProgressEvery
+	if every <= 0 {
+		every = scanProgressEvery
+	}
 
 	registerDirectory := func(path string, info os.FileInfo) bool {
 		if info == nil {
@@ -592,7 +606,7 @@ func ScanDirectoryParallel(ctx context.Context, rootDir string, workers int, sca
 			// The total is genuinely unknown while discovering, so current and
 			// total move together; that is the same "growing denominator"
 			// convention scanFolder already uses for its per-book counter.
-			if n := int(dirsFound.Add(1)); n%scanProgressEvery == 0 {
+			if n := int(dirsFound.Add(1)); n%every == 0 {
 				scanLog.UpdateProgress(n, n, fmt.Sprintf("Discovering folders: %d found (%s)", n, filepath.Base(path)))
 			}
 		}
@@ -621,7 +635,7 @@ func ScanDirectoryParallel(ctx context.Context, rootDir string, workers int, sca
 				// 2026-08-16. Unlike the discovery walk above, the denominator
 				// is known here, so this is real progress rather than a
 				// growing count.
-				if n := int(dirsScanned.Add(1)); n%scanProgressEvery == 0 || n == len(dirs) {
+				if n := int(dirsScanned.Add(1)); n%every == 0 || n == len(dirs) {
 					scanLog.UpdateProgress(n, len(dirs),
 						fmt.Sprintf("Scanning folders: %d/%d (%s)", n, len(dirs), filepath.Base(scanDir)))
 				}
@@ -654,8 +668,18 @@ func ScanDirectoryParallel(ctx context.Context, rootDir string, workers int, sca
 				}
 			}
 
-			// Group files into logical books using album tags
-			localBooks := groupFilesIntoBooks(ctx, audioFiles)
+			// Group files into logical books using album tags.
+			//
+			// The per-file checkpoint is what keeps a single-huge-directory
+			// library alive: with one directory the per-directory counters
+			// above fire once, at the very end, so this callback is the only
+			// thing reporting during what may be hours of tag reading.
+			localBooks := groupFilesIntoBooks(ctx, audioFiles, func() {
+				if n := int(filesScanned.Add(1)); n%every == 0 {
+					scanLog.UpdateProgress(n, n,
+						fmt.Sprintf("Reading tags: %d files (%s)", n, filepath.Base(scanDir)))
+				}
+			})
 
 			// Merge results
 			if len(localBooks) > 0 {
@@ -1864,7 +1888,24 @@ func quickReadMultiFileInfo(filePath string) MultiFileInfo {
 // When all files in a directory share the same non-empty album tag, they become a
 // single directory-based Book (with segments created later). Otherwise, each file
 // is treated as an individual Book (existing hash-based dedup handles linking).
-func groupFilesIntoBooks(ctx context.Context, files []string) []Book {
+// groupFilesIntoBooks groups a directory's audio files into logical books.
+//
+// onFileScanned, if supplied, is invoked once per file as the tag-reading pass
+// walks them. It exists because this loop is the longest uninterrupted stretch
+// of work in a scan: it opens and reads tags from every file in one directory.
+// A library kept as a single flat folder of tens of thousands of files spends
+// its entire scan inside this one call, so per-directory progress reporting
+// cannot see it -- there is only ever one directory -- and the stuck-op
+// watchdog kills the scan while it is working. Variadic so the existing
+// callers and tests need no change.
+func groupFilesIntoBooks(ctx context.Context, files []string, onFileScanned ...func()) []Book {
+	noteFile := func() {
+		for _, fn := range onFileScanned {
+			if fn != nil {
+				fn()
+			}
+		}
+	}
 	if len(files) <= 1 {
 		var books []Book
 		for _, f := range files {
@@ -1885,6 +1926,7 @@ func groupFilesIntoBooks(ctx context.Context, files []string) []Book {
 		infos := make([]MultiFileInfo, len(files))
 		for i, f := range files {
 			infos[i] = quickReadMultiFileInfo(f)
+			noteFile()
 		}
 		if ok, sorted := DetectMultiFileGroup(infos, DefaultMultiFileConfig()); ok {
 			segs := make([]string, len(sorted))
@@ -1942,6 +1984,11 @@ func groupFilesIntoBooks(ctx context.Context, files []string) []Book {
 	var noAlbum []string
 	for _, f := range files {
 		album := quickReadAlbum(f)
+		// This is the other unbounded tag-reading pass, and the one a flat
+		// library actually hits: a folder of many unrelated books fails the
+		// multi-file-group check above and lands here, reading tags from every
+		// file with no checkpoint of its own.
+		noteFile()
 		if album == "" {
 			noAlbum = append(noAlbum, f)
 		} else {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,5 +1,5 @@
 // file: internal/scanner/scanner.go
-// version: 1.52.0
+// version: 1.53.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
 // last-edited: 2026-08-16
 
@@ -44,6 +44,18 @@ var saveBook func(ctx context.Context, book *Book) error = saveBookToDatabase
 
 // defaultLog is a package-level logger for functions that cannot accept a logger parameter.
 var defaultLog = logger.New("scanner")
+
+// scanProgressEvery is how many directories ScanDirectoryParallel processes
+// between liveness checkpoints.
+//
+// The bound that matters is wall-clock, not count: the stuck-op watchdog kills
+// an operation after ProgressTimeout (5m) without an UpdateProgress. A single
+// directory is scanned in well under a second even when it holds hundreds of
+// files, so 20 keeps the gap between checkpoints to seconds while costing one
+// progress write per 20 directories rather than one per directory -- the
+// reporter persists each update, so checkpointing every single directory would
+// add ~13k writes to a full-library scan for no extra safety.
+const scanProgressEvery = 20
 
 // Counters for store failures that were previously swallowed silently
 // (audit 2026-07-17 H5). Package-level atomics because saveBookToDatabase is
@@ -504,6 +516,12 @@ func ScanDirectoryParallel(ctx context.Context, rootDir string, workers int, sca
 	// (audit 2026-07-17 R-5/M8). Atomic: ReadDir failures occur in workers.
 	var walkErrCount atomic.Int64
 
+	// dirsFound / dirsScanned drive the liveness checkpoints below. Both
+	// phases of this function used to run silently; see the comments at each
+	// UpdateProgress call for why that killed the 2026-08-16 rescan.
+	var dirsFound atomic.Int64
+	var dirsScanned atomic.Int64
+
 	registerDirectory := func(path string, info os.FileInfo) bool {
 		if info == nil {
 			return false
@@ -562,6 +580,21 @@ func ScanDirectoryParallel(ctx context.Context, rootDir string, workers int, sca
 			if !registerDirectory(path, info) {
 				return filepath.SkipDir
 			}
+			// Checkpoint during discovery. Until 2026-08-16 this walk ran
+			// start-to-finish without a single UpdateProgress, so on a large
+			// import root it looked identical to a hung process: the caller
+			// had logged "Scanning folder N/M" and then went quiet for as long
+			// as the walk took. The stuck-op watchdog kills an operation after
+			// ProgressTimeout (5m) of silence, which is exactly how the
+			// 2026-08-16 rescan died -- mid-walk of a folder holding 17,469
+			// books, with the process demonstrably busy the whole time.
+			//
+			// The total is genuinely unknown while discovering, so current and
+			// total move together; that is the same "growing denominator"
+			// convention scanFolder already uses for its per-book counter.
+			if n := int(dirsFound.Add(1)); n%scanProgressEvery == 0 {
+				scanLog.UpdateProgress(n, n, fmt.Sprintf("Discovering folders: %d found (%s)", n, filepath.Base(path)))
+			}
 		}
 		return nil
 	})
@@ -579,8 +612,20 @@ func ScanDirectoryParallel(ctx context.Context, rootDir string, workers int, sca
 		wg.Add(1)
 		go func(scanDir string) {
 			defer wg.Done()
-			semaphore <- struct{}{}        // Acquire
-			defer func() { <-semaphore }() // Release
+			semaphore <- struct{}{} // Acquire
+			defer func() {
+				<-semaphore // Release
+				// Checkpoint per completed directory. This is the long phase
+				// -- it stats and group-detects every audio file under each
+				// directory -- and it reported nothing at all until
+				// 2026-08-16. Unlike the discovery walk above, the denominator
+				// is known here, so this is real progress rather than a
+				// growing count.
+				if n := int(dirsScanned.Add(1)); n%scanProgressEvery == 0 || n == len(dirs) {
+					scanLog.UpdateProgress(n, len(dirs),
+						fmt.Sprintf("Scanning folders: %d/%d (%s)", n, len(dirs), filepath.Base(scanDir)))
+				}
+			}()
 
 			// Read directory entries
 			entries, err := os.ReadDir(scanDir)
@@ -699,13 +744,47 @@ func ProcessBooksParallel(ctx context.Context, books []Book, workers int, progre
 		scanLog.Info("scan complete: %d files processed", total)
 	}()
 
+	// Build the AI fallback parser from the configured LLM backend.
+	//
+	// Until 2026-08-16 this block ignored AIBackend entirely: it constructed
+	// the cloud OpenAI parser whenever EnableAIParsing was set, passing
+	// enabled=true unconditionally. The effect was that a deployment with
+	// ai_backend.llm_mode="disabled" and a local Ollama endpoint configured
+	// still sent every scan batch to api.openai.com -- which is exactly how
+	// the 2026-08-16 rescan burned its batches against an exhausted-credit
+	// key. Routing through EffectiveLLMMode makes the operator's setting the
+	// thing that decides, and keeps this in step with the "llmparser" service
+	// in internal/ai/register.go rather than being a second, divergent copy.
 	var aiParser *ai.OpenAIParser
 	aiEnabled := false
 	if config.AppConfig.EnableAIParsing {
-		if config.AppConfig.OpenAIAPIKey == "" {
-			scanLog.Warn("AI parsing enabled but OpenAI API key is not configured")
-		} else {
-			aiParser = ai.NewOpenAIParser(&config.AppConfig, config.AppConfig.OpenAIAPIKey, true)
+		cfg := &config.AppConfig
+		switch mode := cfg.EffectiveLLMMode(); mode {
+		case config.AIBackendModeDisabled:
+			scanLog.Info("AI parsing skipped: llm_mode is disabled")
+		case config.AIBackendModeLocal:
+			baseURL := cfg.AIBackend.LocalBaseURL
+			if baseURL == "" {
+				baseURL = cfg.Embedding.BaseURL
+			}
+			if baseURL == "" {
+				scanLog.Warn("AI parsing enabled with llm_mode=local but no local base URL is configured")
+				break
+			}
+			aiParser = ai.NewOpenAIParserWithBaseURL(cfg, "ollama", baseURL, cfg.AIBackend.LocalLLMModel, true)
+			if aiParser != nil && aiParser.IsEnabled() {
+				aiEnabled = true
+				scanLog.Info("local LLM parser initialized for filename metadata fallback (base_url=%s model=%s)",
+					baseURL, cfg.AIBackend.LocalLLMModel)
+			} else {
+				scanLog.Warn("failed to initialize local LLM parser, AI fallback disabled")
+			}
+		default: // openai, openai-fallback-local
+			if cfg.OpenAIAPIKey == "" {
+				scanLog.Warn("AI parsing enabled but OpenAI API key is not configured")
+				break
+			}
+			aiParser = ai.NewOpenAIParser(cfg, cfg.OpenAIAPIKey, true)
 			if aiParser != nil && aiParser.IsEnabled() {
 				aiEnabled = true
 				scanLog.Debug("OpenAI parser initialized for filename metadata fallback")

--- a/todo.d/20260816-abs-series-hollow-entries.md
+++ b/todo.d/20260816-abs-series-hollow-entries.md
@@ -1,20 +1,31 @@
-- [ ] **ABS series list returns hollow entries, and the app renders no series at all.**
-      Measured 2026-08-16 against production, using the client's exact query
-      (`?page=0&limit=50&sort=name`, the params AudioBooth actually sends):
-      - 50 results returned, `total=15528` — the server side is healthy and
-        pagination works.
-      - **27 of 50** have an empty `books: []`.
-      - **9 of those 27 are self-contradictory**: `numBooks >= 1` with
-        `books: []` and `totalDuration: 0` (e.g. "Salem's Lot (read by Ron
-        McLarty)" reports `numBooks=1`). The remaining 18 report `numBooks=0`.
+- [ ] **ABS series list emits a non-ABS `books[]` shape, and no series render in ABS clients.**
+      Measured 2026-08-16 against production with the client's exact query
+      (`?page=0&limit=50&sort=name`, what AudioBooth actually sends).
 
-      **Unexplained, and deliberately not assumed:** 23 of the 50 entries are
-      well-formed and have books, yet the app's Series tab shows "No Series
-      Found". The hollow entries are a real bug worth fixing, but they do NOT
-      by themselves explain an empty render — a client that skipped bad entries
-      would still show 23. Do not let the hollow-series finding stand in as the
-      cause of the empty screen without evidence; the likely-but-unverified
-      hypothesis is that the client aborts parsing the whole list on the first
-      malformed entry rather than skipping it.
+      **Root cause (evidenced):** ABS defines a series' `books` as full
+      `LibraryItem` objects. Ours emit six ad-hoc fields only:
+      `duration, id, libraryId, libraryItemId, sequence, title` — no `media`,
+      no `media.metadata`, no `mediaType`, no `coverPath`, no `path`/`ino`.
 
-      Native API is healthy, so the defect is in the ABS compat layer.
+      The control that makes this conclusive is the **playlists** endpoint,
+      which the same app renders correctly: its items embed a complete
+      `libraryItem` with all 20 ABS fields including `media.metadata`,
+      `coverPath` and `mediaType`. Same client, same auth, same library — the
+      one with the correct shape works, the one with the ad-hoc shape does not.
+      A typed (Swift) client decoding `books: [LibraryItem]` fails on the first
+      entry and discards the whole response, which is why **23 of 50
+      well-formed series still render as zero**.
+
+      Ruled out — do not re-investigate:
+      - Not a timeout: series is 20 KB in 0.34s; playlists is 131 KB in 3.2s
+        and renders fine.
+      - Not auth, not pagination, not the query params: HTTP 200,
+        `results=50`, `total=15528`.
+
+      **Secondary bug, worth fixing in the same pass:** 27 of 50 entries have
+      `books: []`, and 9 of those are self-contradictory — `numBooks >= 1` with
+      `books: []` and `totalDuration: 0` (e.g. "Salem's Lot (read by Ron
+      McLarty)" reports `numBooks=1`). The other 18 report `numBooks=0`.
+
+      Fix: build the series `books` array from the same library-item serializer
+      the playlists path already uses, rather than a bespoke projection.

--- a/todo.d/20260816-abs-series-hollow-entries.md
+++ b/todo.d/20260816-abs-series-hollow-entries.md
@@ -1,0 +1,20 @@
+- [ ] **ABS series list returns hollow entries, and the app renders no series at all.**
+      Measured 2026-08-16 against production, using the client's exact query
+      (`?page=0&limit=50&sort=name`, the params AudioBooth actually sends):
+      - 50 results returned, `total=15528` — the server side is healthy and
+        pagination works.
+      - **27 of 50** have an empty `books: []`.
+      - **9 of those 27 are self-contradictory**: `numBooks >= 1` with
+        `books: []` and `totalDuration: 0` (e.g. "Salem's Lot (read by Ron
+        McLarty)" reports `numBooks=1`). The remaining 18 report `numBooks=0`.
+
+      **Unexplained, and deliberately not assumed:** 23 of the 50 entries are
+      well-formed and have books, yet the app's Series tab shows "No Series
+      Found". The hollow entries are a real bug worth fixing, but they do NOT
+      by themselves explain an empty render — a client that skipped bad entries
+      would still show 23. Do not let the hollow-series finding stand in as the
+      cause of the empty screen without evidence; the likely-but-unverified
+      hypothesis is that the client aborts parsing the whole list on the first
+      malformed entry rather than skipping it.
+
+      Native API is healthy, so the defect is in the ABS compat layer.

--- a/todo.d/20260816-collections-not-implemented.md
+++ b/todo.d/20260816-collections-not-implemented.md
@@ -1,0 +1,27 @@
+- [ ] **Implement collections (server-wide), and stop the read endpoint lying about it.**
+      ABS clients show "No Collections" and cannot create one. Measured on
+      2026-08-16 against production:
+      - `GET /api/libraries/:libraryId/collections` is wired to `h.EmptyPage`
+        (`internal/server/handlers/abs/handler.go:403`) — a hardcoded stub that
+        always returns `{"results":[],"total":0}`. It would report zero even if
+        collections existed, which is why this went unnoticed.
+      - `POST /api/collections` has **no route at all**. The app fired 15 of
+        them in ten seconds; every one got 404.
+      - There is **no `Collection` model** anywhere in `internal/database` —
+        only `UserPlaylist`. This is unbuilt, not misconfigured.
+
+      Requirements (from the user, 2026-08-16):
+      - Collections are **server-wide / shared across all users**, not per-user.
+        (The app states this in its own UI: "Collections are shared across all
+        users on the server.")
+      - **Only an admin, or a user holding a dedicated collections permission,
+        may create them.** Reads stay available to ordinary library viewers.
+        Follow the existing `s.perm(auth.Perm...)` pattern used by the playlist
+        routes in `wire_library_routes.go`.
+
+      Interim honesty fix, independent of building the feature: `EmptyPage` on
+      this route should return **501 Not Implemented**, not a 200 empty page.
+      This is the same "plausible success for work that never happened" defect
+      class as the iTunes operation stubs fixed in #2492 — a 501 would have made
+      it obvious the day it shipped and would tell clients to hide the Create
+      button instead of firing doomed POSTs.


### PR DESCRIPTION
Two defects that together killed the 2026-08-16 library rescan. Both were found by reading the journal for the window in which the scan went silent, not by inspection.

## 1. The scan reported nothing while it was working

`ScanDirectoryParallel` ran both of its phases — the `WalkDir` that discovers directories, and the parallel pass that reads each one — without a single `UpdateProgress` call. The stuck-op watchdog kills an operation after `ProgressTimeout` (5m) of silence, so on a large import folder a busy scan is indistinguishable from a hung one.

Production evidence:

```
13:12:11  AI batch parsing disabled ... remaining 1459 books keep filename-derived metadata
13:12:38  scanner multi-file group detected  (busy)
13:14:05  scanner multi-file group detected  (busy)
13:15:18  scanner multi-file group detected  (busy)
13:16:01  scanner multi-file group detected  (busy)
13:17:34  registry: strike recorded  kind=stuck  "no progress for 5m23s (timeout=5m0s)"
13:17:39  op -> interrupted_dropped
13:28:22  library scan failed  err="scan canceled: context canceled"
```

The process was demonstrably working the entire time it was declared stuck — mid-walk of `/mnt/bigdata/books/newbooks`, which holds 17,469 books. Both phases now checkpoint every 20 directories.

## 2. The scanner ignored the configured LLM backend

`scanner.go` built the **cloud** OpenAI parser whenever `EnableAIParsing` was set, passing `enabled=true` and ignoring `ai_backend.llm_mode` entirely. Production had `llm_mode: "disabled"` and a working local Ollama endpoint already configured at `local_base_url` — and the scan still sent every batch to `api.openai.com`, where it got `insufficient_quota / credit_balance_exhausted`.

Parser construction now routes through `EffectiveLLMMode`, handling local / openai / disabled, so it matches the `llmparser` service in `internal/ai/register.go` instead of being a second, divergent copy.

## Testing

`TestScanDirectoryParallel_ChecksInLongEnoughToSurviveTheWatchdog` asserts the **count** of checkpoints, not merely that one happened — a single call at the start or end would satisfy "reports progress" while leaving an arbitrarily long silent stretch in the middle, which is the actual defect.

Mutation-tested: with both checkpoints neutralized the test fails with `got 0 progress checkpoints for 60 directories, want >= 3`; restored, it passes. `go build ./...` and `go vet ./internal/scanner/` clean. (`go vet` caught a real bug during development — the new log line used slog-style key/value pairs on a printf-style logger, which would have silently dropped them.)

## Not addressed here

The AI-batch fix from the previous PR is confirmed working in production — the phase aborted at batch 1 in 16.3s instead of grinding ~25 minutes, matching the real error. But that only relocated the silence to the next phase; this PR fixes that phase. The scan has still never completed end-to-end, and that remains unverified until a run reaches `outcome=completed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS