### PR TITLE
fix(ops,abs): resume interrupted jobs; serve author/narrator drill-downs; split compound credits

### DIFF
--- a/changelog.d/20260817_050000_fix_op_resume_and_narrator_split.md
+++ b/changelog.d/20260817_050000_fix_op_resume_and_narrator_split.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **Interrupted operations now actually resume.** Two stacked bugs meant a job
+  killed by a restart never came back. `GetInterruptedOperations` matched only
+  `running`/`queued`/`interrupted`, while the registry mints `interrupted_quiesced`
+  (every ResumePolicy except ResumeDrop), `interrupted_dropped`,
+  `interrupted_restart` and `interrupted_ask` — so the startup sweep was blind to
+  the very rows it exists to resume. And even when a row was found, `ResumeRestart`
+  only set it to `"queued"` without enqueueing it, so nothing ever ran it. Status
+  matching is now a prefix test, and `ResumeRestart` re-enqueues for real.
+- **Compound narrator and author names are split into individual people.** The
+  splitter was `strings.Split(name, " & ")` and nothing else, duplicated verbatim in
+  two packages, and gated behind `strings.Contains(name, " & ")` so it never even ran
+  for comma-separated credits. "Kate Reading, Michael Kramer" was therefore one
+  narrator. There is now a single implementation in `internal/util` handling `&`,
+  `and`, `;`, `,`, `with`, `+` and `/`, de-duplicating results, and deliberately
+  refusing to split surname-first names like "Le Guin, Ursula".

--- a/changelog.d/20260817_051500_fix_abs_author_narrator_drilldown.md
+++ b/changelog.d/20260817_051500_fix_abs_author_narrator_drilldown.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **Tapping an author or a narrator in the mobile app now shows their books.** Both
+  drill-downs answered "No Books Found" for every contributor in the library. The
+  `?filter=` handler implemented exactly one group, `series`; `authors` and
+  `narrators` fell through to the branch that deliberately serves an empty page
+  rather than the whole library, and were never implemented behind it. Reproduced on
+  production and confirmed by the server's own warning log, which had been recording
+  both groups by name.
+- **Compound narrator credits are split into individual people in the Narrators
+  tab.** A single stored string like "Jeff Hays, Annie Ellicott" was its own entry
+  reading "1 book" — the library had entries naming eight narrators — and every book
+  behind one was missing from the real narrators' counts. The tab now lists each
+  person once with a correct count. This changes the presentation only: the stored
+  narrator rows still hold the compound string, and the web UI still shows it.
+- Author and narrator counts on the tab and the number of books behind the tap are
+  now computed from one map, so they cannot drift apart.

--- a/internal/audiobooks/service_filtering.go
+++ b/internal/audiobooks/service_filtering.go
@@ -1,12 +1,13 @@
 // file: internal/audiobooks/service_filtering.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: b4e8c3d2-e5f6-7a80-9b0c-1d2e3f4a5b6c
-// last-edited: 2026-08-14
+// last-edited: 2026-08-17
 
 package audiobooks
 
 import (
 	"fmt"
+	"github.com/falkcorp/audiobook-organizer/internal/util"
 	"log/slog"
 	"sort"
 	"strconv"
@@ -1082,20 +1083,12 @@ func (svc *AudiobookService) buildBookSummaryFilterWithLookupCount(f ListFilters
 	return bsf, true, pebbleLookupsPtr
 }
 
-// splitMultipleNames splits a name string on " & " to support multiple authors/narrators.
+// splitMultipleNames delegates to util.SplitCreditNames, the single source of
+// truth for author/narrator credit splitting. This used to be a local
+// strings.Split(name, " & "), duplicated verbatim in
+// internal/server/handlers/operations/handler.go; both copies are gone.
 func splitMultipleNames(name string) []string {
-	parts := strings.Split(name, " & ")
-	var result []string
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			result = append(result, p)
-		}
-	}
-	if len(result) == 0 {
-		return []string{name}
-	}
-	return result
+	return util.SplitCreditNames(name)
 }
 
 // FetchBookFilesForBooks performs the targeted batch fetch via memdb's

--- a/internal/database/pebble_store_operations.go
+++ b/internal/database/pebble_store_operations.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_operations.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e4277998-6d7e-4f2a-9b5c-0a620a98105e
-// last-edited: 2026-08-14
+// last-edited: 2026-08-17
 
 package database
 
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -457,6 +458,26 @@ func (p *PebbleStore) DeleteOperationWithLogs(id string) error {
 	return batch.Commit(pebble.Sync)
 }
 
+// isResumableOpStatus reports whether an operation row in this status should be
+// handed to the startup resume sweep (server_lifecycle.go
+// resumeInterruptedOperations).
+//
+// MATCH THE PREFIX, NOT A LIST. This used to be an inline
+// running/queued/interrupted comparison, while the registry mints a whole family
+// of interrupted_* variants: interrupted_quiesced (registry.go, returned for
+// EVERY ResumePolicy except ResumeDrop), interrupted_dropped,
+// interrupted_restart, interrupted_ask. None of those matched, so the sweep was
+// blind to exactly the rows it exists to resume - a library.scan killed by a
+// deploy on 2026-08-17 sat at interrupted_quiesced and never came back.
+//
+// legacyStatusFor carries this same warning for this same reason. Matching the
+// leading "interrupted" means a seventh variant works without anyone
+// remembering this function exists.
+func isResumableOpStatus(status string) bool {
+	return status == "running" || status == "queued" ||
+		strings.HasPrefix(status, "interrupted")
+}
+
 func (p *PebbleStore) GetInterruptedOperations() ([]Operation, error) {
 	var ops []Operation
 	iter, err := p.db.NewIter(&pebble.IterOptions{
@@ -473,7 +494,7 @@ func (p *PebbleStore) GetInterruptedOperations() ([]Operation, error) {
 		if err := json.Unmarshal(iter.Value(), &op); err != nil {
 			continue
 		}
-		if op.Status == "running" || op.Status == "queued" || op.Status == "interrupted" {
+		if isResumableOpStatus(op.Status) {
 			ops = append(ops, op)
 		}
 	}

--- a/internal/database/pebble_store_operations_interrupted_test.go
+++ b/internal/database/pebble_store_operations_interrupted_test.go
@@ -1,0 +1,41 @@
+// file: internal/database/pebble_store_operations_interrupted_test.go
+// version: 1.0.0
+// guid: 7f2a4c81-93de-4b06-a15f-8c3d206e4b77
+// last-edited: 2026-08-17
+
+package database
+
+import "testing"
+
+// The startup sweep (server_lifecycle.go resumeInterruptedOperations) can only
+// resume what GetInterruptedOperations returns. It used to enumerate
+// running/queued/interrupted, while the registry mints a whole interrupted_*
+// family — so a library.scan killed by a deploy sat at interrupted_quiesced,
+// was invisible to the sweep, and never came back.
+//
+// This pins the PREFIX rule rather than a list, so a future seventh variant is
+// picked up without anyone editing this test.
+func TestInterruptedStatusMatching(t *testing.T) {
+	resumable := []string{
+		"running",
+		"queued",
+		"interrupted",
+		"interrupted_quiesced",
+		"interrupted_dropped",
+		"interrupted_restart",
+		"interrupted_ask",
+		"interrupted_something_invented_later",
+	}
+	for _, st := range resumable {
+		if !isResumableOpStatus(st) {
+			t.Errorf("status %q must be picked up by the resume sweep", st)
+		}
+	}
+
+	terminal := []string{"completed", "failed", "canceled", "cancelled", "pending", ""}
+	for _, st := range terminal {
+		if isResumableOpStatus(st) {
+			t.Errorf("status %q must NOT be treated as resumable", st)
+		}
+	}
+}

--- a/internal/server/handlers/abs/authors_narrators_test.go
+++ b/internal/server/handlers/abs/authors_narrators_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/authors_narrators_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4f8b23e7-16c0-4d95-a3e2-58971bd0c4fa
-// last-edited: 2026-08-02
+// last-edited: 2026-08-17
 
 package abs_test
 
@@ -163,12 +163,20 @@ func TestNarrators_EveryEntryCarriesAnID(t *testing.T) {
 // Asserted through the HTTP RESPONSE rather than by calling the helper: a test that
 // recomputed the formula and compared it to itself would pass no matter what the
 // endpoint actually emits.
+// Fixtures must be names that survive SplitCreditNames intact, because the list is
+// now built from split credits (see contributorDTOs) and a compound fixture would
+// legitimately not appear under its original string. Escaping is a property of the
+// base64 OUTPUT, not of the input bytes, so nothing is lost by choosing them:
+// "Zoë O'Malley" encodes to Wm/DqyBPJ01hbGxleQ== — containing BOTH the '/' that
+// would break the image URL path and the '=' padding — which exercises the escape
+// harder than the old "a?b&c=d" did.
 func TestNarrators_IDMatchesTheRealABSFormula(t *testing.T) {
 	names := []string{
 		"Victor Bevine",
-		"Homer, transl. Samuel Butler", // comma + spaces
-		"Ellé Jones",                   // non-ASCII
-		"a?b&c=d",                      // characters that must survive escaping
+		// Comma + spaces, AND the surname-first form the splitter must NOT split.
+		"Butler, Samuel",
+		"Ellé Jones",   // non-ASCII
+		"Zoë O'Malley", // base64 contains '/' and '=' — both must survive escaping
 	}
 	w := newWriteHarness(t)
 	w.seed.lib.addNarrators(names...)
@@ -202,6 +210,21 @@ func TestNarrators_IDMatchesTheRealABSFormula(t *testing.T) {
 		if strings.Contains(got, "/") {
 			t.Errorf("id for %q = %q contains a raw '/', which breaks the image URL path", name, got)
 		}
+	}
+
+	// Guards the guard: if every fixture happened to base64-encode to a string with
+	// nothing to escape, the loop above would pass while asserting nothing about the
+	// escaping at all — the same vacuous-fixture trap the list-shape test documents.
+	escaped := false
+	for _, name := range names {
+		if raw := base64.StdEncoding.EncodeToString([]byte(name)); url.QueryEscape(raw) != raw {
+			escaped = true
+			break
+		}
+	}
+	if !escaped {
+		t.Fatal("no fixture produced a base64 id needing escaping, so this test proves nothing " +
+			"about encodeURIComponent — pick a name whose base64 contains '+', '/' or '='")
 	}
 }
 

--- a/internal/server/handlers/abs/browse.go
+++ b/internal/server/handlers/abs/browse.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/browse.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: 5e0b83c7-2a41-4d96-b7e8-1c53fd90a2b4
-// last-edited: 2026-08-16
+// last-edited: 2026-08-17
 
 package abs
 
@@ -18,6 +18,7 @@ import (
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
+	"github.com/falkcorp/audiobook-organizer/internal/util"
 	"github.com/gin-gonic/gin"
 )
 
@@ -863,35 +864,38 @@ const absAuthorsCacheTTL = 5 * time.Minute
 // Building the list once turns pages 2..93 into slice arithmetic. That is why this
 // caches the whole DOCUMENT rather than just the count: the count was never the
 // expensive part here.
-func (h *Handler) contributorsCached(ctx context.Context) ([]authorDTO, []narratorDTO, error) {
+func (h *Handler) contributorsCached(ctx context.Context) (*contributorIndex, error) {
 	now := h.now()
 
 	h.authorsCacheMu.Lock()
 	if h.authorsCache != nil && now.Sub(h.authorsCacheAt) < absAuthorsCacheTTL {
-		a, n := h.authorsCache, h.narratorsCache
+		idx := h.authorsCache
 		h.authorsCacheMu.Unlock()
-		return a, n, nil
+		return idx, nil
 	}
 	h.authorsCacheMu.Unlock()
 
 	// Built OUTSIDE the lock. Holding it across a full-library scan would serialize
 	// every concurrent page request behind one rebuild — which is precisely the
 	// 93-requests-in-a-row access pattern this exists to serve.
-	authors, narrators, err := h.contributorDTOs(ctx)
+	idx, err := h.contributorDTOs(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	h.authorsCacheMu.Lock()
-	h.authorsCache, h.narratorsCache, h.authorsCacheAt = authors, narrators, now
+	h.authorsCache, h.authorsCacheAt = idx, now
 	h.authorsCacheMu.Unlock()
-	return authors, narrators, nil
+	return idx, nil
 }
 
 // authorDTOsCached is the author-only view of the shared contributor cache.
 func (h *Handler) authorDTOsCached(ctx context.Context) ([]authorDTO, error) {
-	authors, _, err := h.contributorsCached(ctx)
-	return authors, err
+	idx, err := h.contributorsCached(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return idx.authors, nil
 }
 
 // authorDTOs builds the author list once, shared by /authors and /personalized.
@@ -930,6 +934,24 @@ func (h *Handler) visibleBookSummaries(f database.BookSummaryFilter) ([]database
 	}
 }
 
+// contributorIndex is ONE consistent view of the library's contributors: the two
+// client-visible lists, and the visible book ids behind every entry in them.
+//
+// The lists and the id maps exist in the same struct because the drill-down
+// (?filter=authors.<id>) and the tile it was tapped from must be answered from the
+// same build. Keeping them apart is what made the equivalent /items?filter=series
+// bug possible, and the fix there was exactly this: serve the drill-down from the
+// grouping the list itself was rendered from.
+//
+// authorBooks is keyed by author id (an entity); narratorBooks by narrator NAME,
+// because narrators are not entities in Audiobookshelf — see narratorID.
+type contributorIndex struct {
+	authors       []authorDTO
+	narrators     []narratorDTO
+	authorBooks   map[int][]string
+	narratorBooks map[string][]string
+}
+
 // contributorDTOs builds the author AND narrator lists from the VISIBLE books only.
 //
 // Both are derived from one pass so the two tabs can never disagree with each other or
@@ -951,13 +973,19 @@ func (h *Handler) visibleBookSummaries(f database.BookSummaryFilter) ([]database
 //
 // The tab and the book page must agree about who narrated a book, so this uses the
 // same three-tier resolution rather than a second, narrower rule.
-func (h *Handler) contributorDTOs(ctx context.Context) ([]authorDTO, []narratorDTO, error) {
+func (h *Handler) contributorDTOs(ctx context.Context) (*contributorIndex, error) {
 	books, err := h.visibleBookSummaries(absItemFilterBase())
 	if err != nil {
-		return nil, nil, err
+		return nil, err
+	}
+	idx := &contributorIndex{
+		authors:       []authorDTO{},
+		narrators:     []narratorDTO{},
+		authorBooks:   map[int][]string{},
+		narratorBooks: map[string][]string{},
 	}
 	if len(books) == 0 {
-		return []authorDTO{}, []narratorDTO{}, nil
+		return idx, nil
 	}
 	ids := make([]string, 0, len(books))
 	for i := range books {
@@ -966,66 +994,88 @@ func (h *Handler) contributorDTOs(ctx context.Context) ([]authorDTO, []narratorD
 
 	authorsByBook, err := h.library.GetAuthorsByBookIDs(ctx, ids)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	narratorsByBook, err := h.library.GetNarratorsByBookIDs(ctx, ids)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	type authorAgg struct {
-		name  string
-		id    int
-		books int
+		name string
+		id   int
 	}
 	authorSeen := map[int]*authorAgg{}
-	for _, list := range authorsByBook {
-		for _, a := range list {
+	// Walked in the order visibleBookSummaries returned, NOT by ranging the
+	// authorsByBook map, so the id lists — and therefore the drill-down's page
+	// order — are stable between rebuilds rather than reshuffling per request.
+	for i := range books {
+		bookID := books[i].ID
+		for _, a := range authorsByBook[bookID] {
 			if strings.TrimSpace(a.Name) == "" {
 				continue
 			}
-			agg, ok := authorSeen[a.ID]
-			if !ok {
-				agg = &authorAgg{name: a.Name, id: a.ID}
-				authorSeen[a.ID] = agg
+			if _, ok := authorSeen[a.ID]; !ok {
+				authorSeen[a.ID] = &authorAgg{name: a.Name, id: a.ID}
 			}
-			agg.books++
+			// numBooks is len(authorBooks[id]) rather than its own counter, so the
+			// count the tile shows and the set the drill-down pages CANNOT disagree.
+			// A book credited to the same author twice must still count once.
+			if list := idx.authorBooks[a.ID]; len(list) == 0 || list[len(list)-1] != bookID {
+				idx.authorBooks[a.ID] = append(list, bookID)
+			}
 		}
 	}
 	// One entry per VISIBLE book, resolved through the same three tiers the book
 	// page uses. Counting per book (not per junction row) keeps numBooks honest.
-	narratorSeen := map[string]int{}
+	//
+	// 🔴 SPLIT COMPOUND CREDITS. A single stored string "Jeff Hays, Annie Ellicott"
+	// is two people; left whole it became its own Narrators-tab entry reading
+	// "1 book", and the real narrators' counts were short by that book. The library
+	// had entries naming EIGHT narrators. This splits the presentation only — the
+	// stored BookNarrator/NarratorsJSON rows still hold the compound string, and the
+	// web UI still shows it, so this is not the data fix.
+	narratorSeen := map[string]struct{}{}
 	for i := range books {
-		for _, name := range resolveNarratorsFromSummary(&books[i], narratorsByBook[books[i].ID]) {
-			if name = strings.TrimSpace(name); name != "" {
-				narratorSeen[name]++
+		bookID := books[i].ID
+		for _, raw := range resolveNarratorsFromSummary(&books[i], narratorsByBook[bookID]) {
+			for _, name := range util.SplitCreditNames(raw) {
+				if name = strings.TrimSpace(name); name == "" {
+					continue
+				}
+				narratorSeen[name] = struct{}{}
+				// Splitting can yield the same person twice for one book (tier 2 and
+				// tier 3 both naming them); the book must still be listed once.
+				if list := idx.narratorBooks[name]; len(list) == 0 || list[len(list)-1] != bookID {
+					idx.narratorBooks[name] = append(list, bookID)
+				}
 			}
 		}
 	}
 
 	now := msEpoch(h.now())
-	authors := make([]authorDTO, 0, len(authorSeen))
+	idx.authors = make([]authorDTO, 0, len(authorSeen))
 	for _, agg := range authorSeen {
-		authors = append(authors, authorDTO{
+		idx.authors = append(idx.authors, authorDTO{
 			AddedAt:   now,
 			ID:        strconv.Itoa(agg.id),
 			LastFirst: lastFirst(agg.name),
 			LibraryID: h.libraryID(),
 			Name:      agg.name,
-			NumBooks:  agg.books,
+			NumBooks:  len(idx.authorBooks[agg.id]),
 			UpdatedAt: now,
 		})
 	}
-	sort.SliceStable(authors, func(i, j int) bool { return authors[i].Name < authors[j].Name })
+	sort.SliceStable(idx.authors, func(i, j int) bool { return idx.authors[i].Name < idx.authors[j].Name })
 
-	narrators := make([]narratorDTO, 0, len(narratorSeen))
-	for name, count := range narratorSeen {
-		n := count
-		narrators = append(narrators, narratorDTO{ID: narratorID(name), Name: name, NumBooks: &n})
+	idx.narrators = make([]narratorDTO, 0, len(narratorSeen))
+	for name := range narratorSeen {
+		n := len(idx.narratorBooks[name])
+		idx.narrators = append(idx.narrators, narratorDTO{ID: narratorID(name), Name: name, NumBooks: &n})
 	}
-	sort.SliceStable(narrators, func(i, j int) bool { return narrators[i].Name < narrators[j].Name })
+	sort.SliceStable(idx.narrators, func(i, j int) bool { return idx.narrators[i].Name < idx.narrators[j].Name })
 
-	return authors, narrators, nil
+	return idx, nil
 }
 
 // LibraryAuthors handles GET /api/libraries/:libraryId/authors.
@@ -1104,12 +1154,12 @@ func (h *Handler) LibraryNarrators(c *gin.Context) {
 	// Derived from the VISIBLE books, exactly like the author list — ListNarrators
 	// returns every narrator row in the store, including those attached only to
 	// unorganized iTunes-tree books whose "narrator" is really a track name.
-	_, out, err := h.contributorsCached(c.Request.Context())
+	idx, err := h.contributorsCached(c.Request.Context())
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "could not list narrators")
 		return
 	}
-	respondJSON(c, http.StatusOK, narratorsResponse{Narrators: out})
+	respondJSON(c, http.StatusOK, narratorsResponse{Narrators: idx.narrators})
 }
 
 // narratorID derives a narrator's client-visible id from their name, matching real
@@ -1349,7 +1399,7 @@ func (h *Handler) resolveItem(c *gin.Context) *database.Book {
 // returned, and never block startup.
 func (h *Handler) WarmContributors(ctx context.Context) {
 	started := time.Now()
-	if _, _, err := h.contributorsCached(ctx); err != nil {
+	if _, err := h.contributorsCached(ctx); err != nil {
 		slog.Warn("abs: contributor cache warm failed; the first request will rebuild it", "err", err)
 		return
 	}
@@ -1422,6 +1472,32 @@ func (h *Handler) filteredItems(c *gin.Context, raw string, p pageParams, resp *
 		// the drill-down cannot disagree, and it is already ordered by series
 		// sequence — which is the order a series should be read in.
 		ids = bySeries[seriesID].bookIDs
+	case "authors":
+		// The value is the author ID the /authors list published, which is
+		// strconv.Itoa of the store's int id — not a name.
+		authorID, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil {
+			slog.Warn("abs: author filter value is not an author id", "value", value)
+			respondJSON(c, http.StatusOK, resp)
+			return
+		}
+		idx, ierr := h.contributorsCached(c.Request.Context())
+		if ierr != nil {
+			respondError(c, http.StatusInternalServerError, "could not list library items")
+			return
+		}
+		ids = idx.authorBooks[authorID]
+	case "narrators":
+		// Narrators are addressed by NAME, not by id — narratorID is just base64 of
+		// the name, so decoding the filter token yields the name back. Verified
+		// against the live client: it sends narrators.<the id from /narrators>, and
+		// prod logged group=narrators value="Jeff Hays, Annie Ellicott".
+		idx, ierr := h.contributorsCached(c.Request.Context())
+		if ierr != nil {
+			respondError(c, http.StatusInternalServerError, "could not list library items")
+			return
+		}
+		ids = idx.narratorBooks[strings.TrimSpace(value)]
 	default:
 		slog.Warn("abs: unimplemented item filter group, serving empty page",
 			"group", group, "value", value)

--- a/internal/server/handlers/abs/handler.go
+++ b/internal/server/handlers/abs/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/handler.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: fb0271c6-3a49-4d85-9e13-8c507b2ad64f
-// last-edited: 2026-08-13
+// last-edited: 2026-08-17
 
 // Package abs implements the Audiobookshelf-compatible auth surface (design spec
 // Phase 1): GET /ping, GET /status, POST /login, POST /auth/refresh, POST /logout,
@@ -271,12 +271,16 @@ type Handler struct {
 	itemsCountMu sync.Mutex
 	itemsCount   map[string]itemsCountEntry
 
-	// authorsCache holds the fully-built author list. The client requests up to 93
-	// consecutive pages of it (jump-to-letter), and building it walks the whole
-	// library — see authorDTOsCached in browse.go.
+	// authorsCache holds the fully-built contributor index: the author and narrator
+	// lists AND the book ids behind each entry. The client requests up to 93
+	// consecutive pages of the author list (jump-to-letter), and building it walks
+	// the whole library — see authorDTOsCached in browse.go.
+	//
+	// 🔴 ONE POINTER, NOT PARALLEL SLICES. The lists and the id maps are published
+	// together or not at all, so a drill-down can never be answered from a different
+	// build than the tile whose count the user just read.
 	authorsCacheMu sync.Mutex
-	authorsCache   []authorDTO
-	narratorsCache []narratorDTO
+	authorsCache   *contributorIndex
 	authorsCacheAt time.Time
 
 	// seriesBooksCache maps series id → the visible books in that series.

--- a/internal/server/handlers/abs/item_filter_contributor_test.go
+++ b/internal/server/handlers/abs/item_filter_contributor_test.go
@@ -1,0 +1,253 @@
+// file: internal/server/handlers/abs/item_filter_contributor_test.go
+// version: 1.0.0
+// guid: 4d17b8e0-96ca-4c33-a5f1-2e0b7d4996a1
+// last-edited: 2026-08-17
+
+package abs_test
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// ── ?filter=authors.* and ?filter=narrators.* ───────────────────────────────
+//
+// 🔴 THE DEFECT. Tapping any author or any narrator showed "No Books Found".
+// filteredItems implemented exactly ONE group, `series`; everything else fell to a
+// default branch that logs and serves an empty page. That default is correct
+// policy — an unrecognised filter must NOT answer with the whole library — but
+// authors and narrators were never actually implemented behind it.
+//
+// Reproduced on production 2026-08-17: both
+//
+//	/items?filter=authors.NDY5NTk=                      (author id 46959)
+//	/items?filter=narrators.SmVmZiBIYXlzLCBBbm5pZSBFbGxpY290dA==
+//
+// answered {"results":[],"total":0}, and the server's own warning log named the
+// groups: group=narrators value="Jeff Hays, Annie Ellicott", group=authors
+// value=46959. The log was the oracle for the token format — no fixture carries a
+// filter — which is exactly what that log was added for.
+
+// absSeedContributors builds a library where authors and narrators overlap
+// partially, so an "returns only this author's books" assertion can actually fail:
+// if every book shared every contributor, an unfiltered response would satisfy it.
+func absSeedContributors(t *testing.T) *oracleSeed {
+	t.Helper()
+	seed := seedOracleLibrary(t)
+
+	intp := func(i int) *int { return &i }
+	strp := func(s string) *string { return &s }
+	boolp := func(b bool) *bool { return &b }
+
+	// Organized + primary, or absItemFilterBase excludes them and the lists come
+	// back empty for a reason unrelated to what is under test.
+	add := func(id, title string) {
+		seed.lib.addBook(&database.Book{
+			ID: id, Title: title,
+			Duration:     intp(3600),
+			LibraryState: strp("organized"), IsPrimaryVersion: boolp(true),
+		}, nil, nil)
+	}
+	add("c-b1", "Contributor Book One")
+	add("c-b2", "Contributor Book Two")
+	add("c-b3", "Contributor Book Three")
+
+	// Author 900 has two of the three books; author 901 has the third. The
+	// exclusion assertion is meaningless without a book the filter must LEAVE OUT.
+	seed.lib.addAuthor(900, "Aria Author", "c-b1", "c-b2")
+	seed.lib.addAuthor(901, "Other Author", "c-b3")
+
+	// b1 carries a COMPOUND credit, b2 names one of the same people alone. That
+	// overlap is the whole point: after splitting, "Jeff Hays" must own BOTH books
+	// while "Annie Ellicott" owns only b1.
+	seed.lib.attachNarrators("c-b1", "Jeff Hays, Annie Ellicott")
+	seed.lib.attachNarrators("c-b2", "Jeff Hays")
+	seed.lib.attachNarrators("c-b3", "Zoë O'Malley")
+	return seed
+}
+
+func absContribHarness(t *testing.T) (*harness, string) {
+	t.Helper()
+	h := newHarness(t, "jwt", nil, withLibrary(absSeedContributors(t)), withUserData(fixtureUserData()))
+	h.seedUser(t, "u1", "oracle", "", "pw-pw-pw-pw")
+	tok := str(t, userObj(t, h.login(t, "oracle", "pw-pw-pw-pw")), "accessToken")
+	return h, tok
+}
+
+// absNarratorRows returns name → id from the live /narrators response, so tests
+// filter with the id the SERVER published rather than one they recomputed. A test
+// that derives the id itself proves only that it agrees with itself.
+func absNarratorRows(t *testing.T, h *harness, tok string) (map[string]string, map[string]int) {
+	t.Helper()
+	code, body := h.doAny(t, request{
+		method:  http.MethodGet,
+		path:    "/api/libraries/" + h.libraryID() + "/narrators",
+		headers: bearer(tok),
+	})
+	if code != http.StatusOK {
+		t.Fatalf("GET narrators = %d, want 200", code)
+	}
+	m, ok := body.(map[string]any)
+	if !ok {
+		t.Fatalf("narrators body is %T, want an object", body)
+	}
+	ids, counts := map[string]string{}, map[string]int{}
+	for _, entry := range requireArray(t, m, "narrators") {
+		n, _ := entry.(map[string]any)
+		if n == nil {
+			continue
+		}
+		name, _ := n["name"].(string)
+		id, _ := n["id"].(string)
+		ids[name] = id
+		if nb, ok := n["numBooks"].(float64); ok {
+			counts[name] = int(nb)
+		}
+	}
+	return ids, counts
+}
+
+func TestLibraryItems_AuthorFilterReturnsOnlyThatAuthorsBooks(t *testing.T) {
+	h, tok := absContribHarness(t)
+
+	all := absItemTitles(absItemsFiltered(t, h, tok, ""))
+	if len(all) < 3 {
+		t.Fatalf("unfiltered library has %d items (%v); with fewer than 3 the "+
+			"exclusion assertion below cannot distinguish a working filter", len(all), all)
+	}
+
+	got := absItemsFiltered(t, h, tok, absFilterToken("authors", "900"))
+	titles := absItemTitles(got)
+
+	// EXCLUSION is the assertion. Returning the whole library also "includes" this
+	// author's books — that was the shape of the series defect, and the reason the
+	// unfiltered response is fetched above.
+	want := map[string]bool{"Contributor Book One": true, "Contributor Book Two": true}
+	for _, title := range titles {
+		if !want[title] {
+			t.Fatalf("author filter returned %q, which is not author 900's: %v", title, titles)
+		}
+	}
+	if len(titles) != 2 {
+		t.Fatalf("author filter returned %d items %v, want exactly 2", len(titles), titles)
+	}
+	if total, _ := got["total"].(float64); int(total) != 2 {
+		t.Fatalf("total = %v, want 2 (the filtered set, not the library)", got["total"])
+	}
+}
+
+func TestLibraryItems_NarratorFilterReturnsOnlyThatNarratorsBooks(t *testing.T) {
+	h, tok := absContribHarness(t)
+	ids, _ := absNarratorRows(t, h, tok)
+
+	id, ok := ids["Annie Ellicott"]
+	if !ok {
+		t.Fatalf("narrator list has no %q — the compound credit was not split; got %v",
+			"Annie Ellicott", ids)
+	}
+
+	// The id arrives percent-escaped, exactly as the client would send it in a query
+	// string; unescaping is the gin layer's job and is part of what this exercises.
+	got := absItemsFiltered(t, h, tok, "narrators."+id)
+	titles := absItemTitles(got)
+	if len(titles) != 1 || titles[0] != "Contributor Book One" {
+		t.Fatalf("narrator filter returned %v, want exactly [Contributor Book One]", titles)
+	}
+	if total, _ := got["total"].(float64); int(total) != 1 {
+		t.Fatalf("total = %v, want 1", got["total"])
+	}
+}
+
+// 🔴 THE COMPOUND CREDIT IS THE REPORTED BUG. The Narrators tab listed
+// "Jeff Hays, Annie Ellicott" as a single person with 1 book — and the library had
+// entries naming EIGHT. Every one of those is a name nobody can tap usefully, and
+// every book behind it is missing from the real narrators' counts.
+func TestNarrators_CompoundCreditIsSplitIntoPeople(t *testing.T) {
+	h, tok := absContribHarness(t)
+	ids, counts := absNarratorRows(t, h, tok)
+
+	if _, present := ids["Jeff Hays, Annie Ellicott"]; present {
+		t.Error("the compound string is still its own narrator entry — it must be split")
+	}
+	for _, name := range []string{"Jeff Hays", "Annie Ellicott"} {
+		if _, present := ids[name]; !present {
+			t.Errorf("narrator %q missing after splitting; got %v", name, ids)
+		}
+	}
+	// Jeff Hays narrated b1 (compound) AND b2 (alone). Counting the compound entry
+	// separately is what made both counts wrong, so the count is the assertion.
+	if got := counts["Jeff Hays"]; got != 2 {
+		t.Errorf("numBooks for Jeff Hays = %d, want 2 (the compound book AND the solo one)", got)
+	}
+	if got := counts["Annie Ellicott"]; got != 1 {
+		t.Errorf("numBooks for Annie Ellicott = %d, want 1", got)
+	}
+	// Surname-first must NOT be split into two people — the guard that makes the
+	// splitter safe to run over a whole library.
+	if _, present := ids["Zoë O'Malley"]; !present {
+		t.Errorf("Zoë O'Malley vanished from the list; got %v", ids)
+	}
+}
+
+// 🔴 THE TILE'S COUNT AND THE DRILL-DOWN'S TOTAL COME FROM ONE MAP. If they are
+// computed separately they drift, and the user sees "15 books" open onto 3.
+func TestNarratorFilter_TileCountEqualsDrillDownTotal(t *testing.T) {
+	h, tok := absContribHarness(t)
+	ids, counts := absNarratorRows(t, h, tok)
+
+	for name, id := range ids {
+		got := absItemsFiltered(t, h, tok, "narrators."+id)
+		total, _ := got["total"].(float64)
+		if int(total) != counts[name] {
+			t.Errorf("narrator %q: tile says %d books, drill-down total says %d",
+				name, counts[name], int(total))
+		}
+	}
+}
+
+// narratorID and absFilterGroup must be exact inverses. They are written in
+// different places against different specs — one mirrors real ABS's
+// encodeURIComponent(base64(name)), the other accepts four base64 alphabets — and
+// nothing but this pins them together.
+//
+// The '+' case is the one that fails silently: base64 emits '+', and an unescaped
+// '+' in a query string decodes to a SPACE, so the name would come back mangled
+// rather than erroring. No plausible narrator name produces a '+' (searched: it
+// needs an unusual byte pair), so the fixture is synthetic on purpose — the
+// hazard is real even where the name is not.
+func TestNarratorID_RoundTripsThroughTheFilterToken(t *testing.T) {
+	for _, name := range []string{
+		"Jeff Hays",
+		"Zoë O'Malley", // base64 contains '/' and '='
+		"Butler, Samuel",
+		"Ellé Jones",
+		"é~", // base64 "w6l+" — the '+' that would otherwise become a space
+	} {
+		t.Run(name, func(t *testing.T) {
+			// Simulates the full trip: the server escapes the id, the client puts it
+			// in a query string, and the URL layer unescapes it before the handler.
+			token := "narrators." + url.QueryEscape(base64.StdEncoding.EncodeToString([]byte(name)))
+			q, err := url.ParseQuery("filter=" + token)
+			if err != nil {
+				t.Fatalf("token %q is not a legal query value: %v", token, err)
+			}
+			raw := q.Get("filter")
+
+			dot := len("narrators.")
+			if len(raw) <= dot || raw[:dot] != "narrators." {
+				t.Fatalf("filter came back as %q, want a narrators. token", raw)
+			}
+			decoded, derr := base64.StdEncoding.DecodeString(raw[dot:])
+			if derr != nil {
+				t.Fatalf("value %q did not decode as base64: %v", raw[dot:], derr)
+			}
+			if string(decoded) != name {
+				t.Fatalf("round trip gave %q, want %q", decoded, name)
+			}
+		})
+	}
+}

--- a/internal/server/handlers/operations/handler.go
+++ b/internal/server/handlers/operations/handler.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/falkcorp/audiobook-organizer/internal/util"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -247,7 +248,7 @@ func (h *Handler) OptimizeDatabase(c *gin.Context) {
 		// Split compound author names into individual book_authors
 		if book.AuthorID != nil {
 			author, err := h.store.GetAuthorByID(*book.AuthorID)
-			if err == nil && author != nil && strings.Contains(author.Name, " & ") {
+			if err == nil && author != nil && util.IsCompoundCreditName(author.Name) {
 				names := splitMultipleNames(author.Name)
 				if len(names) > 1 {
 					var bookAuthors []database.BookAuthor
@@ -274,7 +275,7 @@ func (h *Handler) OptimizeDatabase(c *gin.Context) {
 		}
 
 		// Split compound narrator names into individual book_narrators
-		if book.Narrator != nil && strings.Contains(*book.Narrator, " & ") {
+		if book.Narrator != nil && util.IsCompoundCreditName(*book.Narrator) {
 			names := splitMultipleNames(*book.Narrator)
 			if len(names) > 1 {
 				var bookNarrators []database.BookNarrator
@@ -309,19 +310,12 @@ func (h *Handler) OptimizeDatabase(c *gin.Context) {
 // splitMultipleNames splits an "A & B & C" string into its trimmed parts. It
 // mirrors the server-package helper of the same name (a trivial pure function
 // that was only used by this domain).
+// splitMultipleNames delegates to util.SplitCreditNames. It was a verbatim
+// second copy of the audiobooks package's " & "-only splitter; package
+// operations deliberately does not import package audiobooks, so the shared
+// implementation lives in the leaf package internal/util.
 func splitMultipleNames(name string) []string {
-	parts := strings.Split(name, " & ")
-	var result []string
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			result = append(result, p)
-		}
-	}
-	if len(result) == 0 {
-		return []string{name}
-	}
-	return result
+	return util.SplitCreditNames(name)
 }
 
 // SweepTombstones implements POST /operations/sweep-tombstones.

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 3.18.0
+// version: 3.19.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-08-14
+// last-edited: 2026-08-17
 
 package server
 
@@ -93,8 +93,32 @@ func (s *Server) resumeInterruptedOperations() {
 func (s *Server) resumeV2Op(opID, opType string, policy opsregistry.ResumePolicy) {
 	switch policy {
 	case opsregistry.ResumeRestart:
-		// Reset existing row to "queued"; checkpoint saved under the original op ID remains accessible.
-		_ = s.Store().UpdateOperationV2Status(opID, "queued", nil, nil, nil)
+		// Marking the row "queued" is NOT enough, which is what this used to do.
+		// Nothing scans the store for queued rows — the dispatcher works from
+		// the registry's own queue — so a ResumeRestart op was set to "queued"
+		// and then sat there forever. Measured 2026-08-17: a library.scan
+		// (ResumePolicy=ResumeRestart since #2500) was killed by a deploy and
+		// never came back, and no scan was running afterwards.
+		//
+		// Re-enqueue for real, the way ResumeRequeue does. Params are nil for
+		// the same reason they are nil there: the concrete params type is not
+		// known at this call site (LoadParams is generic over T), and every
+		// ResumeRestart op today treats nil as "do the whole thing" — which is
+		// exactly the intended restart semantic. An op that needs its original
+		// params to restart correctly must persist them itself.
+		newID, err := s.opRegistry.EnqueueOp(context.Background(), opType, nil)
+		if err != nil {
+			slog.Warn("Failed to re-enqueue v2 op on restart-resume", "opID", opID, "opType", opType, "err", err)
+			_ = s.Store().UpdateOperationError(opID, "failed to resume: "+err.Error())
+			return
+		}
+		// Close the old row out rather than leaving it mid-flight, so the
+		// timeline shows one finished attempt and one fresh run instead of a
+		// phantom that never moves again.
+		now := time.Now()
+		reason := fmt.Sprintf("interrupted during %s — restarted as %s", opType, newID)
+		_ = s.Store().UpdateOperationV2Status(opID, "interrupted_restart", nil, &now, &reason)
+		slog.Info("Restarted interrupted operation", "oldOpID", opID, "newOpID", newID, "opType", opType)
 	case opsregistry.ResumeRequeue:
 		// Re-enqueue from zero (idempotent op).
 		if _, err := s.opRegistry.EnqueueOp(context.Background(), opType, nil); err != nil {

--- a/internal/util/names.go
+++ b/internal/util/names.go
@@ -1,0 +1,103 @@
+// file: internal/util/names.go
+// version: 1.0.0
+// guid: 3a91c4e7-52bd-4f16-8c03-9e7d1b5a2f48
+// last-edited: 2026-08-17
+
+package util
+
+import "strings"
+
+// creditSeparators are the delimiters that split a credit string into
+// individual people, longest-first so " and " is consumed before the bare "&"
+// inside it.
+//
+// This list is deliberately EXPLICIT rather than a general tokenizer. A comma is
+// included because comma-separated credits ("Kate Reading, Michael Kramer") are
+// the common case in real tags — but that is also what makes a naive split
+// dangerous, since "Smith, John" is one person written surname-first.
+// SplitCreditNames guards that case; do not widen this list without extending
+// the guard.
+var creditSeparators = []string{" & ", " and ", "; ", ";", ", ", " with ", " + ", "/", "&"}
+
+// looksLikeSurnameFirst reports whether a two-part comma split looks like one
+// person written "Surname, Given" rather than two people.
+//
+// The signal is that the RIGHT side is a lone word: "Smith, John" and
+// "Le Guin, Ursula" both are, while a real list has a surname on the right
+// ("Kate Reading, Michael Kramer"). Testing the left side too was the first
+// attempt and it broke on multi-word surnames like "Le Guin".
+//
+// This deliberately errs toward NOT splitting. A genuine list ending in a
+// mononym ("Kate Reading, Cher") is left compound — rare, and merging two names
+// is far easier to spot and undo than shredding one person into two phantom
+// narrators that then pollute every narrator list and filter.
+func looksLikeSurnameFirst(left, right string) bool {
+	return left != "" && len(strings.Fields(right)) == 1
+}
+
+// SplitCreditNames splits an author/narrator credit string into individual
+// names, de-duplicated, order preserved.
+//
+// This is the SINGLE source of truth for name splitting. It previously existed
+// as two independent copies — internal/audiobooks/service_filtering.go and
+// internal/server/handlers/operations/handler.go — each of which was
+// strings.Split(name, " & ") and nothing else. Every comma-separated,
+// "and"-joined or semicolon-joined credit therefore stayed one "person", which
+// is how the narrator list fills with entries that are not people and why
+// multi-narrator books drop out of narrator filters entirely.
+//
+// Returns the input as a single element when nothing splits, so callers can
+// treat the result uniformly.
+func SplitCreditNames(name string) []string {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return []string{name}
+	}
+
+	// "Smith, John" is one person, not two. Guard only the simple two-part
+	// case: more parts, or multi-word sides, is a real list.
+	if parts := strings.Split(trimmed, ","); len(parts) == 2 {
+		l, r := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+		if l != "" && r != "" && looksLikeSurnameFirst(l, r) {
+			return []string{trimmed}
+		}
+	}
+
+	work := []string{trimmed}
+	for _, sep := range creditSeparators {
+		var next []string
+		for _, chunk := range work {
+			for _, piece := range strings.Split(chunk, sep) {
+				if p := strings.TrimSpace(piece); p != "" {
+					next = append(next, p)
+				}
+			}
+		}
+		work = next
+	}
+
+	// Drop duplicates, preserving order: "A & A" and repeated tag credits must
+	// not create two identical narrator rows.
+	seen := make(map[string]struct{}, len(work))
+	var result []string
+	for _, p := range work {
+		key := strings.ToLower(p)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, p)
+	}
+
+	if len(result) == 0 {
+		return []string{name}
+	}
+	return result
+}
+
+// IsCompoundCreditName reports whether a credit string names more than one
+// person. Use this instead of strings.Contains(name, " & ") when gating a split:
+// the old gate meant the splitter never even ran for comma-separated credits.
+func IsCompoundCreditName(name string) bool {
+	return len(SplitCreditNames(name)) > 1
+}

--- a/internal/util/names_test.go
+++ b/internal/util/names_test.go
@@ -1,0 +1,78 @@
+// file: internal/util/names_test.go
+// version: 1.0.0
+// guid: 6c05f39a-71b4-4e28-9d1a-3f8b0c27e5d6
+// last-edited: 2026-08-17
+
+package util_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/util"
+)
+
+func TestSplitCreditNames(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		// The case that motivated this: " & " was the ONLY separator, so every
+		// comma-separated credit stayed one "narrator".
+		{"comma", "Kate Reading, Michael Kramer", []string{"Kate Reading", "Michael Kramer"}},
+		{"ampersand", "Michael Kramer & Kate Reading", []string{"Michael Kramer", "Kate Reading"}},
+		{"and", "Michael Kramer and Kate Reading", []string{"Michael Kramer", "Kate Reading"}},
+		{"semicolon", "Michael Kramer; Kate Reading", []string{"Michael Kramer", "Kate Reading"}},
+		{"with", "Michael Kramer with Kate Reading", []string{"Michael Kramer", "Kate Reading"}},
+		{"slash", "Michael Kramer/Kate Reading", []string{"Michael Kramer", "Kate Reading"}},
+		{"bare ampersand", "Michael Kramer&Kate Reading", []string{"Michael Kramer", "Kate Reading"}},
+		{"three", "A Adams, B Brown & C Clark", []string{"A Adams", "B Brown", "C Clark"}},
+
+		// Must NOT split: one person written surname-first.
+		{"surname first", "Smith, John", []string{"Smith, John"}},
+		{"surname first spaced", "Le Guin, Ursula", []string{"Le Guin, Ursula"}},
+		// Errs toward NOT splitting: a list ending in a mononym stays compound.
+		// Merging two names is easier to spot and undo than shredding one person
+		// into two phantom narrators.
+		{"mononym tail stays compound", "Kate Reading, Cher", []string{"Kate Reading, Cher"}},
+
+		// Single names pass through untouched.
+		{"single", "Michael Kramer", []string{"Michael Kramer"}},
+		{"empty", "", []string{""}},
+
+		// Duplicates collapse rather than creating two identical rows.
+		{"dupe", "Kate Reading & Kate Reading", []string{"Kate Reading"}},
+		{"dupe case", "Kate Reading & KATE READING", []string{"Kate Reading"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := util.SplitCreditNames(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("SplitCreditNames(%q) = %#v, want %#v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// The old gate was strings.Contains(name, " & "), which meant the splitter never
+// even ran for comma-separated credits — the bug behind the bug.
+func TestIsCompoundCreditName(t *testing.T) {
+	compound := []string{
+		"Kate Reading, Michael Kramer",
+		"Michael Kramer & Kate Reading",
+		"Michael Kramer and Kate Reading",
+		"A; B",
+	}
+	for _, s := range compound {
+		if !util.IsCompoundCreditName(s) {
+			t.Errorf("%q must be treated as compound", s)
+		}
+	}
+	simple := []string{"Michael Kramer", "Smith, John", "", "Le Guin, Ursula"}
+	for _, s := range simple {
+		if util.IsCompoundCreditName(s) {
+			t.Errorf("%q must NOT be treated as compound", s)
+		}
+	}
+}


### PR DESCRIPTION
Three defects, all of the shape "the code looks like it does this, and does not".
All three were reproduced before anything was changed.

## 1. 🔴 Tapping an author or a narrator showed "No Books Found"

`filteredItems` implemented exactly ONE filter group, `series`. Everything else fell
to a `default` that logs and serves an empty page. That default is *correct* — an
unrecognised filter must not answer with the whole library, which was the earlier
series defect — but `authors` and `narrators` were never implemented behind it, so
the deliberate empty page became the permanent answer for every contributor.

Reproduced on production first:

```
/items?filter=authors.NDY5NTk=                                -> {"results":[],"total":0}
/items?filter=narrators.SmVmZiBIYXlzLCBBbm5pZSBFbGxpY290dA==  -> {"results":[],"total":0}
```

The token format came from the server's own log, not a guess — it had been recording
`group=narrators value="Jeff Hays, Annie Ellicott"` and `group=authors value=46959`
all along, which is exactly what that log was added for. Authors are addressed by
entity id; narrators by **name** (`narratorID` is base64 of the name, so decoding the
token yields the name back).

Both drill-downs are served from the **same pass that builds the tab**, hoisted into a
`contributorIndex` holding the two lists *and* the book ids behind every entry,
published under one pointer. A drill-down therefore cannot be answered from a
different build than the tile whose count the user just read, and `numBooks` is
`len(bookIDs)` rather than a parallel counter — the two cannot drift by construction.

## 2. Compound narrator credits are split into people

"Jeff Hays, Annie Ellicott" was its own Narrators entry reading "1 book"; the live
library has entries naming **eight**. Each is a name nobody can usefully tap, and each
steals a book from the real narrators' counts.

The splitter itself was `strings.Split(name, " & ")` and nothing else, duplicated
verbatim in two packages, and gated behind `strings.Contains(name, " & ")` — so for a
comma-separated credit it never even ran. There is now one implementation in
`internal/util` handling `&`, `and`, `;`, `,`, `with`, `+`, `/`, de-duplicating
case-insensitively, and deliberately refusing to split surname-first names like
`Le Guin, Ursula`. It errs toward **not** splitting: merging two names is far easier
to spot and undo than shredding one person into two phantom narrators.

**Scope, stated plainly: this fixes the ABS tab, not the data.** `BookNarrator` and
`NarratorsJSON` still store the compound string and the web UI still renders it.

## 3. Interrupted jobs never resumed

Two stacked bugs, either one sufficient:

- **`GetInterruptedOperations` was blind to most interrupted rows.** It matched
  `running`/`queued`/`interrupted` exactly, but the registry mints an `interrupted_*`
  family — `interrupted_quiesced` (returned for **every** `ResumePolicy` except
  `ResumeDrop`), `_dropped`, `_restart`, `_ask`. Now a prefix test.
- **`ResumeRestart` never enqueued anything.** It set the row to `"queued"` and
  stopped; nothing scans the store for queued rows. It now re-enqueues via `EnqueueOp`.

Observed: a `library.scan` killed by a deploy sat at `interrupted_quiesced` with no
scan running afterwards.

## Verification

Every test here was **mutation-tested** — reverted the fix, watched the test fail:

| Mutation | Result |
|---|---|
| Delete the `authors`/`narrators` filter cases | 3 tests fail |
| Stop splitting compound credits | 2 tests fail, incl. both per-person counts |
| Prefix match → exact match | 6 assertions fail |
| Separator list → `" & "` only | 7 assertions fail |

New tests assert **exclusion** for the drill-downs (returning everything also
"includes" the right books — that is the bug shape), tile count == drill-down total
for every narrator, and a `narratorID`↔`absFilterGroup` round trip that includes the
synthetic `"é~"` because its base64 contains `+`, which decodes to a **space** in a
query string if the escape is ever dropped.

One existing test's fixtures changed rather than the code:
`TestNarrators_IDMatchesTheRealABSFormula` seeded two strings the splitter now
legitimately splits. Its subject is the ID formula, and escaping is a property of the
base64 *output*, so the fixtures moved to names that survive splitting while encoding
to something harder — `Zoë O'Malley` → `Wm/DqyBPJ01hbGxleQ==`, carrying both the `/`
that would break the image URL path and the `=` padding. Added a guard that fails the
test if no fixture ever needs escaping, and `Butler, Samuel` now doubles as a
surname-first regression.

`go build ./internal/...` and `go vet` clean; full `internal/server/handlers/abs`
package green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS