### PR TITLE
docs(todo): narrator names are never split into individual narrators

### DIFF
--- a/changelog.d/20260817_045000_docs_narrator_names_not_split.md
+++ b/changelog.d/20260817_045000_docs_narrator_names_not_split.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Documented that compound narrator names are never split into individual
+  narrators.** A book credited to "Michael Kramer & Kate Reading" is stored as one
+  narrator record whose name is the whole string, so narrator filtering and
+  faceting miss every multi-narrator book. The `BookNarrator` join table already
+  supports many-to-many — the rows just never get created, because nothing splits
+  on the ingest path. The only splitter in the repo lives inside
+  `OptimizeDatabase`, runs only when invoked, and matches `" & "` and nothing else,
+  so comma-separated credits stay compound.

--- a/todo.d/20260817-narrator-names-not-split-into-multiple-fields.md
+++ b/todo.d/20260817-narrator-names-not-split-into-multiple-fields.md
@@ -1,0 +1,49 @@
+### Compound narrator names are not split into individual narrators
+
+A book narrated by two or three people is stored as one narrator whose *name* is
+the whole credit string — "Michael Kramer & Kate Reading" is a single narrator
+record, not two. Filtering, faceting, and "more by this narrator" therefore miss
+every multi-narrator book, and the narrator list is polluted with entries that are
+not people.
+
+The schema is not the problem. `BookNarrator` (`internal/database/store.go:107`) is
+a proper many-to-many join, `SetBookNarrators` exists, and `NarratorsJSON`
+(`store.go:253`) carries a second tier into the summary projection. Nothing needs
+migrating — the rows just never get created.
+
+**Where it goes wrong: nothing splits at ingest.** `internal/metadata/metadata.go:266-269`
+reads `PERFORMER` / `TXXX:NARRATOR` / `©nrt` into a single `metadata.Narrator`
+string, runs `cleanTagValue` over it, and stores it whole. There is no split on that
+path, so every scan and every metadata apply writes compound names straight through.
+
+**The splitter that does exist is in the wrong place and too narrow.** The only
+narrator-splitting code in the repo lives inside `OptimizeDatabase`
+(`internal/server/handlers/operations/handler.go:276`, reporting a `narrators_split`
+count). Three problems with relying on it:
+
+1. **It is a manual maintenance op, not a rule.** It repairs history when someone
+   runs it; the next scan re-introduces compound names immediately. Splitting
+   belongs on the ingest path, with the op kept only as a backfill for old rows.
+2. **It only splits on `" & "`.** `splitMultipleNames`
+   (`internal/audiobooks/service_filtering.go:1086`) is `strings.Split(name, " & ")`
+   and nothing else — so `"Kate Reading, Michael Kramer"`, `" and "`, `";"` and
+   `" with "` are all left as one name. Comma-separated credits are the common case
+   in real tags.
+3. **It leaves two sources of truth.** `book.Narrator` keeps the compound string
+   after the join rows are written, so callers reading the scalar and callers
+   reading `book_narrators` disagree. Decide which is authoritative and say so.
+
+Also note it walks `GetAllBooksCore(0, 0)` — the entire library in memory — in a
+plain sequential loop, which is the shape CLAUDE.md's concurrency rule calls out. If
+this gets promoted to a real backfill it needs a bounded worker pool.
+
+**Suggested shape:**
+
+- Split at ingest, in `internal/metadata`, so scans and applies both benefit.
+- Widen the separator set beyond `" & "`: comma, `" and "`, `";"`, `" with "`, and
+  narrator-specific noise like a trailing "(Narrator)". Be conservative — a name
+  containing a comma ("Smith, John") must not be shredded, so prefer an explicit
+  separator list over a generic tokenizer, and add fixtures for the ambiguous cases.
+- Keep `OptimizeDatabase`'s pass as a one-time backfill for existing rows, using the
+  same splitter rather than a second copy of the logic.
+- Decide and document whether `book.Narrator` or `book_narrators` wins.


### PR DESCRIPTION
A book narrated by two people is stored as **one** narrator whose name is the whole credit string — "Michael Kramer & Kate Reading" is a single record, not two. Narrator filtering and faceting therefore miss every multi-narrator book.

**The schema is fine.** `BookNarrator` (`store.go:107`) is a real many-to-many join, `SetBookNarrators` exists, `NarratorsJSON` (`store.go:253`) carries a second tier. Nothing needs migrating — the rows just never get created.

**Nothing splits at ingest.** `internal/metadata/metadata.go:266-269` reads `PERFORMER` / `TXXX:NARRATOR` / `©nrt` into one `metadata.Narrator` string and stores it whole, so every scan and every metadata apply writes compound names straight through.

**The one splitter that exists is in the wrong place and too narrow** — inside `OptimizeDatabase` (`handlers/operations/handler.go:276`):

| problem | detail |
|---|---|
| Manual op, not a rule | repairs history when run; the next scan re-introduces compound names |
| Splits on `" & "` only | `splitMultipleNames` is `strings.Split(name, " & ")` — commas, `" and "`, `";"` all survive |
| Two sources of truth | `book.Narrator` keeps the compound string alongside the new join rows |

It also walks `GetAllBooksCore(0, 0)` in a plain sequential loop — the shape CLAUDE.md's concurrency rule calls out, if it ever gets promoted to a real backfill.

Suggested shape is in the fragment. Note the conservative bit: a name like "Smith, John" must not be shredded, so prefer an explicit separator list over a generic tokenizer.

**No behaviour change** — fragment + changelog only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS