### PR TITLE
docs(todo): the scan-error restore is two layers, not frontend wiring

### DIFF
--- a/changelog.d/20260817_041000_docs_scan_error_restore_real_scope.md
+++ b/changelog.d/20260817_041000_docs_scan_error_restore_real_scope.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Corrected the recorded scope of the scan-error restore.** The TODO entry for
+  "import-path scan no longer surfaces per-file scan errors" described the fix as
+  frontend wiring — poll the operation, feed failures into `ScanStatus.errors`.
+  That assumed the backend already collects per-file failures. It does not: nothing
+  in `internal/scanner/` accumulates them, and the ones that are logged are free
+  text at Debug/Warn with the path interpolated into the message rather than in
+  structured `attrs`. The entry now describes both layers of work so the task is
+  not picked up as a small one.

--- a/todo.d/20260816-scan-errors-not-surfaced-after-async-trigger.md
+++ b/todo.d/20260816-scan-errors-not-surfaced-after-async-trigger.md
@@ -17,9 +17,27 @@ the operation. The count is non-zero only when the trigger call itself throws,
 so a scan that finds ten corrupt files reports "Scan complete. Found N
 audiobooks." and offers no way to see them.
 
-**To restore:** poll the operation (or read its logs — `GET /operations/v2/:id`
-already returns `data.logs` alongside `data.operation`) and feed per-file
-failures into `ScanStatus.errors`.
+**To restore — TWO layers, not one.** An earlier version of this note said the fix
+was to poll the operation and feed per-file failures into `ScanStatus.errors`. That
+assumed the data exists on the backend. Verified 2026-08-17 that it does not:
+
+- **Nothing collects per-file failures.** `Errors []`, `FailedFiles`, `SkippedFiles`
+  do not appear anywhere in `internal/scanner/` — the scan never accumulates which
+  files failed, so there is no list to fetch.
+- **The failures that do get logged are free text, mostly below the bar.**
+  `scanner.go:1672` logs a tag-read failure at **Debug**; `process_file.go:100` logs
+  one at **Warn**. Both interpolate the path into the message string rather than
+  putting it in structured `attrs`, so a client would have to regex file paths out of
+  log prose.
+
+So the work is:
+
+1. **Backend** — emit per-file failures into the operation log at warn/error with the
+   file path (and reason) in structured `attrs`, not interpolated into the message.
+2. **Frontend** — read them off `GET /operations/v2/:id` (which already returns
+   `data.logs` beside `data.operation`, so no new endpoint) into `ScanStatus.errors`.
+
+Scope this as a feature, not a wiring fix.
 
 The E2E test that covered this,
 `web/tests/e2e/scan-import-organize.spec.ts` › *scan operation: handles errors


### PR DESCRIPTION
## Why

The TODO entry filed alongside the E2E mock repair (#2504) described the scan-error restore as frontend wiring:

> **To restore:** poll the operation (or read its logs — `GET /operations/v2/:id` already returns `data.logs` alongside `data.operation`) and feed per-file failures into `ScanStatus.errors`.

That prices it as a small task. It isn't — the backend has nothing to hand over.

## What I verified at HEAD

| claim | check | result |
|---|---|---|
| Something collects per-file failures | `grep -rE "Errors \[\]\|FailedFiles\|SkippedFiles" internal/scanner/` | **no matches** — the scan never accumulates which files failed |
| Failures are surfaced at a readable level | `scanner.go:1672` | tag-read failure logged at **Debug** |
| | `process_file.go:100` | tag-read failure logged at **Warn** |
| Failures are machine-readable | both sites | path is **interpolated into the message string**, not in structured `attrs` |

So a client polling `data.logs` today would find nothing to list, and would have to regex file paths out of log prose even for the one Warn-level case.

## What changed

Only the TODO fragment's "To restore" section, which now names both layers:

1. **Backend** — emit per-file failures into the operation log at warn/error with the path and reason in structured `attrs`.
2. **Frontend** — read them off `GET /operations/v2/:id` into `ScanStatus.errors`.

Plus a changelog fragment. **No behaviour change.**

## Why bother

The entry as written would have been picked up as an afternoon's wiring and turned into a feature mid-flight. The E2E test `scan operation: handles errors gracefully` still asserts the button's absence and still flips to failing the moment the capability returns, so the tripwire is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS