### PR TITLE
fix(review): clamp the stored page size that froze the dialog shut

### DIFF
--- a/changelog.d/20260817_042000_fix_review_dialog_page_size_freeze.md
+++ b/changelog.d/20260817_042000_fix_review_dialog_page_size_freeze.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **The metadata review dialog could be frozen permanently by its own page-size
+  setting.** Choosing "250 per page" locked the dialog up, and because the stored
+  preference was only checked for membership in the options list — where 250 was a
+  legal member — every reopen restored 250 and froze it again. The size control
+  lives inside the dialog, so there was no way back: the only escape was clearing
+  `localStorage` by hand. A stored size is now clamped to 50 on read and the
+  correction is written back, so existing stuck users recover on next open. The
+  selector no longer offers 250 or 500.

--- a/web/src/components/audiobooks/MetadataReviewDialog.pagesize.test.ts
+++ b/web/src/components/audiobooks/MetadataReviewDialog.pagesize.test.ts
@@ -1,0 +1,68 @@
+// file: web/src/components/audiobooks/MetadataReviewDialog.pagesize.test.ts
+// version: 1.0.0
+// guid: 4b1c9d2e-8f37-4a05-9c61-2d7e6a4b8f13
+// last-edited: 2026-08-17
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { loadReviewPageSize } from './MetadataReviewDialog';
+import { STORAGE_KEYS } from '../../lib/storageKeys';
+
+const KEY = STORAGE_KEYS.METADATA_REVIEW_PAGE_SIZE;
+
+/**
+ * A stored page size of 250 froze the review dialog badly enough that the size
+ * control — which lives inside the dialog — could not be reached to change it
+ * back. Because the old loader merely checked membership in PAGE_SIZE_OPTIONS,
+ * and 250 was a member, every reopen restored 250 and re-froze. The only escape
+ * was clearing localStorage by hand.
+ *
+ * These tests pin the two properties that make it recoverable: an oversized
+ * stored value is clamped on READ, and the correction is WRITTEN BACK so the
+ * bad value is gone rather than re-clamped forever.
+ */
+describe('loadReviewPageSize', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('clamps the 250 that caused the freeze down to 50', () => {
+    window.localStorage.setItem(KEY, '250');
+    expect(loadReviewPageSize()).toBe(50);
+  });
+
+  it('persists the correction, so the bad value cannot come back', () => {
+    window.localStorage.setItem(KEY, '250');
+    loadReviewPageSize();
+    expect(window.localStorage.getItem(KEY)).toBe('50');
+
+    // Second open reads the corrected value directly — not the clamp path.
+    expect(loadReviewPageSize()).toBe(50);
+  });
+
+  it('clamps 500 as well, not just the reported 250', () => {
+    window.localStorage.setItem(KEY, '500');
+    expect(loadReviewPageSize()).toBe(50);
+  });
+
+  it.each([25, 50, 100])('leaves a still-offered size %i alone', (size) => {
+    window.localStorage.setItem(KEY, String(size));
+    expect(loadReviewPageSize()).toBe(size);
+    // An in-range value must not be rewritten.
+    expect(window.localStorage.getItem(KEY)).toBe(String(size));
+  });
+
+  it('falls back to 25 when nothing is stored', () => {
+    expect(loadReviewPageSize()).toBe(25);
+    // Absent must stay absent — do not seed a preference the user never set.
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it.each(['abc', '', '0', '-100', 'NaN'])(
+    'falls back to 25 for the unusable stored value %j',
+    (raw) => {
+      window.localStorage.setItem(KEY, raw);
+      expect(loadReviewPageSize()).toBe(25);
+    }
+  );
+});

--- a/web/src/components/audiobooks/MetadataReviewDialog.tsx
+++ b/web/src/components/audiobooks/MetadataReviewDialog.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/audiobooks/MetadataReviewDialog.tsx
-// version: 1.16.0
+// version: 1.17.0
 // guid: e7f8a9b0-c1d2-3e4f-5a6b-7c8d9e0f1a2b
-// last-edited: 2026-08-16
+// last-edited: 2026-08-17
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
@@ -55,9 +55,20 @@ const SOURCE_COLORS: Record<string, 'primary' | 'secondary' | 'success' | 'warni
   manual: 'info',
 };
 
-// Matches ActivityLog's selector so users see the same options
-// across pagination controls.
-const PAGE_SIZE_OPTIONS = [25, 50, 100, 250, 500];
+// Review rows are heavy — each renders a full candidate comparison — so this
+// selector deliberately does NOT match ActivityLog's, which lists 250 and 500.
+// A stored size of 250 froze the dialog hard enough that the size control
+// itself could not be reached to change it back (see loadReviewPageSize).
+// 100 is kept because only 250 was observed to lock up; if 100 turns out to
+// stall too, lower MAX_REVIEW_PAGE_SIZE rather than only trimming this list —
+// the clamp is what actually protects users, this list just avoids offering
+// the footgun.
+const PAGE_SIZE_OPTIONS = [25, 50, 100];
+
+// Largest size a stored preference may restore. Anything above is clamped down
+// and rewritten, so a value saved before this cap existed (or by a future build
+// that offers more) can never re-freeze the dialog on open.
+const MAX_REVIEW_PAGE_SIZE = 50;
 
 // Language filter: when enabled (default), candidates whose
 // language disagrees with the book's are hidden. Preference
@@ -124,11 +135,38 @@ function normalizeLanguage(lang: string | undefined | null): string {
 // many times per session — re-picking "250 per page" on every open
 // is annoying.
 
-function loadReviewPageSize(): number {
+// A stored size is CLAMPED, not just validated. The previous version accepted
+// any member of PAGE_SIZE_OPTIONS, and 250 was a member — so a user who picked
+// 250 froze the dialog, and every subsequent open restored 250 and froze it
+// again. The size control is inside the dialog, so there was no way to undo it
+// from the UI: the only escape was clearing localStorage by hand.
+//
+// Clamping on READ (rather than only trimming the options list) is what makes
+// this self-healing for users who already have 250 or 500 persisted from an
+// earlier build — they get 50 on next open without touching devtools.
+export function loadReviewPageSize(): number {
   if (typeof window === 'undefined') return 25;
   const raw = window.localStorage.getItem(STORAGE_KEYS.METADATA_REVIEW_PAGE_SIZE);
-  const n = raw ? Number(raw) : 25;
-  return PAGE_SIZE_OPTIONS.includes(n) ? n : 25;
+  if (raw === null) return 25;
+
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return 25;
+  if (PAGE_SIZE_OPTIONS.includes(n)) return n;
+
+  // Out of range or no longer offered. Persist the correction so the bad value
+  // is gone for good rather than being re-clamped on every open.
+  const safe = Math.min(n, MAX_REVIEW_PAGE_SIZE);
+  const corrected = PAGE_SIZE_OPTIONS.includes(safe) ? safe : MAX_REVIEW_PAGE_SIZE;
+  try {
+    window.localStorage.setItem(
+      STORAGE_KEYS.METADATA_REVIEW_PAGE_SIZE,
+      String(corrected)
+    );
+  } catch {
+    // Private-mode / quota failures are non-fatal: the clamp still applies to
+    // this session, it just re-clamps next open instead of persisting.
+  }
+  return corrected;
 }
 
 function formatDuration(seconds: number): string {


### PR DESCRIPTION
## The bug

Picking **"250 per page"** in the metadata review dialog locks it up — and the lockup is **self-perpetuating**, which is what makes it nasty:

```ts
function loadReviewPageSize(): number {
  const raw = window.localStorage.getItem(STORAGE_KEYS.METADATA_REVIEW_PAGE_SIZE);
  const n = raw ? Number(raw) : 25;
  return PAGE_SIZE_OPTIONS.includes(n) ? n : 25;   // 250 IS a member -> accepted
}
```

`PAGE_SIZE_OPTIONS` was `[25, 50, 100, 250, 500]`, so the stored `250` passed validation and was restored on **every** open. The page-size control lives *inside* the dialog, so a user who hit this could never reach it to change the value back. The only escape was clearing `localStorage` by hand.

## The fix

Two changes, because trimming the options list alone would not have helped anyone already stuck.

**1. Clamp on read, and write the correction back.**

```ts
const safe = Math.min(n, MAX_REVIEW_PAGE_SIZE);          // 50
const corrected = PAGE_SIZE_OPTIONS.includes(safe) ? safe : MAX_REVIEW_PAGE_SIZE;
try { window.localStorage.setItem(KEY, String(corrected)); } catch { /* private mode */ }
return corrected;
```

Clamping on **read** is what makes this self-healing: users who already have `250` or `500` persisted get `50` on next open without touching devtools. Writing it back means the bad value is gone for good rather than re-clamped forever. Non-numeric, zero and negative values fall back to `25`; the write is wrapped so a private-mode quota failure degrades to per-session clamping instead of throwing.

**2. `PAGE_SIZE_OPTIONS` drops 250 and 500.** Review rows are heavy — each renders a full candidate comparison — so this selector deliberately no longer matches ActivityLog's. **100 is kept** because only 250 was observed to lock up; if 100 turns out to stall too, lower `MAX_REVIEW_PAGE_SIZE` rather than only trimming the list, since the clamp is what actually protects users.

## Verification

12 new unit tests, and **mutation-tested rather than trusted green**:

| mutation | result |
|---|---|
| clamp reverted to validate-only | **3 tests fail** |
| write-back removed, clamp kept | **1 test fails** (the persistence test) |

Full frontend suite: **504 passed / 72 files**, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS