### PR TITLE
feat(maintenance): add purge-empty-authors op

### DIFF
--- a/changelog.d/20260817_060000_feat_purge_empty_authors.md
+++ b/changelog.d/20260817_060000_feat_purge_empty_authors.md
@@ -1,0 +1,13 @@
+### Added
+
+- **`maintenance.purge-empty-authors`** — deletes author rows attached to zero
+  books. On the live library that is 4,975 of 12,854 authors (38.7%): not people,
+  but track and chapter titles an importer parsed into the author field
+  ("- Edgedancer", "04 - Heir to the Jedi"). No existing maintenance op covered
+  this — the other author ops all operate on authors that have books.
+
+  Dry-run by default; pass `apply=true` to delete. By default it refuses any author
+  with a non-zero file count, since zero books plus files present is more likely a
+  book that lost its junction link than an empty author, and deleting the author
+  would make repairable damage permanent. `limit` caps a run so a first apply can be
+  inspected before committing to all of it.

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -87,12 +87,17 @@ type MockStore struct {
 	DeleteWorkFunc  func(id string) error
 
 	// Author methods
-	GetAllAuthorsFunc    func() ([]Author, error)
-	GetAuthorByIDFunc    func(id int) (*Author, error)
-	GetAuthorByNameFunc  func(name string) (*Author, error)
-	CreateAuthorFunc     func(name string) (*Author, error)
-	DeleteAuthorFunc     func(id int) error
-	UpdateAuthorNameFunc func(id int, name string) error
+	GetAllAuthorsFunc   func() ([]Author, error)
+	GetAuthorByIDFunc   func(id int) (*Author, error)
+	GetAuthorByNameFunc func(name string) (*Author, error)
+	CreateAuthorFunc    func(name string) (*Author, error)
+	DeleteAuthorFunc    func(id int) error
+	// Count overrides. Without these the getters below are hardcoded to empty
+	// maps, so a test asserting on "author has N books" cannot express its own
+	// fixture and silently exercises the zero case instead.
+	GetAllAuthorBookCountsFunc func() (map[int]int, error)
+	GetAllAuthorFileCountsFunc func() (map[int]int, error)
+	UpdateAuthorNameFunc       func(id int, name string) error
 
 	GetAuthorsByIDsFunc func(ids []int) (map[int]*Author, error)
 
@@ -176,15 +181,15 @@ type MockStore struct {
 	ListOperationSummaryLogsFunc func(limit, offset int) ([]OperationSummaryLog, error)
 
 	// System activity log
-	AddSystemActivityLogFunc    func(source, level, message string) error
-	GetSystemActivityLogsFunc   func(source string, limit int) ([]SystemActivityLog, error)
-	PruneOperationLogsFunc      func(olderThan time.Time) (int, error)
-	PruneOperationChangesFunc   func(olderThan time.Time) (int, error)
+	AddSystemActivityLogFunc  func(source, level, message string) error
+	GetSystemActivityLogsFunc func(source string, limit int) ([]SystemActivityLog, error)
+	PruneOperationLogsFunc    func(olderThan time.Time) (int, error)
+	PruneOperationChangesFunc func(olderThan time.Time) (int, error)
 	// CreateOperationChangeFunc lets a test observe the change rows an
 	// operation writes. CreateOperationChange returned a bare nil with no hook,
 	// so a test could assert an operation's SUMMARY but never its CHANGE LOG —
 	// and the two disagreeing, silently, is itself a defect class here.
-	CreateOperationChangeFunc func(change *OperationChange) error
+	CreateOperationChangeFunc   func(change *OperationChange) error
 	PruneSystemActivityLogsFunc func(olderThan time.Time) (int, error)
 
 	// AI jobs
@@ -236,16 +241,16 @@ type MockStore struct {
 	ListUsersFunc         func() ([]User, error)
 
 	// Sessions
-	CreateSessionFunc         func(userID, ip, userAgent string, ttl time.Duration) (*Session, error)
-	GetSessionFunc            func(id string) (*Session, error)
-	RevokeSessionFunc         func(id string) error
-	ListUserSessionsFunc      func(userID string) ([]Session, error)
+	CreateSessionFunc    func(userID, ip, userAgent string, ttl time.Duration) (*Session, error)
+	GetSessionFunc       func(id string) (*Session, error)
+	RevokeSessionFunc    func(id string) error
+	ListUserSessionsFunc func(userID string) ([]Session, error)
 
-	CreateOAuthIdentityFunc                func(identity *OAuthIdentity) (*OAuthIdentity, error)
-	GetOAuthIdentityByProviderSubjectFunc  func(provider, subject string) (*OAuthIdentity, error)
-	GetOAuthIdentitiesForUserFunc          func(userID string) ([]OAuthIdentity, error)
-	DeleteExpiredSessionsFunc func(now time.Time) (int, error)
-	CountUsersFunc            func() (int, error)
+	CreateOAuthIdentityFunc               func(identity *OAuthIdentity) (*OAuthIdentity, error)
+	GetOAuthIdentityByProviderSubjectFunc func(provider, subject string) (*OAuthIdentity, error)
+	GetOAuthIdentitiesForUserFunc         func(userID string) ([]OAuthIdentity, error)
+	DeleteExpiredSessionsFunc             func(now time.Time) (int, error)
+	CountUsersFunc                        func() (int, error)
 
 	// Roles
 	GetRoleByIDFunc   func(id string) (*Role, error)
@@ -861,6 +866,9 @@ func (m *MockStore) GetBooksByAuthorIDWithRoleCore(authorID int) ([]BookCore, er
 }
 
 func (m *MockStore) GetAllAuthorBookCounts() (map[int]int, error) {
+	if m.GetAllAuthorBookCountsFunc != nil {
+		return m.GetAllAuthorBookCountsFunc()
+	}
 	return map[int]int{}, nil
 }
 
@@ -869,6 +877,9 @@ func (m *MockStore) GetAllWorkBookCounts() (map[string]int, error) {
 }
 
 func (m *MockStore) GetAllAuthorFileCounts() (map[int]int, error) {
+	if m.GetAllAuthorFileCountsFunc != nil {
+		return m.GetAllAuthorFileCountsFunc()
+	}
 	return map[int]int{}, nil
 }
 

--- a/internal/plugins/maintenance/author_purge_empty.go
+++ b/internal/plugins/maintenance/author_purge_empty.go
@@ -1,0 +1,218 @@
+// file: internal/plugins/maintenance/author_purge_empty.go
+// version: 1.0.0
+// guid: 6a2f9c31-84d7-4e05-b1a3-7f92c60d8e54
+// last-edited: 2026-08-17
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// --- purge-empty-authors ---
+//
+// 🔴 WHY THIS EXISTS. Measured on the live library 2026-08-17: 4,975 of 12,854
+// authors (38.7%) are attached to ZERO books. They are not people — they are track
+// and chapter titles that were parsed into the author field by an importer:
+// "- Edgedancer", "(Long Earth 01) The Long Earth", "04 - Heir to the Jedi",
+// "- The Emperor's Soul". Every one of them is a row in the Authors tab a user has
+// to scroll past, and a candidate every author-dedup pass has to compare against.
+//
+// No existing op covers this. maintenance.author-dedup-scan finds duplicates,
+// author-split-scan splits composites, author-conjunction-repair fixes "& Foo"
+// fragments, resolve-production-authors handles production credits — all of them
+// operate on authors that HAVE books.
+
+// emptyAuthorSampleLimit bounds how many names are surfaced in the report, so a
+// reviewer can eyeball what would be deleted without the report becoming the size
+// of the deletion itself.
+const emptyAuthorSampleLimit = 50
+
+// purgeEmptyAuthorsParams are the JSON parameters accepted by the op.
+type purgeEmptyAuthorsParams struct {
+	// Apply, if true, actually deletes. Default false (dry-run/report only).
+	//
+	// 🔴 DELETION IS IRREVERSIBLE AND THIS IS A PRODUCTION LIBRARY, so the default
+	// must be the harmless one. Mirrors dedup.cleanup-orphan-author-embeddings.
+	Apply bool `json:"apply"`
+
+	// RequireZeroFiles, when true (the DEFAULT), refuses to delete an author that
+	// has zero books but a NON-ZERO file count.
+	//
+	// 🔴 THIS IS THE SAFETY THAT MATTERS. Of the 4,975 zero-book authors, 4,153 also
+	// have zero files and are unambiguous junk; the other 822 have files. A zero
+	// book count with files present is more likely a BROKEN LINK — a book row that
+	// lost its junction entry — than an empty author, and deleting the author makes
+	// that damage permanent instead of repairable. Opt out only after deciding what
+	// those 822 actually are.
+	RequireZeroFiles *bool `json:"require_zero_files,omitempty"`
+
+	// Limit caps how many authors are deleted in one run (0 = no cap). Present so a
+	// first apply can be run small and inspected rather than all-or-nothing.
+	Limit int `json:"limit"`
+}
+
+// requireZeroFiles resolves the tri-state pointer to its default of TRUE. A plain
+// bool would default to false, i.e. to the DANGEROUS setting, which is exactly the
+// wrong way round for a flag whose job is to prevent deleting repairable damage.
+func (p purgeEmptyAuthorsParams) requireZeroFiles() bool {
+	return p.RequireZeroFiles == nil || *p.RequireZeroFiles
+}
+
+// emptyAuthorReport is the outcome of one pass.
+type emptyAuthorReport struct {
+	TotalAuthors int
+	ZeroBooks    int
+	// ZeroBooksWithFiles are the zero-book authors HELD BACK by requireZeroFiles.
+	// Reported separately rather than silently folded into the skipped count: they
+	// are the population that needs a decision, and a number nobody sees does not
+	// get one.
+	ZeroBooksWithFiles int
+	Eligible           int
+	Deleted            int
+	Failed             int
+	Sample             []string
+}
+
+func (r emptyAuthorReport) summary() string {
+	return fmt.Sprintf(
+		"authors=%d zero-book=%d held-back(has files)=%d eligible=%d deleted=%d failed=%d",
+		r.TotalAuthors, r.ZeroBooks, r.ZeroBooksWithFiles, r.Eligible, r.Deleted, r.Failed)
+}
+
+func (p *Plugin) purgeEmptyAuthorsDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "maintenance.purge-empty-authors",
+		Liveness:    sdk.LivenessManual,
+		Plugin:      "maintenance",
+		DisplayName: "Purge empty authors",
+		Description: "Deletes author rows attached to zero books — importer junk such as track " +
+			"and chapter titles parsed into the author field ('- Edgedancer', '04 - Heir to the " +
+			"Jedi'). Measured 4,975 of 12,854 authors on this library. DRY-RUN BY DEFAULT: pass " +
+			"apply=true to delete. By default refuses any author with a non-zero file count, " +
+			"since zero books plus files present is more likely a broken junction link than an " +
+			"empty author; pass require_zero_files=false to override. Idempotent.",
+		// ResumeDrop, not Requeue: this is a deletion, and a half-finished run that
+		// silently resumes after a restart is harder to reason about than one that
+		// stops and is re-triggered deliberately. Re-running is cheap and idempotent.
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.purge-empty-authors",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         30 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runPurgeEmptyAuthors,
+	}
+}
+
+func (p *Plugin) runPurgeEmptyAuthors(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	var params purgeEmptyAuthorsParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+	reporter.Logger().Info("purge-empty-authors start",
+		"apply", params.Apply, "require_zero_files", params.requireZeroFiles(), "limit", params.Limit)
+
+	_ = reporter.UpdateProgress(0, 3, "Listing authors…")
+	authors, err := store.GetAllAuthors()
+	if err != nil {
+		return fmt.Errorf("list authors: %w", err)
+	}
+
+	_ = reporter.UpdateProgress(1, 3, "Counting books per author…")
+	bookCounts, err := store.GetAllAuthorBookCounts()
+	if err != nil {
+		return fmt.Errorf("author book counts: %w", err)
+	}
+	// File counts are only consulted for the safety check, so a failure here must
+	// not be silently treated as "zero files" — that would turn a missing signal
+	// into permission to delete. Fail the op instead.
+	var fileCounts map[int]int
+	if params.requireZeroFiles() {
+		fileCounts, err = store.GetAllAuthorFileCounts()
+		if err != nil {
+			return fmt.Errorf("author file counts (needed for the require_zero_files guard): %w", err)
+		}
+	}
+
+	report := emptyAuthorReport{TotalAuthors: len(authors)}
+	var eligible []int
+	for _, a := range authors {
+		if bookCounts[a.ID] != 0 {
+			continue
+		}
+		report.ZeroBooks++
+		if params.requireZeroFiles() && fileCounts[a.ID] != 0 {
+			report.ZeroBooksWithFiles++
+			continue
+		}
+		eligible = append(eligible, a.ID)
+		if len(report.Sample) < emptyAuthorSampleLimit {
+			report.Sample = append(report.Sample, a.Name)
+		}
+	}
+	// Deterministic order so a limited run takes the same slice every time and two
+	// runs of the same report can be diffed.
+	sort.Ints(eligible)
+	if params.Limit > 0 && len(eligible) > params.Limit {
+		eligible = eligible[:params.Limit]
+	}
+	report.Eligible = len(eligible)
+
+	if !params.Apply {
+		msg := "DRY RUN (nothing deleted) — " + report.summary()
+		reporter.Logger().Info("purge-empty-authors dry run",
+			"eligible", report.Eligible, "sample", report.Sample)
+		_ = reporter.UpdateProgress(3, 3, msg)
+		return nil
+	}
+
+	// Deleted one at a time rather than in a bulk batch. DeleteAuthor already
+	// removes the author row, its name index and its aliases, and its junction
+	// sweep iterates the `book_author:` keyspace — which is EMPTY (nothing in the
+	// repo writes it; the live data is the per-book `book_authors:<id>` array), so
+	// the per-author cost is a seek that finds nothing, not a table scan. A bulk
+	// path would duplicate that cleanup for no measured gain.
+	_ = reporter.UpdateProgress(2, 3, fmt.Sprintf("Deleting %d empty authors…", len(eligible)))
+	prog := sdk.NewProgress(reporter, len(eligible))
+	prog.Start(fmt.Sprintf("Deleting %d empty authors…", len(eligible)))
+	for i, id := range eligible {
+		if err := ctx.Err(); err != nil {
+			// Report what was actually done before the cancel, rather than losing it.
+			reporter.Logger().Info("purge-empty-authors cancelled",
+				"deleted", report.Deleted, "remaining", len(eligible)-i)
+			prog.Done("cancelled — " + report.summary())
+			return err
+		}
+		if derr := store.DeleteAuthor(id); derr != nil {
+			// One bad row must not abandon the other thousands; count it and move on.
+			report.Failed++
+			reporter.Logger().Warn("purge-empty-authors: delete failed", "author_id", id, "err", derr)
+			continue
+		}
+		report.Deleted++
+		if (i+1)%200 == 0 {
+			prog.StepN(i+1, fmt.Sprintf("Deleted %d/%d…", report.Deleted, len(eligible)))
+		}
+	}
+
+	msg := report.summary()
+	reporter.Logger().Info("purge-empty-authors complete",
+		"deleted", report.Deleted, "failed", report.Failed, "held_back", report.ZeroBooksWithFiles)
+	prog.Done(msg)
+	return nil
+}

--- a/internal/plugins/maintenance/author_purge_empty_test.go
+++ b/internal/plugins/maintenance/author_purge_empty_test.go
@@ -1,0 +1,180 @@
+// file: internal/plugins/maintenance/author_purge_empty_test.go
+// version: 1.0.0
+// guid: b83c47f1-2065-4ade-9c18-31d70f5b62ea
+// last-edited: 2026-08-17
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// newPurgePlugin wires a MockStore over a fixed author table plus book and file
+// counts, recording every DeleteAuthor call so a dry-run test can assert on
+// SILENCE rather than on a return value — the only assertion that distinguishes
+// "reported correctly" from "deleted anyway".
+func newPurgePlugin(authors []database.Author, books, files map[int]int, deleted *[]int) *Plugin {
+	store := &database.MockStore{
+		GetAllAuthorsFunc:          func() ([]database.Author, error) { return authors, nil },
+		GetAllAuthorBookCountsFunc: func() (map[int]int, error) { return books, nil },
+		GetAllAuthorFileCountsFunc: func() (map[int]int, error) { return files, nil },
+		DeleteAuthorFunc: func(id int) error {
+			*deleted = append(*deleted, id)
+			return nil
+		},
+	}
+	return &Plugin{deps: &fakeDeps{store: store}}
+}
+
+// purgeFixture: 1 real author with books, 2 pure-junk (no books, no files), and 1
+// zero-book author that HAS files — the ambiguous row the guard exists for.
+func purgeFixture() ([]database.Author, map[int]int, map[int]int) {
+	authors := []database.Author{
+		{ID: 1, Name: "Brandon Sanderson"},
+		{ID: 2, Name: "- Edgedancer"},
+		{ID: 3, Name: "04 - Heir to the Jedi"},
+		{ID: 4, Name: "Has Files But No Books"},
+	}
+	books := map[int]int{1: 12, 2: 0, 3: 0, 4: 0}
+	files := map[int]int{1: 40, 2: 0, 3: 0, 4: 7}
+	return authors, books, files
+}
+
+func runPurge(t *testing.T, params string, deleted *[]int) {
+	t.Helper()
+	authors, books, files := purgeFixture()
+	p := newPurgePlugin(authors, books, files, deleted)
+	var raw json.RawMessage
+	if params != "" {
+		raw = json.RawMessage(params)
+	}
+	if err := p.runPurgeEmptyAuthors(context.Background(), raw, &fakeReporter{}); err != nil {
+		t.Fatalf("runPurgeEmptyAuthors: %v", err)
+	}
+}
+
+// 🔴 DRY RUN MUST NOT DELETE. This is the assertion that matters most: the op
+// deletes rows from a production library, so the default has to be inert. A test
+// that only checked the reported counts would pass even if it deleted everything.
+func TestPurgeEmptyAuthors_DryRunDeletesNothing(t *testing.T) {
+	var deleted []int
+	runPurge(t, "", &deleted)
+	if len(deleted) != 0 {
+		t.Fatalf("dry run deleted %v — the default must be inert", deleted)
+	}
+	// And explicitly with apply:false, since a client may send it rather than omit it.
+	deleted = nil
+	runPurge(t, `{"apply":false}`, &deleted)
+	if len(deleted) != 0 {
+		t.Fatalf("apply=false deleted %v", deleted)
+	}
+}
+
+// 🔴 THE GUARD. Author 4 has zero books but seven files — more likely a book that
+// lost its junction entry than an empty author. Deleting it makes repairable damage
+// permanent, so it must be held back unless explicitly overridden.
+func TestPurgeEmptyAuthors_HoldsBackAuthorsWithFiles(t *testing.T) {
+	var deleted []int
+	runPurge(t, `{"apply":true}`, &deleted)
+
+	got := map[int]bool{}
+	for _, id := range deleted {
+		got[id] = true
+	}
+	if got[4] {
+		t.Error("deleted author 4, which has 7 files — that is the row the guard exists for")
+	}
+	if got[1] {
+		t.Error("deleted author 1, who has 12 books")
+	}
+	for _, id := range []int{2, 3} {
+		if !got[id] {
+			t.Errorf("did NOT delete author %d, which has zero books and zero files", id)
+		}
+	}
+	if len(deleted) != 2 {
+		t.Errorf("deleted %v, want exactly authors 2 and 3", deleted)
+	}
+}
+
+// The override must actually override — otherwise the escape hatch is decorative
+// and the 822 real rows can never be cleaned up.
+func TestPurgeEmptyAuthors_RequireZeroFilesFalseIncludesThem(t *testing.T) {
+	var deleted []int
+	runPurge(t, `{"apply":true,"require_zero_files":false}`, &deleted)
+
+	got := map[int]bool{}
+	for _, id := range deleted {
+		got[id] = true
+	}
+	if !got[4] {
+		t.Error("require_zero_files=false did not include author 4 — the override does nothing")
+	}
+	if got[1] {
+		t.Error("deleted author 1, who has 12 books — no flag should ever allow that")
+	}
+	if len(deleted) != 3 {
+		t.Errorf("deleted %v, want authors 2, 3 and 4", deleted)
+	}
+}
+
+// A book count of zero is the ONLY thing that makes a row eligible. Pinned
+// separately because it is the invariant a future refactor is most likely to break
+// while all the flag tests keep passing.
+func TestPurgeEmptyAuthors_NeverDeletesAnAuthorWithBooks(t *testing.T) {
+	authors := []database.Author{
+		{ID: 1, Name: "One Book"},
+		{ID: 2, Name: "Zero Books"},
+	}
+	var deleted []int
+	p := newPurgePlugin(authors, map[int]int{1: 1, 2: 0}, map[int]int{1: 0, 2: 0}, &deleted)
+	if err := p.runPurgeEmptyAuthors(context.Background(),
+		json.RawMessage(`{"apply":true,"require_zero_files":false}`), &fakeReporter{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(deleted) != 1 || deleted[0] != 2 {
+		t.Fatalf("deleted %v, want only author 2 — a single book must protect a row", deleted)
+	}
+}
+
+// Limit exists so a first apply can be run small and inspected. Sorted order makes
+// the slice deterministic, so limit=1 takes the same row every time.
+func TestPurgeEmptyAuthors_LimitCapsTheDeletion(t *testing.T) {
+	var deleted []int
+	runPurge(t, `{"apply":true,"limit":1}`, &deleted)
+	if len(deleted) != 1 {
+		t.Fatalf("limit=1 deleted %v, want exactly one", deleted)
+	}
+	if deleted[0] != 2 {
+		t.Errorf("limit=1 deleted author %d, want the lowest eligible id (2) — order must be deterministic", deleted[0])
+	}
+}
+
+// 🔴 A MISSING SIGNAL IS NOT PERMISSION. If the file counts cannot be read, the
+// guard cannot be evaluated, and treating that as "zero files" would delete exactly
+// the rows the guard protects. The op must fail instead.
+func TestPurgeEmptyAuthors_FileCountFailureAbortsRatherThanDeleting(t *testing.T) {
+	authors, books, _ := purgeFixture()
+	var deleted []int
+	store := &database.MockStore{
+		GetAllAuthorsFunc:          func() ([]database.Author, error) { return authors, nil },
+		GetAllAuthorBookCountsFunc: func() (map[int]int, error) { return books, nil },
+		GetAllAuthorFileCountsFunc: func() (map[int]int, error) { return nil, context.DeadlineExceeded },
+		DeleteAuthorFunc: func(id int) error {
+			deleted = append(deleted, id)
+			return nil
+		},
+	}
+	p := &Plugin{deps: &fakeDeps{store: store}}
+	err := p.runPurgeEmptyAuthors(context.Background(), json.RawMessage(`{"apply":true}`), &fakeReporter{})
+	if err == nil {
+		t.Fatal("file-count failure did not abort the op")
+	}
+	if len(deleted) != 0 {
+		t.Fatalf("deleted %v despite being unable to evaluate the guard", deleted)
+	}
+}

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -58,6 +58,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		// SplitCompositeAuthorName("& Conrad Westmaas") returns nil (no
 		// delimiter, three words), so the split scan skips these rows entirely.
 		p.authorConjunctionRepairDef(),
+		p.purgeEmptyAuthorsDef(),
 		p.seriesNormalizeDef(),
 		p.seriesPruneDef(),
 		p.resolveProductionAuthorsDef(),

--- a/todo.d/20260817-purge-empty-narrators-and-author-narrator-swap.md
+++ b/todo.d/20260817-purge-empty-narrators-and-author-narrator-swap.md
@@ -1,0 +1,28 @@
+### Contributor data cleanup — follow-ups to `maintenance.purge-empty-authors`
+
+- [ ] **Narrator equivalent of the empty-author purge.** There is no
+  `DeleteNarrator` on the store at all — narrators live at `narrator:<id>` with no
+  delete path, so the op cannot be written until that exists. Scope it alongside
+  whatever decides the narrator identity question below.
+- [ ] **Decide what the 822 zero-book-but-has-files authors actually are.** Measured
+  2026-08-17: of 4,975 zero-book authors, 4,153 also have zero files (unambiguous
+  junk, purgeable today) and 822 have files. A zero book count with files present
+  looks more like a book that lost its junction entry than an empty author, so the
+  purge op holds them back by default (`require_zero_files`). Someone has to look at
+  a sample and decide before that flag is ever flipped.
+- [ ] **Author↔narrator swap repair.** Measured lower bound: 1,052 names appear in
+  BOTH the author and narrator tables; 67 of those are swap-shaped (narrates ≥5
+  books, "authors" 1–2), accounting for ~96 book-author links. Ray Porter, Scott
+  Brick, Nick Podehl and Andrea Parsneau all currently exist as authors. This is a
+  LOWER BOUND — the rule only sees names present in both tables, so a swap whose
+  "author" never appears as a narrator elsewhere is invisible to it. Route any
+  repair through the review queue rather than blind-applying; this is far smaller
+  than it looks from the UI, where the impression is driven mostly by the empty
+  authors and (until #2512) the compound narrator entries.
+- [ ] **`DeleteAuthor`'s junction cleanup is dead code.** It iterates the
+  `book_author:` keyspace (singular). Nothing in the repo writes that keyspace — the
+  live data is the per-book `book_authors:<bookID>` array — and the iterator bounds
+  (`book_author:` → `book_author;`) exclude the plural form anyway. So deleting an
+  author who HAS books leaves them referenced inside every `book_authors` array.
+  Harmless for the empty-author purge (no references by definition), a real bug for
+  any other caller.


### PR DESCRIPTION
## 38.7% of the author table is not people

Measured on the live library 2026-08-17: **4,975 of 12,854 authors are attached to
ZERO books.** The names make the cause obvious — they are track and chapter titles
an importer parsed into the author field:

```
- Edgedancer
(Long Earth 01) The Long Earth
04 - Heir to the Jedi
- The Emperor's Soul
```

Every one is a row the user scrolls past in the Authors tab and a candidate every
author-dedup pass has to compare against.

**No existing op covered this.** `author-dedup-scan` finds duplicates,
`author-split-scan` splits composites, `author-conjunction-repair` fixes `"& Foo"`
fragments, `resolve-production-authors` handles production credits — all of them
operate on authors that *have* books.

## Safety

This deletes irreversibly from a production library, so:

| Guard | Behaviour |
|---|---|
| `apply` | **Dry-run by default.** `apply=true` required to delete anything. |
| `require_zero_files` | **Defaults to true.** Holds back any zero-book author with a non-zero file count. |
| file-count read failure | **Aborts.** A missing signal is not permission. |
| `limit` | Caps a run so a first apply can be inspected. Eligible ids sorted → deterministic. |
| held-back rows | Counted and reported **separately**, not folded into a skip count. |

Only 4,153 of the 4,975 also have zero files. The other **822 have files**, and zero
books *with* files present looks more like a book that lost its junction entry than
an empty author — deleting those would make repairable damage permanent. That is why
`require_zero_files` is a `*bool`: so the zero value is the **safe** setting. A plain
`bool` would have defaulted to the dangerous one.

## Why a plain sequential loop, despite the concurrency rule

I checked the cost rather than assuming it. `DeleteAuthor`'s per-author junction
sweep iterates the `book_author:` keyspace — which is **empty**. Nothing in the repo
writes it (the live data is the per-book `book_authors:<bookID>` array), and the
iterator bounds `book_author:` → `book_author;` exclude the plural form anyway. So
the per-author cost is a seek that finds nothing, not a scan of the 51,331 links.
~4,000 seeks does not need a worker pool, and parallel deletes down one Pebble batch
path would add risk for no measured gain.

## Verification

**Mutation-tested** — every safety guard was reverted and the tests watched to fail:

| Mutation | Result |
|---|---|
| Drop the `apply` gate (dry run deletes) | `DryRunDeletesNothing` fails |
| Ignore the file-count guard | `HoldsBackAuthorsWithFiles` fails |
| Default `require_zero_files` to false | 2 tests fail |

The dry-run test asserts on the **recorded `DeleteAuthor` calls**, not on a returned
count — a test checking only the reported numbers would pass even if it deleted
everything.

Also adds `GetAllAuthorBookCountsFunc`/`GetAllAuthorFileCountsFunc` to `MockStore`;
both getters were hardcoded to empty maps with no override hook, so a test could not
express its own fixture and would have silently exercised the zero case.

## Follow-ups filed in `todo.d/`

- Narrator equivalent — **blocked**: no `DeleteNarrator` exists on the store at all.
- A decision on the 822 zero-book-with-files authors.
- Author↔narrator swap repair. Measured **lower bound**: 1,052 names appear in both
  tables; 67 are swap-shaped (narrates ≥5, "authors" ≤2) ≈ 96 links. Ray Porter,
  Scott Brick, Nick Podehl and Andrea Parsneau all currently exist as authors. Far
  smaller than it looks from the UI, where the impression was driven mostly by the
  empty authors and (until #2512) the compound narrator entries.
- `DeleteAuthor`'s junction cleanup is dead code — harmless here (an empty author has
  no references by definition), a real bug for any other caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS