### PR TITLE
fix(abs): record WHY a file 404s instead of five identical silent returns

### DIFF
--- a/changelog.d/20260817_090000_fix_distinguish_file_not_found.md
+++ b/changelog.d/20260817_090000_fix_distinguish_file_not_found.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **"File not found" download failures are now diagnosable.** Five different
+  conditions in the file-serving path all returned an identical 404 with an
+  identical body and **none of them logged anything**, so a report of "it says it
+  can't find the file" could not be traced to a cause without probing production
+  directly. The client-visible answer is unchanged — it is the protocol contract —
+  but the server now records which of the five it was: `no_ino`, `no_syncfile`,
+  `no_bookfile_row`, `abs_path_failed`, or `bytes_missing`, along with the path it
+  tried to serve.
+
+  Diagnosing the live reports took four separate production probes precisely
+  because 1,036 of these 404s had been recorded without recording their kind.

--- a/internal/server/handlers/abs/file_not_found_reason_test.go
+++ b/internal/server/handlers/abs/file_not_found_reason_test.go
@@ -1,0 +1,157 @@
+// file: internal/server/handlers/abs/file_not_found_reason_test.go
+// version: 1.0.0
+// guid: 8b3f0d92-47a1-4e6c-95d8-2c710fa6e534
+// last-edited: 2026-08-17
+
+package abs_test
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// captureLogs redirects the default slog logger into a buffer for the duration of
+// one test and restores it afterwards.
+//
+// 🔴 THE LOG IS THE ONLY OBSERVABLE. Every one of these failures answers the
+// client with an identical 404 and an identical "file not found" body — that is
+// the protocol contract and it is deliberately unchanged. So a test that asserted
+// on the response could not tell the five cases apart either, which is precisely
+// the defect under repair. The log is the surface being tested.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// seedFileServing builds one book with one book_file whose path DOES NOT EXIST,
+// plus the sync file that addresses it, and returns the seed with the book id and
+// the minted ino.
+//
+// The missing path is deliberately inside a real t.TempDir() rather than something
+// like "/nope": the parent directory exists and only the file is absent, which is
+// the exact live shape — a row naming a destination under a tree that is genuinely
+// mounted, where the bytes were never written.
+func seedFileServing(t *testing.T) (seed *oracleSeed, itemID, ino, missingPath string) {
+	t.Helper()
+	seed = seedOracleLibrary(t)
+
+	intp := func(i int) *int { return &i }
+	strp := func(s string) *string { return &s }
+	boolp := func(b bool) *bool { return &b }
+
+	const bookID = "fnf-book"
+	missingPath = filepath.Join(t.TempDir(), "never-written.m4b")
+	seed.lib.addBook(&database.Book{
+		ID: bookID, Title: "File Not Found Book",
+		Duration:     intp(3600),
+		LibraryState: strp("organized"), IsPrimaryVersion: boolp(true),
+	}, []database.BookFile{{ID: "fnf-file", BookID: bookID, FilePath: missingPath}}, nil)
+
+	id, err := seed.lib.MintOrGetSyncFileID(bookID, "fnf-file")
+	if err != nil {
+		t.Fatalf("MintOrGetSyncFileID: %v", err)
+	}
+	// The route addresses an item by its SYNC id, not the internal book id — the
+	// same indirection the client sees.
+	return seed, mustSyncID(t, seed, bookID), id, missingPath
+}
+
+// logReason extracts the reason= value from the captured log, or "" if the log
+// recorded no file-not-found at all.
+func logReason(logs string) string {
+	for _, line := range strings.Split(logs, "\n") {
+		if !strings.Contains(line, "abs: file not found") {
+			continue
+		}
+		for _, f := range strings.Fields(line) {
+			if strings.HasPrefix(f, "reason=") {
+				return strings.TrimPrefix(f, "reason=")
+			}
+		}
+	}
+	return ""
+}
+
+// harnessFor wires the seed into an authenticated harness. The file routes sit
+// behind the ABS auth middleware, so an unauthenticated probe answers 401 and never
+// reaches the code under test at all.
+func harnessFor(t *testing.T, seed *oracleSeed) (*harness, string) {
+	t.Helper()
+	h := newHarness(t, "jwt", nil, withLibrary(seed), withUserData(fixtureUserData()))
+	h.seedUser(t, "u1", "oracle", "", "pw-pw-pw-pw")
+	body := h.login(t, "oracle", "pw-pw-pw-pw")
+	return h, str(t, userObj(t, body), "accessToken")
+}
+
+// 🔴 THE CASE THAT ACTUALLY FIRES IN PRODUCTION. 41.8% of book_file rows point at
+// bytes that are not on disk, and every one of those downloads used to 404 in
+// silence. This is the assertion that a real "can't find the file" report is now
+// self-diagnosing.
+func TestFileNotFound_MissingBytesAreLoggedAsSuch(t *testing.T) {
+	seed, itemID, ino, missingPath := seedFileServing(t)
+	logs := captureLogs(t)
+	h, tok := harnessFor(t, seed)
+
+	res, _ := h.do(t, request{method: http.MethodGet, path: "/api/items/" + itemID + "/file/" + ino + "/download", headers: bearer(tok)})
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", res.Code)
+	}
+	if got := logReason(logs.String()); got != "bytes_missing" {
+		t.Errorf("logged reason = %q, want %q\nlogs:\n%s", got, "bytes_missing", logs.String())
+	}
+	// The served path is the single most useful fact for the next person, because it
+	// names WHICH tree the row pointed into.
+	if !strings.Contains(logs.String(), filepath.Base(missingPath)) {
+		t.Errorf("log does not name the path that was missing\nlogs:\n%s", logs.String())
+	}
+}
+
+// 🔴 THE DISCRIMINATION IS THE WHOLE POINT. A different failure must produce a
+// DIFFERENT reason — otherwise the field is decoration and the next investigation
+// is no better off than the four production probes this replaces.
+func TestFileNotFound_UnknownInoIsADifferentReason(t *testing.T) {
+	seed, itemID, _, _ := seedFileServing(t)
+	logs := captureLogs(t)
+	h, tok := harnessFor(t, seed)
+
+	res, _ := h.do(t, request{method: http.MethodGet, path: "/api/items/" + itemID + "/file/sf-does-not-exist/download", headers: bearer(tok)})
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", res.Code)
+	}
+	if got := logReason(logs.String()); got != "no_syncfile" {
+		t.Errorf("logged reason = %q, want %q\nlogs:\n%s", got, "no_syncfile", logs.String())
+	}
+}
+
+// The client-visible answer must NOT change. The finer distinction is for the
+// server operator; a client can do nothing with it, and ABS clients key off the
+// status and body.
+func TestFileNotFound_ClientAnswerIsUnchanged(t *testing.T) {
+	seed, itemID, ino, _ := seedFileServing(t)
+	_ = captureLogs(t)
+	h, tok := harnessFor(t, seed)
+
+	missing, _ := h.do(t, request{method: http.MethodGet, path: "/api/items/" + itemID + "/file/" + ino + "/download", headers: bearer(tok)})
+	unknown, _ := h.do(t, request{method: http.MethodGet, path: "/api/items/" + itemID + "/file/sf-does-not-exist/download", headers: bearer(tok)})
+
+	if missing.Code != unknown.Code {
+		t.Errorf("status differs between causes: %d vs %d — the client answer must stay identical",
+			missing.Code, unknown.Code)
+	}
+	if missing.Body.String() != unknown.Body.String() {
+		t.Errorf("body differs between causes:\n  %q\n  %q", missing.Body.String(), unknown.Body.String())
+	}
+	if !strings.Contains(missing.Body.String(), "file not found") {
+		t.Errorf("body = %q, want it to still say \"file not found\"", missing.Body.String())
+	}
+}

--- a/internal/server/handlers/abs/stream.go
+++ b/internal/server/handlers/abs/stream.go
@@ -1,11 +1,12 @@
 // file: internal/server/handlers/abs/stream.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e2b19c74-3d05-4f81-a6c3-58790ed4b23f
-// last-edited: 2026-07-30
+// last-edited: 2026-08-17
 
 package abs
 
 import (
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -14,6 +15,36 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/gin-gonic/gin"
 )
+
+// fileNotFound answers the client's 404 unchanged and records WHY on the server.
+//
+// 🔴 FIVE DIFFERENT FAILURES USED TO SHARE ONE SILENT RETURN. The body stays
+// "file not found" for every one of them — that is the protocol contract and the
+// client can do nothing with a finer distinction — but the server could not tell
+// them apart either, and nothing was logged at all. The reasons are genuinely
+// different problems with different fixes:
+//
+//	no_ino             the request carried no ino segment
+//	no_syncfile        no sync file with that ino belongs to this book
+//	no_bookfile_row    the sync file's CurrentFileID matches no book_file row
+//	abs_path_failed    filepath.Abs rejected the stored path
+//	bytes_missing      the row and the path exist; the FILE does not
+//
+// This is not hypothetical tidiness. Diagnosing the live "can't find the file"
+// reports on 2026-08-17 took four separate production probes precisely because the
+// server had recorded 1,036 of these 404s without recording which kind any of them
+// was. The answer turned out to be bytes_missing — 41.8% of book_file rows point at
+// files that are not on disk — and one line of this log would have said so.
+func fileNotFound(c *gin.Context, reason string, attrs ...any) {
+	args := append([]any{
+		"reason", reason,
+		"item", c.Param("id"),
+		"ino", c.Param("ino"),
+		"path", c.Request.URL.Path,
+	}, attrs...)
+	slog.Warn("abs: file not found", args...)
+	respondError(c, http.StatusNotFound, "file not found")
+}
 
 // Byte-serving paths. BOTH of these exist because the two target clients address
 // audio completely differently (§1.8.3):
@@ -50,7 +81,7 @@ func (h *Handler) serveItemFile(c *gin.Context, asAttachment bool) {
 	}
 	ino := strings.TrimSpace(c.Param("ino"))
 	if ino == "" {
-		respondError(c, http.StatusNotFound, "file not found")
+		fileNotFound(c, "no_ino")
 		return
 	}
 
@@ -75,7 +106,10 @@ func (h *Handler) serveItemFile(c *gin.Context, asAttachment bool) {
 		}
 	}
 	if fileID == "" {
-		respondError(c, http.StatusNotFound, "file not found")
+		// The ino is not one of this book's sync files. Either it belongs to another
+		// item (which the book-scoped lookup is deliberately refusing to serve) or the
+		// client is working from a stale item payload.
+		fileNotFound(c, "no_syncfile", "book", book.ID, "syncfiles", len(syncFiles))
 		return
 	}
 
@@ -92,7 +126,10 @@ func (h *Handler) serveItemFile(c *gin.Context, asAttachment bool) {
 		}
 	}
 	if path == "" {
-		respondError(c, http.StatusNotFound, "file not found")
+		// The sync file points at a book_file that is not among this book's rows, or
+		// the row it names carries an empty path. Both are database inconsistencies
+		// rather than anything the request did wrong.
+		fileNotFound(c, "no_bookfile_row", "book", book.ID, "file_id", fileID, "book_files", len(files))
 		return
 	}
 
@@ -142,7 +179,7 @@ func (h *Handler) PublicSessionTrack(c *gin.Context) {
 func (h *Handler) serveAudio(c *gin.Context, path string, asAttachment bool) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
-		respondError(c, http.StatusNotFound, "file not found")
+		fileNotFound(c, "abs_path_failed", "stored_path", path, "err", err)
 		return
 	}
 	if asAttachment {
@@ -156,7 +193,14 @@ func (h *Handler) serveAudio(c *gin.Context, path string, asAttachment bool) {
 		// A missing or unreadable file is a 404, not a 500: the row exists, the bytes
 		// do not, and a client should treat it as "not available" rather than retrying
 		// a server fault forever.
-		respondError(c, http.StatusNotFound, "file not found")
+		//
+		// 🔴 THIS IS THE ONE THAT ACTUALLY FIRES. Measured 2026-08-17: 41.8% of
+		// book_file rows point at a path with no file behind it, all of them under the
+		// organizer's own destination tree. The served path is logged because it is the
+		// single most useful fact for the next person — it says WHICH tree the row
+		// pointed into, which is what separated "files are gone" from "the organizer
+		// recorded destinations it never populated".
+		fileNotFound(c, "bytes_missing", "served_path", abs, "err", err)
 		return
 	}
 	// The body is already written; stop gin from letting any later middleware append


### PR DESCRIPTION
## The problem

`serveItemFile` and `serveAudio` had **five** `respondError(404, "file not found")` sites meaning five different things — and **none of them logged**:

| line | meaning |
|---|---|
| `stream.go:53` | the request carried no ino segment |
| `stream.go:78` | no sync file with that ino belongs to this book |
| `stream.go:95` | the sync file's `CurrentFileID` matches no `book_file` row |
| `stream.go:145` | `filepath.Abs` rejected the stored path |
| `stream.go:159` | the row and path exist; **the bytes do not** |

So a user report of "it says it can't find the file" was undiagnosable from the server side. The production journal held **1,036** of these 404s without recording which kind any of them was, and pinning it down took **four separate production probes**.

The answer turned out to be `bytes_missing` — 41.8% of `book_file` rows point at files that are not on disk (see #2515, which measures it). One line of this log would have said so immediately.

## The change

Each site now names its reason, and the served path is logged for the case that actually fires — the path is what says *which tree* the row pointed into, which is what separated "files are gone" from "the organizer recorded destinations it never populated."

**The client-visible answer is deliberately unchanged**: same 404, same `"file not found"` body. That's the protocol contract, a client can do nothing with a finer distinction, and ABS clients key off status and body. The distinction is for the operator.

## Verification

3 tests, driven through the HTTP layer. That indirection is necessary rather than incidental: the response is byte-identical across all five cases, so a test asserting on the response could not tell them apart either — which *is* the defect. The log is the surface under test.

The fixture puts the missing file inside a real `t.TempDir()` so the parent directory exists and only the file is absent — the exact live shape, not a path that fails for an unrelated reason.

| mutation | result |
|---|---|
| relabel `bytes_missing` as another reason | `MissingBytesAreLoggedAsSuch` fails |
| drop the `reason` field from the log | 2 tests fail |
| leak the reason into the client body | `ClientAnswerIsUnchanged` fails |

That last one guards the contract in the other direction — the fix must not become a behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS