### PR TITLE
feat(maintenance): add missing-file-audit op to find book_file rows with no bytes

### DIFF
--- a/changelog.d/20260817_080000_feat_missing_file_audit.md
+++ b/changelog.d/20260817_080000_feat_missing_file_audit.md
@@ -1,0 +1,18 @@
+### Added
+
+- **New `maintenance.missing-file-audit` operation** — finds the `book_file` rows
+  behind "file not found" download failures. It stats every row's path and reports
+  how many point at bytes that are no longer on disk, broken down per book
+  (fully broken / partially broken / intact) and by library tree.
+
+  Measured on the live library over a 120-book sample: 552 of 1,322 rows (41.8%)
+  were missing and 49 of the 120 books had at least one dead file, 5 of them with
+  no surviving file at all. Every missing path was under the organizer's own
+  destination tree; nothing under the iTunes tree was missing.
+
+  No existing operation could find these — `orphan-book-files-cleanup` matches rows
+  whose `book_id` dangles, and `dedupe-book-file-rows` matches rows sharing an
+  identical path, while these rows have a valid book and *different* paths.
+
+  The operation is **report-only** and requests read capability only, so it is safe
+  to run against a live library at any time, including during a scan.

--- a/internal/plugins/maintenance/missing_file_audit.go
+++ b/internal/plugins/maintenance/missing_file_audit.go
@@ -1,0 +1,314 @@
+// file: internal/plugins/maintenance/missing_file_audit.go
+// version: 1.0.0
+// guid: 4e1c7a92-3b58-4d06-9f21-8c5a0e7b3d64
+// last-edited: 2026-08-17
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// --- missing-file-audit ---
+//
+// 🔴 WHY THIS EXISTS. Downloads fail with "file not found" because a large share
+// of book_file rows point at paths that hold no bytes. Measured on the live
+// library 2026-08-17 over a 120-book sample: 552 of 1,322 rows (41.8%) were
+// missing, and 49 of the 120 books (41%) had at least one dead file. Five books
+// had NO surviving file at all.
+//
+// The shape is specific and it is what makes this worth its own op: EVERY missing
+// path was under the organizer's own destination tree
+// (/mnt/bigdata/books/audiobook-organizer/...), while nothing under the iTunes
+// tree was missing. The typical broken book carries two rows — a phantom at the
+// organized path and the real file still in the iTunes tree:
+//
+//	MISSING .../audiobook-organizer/Morgan Rice/.../A Vow of Glory - ... .m4b
+//	OK      .../itunes/iTunes Media/Audiobooks/Morgan Rice/01 The Sorcerer's ... .m4b
+//
+// NO EXISTING OP FINDS THESE. orphan-book-files-cleanup matches rows whose
+// book_id dangles; these rows have a valid book. dedupe-book-file-rows matches
+// rows sharing an IDENTICAL file_path; these rows have different paths. Both walk
+// straight past the entire population.
+//
+// 🔴 REPORT-ONLY, DELIBERATELY. No repair is offered because the right repair is
+// not yet decided and the two candidates differ in kind: deleting the phantom row,
+// or re-pointing it at the surviving file. Deleting is also not safe uniformly —
+// for the books where every row is missing, deleting them all leaves a book with
+// zero files. Measure first, then choose; see the todo fragment filed with this op.
+
+// missingFileSampleLimit bounds how many example paths are surfaced, so the report
+// stays readable when the finding is tens of thousands of rows.
+const missingFileSampleLimit = 40
+
+// missingFileStatConcurrency is the worker-pool size for the stat sweep.
+//
+// Sized for LATENCY, not for CPU: every item is a single os.Stat against the NAS
+// mount, so the pool is bounded by round-trip time rather than by cores, and
+// runtime.NumCPU() would leave the link idle. Kept to a fixed, modest number
+// because the target is a network filesystem shared with playback and with any
+// scan that happens to be running — this op is diagnostic and must not out-compete
+// the things people are actually using.
+const missingFileStatConcurrency = 24
+
+// missingFileAuditParams are the JSON parameters accepted by the op.
+type missingFileAuditParams struct {
+	// PathPrefix, when set, restricts the audit to rows whose FilePath begins with
+	// it — e.g. only the organized tree. Empty audits every row.
+	PathPrefix string `json:"path_prefix"`
+
+	// SampleLimit overrides how many example missing paths are reported (0 = the
+	// default).
+	SampleLimit int `json:"sample_limit"`
+}
+
+// missingFileReport is the outcome of one sweep.
+type missingFileReport struct {
+	TotalRows int
+	Missing   int
+	Present   int
+
+	// Unreadable counts rows whose existence could NOT be determined — a
+	// permission error, an I/O error, a dead mount.
+	//
+	// 🔴 COUNTED SEPARATELY FROM MISSING, NEVER FOLDED INTO IT. "I could not tell"
+	// and "it is not there" are different findings, and merging them would let a
+	// single unmounted share report the entire library as lost — which, for an op
+	// whose number will be used to decide a bulk repair, is the most damaging
+	// possible way to be wrong.
+	Unreadable int
+
+	BooksTotal    int
+	BooksAllGone  int
+	BooksPartial  int
+	BooksIntact   int
+	MissingByRoot map[string]int
+	Sample        []string
+}
+
+func (r missingFileReport) summary() string {
+	return fmt.Sprintf(
+		"rows=%d missing=%d present=%d unreadable=%d | books=%d fully-broken=%d partially-broken=%d intact=%d",
+		r.TotalRows, r.Missing, r.Present, r.Unreadable,
+		r.BooksTotal, r.BooksAllGone, r.BooksPartial, r.BooksIntact)
+}
+
+func (p *Plugin) missingFileAuditDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "maintenance.missing-file-audit",
+		Liveness:    sdk.LivenessRunItems,
+		Plugin:      "maintenance",
+		DisplayName: "Missing file audit",
+		Description: "Stats every book_file row's path and reports which point at bytes that are " +
+			"no longer on disk — the cause of 'file not found' on download. Reports totals, a " +
+			"per-book breakdown (fully broken / partially broken / intact) and a breakdown of " +
+			"missing paths by tree. REPORT-ONLY: takes no action and modifies nothing. Pass " +
+			"path_prefix to restrict the sweep to one tree.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.missing-file-audit",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		// 🔴 READ ONLY. The op cannot write even if a future edit tried to: it never
+		// requests CapLibraryWrite. That is the guarantee that makes it safe to run
+		// against production at any time, including mid-scan.
+		Capabilities: []sdk.Capability{sdk.CapLibraryRead},
+		Run:          p.runMissingFileAudit,
+	}
+}
+
+// fileExistence is the per-row outcome of the stat sweep.
+type fileExistence uint8
+
+const (
+	fileUnknown fileExistence = iota
+	filePresent
+	fileMissing
+	fileUnreadable
+)
+
+// missingFileItem pairs a row with its index so a worker can record its result by
+// position. Writing results[i] from the worker that owns i needs no lock, whereas
+// a shared map would need one on every single row.
+type missingFileItem struct {
+	idx  int
+	file database.BookFileCore
+}
+
+func (p *Plugin) runMissingFileAudit(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	var params missingFileAuditParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+
+	report, err := auditMissingFiles(ctx, store, params, reporter)
+	if err != nil {
+		return err
+	}
+
+	log := reporter.Logger()
+	roots := make([]string, 0, len(report.MissingByRoot))
+	for r := range report.MissingByRoot {
+		roots = append(roots, r)
+	}
+	sort.Slice(roots, func(a, b int) bool { return report.MissingByRoot[roots[a]] > report.MissingByRoot[roots[b]] })
+	for _, r := range roots {
+		log.Info("missing-file-audit: missing by tree", "tree", r, "count", report.MissingByRoot[r])
+	}
+	log.Info("missing-file-audit complete",
+		"rows", report.TotalRows, "missing", report.Missing, "unreadable", report.Unreadable,
+		"books_fully_broken", report.BooksAllGone, "books_partially_broken", report.BooksPartial,
+		"sample", report.Sample)
+	return nil
+}
+
+// auditMissingFiles performs the sweep and RETURNS the report.
+//
+// Split out from the op body so the numbers can be asserted as values rather than
+// scraped from a progress string — the counts are the entire product of this op and
+// a destructive repair will be sized from them, so they deserve to be tested
+// directly.
+func auditMissingFiles(ctx context.Context, store database.Store, params missingFileAuditParams, reporter sdk.Reporter) (missingFileReport, error) {
+	sampleLimit := params.SampleLimit
+	if sampleLimit <= 0 {
+		sampleLimit = missingFileSampleLimit
+	}
+	log := reporter.Logger()
+	log.Info("missing-file-audit start", "path_prefix", params.PathPrefix, "sample_limit", sampleLimit)
+
+	files, err := store.GetAllBookFilesCore()
+	if err != nil {
+		return missingFileReport{}, fmt.Errorf("load book files: %w", err)
+	}
+
+	items := make([]missingFileItem, 0, len(files))
+	for i := range files {
+		path := strings.TrimSpace(files[i].FilePath)
+		// A row with no path at all is a different defect and is not what this op
+		// measures; counting it as "missing bytes" would inflate the number that a
+		// repair decision gets made from.
+		if path == "" {
+			continue
+		}
+		if params.PathPrefix != "" && !strings.HasPrefix(path, params.PathPrefix) {
+			continue
+		}
+		items = append(items, missingFileItem{idx: len(items), file: files[i]})
+	}
+
+	results := make([]fileExistence, len(items))
+	var missing, present, unreadable atomic.Int64
+
+	prog := sdk.NewProgress(reporter, len(items))
+	prog.Start(fmt.Sprintf("Checking %d book_file path(s)…", len(items)))
+
+	err = registry.RunItems(ctx, reporter, items, func(_ context.Context, it missingFileItem) error {
+		switch _, serr := os.Stat(it.file.FilePath); {
+		case serr == nil:
+			results[it.idx] = filePresent
+			present.Add(1)
+		case os.IsNotExist(serr):
+			results[it.idx] = fileMissing
+			missing.Add(1)
+		default:
+			// Could not determine. Recorded as its own outcome rather than as
+			// missing — see missingFileReport.Unreadable.
+			results[it.idx] = fileUnreadable
+			unreadable.Add(1)
+			log.Warn("missing-file-audit: could not stat", "path", it.file.FilePath, "err", serr)
+		}
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: missingFileStatConcurrency,
+		// One unreadable path must not abandon the sweep: the whole point is the
+		// total, and a partial total is the one number that cannot be acted on.
+		ErrMode: registry.ErrModeCollect,
+		Label: func(i, t int) string {
+			return fmt.Sprintf("Checked %d/%d paths (missing=%d)", i+1, t, missing.Load())
+		},
+	})
+	if err != nil {
+		return missingFileReport{}, fmt.Errorf("stat sweep: %w", err)
+	}
+
+	report := missingFileReport{
+		TotalRows:     len(items),
+		Missing:       int(missing.Load()),
+		Present:       int(present.Load()),
+		Unreadable:    int(unreadable.Load()),
+		MissingByRoot: map[string]int{},
+	}
+
+	// Per-book roll-up. Done after the sweep from the results slice rather than in
+	// the workers, so no shared map is written concurrently.
+	type bookTally struct{ total, gone int }
+	byBook := make(map[string]*bookTally, len(items))
+	for i := range items {
+		id := items[i].file.BookID
+		t := byBook[id]
+		if t == nil {
+			t = &bookTally{}
+			byBook[id] = t
+		}
+		t.total++
+		if results[i] == fileMissing {
+			t.gone++
+			if len(report.Sample) < sampleLimit {
+				report.Sample = append(report.Sample, items[i].file.FilePath)
+			}
+			report.MissingByRoot[missingPathRoot(items[i].file.FilePath)]++
+		}
+	}
+	report.BooksTotal = len(byBook)
+	for _, t := range byBook {
+		switch {
+		case t.gone == 0:
+			report.BooksIntact++
+		case t.gone == t.total:
+			report.BooksAllGone++
+		default:
+			report.BooksPartial++
+		}
+	}
+
+	prog.Done("REPORT ONLY (nothing modified) — " + report.summary())
+	return report, nil
+}
+
+// missingPathRoot reduces a path to the tree it lives under, so the report can say
+// WHERE the missing rows are concentrated rather than only how many there are.
+// That grouping is what turned the live finding from "41% of files are gone" into
+// "every missing file is in the organizer's own destination tree and none are in
+// the iTunes tree" — the same number, but the second one names a cause.
+func missingPathRoot(path string) string {
+	cleaned := filepath.Clean(path)
+	parts := strings.Split(strings.TrimPrefix(cleaned, string(filepath.Separator)), string(filepath.Separator))
+	// Three segments is deep enough to separate the library trees that matter
+	// (mnt/bigdata/books/audiobook-organizer vs mnt/bigdata/books/itunes) without
+	// fragmenting the report into one row per author directory.
+	const rootDepth = 4
+	if len(parts) > rootDepth {
+		parts = parts[:rootDepth]
+	}
+	return string(filepath.Separator) + filepath.Join(parts...)
+}

--- a/internal/plugins/maintenance/missing_file_audit_test.go
+++ b/internal/plugins/maintenance/missing_file_audit_test.go
@@ -1,0 +1,171 @@
+// file: internal/plugins/maintenance/missing_file_audit_test.go
+// version: 1.0.0
+// guid: 5c8e2a17-96d4-4b3f-a70e-1d92f4c6b085
+// last-edited: 2026-08-17
+
+package maintenance
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// auditFixture builds REAL files on disk and REAL absent paths beside them, and
+// returns rows pointing at both.
+//
+// 🔴 THE FILES ARE ACTUALLY CREATED. This op's entire output is the result of
+// os.Stat, so a fixture that faked the filesystem would be testing the fake and
+// would pass just as happily with the stat inverted. A tmpdir costs nothing and
+// makes the assertions mean what they say.
+func auditFixture(t *testing.T) (dir string, rows []database.BookFileCore) {
+	t.Helper()
+	dir = t.TempDir()
+	write := func(name string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write fixture %s: %v", name, err)
+		}
+		return p
+	}
+	return dir, []database.BookFileCore{
+		// "intact" — every file present.
+		{ID: "f1", BookID: "intact", FilePath: write("intact-1.m4b")},
+		{ID: "f2", BookID: "intact", FilePath: write("intact-2.m4b")},
+		// "partial" — the live shape: a phantom row beside a surviving real file.
+		{ID: "f3", BookID: "partial", FilePath: filepath.Join(dir, "gone.m4b")},
+		{ID: "f4", BookID: "partial", FilePath: write("partial-real.m4b")},
+		// "allgone" — nothing survives.
+		{ID: "f5", BookID: "allgone", FilePath: filepath.Join(dir, "vanished-1.m4b")},
+		{ID: "f6", BookID: "allgone", FilePath: filepath.Join(dir, "vanished-2.m4b")},
+	}
+}
+
+func runAudit(t *testing.T, rows []database.BookFileCore, params missingFileAuditParams) missingFileReport {
+	t.Helper()
+	store := &database.MockStore{
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return rows, nil },
+	}
+	rep, err := auditMissingFiles(context.Background(), store, params, &fakeReporter{})
+	if err != nil {
+		t.Fatalf("auditMissingFiles: %v", err)
+	}
+	return rep
+}
+
+// The counts are the whole product of this op and a destructive repair will be
+// sized from them, so they are pinned exactly rather than loosely.
+func TestMissingFileAudit_CountsMissingAndPresent(t *testing.T) {
+	_, rows := auditFixture(t)
+	got := runAudit(t, rows, missingFileAuditParams{})
+
+	for _, c := range []struct {
+		name      string
+		got, want int
+	}{
+		{"TotalRows", got.TotalRows, 6},
+		{"Missing", got.Missing, 3},
+		{"Present", got.Present, 3},
+		{"Unreadable", got.Unreadable, 0},
+		{"BooksTotal", got.BooksTotal, 3},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s = %d, want %d", c.name, c.got, c.want)
+		}
+	}
+}
+
+// 🔴 A BOOK WITH ONE DEAD FILE IS NOT A BOOK WITH NO FILES LEFT.
+//
+// The partially-broken books can be repaired by dropping the phantom row; the
+// fully-broken ones cannot, because dropping every row leaves a book with nothing
+// at all. Collapsing the two categories would let the report recommend a repair
+// that destroys the second group — which is the only reason the distinction is
+// computed.
+func TestMissingFileAudit_SeparatesFullyBrokenFromPartiallyBroken(t *testing.T) {
+	_, rows := auditFixture(t)
+	got := runAudit(t, rows, missingFileAuditParams{})
+
+	if got.BooksAllGone != 1 {
+		t.Errorf("BooksAllGone = %d, want 1 (the book whose every file is missing)", got.BooksAllGone)
+	}
+	if got.BooksPartial != 1 {
+		t.Errorf("BooksPartial = %d, want 1 (the book with a phantom row beside a real file)", got.BooksPartial)
+	}
+	if got.BooksIntact != 1 {
+		t.Errorf("BooksIntact = %d, want 1", got.BooksIntact)
+	}
+}
+
+// path_prefix is what makes the op usable one tree at a time — the live finding
+// was that missing rows are confined to a single tree, and confirming that needs a
+// restricted sweep.
+func TestMissingFileAudit_PathPrefixRestrictsTheSweep(t *testing.T) {
+	dir, rows := auditFixture(t)
+
+	none := runAudit(t, rows, missingFileAuditParams{PathPrefix: filepath.Join(dir, "no-such-subtree")})
+	if none.TotalRows != 0 {
+		t.Errorf("a prefix matching nothing swept %d rows, want 0", none.TotalRows)
+	}
+	// 🔴 ANTI-VACUOUS: the assertion above would also pass if the sweep were simply
+	// broken, so prove the same fixture is fully visible without the prefix.
+	all := runAudit(t, rows, missingFileAuditParams{PathPrefix: dir})
+	if all.TotalRows != 6 {
+		t.Errorf("prefix matching the fixture dir swept %d rows, want 6", all.TotalRows)
+	}
+}
+
+// A row with no path at all is a different defect. Counting it as missing bytes
+// would inflate the number a bulk repair gets sized from.
+func TestMissingFileAudit_SkipsRowsWithNoPath(t *testing.T) {
+	_, rows := auditFixture(t)
+	rows = append(rows, database.BookFileCore{ID: "f7", BookID: "nopath", FilePath: "   "})
+	got := runAudit(t, rows, missingFileAuditParams{})
+
+	if got.TotalRows != 6 {
+		t.Errorf("TotalRows = %d, want 6 — the blank-path row must not be swept", got.TotalRows)
+	}
+	if got.Missing != 3 {
+		t.Errorf("Missing = %d, want 3 — a blank path is not missing bytes", got.Missing)
+	}
+}
+
+// The sample is what lets a human sanity-check the number before acting on it, so
+// it must actually name the missing paths and not, say, the present ones.
+func TestMissingFileAudit_SampleNamesMissingPathsOnly(t *testing.T) {
+	dir, rows := auditFixture(t)
+	got := runAudit(t, rows, missingFileAuditParams{})
+
+	if len(got.Sample) != 3 {
+		t.Fatalf("Sample has %d entries, want 3", len(got.Sample))
+	}
+	present := map[string]bool{
+		filepath.Join(dir, "intact-1.m4b"):     true,
+		filepath.Join(dir, "intact-2.m4b"):     true,
+		filepath.Join(dir, "partial-real.m4b"): true,
+	}
+	for _, s := range got.Sample {
+		if present[s] {
+			t.Errorf("Sample names %q, which EXISTS — the sample must list missing paths", s)
+		}
+	}
+}
+
+// missingPathRoot is what turned "41% of files are gone" into "every one of them is
+// in the organizer's own tree and none are in the iTunes tree" — the same number,
+// but the second one names a cause.
+func TestMissingPathRoot_GroupsByLibraryTree(t *testing.T) {
+	cases := map[string]string{
+		"/mnt/bigdata/books/audiobook-organizer/Morgan Rice/x/y.m4b": "/mnt/bigdata/books/audiobook-organizer",
+		"/mnt/bigdata/books/itunes/iTunes Media/Audiobooks/z.m4b":    "/mnt/bigdata/books/itunes",
+		"/short/path.m4b": "/short/path.m4b",
+	}
+	for in, want := range cases {
+		if got := missingPathRoot(in); got != want {
+			t.Errorf("missingPathRoot(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/plugins/maintenance/missing_file_audit_test.go
+++ b/internal/plugins/maintenance/missing_file_audit_test.go
@@ -133,6 +133,45 @@ func TestMissingFileAudit_SkipsRowsWithNoPath(t *testing.T) {
 	}
 }
 
+// 🔴 "I COULD NOT TELL" IS NOT "IT IS NOT THERE".
+//
+// This is the op's most important safety property and the one a reader is most
+// likely to simplify away, because folding unreadable into missing makes the code
+// shorter and every other test still passes. It must not be folded: the Missing
+// count is what a bulk repair gets sized from, so a single unmounted share or a
+// permissions fault would otherwise report the ENTIRE library as lost and invite a
+// mass deletion of rows whose files are fine.
+//
+// The lever is a path containing a NUL byte. Go rejects it before the syscall, so
+// os.Stat returns "invalid argument" identically on every platform — no dependence
+// on filesystem permissions or on name-length limits that differ between a macOS
+// dev box and a Linux CI container.
+func TestMissingFileAudit_UnreadableIsNotCountedAsMissing(t *testing.T) {
+	_, rows := auditFixture(t)
+	rows = append(rows, database.BookFileCore{
+		ID: "f8", BookID: "unreadable", FilePath: "/tmp/cannot\x00stat.m4b",
+	})
+	got := runAudit(t, rows, missingFileAuditParams{})
+
+	if got.Unreadable != 1 {
+		t.Errorf("Unreadable = %d, want 1 — a stat that failed for any reason other than "+
+			"absence must be reported as undetermined", got.Unreadable)
+	}
+	if got.Missing != 3 {
+		t.Errorf("Missing = %d, want 3 — the unreadable row must NOT inflate the missing "+
+			"count that a repair is sized from", got.Missing)
+	}
+	// And it must not be silently counted as present either, which would hide it.
+	if got.Present != 3 {
+		t.Errorf("Present = %d, want 3", got.Present)
+	}
+	// A book whose only row is undetermined is not a book with no files left.
+	if got.BooksAllGone != 1 {
+		t.Errorf("BooksAllGone = %d, want 1 — the undetermined book must not be declared "+
+			"fully broken", got.BooksAllGone)
+	}
+}
+
 // The sample is what lets a human sanity-check the number before acting on it, so
 // it must actually name the missing paths and not, say, the present ones.
 func TestMissingFileAudit_SampleNamesMissingPathsOnly(t *testing.T) {

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -59,6 +59,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		// delimiter, three words), so the split scan skips these rows entirely.
 		p.authorConjunctionRepairDef(),
 		p.purgeEmptyAuthorsDef(),
+		p.missingFileAuditDef(),
 		p.seriesNormalizeDef(),
 		p.seriesPruneDef(),
 		p.resolveProductionAuthorsDef(),

--- a/todo.d/20260817-decide-missing-book-file-row-repair.md
+++ b/todo.d/20260817-decide-missing-book-file-row-repair.md
@@ -1,0 +1,17 @@
+- [ ] **Decide the repair for `book_file` rows whose bytes are gone.** `maintenance.missing-file-audit`
+      now measures them (41.8% of rows in a 120-book sample; every one under the organizer's own
+      destination tree, none under the iTunes tree). Two candidate repairs, which differ in kind:
+      delete the phantom row, or re-point it at the surviving file. Deleting is **not** uniformly
+      safe — books whose every row is missing would be left with no files at all, so those need a
+      separate decision. Run the audit library-wide first, then choose. Also worth answering: why
+      the organizer recorded destination rows it never populated (suspect the library-wide move
+      in #2479).
+- [ ] **Register `HEAD` for the audio/file routes.** The server registers no `HEAD` handler
+      anywhere, so `HEAD /api/items/:id/file/:ino/download` 404s on a file that exists. Upstream
+      Audiobookshelf runs on Express, which auto-answers `HEAD` for a `GET` route; gin does not.
+      Not currently causing failures — the production journal shows real clients only send `GET` —
+      but any client that preflights with `HEAD` would see "file not found".
+- [ ] **Differentiate the five `"file not found"` returns** in `internal/server/handlers/abs/stream.go`
+      (lines 53/78/95/145/159). They mean ino-absent, no syncfile for this book, no `book_file` for
+      the syncfile's `CurrentFileID`, `filepath.Abs` failed, and bytes-missing — and none of them
+      logs, so every one presents identically and the next report is undiagnosable.


### PR DESCRIPTION
## The user-visible bug

> "I try and download the book but it fails saying it can't find the file."

Confirmed in the production journal: **1,036 `GET` 404s on `/api/items/:id/file/:ino[/download]`** from real clients.

## Measurement

Probed every audio file of a 120-book sample (not just `audioFiles[0]`, which is what hid this) and stat'd every path on the server:

| | count |
|---|---|
| `book_file` rows probed | 1,322 |
| **Bytes missing** | **552 (41.8%)** |
| Books with ≥1 dead file | **49 of 120 (41%)** |
| Books with **no** surviving file | **5** |

**Every missing path is under `/mnt/bigdata/books/audiobook-organizer/…` — the organizer's own destination tree. Nothing under `books/itunes` is missing.** The typical broken book carries a phantom row at the organized path beside the real file still in the iTunes tree:

```
MISSING  .../audiobook-organizer/Morgan Rice/…/A Vow of Glory - … - read by narrator.m4b
OK       .../itunes/iTunes Media/Audiobooks/Morgan Rice/01 The Sorcerer's Ring - 05 - A Vow.m4b
```

## Why a new op

No existing operation can find these:

- `orphan-book-files-cleanup` matches rows whose **`book_id` dangles** — these have a valid book.
- `dedupe-book-file-rows` matches rows sharing an **identical `file_path`** — these have *different* paths.
- `file-integrity-check` compares **hashes**, not existence.

## Design

**Report-only, and read-capability-only** (`CapLibraryRead`, no `CapLibraryWrite`) — safe to run against production at any time, including mid-scan.

No repair is offered because the right repair isn't decided, and the candidates differ in kind: delete the phantom row, or re-point it at the surviving file. Deleting is also **not uniformly safe** — the 5 books whose every row is missing would be left with no files at all, which is why fully-broken and partially-broken are counted separately. Filed as a todo fragment.

The stat sweep is a bounded worker pool (`registry.RunItems`, concurrency 24) sized for **network round-trip latency, not cores** — every item is one `os.Stat` against the NAS, so `NumCPU()` would leave the link idle, while an unbounded fan-out would out-compete playback.

`Unreadable` is counted **separately from `Missing`**: "I could not tell" and "it is not there" are different findings, and merging them would let one unmounted share report the whole library as lost.

## Verification

7 tests, fixtures that create **real files on disk** (the op's whole output is `os.Stat`, so a faked filesystem would test the fake).

Mutations — note the third:

| mutation | result |
|---|---|
| collapse fully-broken into partially-broken | `SeparatesFullyBrokenFromPartiallyBroken` fails |
| stop skipping blank-path rows | `SkipsRowsWithNoPath` fails |
| count an unreadable stat as missing | **initially SURVIVED** → added `UnreadableIsNotCountedAsMissing`, now fails |

That third mutation is why the test exists: the op's most important safety property had no coverage until mutation testing went looking for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS