### PR TITLE
fix(util): trim separator punctuation stranded by ordered credit splitting

### DIFF
--- a/changelog.d/20260817_070000_fix_credit_split_trailing_punctuation.md
+++ b/changelog.d/20260817_070000_fix_credit_split_trailing_punctuation.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **Narrators no longer appear twice, once with a stray comma.** A credit written
+  with an Oxford comma — "Lance Parkin, Stephen Cole, Alan Barnes, & Jonathan
+  Morris" — was split on `" & "` before `", "`, which stranded a comma at the end
+  of the preceding name. "Alan Barnes," was then listed as a separate narrator from
+  "Alan Barnes", splitting one reader's books across two entries (14 books and 1).
+  Split pieces now have leading and trailing separator punctuation trimmed.
+  Measured against the live narrator list: 11 names cleaned, 8 of them merging into
+  an entry for the same person that already existed, and no narrator lost.
+  Punctuation that belongs to a name — "Sammy Davis Jr.", "Alex Hill-Knight" — is
+  deliberately left alone.

--- a/internal/util/names.go
+++ b/internal/util/names.go
@@ -1,5 +1,5 @@
 // file: internal/util/names.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3a91c4e7-52bd-4f16-8c03-9e7d1b5a2f48
 // last-edited: 2026-08-17
 
@@ -18,6 +18,33 @@ import "strings"
 // SplitCreditNames guards that case; do not widen this list without extending
 // the guard.
 var creditSeparators = []string{" & ", " and ", "; ", ";", ", ", " with ", " + ", "/", "&"}
+
+// creditPieceCutset is the punctuation stripped from the ENDS of a split piece.
+//
+// 🔴 SEPARATOR CHARACTERS ONLY — deliberately NOT a general punctuation strip.
+// A period and a hyphen are part of real names ("Sammy Davis Jr.",
+// "Alex Hill-Knight", "E. E. Knight"); trimming those would mint a new phantom
+// duplicate next to the correctly-spelled entry, which is exactly the defect this
+// trimming exists to remove. Every character here already appears in
+// creditSeparators, so removing it can only ever undo a split artifact.
+const creditPieceCutset = " \t,;&+/"
+
+// trimCreditPiece removes leading and trailing separator punctuation left behind
+// when one separator's split strands another separator's character.
+//
+// 🔴 WHY THIS IS NEEDED. Separators are applied in sequence, so an earlier one can
+// cut a string at a point that leaves a later one's character at an end, where it
+// no longer matches. The live case is the Oxford comma: " & " splits
+// "…, Alan Barnes, & Jonathan Morris" into "…, Alan Barnes," first, and the later
+// ", " pass cannot reach that final comma because nothing follows it.
+//
+// Measured against the live narrator list 2026-08-17 (3,289 entries): this cutset
+// changes 11 names and loses none. 8 of the 11 merge into an entry for the SAME
+// person that already existed alongside them — "Alan Barnes" had 14 books while
+// "Alan Barnes," had 1 — and the other 3 simply become clean.
+func trimCreditPiece(s string) string {
+	return strings.Trim(s, creditPieceCutset)
+}
 
 // looksLikeSurnameFirst reports whether a two-part comma split looks like one
 // person written "Surname, Given" rather than two people.
@@ -68,7 +95,11 @@ func SplitCreditNames(name string) []string {
 		var next []string
 		for _, chunk := range work {
 			for _, piece := range strings.Split(chunk, sep) {
-				if p := strings.TrimSpace(piece); p != "" {
+				// Trimmed rather than merely TrimSpace'd so a stranded separator
+				// character cannot become part of a person's name, and so the
+				// emptiness check below sees a piece that is only punctuation
+				// (an "A & & B" credit) for what it is.
+				if p := trimCreditPiece(piece); p != "" {
 					next = append(next, p)
 				}
 			}

--- a/internal/util/names_test.go
+++ b/internal/util/names_test.go
@@ -1,5 +1,5 @@
 // file: internal/util/names_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6c05f39a-71b4-4e28-9d1a-3f8b0c27e5d6
 // last-edited: 2026-08-17
 
@@ -73,6 +73,52 @@ func TestIsCompoundCreditName(t *testing.T) {
 	for _, s := range simple {
 		if util.IsCompoundCreditName(s) {
 			t.Errorf("%q must NOT be treated as compound", s)
+		}
+	}
+}
+
+// 🔴 THE OXFORD COMMA LEAKS PUNCTUATION INTO A PERSON'S NAME.
+//
+// Measured on the live library 2026-08-17, AFTER the splitter shipped: the
+// narrator list contained BOTH "Alan Barnes" (14 books) and "Alan Barnes," (1
+// book) as separate people, and 8 such pairs in total across 3,289 entries. The
+// trailing comma is not in the source data — the splitter creates it.
+//
+// Why: creditSeparators applies " & " BEFORE ", ". The real credit below splits on
+// " & " into "Lance Parkin, Stephen Cole, Alan Barnes," + "Jonathan Morris"; the
+// later ", " pass then cannot reach the final comma, because it is now at the end
+// of the string with no space after it and so matches no separator. TrimSpace
+// removes whitespace only, and the comma rides through into the narrator table.
+func TestSplitCreditNames_OxfordCommaDoesNotLeakPunctuation(t *testing.T) {
+	// The literal narratorName of a real book in the production library. A
+	// constructed input would have verified my model of the bug rather than the
+	// bug.
+	const real = "Lance Parkin, Stephen Cole, Alan Barnes, & Jonathan Morris"
+	want := []string{"Lance Parkin", "Stephen Cole", "Alan Barnes", "Jonathan Morris"}
+	if got := util.SplitCreditNames(real); !reflect.DeepEqual(got, want) {
+		t.Errorf("SplitCreditNames(%q) =\n  %#v\nwant\n  %#v", real, got, want)
+	}
+}
+
+// Once the punctuation is trimmed, the two spellings must collapse to ONE entry
+// rather than to two that merely look alike. Pinned separately because a fix that
+// trimmed but ran before the de-dup pass would still emit a duplicate.
+func TestSplitCreditNames_TrimmedFormsDeduplicate(t *testing.T) {
+	got := util.SplitCreditNames("Alan Barnes, & Alan Barnes")
+	if want := []string{"Alan Barnes"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v — the trimmed forms are the same person", got, want)
+	}
+}
+
+// 🔴 TRIM SEPARATORS, NOT PUNCTUATION IN GENERAL. A period and a hyphen are part of
+// real names; stripping them would mint a NEW phantom duplicate ("Sammy Davis Jr"
+// alongside "Sammy Davis Jr.") — the same defect this fix exists to remove, one
+// character class over.
+func TestSplitCreditNames_KeepsPunctuationThatBelongsToTheName(t *testing.T) {
+	keep := []string{"Sammy Davis Jr.", "Alex Hill-Knight", "E. E. Knight", "Smith, John"}
+	for _, s := range keep {
+		if got := util.SplitCreditNames(s); len(got) != 1 || got[0] != s {
+			t.Errorf("SplitCreditNames(%q) = %#v, want it left exactly alone", s, got)
 		}
 	}
 }


### PR DESCRIPTION
## The bug

The narrator list contains the same reader twice, once with a stray comma:

| entry | books |
|---|---|
| `Alan Barnes` | 14 |
| `Alan Barnes,` | 1 |

Both are live in production right now (verified via the ABS narrator drill-down).

## Root cause

`creditSeparators` is applied **in sequence**, and `" & "` comes before `", "`. A real
credit in the library:

```
"Lance Parkin, Stephen Cole, Alan Barnes, & Jonathan Morris"
```

splits on `" & "` first into `"Lance Parkin, Stephen Cole, Alan Barnes,"`. The later
`", "` pass then cannot reach that final comma — it now sits at the end of the string
with nothing after it, so it matches no separator. `strings.TrimSpace` removes
whitespace only, and the comma rides through into the narrator table as part of the
person's name.

It's the **Oxford comma before an ampersand** that triggers it.

## Fix

Split pieces are trimmed of leading/trailing **separator** characters, via a cutset
restricted to characters that already appear in `creditSeparators`. A period or hyphen
that belongs to a name (`Sammy Davis Jr.`, `Alex Hill-Knight`, `E. E. Knight`) is
deliberately preserved — trimming those would mint a new phantom duplicate next to the
correctly-spelled entry, i.e. the same defect one character class over. That constraint
has its own test.

## Verification

Against the live 3,289-entry narrator list:

- **11** names change
- **8** of those merge into an entry for the same person that already existed
- **3** simply become clean
- **0** narrators are lost (no name trims to empty)

Test input is the literal `narratorName` of a real book, not a constructed string.

Both mutations caught:

| mutation | result |
|---|---|
| revert trim → `TrimSpace` | 2 tests fail |
| overreach → add `.` and `-` to the cutset | `KeepsPunctuationThatBelongsToTheName` fails |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS