### PR TITLE
fix(review,config): stop blocking on the apply op, stop defaulting to OpenAI

### DIFF
--- a/changelog.d/20260817_043000_fix_nonblocking_apply_and_llm_mode.md
+++ b/changelog.d/20260817_043000_fix_nonblocking_apply_and_llm_mode.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **Applying metadata no longer holds the review dialog hostage.** The apply already
+  ran as a background operation server-side, but the dialog then sat on
+  `pollOperationV2` until every book finished, which cancelled out the benefit. It
+  now dispatches, toasts "Metadata apply queued for N book(s) — watch the bell for
+  progress", and returns. The bell already tracks every background op, so progress is
+  not lost. The Apply buttons re-enable immediately instead of after the batch, and
+  further applies queue server-side rather than being locked out.
+- **A blank `llm_mode` no longer silently means OpenAI.** `EffectiveLLMMode()` fell
+  through to OpenAI whenever an API key happened to be set, so an empty config field
+  chose a paid external service with nothing logged — on 2026-08-16 that ran a whole
+  library scan against OpenAI until the account hit `credit_balance_exhausted`, at
+  which point 77 consecutive batches failed and the watchdog killed the scan. A blank
+  mode now prefers the local backend whenever one is configured.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -448,6 +448,18 @@ func (c *Config) EffectiveLLMMode() string {
 	if c.AIBackend.LLMMode != "" {
 		return c.AIBackend.LLMMode
 	}
+	// A blank llm_mode used to resolve straight to OpenAI whenever an API key
+	// happened to be present. That made an empty config field silently choose a
+	// paid external service, and nothing logged the choice — on 2026-08-16 it
+	// ran a whole library scan against OpenAI until the account hit
+	// credit_balance_exhausted, whereupon 77 consecutive batches failed and the
+	// stuck-op watchdog killed the scan.
+	//
+	// Prefer the local backend when one is configured. Falling back to OpenAI is
+	// still possible, but only when there is no local option at all.
+	if c.AIBackend.LocalBaseURL != "" || c.Embedding.BaseURL != "" {
+		return AIBackendModeLocal
+	}
 	if c.OpenAIAPIKey != "" && (c.EnableAIParsing || c.MetadataScoring.LLMEnabled) {
 		return AIBackendModeOpenAI
 	}

--- a/web/src/components/audiobooks/MetadataReviewDialog.tsx
+++ b/web/src/components/audiobooks/MetadataReviewDialog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/MetadataReviewDialog.tsx
-// version: 1.17.0
+// version: 1.18.0
 // guid: e7f8a9b0-c1d2-3e4f-5a6b-7c8d9e0f1a2b
 // last-edited: 2026-08-17
 
@@ -26,7 +26,6 @@ import {
   ToggleButton,
   ToggleButtonGroup,
   Tooltip,
-  LinearProgress,
   Typography,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
@@ -221,14 +220,20 @@ export function MetadataReviewDialog({
   const [onlyWithTranscription, setOnlyWithTranscription] = useState(false);
   const [onlyTranscriptionMatched, setOnlyTranscriptionMatched] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
-  // Live progress of the background apply op, so a long batch shows movement
-  // instead of a spinner that looks identical to a hung request.
-  const [applyOpId, setApplyOpId] = useState<string | null>(null);
-  const [applyProgress, setApplyProgress] = useState<{
-    current: number;
-    total: number;
-    message: string;
-  } | null>(null);
+  // Apply progress is NOT rendered here any more. The dialog dispatches the
+  // background op and returns immediately, so there is nothing to show a bar
+  // for — the bell (OperationsIndicator, fed by useOperationsStore) owns
+  // progress for every background op, this one included.
+  //
+  // Guards the deferred list refresh below: once the dialog unmounts there is
+  // no state left to refresh, and setting it would warn.
+  const applyWatchAliveRef = useRef(true);
+  useEffect(() => {
+    applyWatchAliveRef.current = true;
+    return () => {
+      applyWatchAliveRef.current = false;
+    };
+  }, []);
   // Books in this set have been manually split from their duplicate group and
   // render as standalone rows. Reset when the page changes.
   const [ungroupedIds, setUngroupedIds] = useState<Set<string>>(new Set());
@@ -456,40 +461,34 @@ export function MetadataReviewDialog({
   const runApplyOp = useCallback(
     async (requestedIds: string[], writeBack?: boolean): Promise<boolean> => {
       const dispatch = await api.batchApplyFromCache(requestedIds, writeBack);
-      setApplyOpId(dispatch.op_id);
-      setApplyProgress({ current: 0, total: requestedIds.length, message: 'starting…' });
-      try {
-        const op = await api.pollOperationV2(dispatch.op_id, (o) => {
-          setApplyProgress({
-            current: o.progress_current ?? 0,
-            total: o.progress_total ?? requestedIds.length,
-            message: o.progress_message ?? o.current_item ?? 'applying…',
-          });
+
+      // Hand the op off and return. The apply already runs as a background
+      // operation server-side; awaiting it here was what made the dialog feel
+      // synchronous — you clicked Apply on 100 books and then watched a
+      // progress bar instead of getting on with your evening.
+      //
+      // The bell picks this up for free: OperationsIndicator renders whatever
+      // is in useOperationsStore.activeOperations, and the dispatched op is
+      // there. Same shape as the bulk metadata fetch on the Library page.
+      toast(
+        `Metadata apply queued for ${requestedIds.length.toLocaleString()} book(s) — watch the bell for progress.`,
+        'success'
+      );
+
+      // Still re-read server state rather than diffing a client-side guess —
+      // just when the op FINISHES instead of blocking on it. If the dialog is
+      // closed by then this resolves against an unmounted component, so the
+      // refresh is guarded by the same ref the unmount path clears.
+      hasChangesRef.current = true;
+      void api
+        .pollOperationV2(dispatch.op_id)
+        .catch(() => undefined)
+        .finally(() => {
+          if (!applyWatchAliveRef.current) return;
+          setRefreshKey((k) => k + 1);
         });
-        if (op.status === 'completed') {
-          hasChangesRef.current = true;
-          // progress_message carries the op's own tally, e.g.
-          // "complete: applied 248 of 250 (no candidates 2, ...)".
-          toast(op.progress_message || `Applied metadata to ${requestedIds.length} books`, 'success');
-          return true;
-        }
-        if (op.status === 'canceled') {
-          // Partial work is real and already on disk. Say so instead of
-          // implying the batch left no trace.
-          hasChangesRef.current = true;
-          toast('Metadata apply canceled — books applied before the cancel were kept', 'warning');
-          return true;
-        }
-        toast(op.progress_message || 'Metadata apply failed', 'error');
-        return true;
-      } finally {
-        setApplyOpId(null);
-        setApplyProgress(null);
-        // Always re-read: even a failed or canceled op may have applied some
-        // books before it stopped, and leaving the list stale would show rows
-        // as pending that are already done.
-        setRefreshKey((k) => k + 1);
-      }
+
+      return true;
     },
     [toast]
   );
@@ -1693,31 +1692,8 @@ export function MetadataReviewDialog({
           )}
         </DialogContent>
         <DialogActions sx={{ gap: 2 }}>
-          {/* Live op progress. A long batch used to be indistinguishable from a
-              hung request — same spinner either way — which is what made a
-              working 2-minute apply read as a failure. */}
-          {applyProgress && (
-            <Box sx={{ flex: 1, minWidth: 0, mr: 1 }}>
-              <LinearProgress
-                variant={applyProgress.total > 0 ? 'determinate' : 'indeterminate'}
-                value={
-                  applyProgress.total > 0
-                    ? Math.min(100, (applyProgress.current / applyProgress.total) * 100)
-                    : 0
-                }
-              />
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                noWrap
-                title={applyProgress.message}
-                sx={{ display: 'block' }}
-              >
-                {applyProgress.current}/{applyProgress.total} — {applyProgress.message}
-                {applyOpId ? ` (op ${applyOpId.slice(0, 8)})` : ''}
-              </Typography>
-            </Box>
-          )}
+          {/* No inline apply progress: the dialog no longer waits on the op, so
+              there is nothing here to track. Progress lives in the bell. */}
           <Button onClick={handleClose}>Close</Button>
           <Button
             variant="contained"


### PR DESCRIPTION
Two papercuts where the code does the right thing and then undoes it.

## 1. Apply blocked the dialog

`batchApplyFromCache` returns an op id immediately — the apply genuinely runs as a background op. But `runApplyOp` then awaited `pollOperationV2` until the op finished, so clicking Apply on 100 books gave a progress bar and a locked dialog instead of a receipt.

Now: dispatch → toast `Metadata apply queued for N book(s) — watch the bell for progress` → return. The bell (`OperationsIndicator`, fed by `useOperationsStore.activeOperations`) already renders every background op, so nothing is lost. Same shape as the bulk metadata fetch on the Library page.

The inline progress bar and its `applyOpId`/`applyProgress` state are removed — two progress UIs for one op is worse than one. The deferred poll survives only to re-read the review list when the op completes, guarded by a ref so it is inert after unmount.

**This also ends the apply lockout:** `setApplying(false)` runs in the `finally` after `runApplyOp`, which now returns in milliseconds. Concurrent applies remain serialized server-side by `ConcurrencyKey: "metadata.batch-apply-cached"` (`batch_apply_op.go:71`), which **queues rather than rejects** — deliberately left alone, since it is what stops two applies racing on the same books.

## 2. A blank `llm_mode` silently meant OpenAI

```go
if c.AIBackend.LLMMode != "" { return c.AIBackend.LLMMode }
if c.OpenAIAPIKey != "" && (...) { return AIBackendModeOpenAI }  // <- empty field picks a paid service
```

Nothing logged the choice. On 2026-08-16 that ran a whole library scan against OpenAI until the account hit `credit_balance_exhausted`, whereupon 77 consecutive batches failed and the stuck-op watchdog killed the scan.

A blank mode now prefers the local backend whenever one is configured, falling through to OpenAI only when there is no local option at all.

## Verification

- `go build` + `go vet ./internal/config` — clean
- 76 frontend tests pass across `src/components/audiobooks/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS