### PR TITLE
fix(abs): serve series books as real LibraryItem objects

### DIFF
--- a/changelog.d/20260816-abs-series-library-items.md
+++ b/changelog.d/20260816-abs-series-library-items.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **Series now appear in ABS apps.** The series list returned book entries in an
+  ad-hoc shape — six fields, with no `media`, `mediaType` or cover — instead of
+  the `LibraryItem` objects the ABS API defines. Clients decode a series' books
+  as a single typed list, so one undecodable entry discarded the whole response
+  and the Series tab showed "No Series Found" even though 23 of the 50 series on
+  the first page had real books. Series books are now built by the same
+  serializer the (working) playlists route uses.
+
+- **A series no longer reports a book count it cannot list.** 9 of 50 series on
+  production reported one or more books while returning an empty list, because
+  books without a resolvable sync id are dropped after the count is taken.
+  `numBooks` now counts the books actually served — the rule `totalDuration`
+  already followed — and a mismatch is logged rather than silently served.

--- a/internal/server/handlers/abs/browse.go
+++ b/internal/server/handlers/abs/browse.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/browse.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 5e0b83c7-2a41-4d96-b7e8-1c53fd90a2b4
-// last-edited: 2026-08-13
+// last-edited: 2026-08-16
 
 package abs
 
@@ -572,10 +572,33 @@ func (h *Handler) LibrarySeries(c *gin.Context) {
 		series = series[start:end]
 	}
 
+	// 🔴 THE BOOK OBJECTS WERE NOT LIBRARY ITEMS, so no series rendered at all.
+	//
+	// ABS defines a series' `books` as full LibraryItem objects. This route
+	// emitted six ad-hoc fields instead -- id, libraryItemId, libraryId, title,
+	// sequence, duration -- with no `media`, no `media.metadata`, no
+	// `mediaType`, no `coverPath`. Measured against production 2026-08-16: the
+	// app's own request returned HTTP 200 with 50 well-formed-looking rows, and
+	// the Series tab showed "No Series Found".
+	//
+	// The control that identifies this as the cause is the PLAYLISTS route,
+	// which the same client renders correctly on the same library with the same
+	// auth: its items embed a complete libraryItem (20 fields, including
+	// media.metadata and coverPath) built by minifiedItem. A typed client
+	// decodes `books: [LibraryItem]` as a unit, so one undecodable entry
+	// discards the whole response -- which is why 23 of the 50 having real
+	// books did not put 23 series on screen. It was 0 or nothing.
+	//
+	// Enrichment is deliberately PAGE-SCOPED. Building library items for every
+	// series would rebuild the whole library on each cache miss; the note above
+	// already measured the unpaginated body at ~10.8 MB / 31,139 book rows.
+	// Only the ~50 series actually being returned are hydrated.
+	enriched := h.seriesPageBooks(c.Request.Context(), series, bySeries)
+
 	results := make([]any, 0, len(series))
 	for _, s := range series {
 		built := bySeries[s.ID]
-		items, total := built.items, built.totalDuration
+		items, total := enriched[s.ID], built.totalDuration
 		if items == nil {
 			items = []any{}
 		}
@@ -591,8 +614,24 @@ func (h *Handler) LibrarySeries(c *gin.Context) {
 			// during widget build (§1.7.3 item 5). Summed from BookSummary.Duration,
 			// which is already an int — do not introduce a float on the way here.
 			"totalDuration": total,
-			"numBooks":      counts[s.ID],
+			// Count the books actually SERVED, not every row the store counts.
+			//
+			// This is the same rule totalDuration above already follows, applied
+			// to the field next to it. Measured on production 2026-08-16, 9 of 50
+			// series on page 0 claimed numBooks >= 1 while carrying books: [] and
+			// totalDuration: 0 -- because seriesBookEntry drops books with no
+			// resolvable sync id, and the count came from a store query that knew
+			// nothing about that. A row that reports a book count it cannot list
+			// is a row the client has to decide how to disbelieve.
+			//
+			// counts is still consulted so a series whose books were all dropped
+			// is visible as such, rather than silently reading as an empty series
+			// that genuinely has no books.
+			"numBooks": len(items),
 		})
+		if want := counts[s.ID]; want != len(items) {
+			h.logSeriesBookCountMismatch(s.ID, s.Name, want, len(items))
+		}
 	}
 	// Total is the FULL series count, NOT len(results). The client decides whether
 	// another page exists with `page*limit < total` (the same rule recorded on
@@ -606,6 +645,86 @@ func (h *Handler) LibrarySeries(c *gin.Context) {
 		Limit:   limit,
 		Page:    page,
 	})
+}
+
+// seriesPageBooks hydrates each series' book list into real ABS LibraryItem
+// objects, for the page being served only.
+//
+// It reuses seriesBooksCached's ordering (reading order, already sorted) and the
+// same minifiedItem serializer the playlists route uses, so the two routes
+// cannot drift into disagreeing about what a library item looks like -- which is
+// exactly the divergence that made this route render nothing while playlists
+// worked.
+//
+// On any failure it returns what it has rather than nothing: a series page
+// missing hydration is worth serving, a 500 is not. That matches the existing
+// rule for counts and seriesBooksCached above.
+func (h *Handler) seriesPageBooks(
+	ctx context.Context,
+	series []database.Series,
+	bySeries map[int]seriesBooksBuilt,
+) map[int][]any {
+	out := make(map[int][]any, len(series))
+
+	// One batched load for the whole page rather than one per series.
+	var ids []string
+	seen := make(map[string]struct{})
+	for _, s := range series {
+		for _, id := range bySeries[s.ID].bookIDs {
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
+		return out
+	}
+
+	books, err := h.library.GetBooksByIDs(ids)
+	if err != nil {
+		return out
+	}
+	views, err := h.loadItemViews(ctx, books)
+	if err != nil {
+		return out
+	}
+
+	byID := make(map[string]libraryItemDTO, len(views))
+	for i := range views {
+		byID[views[i].Book.ID] = h.minifiedItem(&views[i])
+	}
+
+	for _, s := range series {
+		built := bySeries[s.ID]
+		items := make([]any, 0, len(built.bookIDs))
+		for _, id := range built.bookIDs {
+			dto, ok := byID[id]
+			if !ok {
+				// A book that vanished between the cached grouping and now.
+				// Dropping it keeps the array decodable, which is the whole
+				// point of this change; numBooks is computed from what survives.
+				continue
+			}
+			items = append(items, dto)
+		}
+		out[s.ID] = items
+	}
+	return out
+}
+
+// logSeriesBookCountMismatch reports a series whose store count disagrees with
+// the number of books actually served.
+//
+// It is rate-limited by being WARN on a route the app polls: the condition is
+// real (9 of 50 on production 2026-08-16) and worth seeing, but it is a data
+// observation, not a request failure.
+func (h *Handler) logSeriesBookCountMismatch(id int, name string, want, got int) {
+	slog.Warn("abs: series book count disagrees with the books served",
+		"series_id", id, "series_name", name,
+		"store_count", want, "served", got,
+		"note", "books without a resolvable sync id are dropped; numBooks reports what was served")
 }
 
 // absSeriesBooksCacheTTL bounds how long the series→books map is reused. Matches
@@ -628,7 +747,6 @@ const absSeriesBooksCacheTTL = 5 * time.Minute
 // expensive part here is not the grouping: it is MintOrGetSyncID, one call per
 // book. Caching summaries would still mint ~16,500 ids on EVERY series request.
 type seriesBooksBuilt struct {
-	items         []any
 	totalDuration int
 	// bookIDs is the same set in the same order, kept so the ?filter=series.<id>
 	// path on /items can reuse this grouping instead of re-deriving it. Reusing it
@@ -681,13 +799,15 @@ func (h *Handler) seriesBooksCached() (map[int]seriesBooksBuilt, error) {
 			return list[a].Title < list[b].Title
 		})
 
-		built := seriesBooksBuilt{items: make([]any, 0, len(list))}
+		built := seriesBooksBuilt{}
 		for i := range list {
-			entry, ok := h.seriesBookEntry(&list[i])
-			if !ok {
+			// Books with no resolvable sync id are dropped here, before they can
+			// reach the response. The client splits compound ids at a fixed byte
+			// offset of 36, so a 26-char ULID does not merely look wrong, it
+			// mis-parses -- the rule #2366 established for playlist items.
+			if !h.hasSyncID(list[i].ID) {
 				continue
 			}
-			built.items = append(built.items, entry)
 			built.bookIDs = append(built.bookIDs, list[i].ID)
 			// Summed over the books actually SERVED, not over every row in the
 			// series: a duration counting books the client cannot see would
@@ -705,38 +825,16 @@ func (h *Handler) seriesBooksCached() (map[int]seriesBooksBuilt, error) {
 	return m, nil
 }
 
-// seriesBookEntry is the per-book shape embedded in a series row.
+// hasSyncID reports whether a book has a resolvable client-visible sync id.
 //
-// sequence is a STRING, never a number: contract §6.5 / §1.7.3 — Dart's
-// `as String?` on a number THROWS inside build() and red-screens the book detail
-// sheet. An absent sequence is null rather than "0", which would sort and display
-// as a real position the data does not claim.
-// It returns ok=false when the book has no resolvable sync id. Such a book is
-// DROPPED rather than emitted with the raw ULID or a null: the client splits
-// compound ids at a fixed byte offset of 36, so a 26-char ULID does not merely
-// look wrong, it mis-parses — and a null entry red-screens the list outright.
-// That is the same rule #2366 established for playlist items.
-func (h *Handler) seriesBookEntry(b *database.BookSummary) (gin.H, bool) {
-	sid, err := h.identity.MintOrGetSyncID(b.ID)
-	if err != nil || sid == "" {
-		return nil, false
-	}
-	var seq any
-	if b.SeriesSequence != nil {
-		seq = strconv.Itoa(*b.SeriesSequence)
-	}
-	dur := 0
-	if b.Duration != nil {
-		dur = *b.Duration
-	}
-	return gin.H{
-		"id":            sid,
-		"libraryItemId": sid,
-		"libraryId":     h.libraryID(),
-		"title":         b.Title,
-		"sequence":      seq,
-		"duration":      dur,
-	}, true
+// This replaced seriesBookEntry, which built a six-field ad-hoc book object
+// that no ABS client could decode (see the note in LibrarySeries). The
+// filtering it did was the part worth keeping: the id check decides which books
+// can be served at all, and it must happen while the series grouping is built
+// so bookIDs and the served list cannot disagree.
+func (h *Handler) hasSyncID(bookID string) bool {
+	sid, err := h.identity.MintOrGetSyncID(bookID)
+	return err == nil && sid != ""
 }
 
 // absAuthorsCacheTTL bounds how long the built author list is reused.

--- a/internal/server/handlers/abs/series_books_test.go
+++ b/internal/server/handlers/abs/series_books_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/series_books_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7f2c5d81-3ab9-4e60-9c47-58d3e0b6a214
-// last-edited: 2026-08-13
+// last-edited: 2026-08-16
 
 package abs_test
 
@@ -82,16 +82,47 @@ func absSeriesRows(t *testing.T, h *harness, tok string) map[string]map[string]a
 	return rows
 }
 
+// absBookTitles reads each book's title from media.metadata.title.
+//
+// It used to read a top-level "title". That field existed only because this
+// route emitted a six-field ad-hoc book object instead of an ABS LibraryItem,
+// which is why no ABS client could decode the series list and the app showed
+// "No Series Found" while this test passed. The title now lives where ABS puts
+// it, so reading it from there is also an assertion that the shape is right:
+// if the response regresses to the flat projection, every title comes back
+// empty and the callers below fail.
 func absBookTitles(row map[string]any) []string {
 	books, _ := row["books"].([]any)
 	out := make([]string, 0, len(books))
 	for _, b := range books {
-		if m, ok := b.(map[string]any); ok {
-			title, _ := m["title"].(string)
-			out = append(out, title)
+		m, ok := b.(map[string]any)
+		if !ok {
+			continue
 		}
+		media, _ := m["media"].(map[string]any)
+		meta, _ := media["metadata"].(map[string]any)
+		title, _ := meta["title"].(string)
+		out = append(out, title)
 	}
 	return out
+}
+
+// absBookIsLibraryItem reports whether a series book carries the fields an ABS
+// client requires of a LibraryItem. This is the shape check the old test could
+// not make, because the old shape had none of them.
+func absBookIsLibraryItem(b any) bool {
+	m, ok := b.(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, k := range []string{"id", "libraryId", "mediaType", "media", "path"} {
+		if _, present := m[k]; !present {
+			return false
+		}
+	}
+	media, _ := m["media"].(map[string]any)
+	_, hasMeta := media["metadata"]
+	return hasMeta
 }
 
 func TestLibrarySeries_BooksAreTheSeriesOwnBooksInSequenceOrder(t *testing.T) {
@@ -160,4 +191,64 @@ func absSeriesKeys(m map[string]map[string]any) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// TestLibrarySeries_BooksAreLibraryItems pins the 2026-08-16 fix.
+//
+// The series list returned HTTP 200 with 50 plausible rows and the app's Series
+// tab showed "No Series Found". The books were not LibraryItem objects: they
+// carried six ad-hoc fields (id, libraryItemId, libraryId, title, sequence,
+// duration) and none of media, media.metadata, mediaType, coverPath or path.
+//
+// The control that identified it is the playlists route, which the same client
+// renders correctly and which embeds a full libraryItem via minifiedItem. A
+// typed client decodes books: [LibraryItem] as a unit, so one undecodable entry
+// discards the entire response — which is why 23 of 50 series having real books
+// still put zero on screen.
+//
+// Asserting the FIELDS rather than a rendered title is the point: a test that
+// only checked titles passed against the broken shape for as long as it shipped.
+func TestLibrarySeries_BooksAreLibraryItems(t *testing.T) {
+	seed := absSeedTwoSeries(t)
+	h := newHarness(t, "jwt", nil, withLibrary(seed), withUserData(fixtureUserData()))
+	h.seedUser(t, "u1", "oracle", "", "pw-pw-pw-pw")
+	tok := str(t, userObj(t, h.login(t, "oracle", "pw-pw-pw-pw")), "accessToken")
+
+	odyssey, ok := absSeriesRows(t, h, tok)["Odyssey Cycle"]
+	if !ok {
+		t.Fatal("series list has no 'Odyssey Cycle'")
+	}
+
+	books, _ := odyssey["books"].([]any)
+	if len(books) == 0 {
+		t.Fatal("Odyssey Cycle served no books")
+	}
+	for i, b := range books {
+		if !absBookIsLibraryItem(b) {
+			t.Errorf("book %d is not a decodable ABS LibraryItem: %#v\n"+
+				"an ABS client decodes books as [LibraryItem] and drops the WHOLE "+
+				"response on one bad entry — this is why no series rendered", i, b)
+		}
+	}
+}
+
+// TestLibrarySeries_NumBooksMatchesTheBooksServed pins the self-consistency
+// rule. Measured on production 2026-08-16, 9 of 50 series on page 0 reported
+// numBooks >= 1 while carrying books: [] and totalDuration: 0, because books
+// with no resolvable sync id are dropped after the count is taken.
+func TestLibrarySeries_NumBooksMatchesTheBooksServed(t *testing.T) {
+	seed := absSeedTwoSeries(t)
+	h := newHarness(t, "jwt", nil, withLibrary(seed), withUserData(fixtureUserData()))
+	h.seedUser(t, "u1", "oracle", "", "pw-pw-pw-pw")
+	tok := str(t, userObj(t, h.login(t, "oracle", "pw-pw-pw-pw")), "accessToken")
+
+	for name, row := range absSeriesRows(t, h, tok) {
+		books, _ := row["books"].([]any)
+		num, _ := row["numBooks"].(float64)
+		if int(num) != len(books) {
+			t.Errorf("%s: numBooks=%d but %d books served — a row that reports a "+
+				"count it cannot list forces the client to guess which to believe",
+				name, int(num), len(books))
+		}
+	}
 }


### PR DESCRIPTION
The Series tab in ABS clients showed **"No Series Found"** while the endpoint returned HTTP 200 with 50 well-formed-looking rows.

## Root cause

ABS defines a series' `books` as full `LibraryItem` objects. This route emitted six ad-hoc fields instead:

```
id, libraryItemId, libraryId, title, sequence, duration
```

with **no `media`, no `media.metadata`, no `mediaType`, no `coverPath`, no `path`**.

## The control that identifies it

The **playlists** route renders correctly in the same app, on the same library, with the same auth — and it embeds a complete `libraryItem` (20 fields including `media.metadata` and `coverPath`) built by `minifiedItem`.

| Route | book/item shape | Renders? |
|---|---|---|
| Series | 6 ad-hoc fields | ❌ nothing |
| Playlists | full `libraryItem` via `minifiedItem` | ✅ yes |

A typed client decodes `books: [LibraryItem]` as a unit, so **one** undecodable entry discards the whole response. That is why 23 of 50 series having real books still put **zero** on screen — it was all-or-nothing, and it was nothing.

Ruled out by measurement, so nobody re-investigates: not a timeout (series is 20 KB / 0.34s; playlists is 131 KB / 3.2s and works), not auth, not pagination, not the query params (HTTP 200, `results=50`, `total=15528`).

## Changes

- Series books are built by the same `minifiedItem` serializer playlists uses, so the two routes can't drift apart on what a library item is.
- **Hydration is page-scoped** — only the ~50 series being returned are loaded, not all 15,528. The existing note in this file measured the unpaginated body at ~10.8 MB / 31,139 rows, so hydrating everything was not an option.
- `numBooks` now counts books **actually served**, the rule `totalDuration` already followed. On production 9 of 50 series claimed `numBooks>=1` while carrying `books: []`, because books without a resolvable sync id are dropped after the count is taken. Mismatches are now logged rather than silently served.
- `seriesBookEntry` → `hasSyncID`: the id filtering it did was worth keeping; the ad-hoc object it built was the defect.

## Testing

`TestLibrarySeries_BooksAreLibraryItems` asserts the **fields**, not a rendered title — a title-only test passed against the broken shape for as long as it shipped. `absBookTitles` now reads `media.metadata.title`, so it doubles as a shape assertion.

Mutation-tested with the flat projection restored:

```
--- FAIL: TestLibrarySeries_BooksAreTheSeriesOwnBooksInSequenceOrder
    Odyssey Cycle books = [ ], want [Odyssey Book One Odyssey Book Two]
--- FAIL: TestLibrarySeries_BooksAreLibraryItems
    book 0 is not a decodable ABS LibraryItem: map[...]{"duration":0, "id":"s10-b1", "libraryItemId":"s10-b1", "title":"x"}
```

Full `./internal/server/handlers/abs/` suite green; `go build ./...` and `go vet` clean.

## Not verified

The empty-render → decode-failure link is inferred from the playlists control, not from client source I can read. If the Series tab is still empty after this deploys, that inference is wrong and the next step is client-side logs — the server shape will at least be ABS-correct either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS