### PR TITLE
feat(ops): real checkpoint/resume — RunItems under concurrency, and library.scan mid-scan

### DIFF
--- a/changelog.d/20260817_100000_feat_runitems_checkpoint_resume.md
+++ b/changelog.d/20260817_100000_feat_runitems_checkpoint_resume.md
@@ -1,0 +1,16 @@
+### Added
+
+- **`registry.RunItems` can now checkpoint and resume under concurrency.** Adds
+  `ResumeFrom`, `CheckpointEvery` and `CheckpointStateFn` to `RunItemsOptions`.
+  Concurrent checkpointing was previously refused outright — the comment said
+  "parallel writes to reporter.Checkpoint would race on the shared state blob" —
+  which left every op that follows the mandated worker-pool pattern unable to
+  resume, and is why 100 of 140 op definitions were `ResumePolicy: drop`.
+
+  The mechanism is a contiguous-completion watermark: a completion *count* is not
+  a resume point when workers finish out of order (items 0,1,2,5 done is "4
+  completed", and resuming at 4 would silently skip 3 and 4), so the checkpoint
+  records only the unbroken completed prefix. A failed item never advances the
+  watermark, so a resume retries it instead of skipping it.
+
+  Behaviour is unchanged for callers that do not set the new fields.

--- a/changelog.d/20260817_110000_feat_library_scan_resume.md
+++ b/changelog.d/20260817_110000_feat_library_scan_resume.md
@@ -1,0 +1,22 @@
+### Added
+
+- **`library.scan` now genuinely resumes instead of starting over.** Its
+  definition previously carried the comment "⚠️ THIS RE-RUNS THE SCAN FROM THE
+  START, IT DOES NOT CONTINUE MID-SCAN" — accurate, because nothing in the scan
+  path called `Checkpoint()` and `libraryScanParams` had no fields for a resume
+  point to land in. A production scan on 2026-08-17 ran 3h50m+ against a
+  63,044-book library; a restart discarded all of it.
+
+  The scan now checkpoints `resume_folder_idx` / `resume_item_offset` after every
+  completed chunk of books and every completed folder. Completed folders are
+  skipped whole; the folder that was in flight resumes at the last completed
+  chunk boundary.
+
+  Granularity is deliberately per-chunk, not per-folder: one production folder
+  holds ~14,000 items, so a checkpoint that could only say "folder 3 of 5" would
+  still throw away hours. Books are sorted by path before chunking so an offset
+  means the same thing across runs — directory-walk order varies per run, and
+  resuming into a differently-ordered slice would skip an arbitrary set.
+
+  A chunk that fails is not checkpointed, so a resume retries it rather than
+  stepping over books that were never processed.

--- a/internal/operations/registry/run_items.go
+++ b/internal/operations/registry/run_items.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/run_items.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: a2b3c4d5-e6f7-8901-abcd-ef2345678901
-// last-edited: 2026-08-13
+// last-edited: 2026-08-17
 
 package registry
 
@@ -51,10 +51,39 @@ type RunItemsOptions struct {
 	// closure to capture the current item's ID or any other state needed to
 	// build the checkpoint. Errors are logged but do not fail the item.
 	//
-	// Not called in concurrent mode — parallel writes to reporter.Checkpoint
-	// would race on the shared state blob. Use OpFreshness.Stamp instead for
-	// concurrent per-item checkpointing.
+	// For CONCURRENT mode use CheckpointStateFn below, which is serialized and
+	// carries a watermark that is correct under out-of-order completion.
 	CheckpointFn func(ctx context.Context) error
+
+	// ResumeFrom skips the first N items because a previous run already
+	// completed them. It slices items[ResumeFrom:] and shifts ProgressOffset by
+	// the same amount, so the progress bar keeps reporting absolute position in
+	// the original collection rather than restarting at 1.
+	//
+	// Pair it with CheckpointStateFn: the watermark handed to that callback is
+	// exactly the value to store and feed back here on the next run.
+	ResumeFrom int
+
+	// CheckpointEvery throttles CheckpointStateFn to once per N completed
+	// items. 0 means every item. Ignored when CheckpointStateFn is nil.
+	CheckpointEvery int
+
+	// CheckpointStateFn is the concurrent-safe checkpoint hook. It receives the
+	// ABSOLUTE contiguous-completion watermark: the number of items from the
+	// start of the original collection that are all finished, including any
+	// skipped by ResumeFrom. Calls are serialized, so the callback may write
+	// the shared state blob without further locking.
+	//
+	// The watermark is the unbroken completed PREFIX, not the completed count.
+	// With workers finishing out of order, items 0,1,2,5 done means the
+	// watermark is 3 — item 5 is re-run on resume. That is deliberate: every
+	// item below the watermark is provably complete no matter what order the
+	// pool finished in, which is the property that made concurrent
+	// checkpointing unsafe before. Item-level idempotence covers the re-run.
+	//
+	// A FAILED item never advances the watermark, so a resume retries it rather
+	// than skipping silently over it.
+	CheckpointStateFn func(ctx context.Context, watermark int) error
 
 	// ProgressOffset shifts UpdateProgress current values by this amount.
 	// Use when iterating a sub-slice of a larger set so the progress bar
@@ -66,6 +95,38 @@ type RunItemsOptions struct {
 	// Defaults to len(items) when zero. Set to the full collection size
 	// when iterating a sub-slice (pairs with ProgressOffset).
 	ProgressTotal int
+}
+
+// completionTracker records which item indices have finished successfully and
+// exposes the contiguous completed prefix ("watermark").
+//
+// It exists because a completion COUNT is not a resume point under concurrency.
+// Workers finish out of order, so "4 done" may mean indices {0,1,2,5}; resuming
+// at 4 would skip 3 and 4 entirely. The watermark answers the only question a
+// resume can safely act on: how many items from the start are ALL finished.
+type completionTracker struct {
+	mu        sync.Mutex
+	done      []bool
+	watermark int
+}
+
+func newCompletionTracker(n int) *completionTracker {
+	return &completionTracker{done: make([]bool, n)}
+}
+
+// complete marks index i finished and returns the new watermark. Advancing is
+// O(1) amortised: the scan resumes from the previous watermark and each index is
+// stepped over at most once across the whole run.
+func (c *completionTracker) complete(i int) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if i >= 0 && i < len(c.done) {
+		c.done[i] = true
+	}
+	for c.watermark < len(c.done) && c.done[c.watermark] {
+		c.watermark++
+	}
+	return c.watermark
 }
 
 // RunItems fans out fn over items, managing:
@@ -92,9 +153,62 @@ func RunItems[T any](ctx context.Context, r Reporter, items []T, fn func(ctx con
 		return nil
 	}
 
+	// Resume: drop the already-completed prefix. ProgressTotal is pinned to the
+	// ORIGINAL length first, so a resumed run still reports "4200/14000" rather
+	// than restarting the denominator at the size of the remainder — a resumed
+	// op that appears to start over is exactly the confusion this whole change
+	// exists to remove.
+	resumeFrom := opt.ResumeFrom
+	if resumeFrom < 0 {
+		resumeFrom = 0
+	}
+	if resumeFrom > 0 {
+		if opt.ProgressTotal == 0 {
+			opt.ProgressTotal = total
+		}
+		if resumeFrom >= total {
+			// Everything was already done in the previous run. Report the work
+			// as fully complete so the bar does not sit at a stale value.
+			_ = r.UpdateProgress(opt.ProgressTotal, opt.ProgressTotal, "resumed: all items already complete")
+			return nil
+		}
+		opt.ProgressOffset += resumeFrom
+		items = items[resumeFrom:]
+		total = len(items)
+	}
+
 	progTotal := total
 	if opt.ProgressTotal > 0 {
 		progTotal = opt.ProgressTotal
+	}
+
+	// Concurrent-safe checkpointing. tracker is nil when the caller did not ask
+	// for it, so the zero-value options path allocates nothing.
+	var tracker *completionTracker
+	var ckptMu sync.Mutex
+	lastCkpt := 0
+	if opt.CheckpointStateFn != nil {
+		tracker = newCompletionTracker(total)
+	}
+	maybeCheckpoint := func(ctx context.Context, i int) {
+		if tracker == nil {
+			return
+		}
+		mark := tracker.complete(i)
+		every := opt.CheckpointEvery
+		if every < 1 {
+			every = 1
+		}
+		ckptMu.Lock()
+		defer ckptMu.Unlock()
+		// Guard on the watermark, not the completion count: with a gap open the
+		// watermark stalls, and checkpointing the same value repeatedly is
+		// pointless write amplification.
+		if mark <= lastCkpt || mark-lastCkpt < every && mark < total {
+			return
+		}
+		lastCkpt = mark
+		_ = opt.CheckpointStateFn(ctx, resumeFrom+mark)
 	}
 
 	lbl := opt.Label
@@ -129,6 +243,12 @@ func RunItems[T any](ctx context.Context, r Reporter, items []T, fn func(ctx con
 		// SetCurrentItem above still gets the pre-work label: it names the item
 		// being STARTED, which is what it is for.
 		_ = r.UpdateProgress(opt.ProgressOffset+done, progTotal, lbl(i, progTotal))
+		// Only a SUCCESS may advance the watermark. Marking a failed item done
+		// would let a resume skip straight past it, turning one failure into
+		// permanently unprocessed work that nothing ever revisits.
+		if err == nil {
+			maybeCheckpoint(ctx, i)
+		}
 		return err
 	}
 

--- a/internal/operations/registry/run_items_resume_test.go
+++ b/internal/operations/registry/run_items_resume_test.go
@@ -1,0 +1,329 @@
+// file: internal/operations/registry/run_items_resume_test.go
+// version: 1.0.0
+// guid: 6d1f8a27-4c30-4b9e-9a55-71e2c8d40b93
+// last-edited: 2026-08-17
+
+package registry_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+)
+
+// ckptReporter records the progress values RunItems reports so a resumed run can
+// be asserted to keep an ABSOLUTE denominator rather than restarting at the size
+// of the remainder.
+type ckptReporter struct {
+	mu       sync.Mutex
+	progress [][2]int // {current, total}
+}
+
+func (s *ckptReporter) UpdateProgress(current, total int, _ string) error {
+	s.mu.Lock()
+	s.progress = append(s.progress, [2]int{current, total})
+	s.mu.Unlock()
+	return nil
+}
+func (s *ckptReporter) SetCurrentItem(_ string)                          {}
+func (s *ckptReporter) Log(_ slog.Level, _ string, _ ...slog.Attr) error { return nil }
+func (s *ckptReporter) Logger() *slog.Logger                             { return slog.Default() }
+func (s *ckptReporter) Checkpoint(_ any) error                           { return nil }
+func (s *ckptReporter) IsCanceled() bool                                 { return false }
+func (s *ckptReporter) Trigger(_ context.Context, _ string, _ any) error { return nil }
+func (s *ckptReporter) RunPhase(ctx context.Context, _ string, fn func(context.Context, registry.Reporter) error) error {
+	return fn(ctx, s)
+}
+
+func (s *ckptReporter) lastProgress() [2]int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.progress) == 0 {
+		return [2]int{0, 0}
+	}
+	return s.progress[len(s.progress)-1]
+}
+
+// marks collects watermarks handed to CheckpointStateFn.
+type marks struct {
+	mu sync.Mutex
+	v  []int
+}
+
+func (m *marks) add(w int) {
+	m.mu.Lock()
+	m.v = append(m.v, w)
+	m.mu.Unlock()
+}
+
+func (m *marks) max() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	best := 0
+	for _, x := range m.v {
+		if x > best {
+			best = x
+		}
+	}
+	return best
+}
+
+func (m *marks) all() []int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := append([]int(nil), m.v...)
+	return out
+}
+
+// TestRunItems_ResumeFrom_SkipsExactlyThePrefix is the core resume guarantee.
+func TestRunItems_ResumeFrom_SkipsExactlyThePrefix(t *testing.T) {
+	r := &ckptReporter{}
+	items := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	var mu sync.Mutex
+	var seen []int
+
+	err := registry.RunItems(context.Background(), r, items, func(_ context.Context, n int) error {
+		mu.Lock()
+		seen = append(seen, n)
+		mu.Unlock()
+		return nil
+	}, registry.RunItemsOptions{ResumeFrom: 4})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sort.Ints(seen)
+	want := []int{4, 5, 6, 7, 8, 9}
+	if len(seen) != len(want) {
+		t.Fatalf("expected %d items run, got %d (%v)", len(want), len(seen), seen)
+	}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Fatalf("expected items %v, got %v", want, seen)
+		}
+	}
+}
+
+// TestRunItems_ResumeFrom_KeepsAbsoluteProgress guards the specific confusion
+// that motivated this work: a resumed op whose progress bar restarts at 1 is
+// indistinguishable from an op that started over.
+func TestRunItems_ResumeFrom_KeepsAbsoluteProgress(t *testing.T) {
+	r := &ckptReporter{}
+	items := make([]int, 100)
+	for i := range items {
+		items[i] = i
+	}
+
+	err := registry.RunItems(context.Background(), r, items, func(_ context.Context, _ int) error {
+		return nil
+	}, registry.RunItemsOptions{ResumeFrom: 60})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := r.lastProgress()
+	if got[1] != 100 {
+		t.Fatalf("resumed run must keep the ORIGINAL total as the denominator; got total=%d, want 100", got[1])
+	}
+	if got[0] != 100 {
+		t.Fatalf("final progress should reach the absolute total; got current=%d, want 100", got[0])
+	}
+	// The first reported value must be past the resume point, not 1.
+	r.mu.Lock()
+	first := r.progress[0]
+	r.mu.Unlock()
+	if first[0] <= 60 {
+		t.Fatalf("first progress after resuming at 60 should exceed 60, got %d", first[0])
+	}
+}
+
+// TestRunItems_ResumeFrom_BeyondEndRunsNothing covers the case where the previous
+// run actually finished everything before dying.
+func TestRunItems_ResumeFrom_BeyondEndRunsNothing(t *testing.T) {
+	r := &ckptReporter{}
+	items := []int{1, 2, 3}
+	ran := 0
+	err := registry.RunItems(context.Background(), r, items, func(_ context.Context, _ int) error {
+		ran++
+		return nil
+	}, registry.RunItemsOptions{ResumeFrom: 3})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ran != 0 {
+		t.Fatalf("expected 0 items to run when ResumeFrom >= len(items), got %d", ran)
+	}
+}
+
+// TestRunItems_Watermark_StopsAtAGap is THE correctness property. Item 2 blocks
+// until every other item has finished, so the pool completes out of order and
+// indices 3..7 are done while 2 is not. No checkpoint may claim more than 2.
+func TestRunItems_Watermark_StopsAtAGap(t *testing.T) {
+	r := &ckptReporter{}
+	items := []int{0, 1, 2, 3, 4, 5, 6, 7}
+	m := &marks{}
+
+	var others sync.WaitGroup
+	others.Add(len(items) - 3) // items 3..7
+
+	// Snapshot the checkpoints as they stand while item 2 is still in flight.
+	// Asserting after RunItems returns would be useless: by then item 2 has
+	// finished and the watermark has legitimately jumped to 8.
+	var duringGap []int
+
+	err := registry.RunItems(context.Background(), r, items, func(_ context.Context, n int) error {
+		switch {
+		case n == 2:
+			// Hold the gap open until everything above it has completed, then
+			// record what the checkpointer believed at that instant.
+			others.Wait()
+			duringGap = m.all()
+		case n > 2:
+			others.Done()
+		}
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency:       8,
+		CheckpointStateFn: func(_ context.Context, w int) error { m.add(w); return nil },
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Items 3..7 had all completed at that moment, so a naive "completed count"
+	// checkpoint would have recorded 5 or more. The watermark must not exceed 2.
+	for _, w := range duringGap {
+		if w > 2 {
+			t.Fatalf("watermark %d claims item 2 is complete while it was still running; "+
+				"a resume would skip it. marks during the gap: %v", w, duringGap)
+		}
+	}
+	// Known-GOOD half: once the gap closes the watermark must reach the total,
+	// otherwise this test would also pass against a checkpointer stuck at zero.
+	if got := m.max(); got != len(items) {
+		t.Fatalf("after item 2 completed the watermark should reach %d, got %d", len(items), got)
+	}
+}
+
+// TestRunItems_Watermark_FailedItemDoesNotAdvance ensures a failure is retried on
+// resume rather than skipped. Item 3 fails; the watermark must never exceed 3.
+func TestRunItems_Watermark_FailedItemDoesNotAdvance(t *testing.T) {
+	r := &ckptReporter{}
+	items := []int{0, 1, 2, 3, 4, 5}
+	m := &marks{}
+
+	err := registry.RunItems(context.Background(), r, items, func(_ context.Context, n int) error {
+		if n == 3 {
+			return errors.New("boom")
+		}
+		return nil
+	}, registry.RunItemsOptions{
+		ErrMode:           registry.ErrModeCollect,
+		CheckpointStateFn: func(_ context.Context, w int) error { m.add(w); return nil },
+	})
+	if err == nil {
+		t.Fatal("expected the failing item to surface an error")
+	}
+	if got := m.max(); got > 3 {
+		t.Fatalf("watermark reached %d, but item 3 FAILED — a resume would skip it entirely. marks: %v",
+			got, m.all())
+	}
+	if got := m.max(); got != 3 {
+		t.Fatalf("watermark should have advanced to exactly 3 (items 0,1,2 done), got %d", got)
+	}
+}
+
+// TestRunItems_Watermark_AllCompleteReachesTotal is the known-GOOD half of the
+// pair: without it, a checkpoint function that always reported 0 would satisfy
+// every "must not exceed" assertion above.
+func TestRunItems_Watermark_AllCompleteReachesTotal(t *testing.T) {
+	r := &ckptReporter{}
+	items := make([]int, 64)
+	m := &marks{}
+
+	err := registry.RunItems(context.Background(), r, items, func(_ context.Context, _ int) error {
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency:       8,
+		CheckpointStateFn: func(_ context.Context, w int) error { m.add(w); return nil },
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := m.max(); got != 64 {
+		t.Fatalf("with every item succeeding the watermark must reach 64, got %d", got)
+	}
+}
+
+// TestRunItems_Watermark_IsAbsoluteAcrossResume checks the value handed back is
+// directly reusable as the next ResumeFrom, rather than being relative to the
+// slice actually iterated.
+func TestRunItems_Watermark_IsAbsoluteAcrossResume(t *testing.T) {
+	r := &ckptReporter{}
+	items := make([]int, 50)
+	m := &marks{}
+
+	err := registry.RunItems(context.Background(), r, items, func(_ context.Context, _ int) error {
+		return nil
+	}, registry.RunItemsOptions{
+		ResumeFrom:        20,
+		CheckpointStateFn: func(_ context.Context, w int) error { m.add(w); return nil },
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := m.max(); got != 50 {
+		t.Fatalf("watermark must be absolute (20 skipped + 30 run = 50), got %d — "+
+			"a relative value would resume at 30 and silently re-run 20 items forever", got)
+	}
+}
+
+// TestRunItems_CheckpointEvery_Throttles verifies the throttle reduces writes
+// without losing the final position.
+func TestRunItems_CheckpointEvery_Throttles(t *testing.T) {
+	r := &ckptReporter{}
+	items := make([]int, 100)
+	m := &marks{}
+
+	err := registry.RunItems(context.Background(), r, items, func(_ context.Context, _ int) error {
+		return nil
+	}, registry.RunItemsOptions{
+		CheckpointEvery:   25,
+		CheckpointStateFn: func(_ context.Context, w int) error { m.add(w); return nil },
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n := len(m.all()); n > 10 {
+		t.Fatalf("CheckpointEvery=25 over 100 items should checkpoint a handful of times, got %d", n)
+	}
+	if got := m.max(); got != 100 {
+		t.Fatalf("the final checkpoint must record the completed total regardless of throttling, got %d", got)
+	}
+}
+
+// TestRunItems_NoCheckpointFn_Unchanged pins the default path: callers that never
+// opt in must see exactly the previous behaviour.
+func TestRunItems_NoCheckpointFn_Unchanged(t *testing.T) {
+	r := &ckptReporter{}
+	items := []int{1, 2, 3, 4}
+	ran := 0
+	err := registry.RunItems(context.Background(), r, items, func(_ context.Context, _ int) error {
+		ran++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ran != 4 {
+		t.Fatalf("expected all 4 items to run, got %d", ran)
+	}
+	if got := r.lastProgress(); got != [2]int{4, 4} {
+		t.Fatalf("expected final progress 4/4, got %v", got)
+	}
+}

--- a/internal/scanner/service.go
+++ b/internal/scanner/service.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/service.go
-// version: 1.12.0
+// version: 1.6.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-// last-edited: 2026-08-12
+// last-edited: 2026-08-17
 package scanner
 
 import (
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync/atomic"
 
@@ -60,7 +61,30 @@ type ScanRequest struct {
 	FolderPath  *string
 	Priority    *int
 	ForceUpdate *bool
+
+	// ResumeFolderIdx and ResumeItemOffset restore position from a previous
+	// run's checkpoint. Folders before ResumeFolderIdx are skipped entirely;
+	// within ResumeFolderIdx the first ResumeItemOffset books are skipped.
+	//
+	// Per-FOLDER granularity alone is not enough and that is the whole reason
+	// the offset exists: a single production folder holds ~14,000 items, so both
+	// the tag pass and the metadata pass run for hours INSIDE one folder. A
+	// checkpoint that can only say "folder 3 of 5" throws away most of a day's
+	// work on a restart.
+	ResumeFolderIdx  int
+	ResumeItemOffset int
+
+	// Checkpoint, when non-nil, persists resume position. It is called after
+	// each completed chunk of books and once per completed folder. Implementations
+	// must be safe to call from the scan goroutine and should not block.
+	Checkpoint func(folderIdx, itemOffset int)
 }
+
+// scanChunkSize bounds how many books are processed between checkpoints. It
+// trades checkpoint write volume against how much work a restart repeats: at
+// 500 a killed scan loses at most 500 books of metadata extraction, while a
+// 14,000-item folder writes 28 checkpoints rather than 14,000.
+const scanChunkSize = 500
 
 // ScanStats accumulates per-scan book counts by source.
 type ScanStats struct {
@@ -72,15 +96,24 @@ type ScanStats struct {
 // PerformScan executes the multi-folder scan operation.
 // Accepts a logger.Logger for unified logging, progress, and change tracking.
 //
-// R-7: there is intentionally no checkpoint/resume plumbing here. The old
-// PerformScanWithID saved operations.ScanParams via operations.SaveParams for a
-// resume path that never existed — LoadParams[ScanParams] had zero callers and
-// the method itself had zero callers. The v2 "library.scan" OperationDef uses
-// ResumePolicy=ResumeDrop (see internal/server/library_core_ops.go), so an
-// interrupted scan is dropped and simply restarts from scratch on the next run;
-// a full re-walk is idempotent (the scan cache skips unchanged files). The dead
-// save/clear calls were removed to stop implying a resume contract that isn't
-// honored.
+// Checkpoint/resume: ScanRequest.Checkpoint, ResumeFolderIdx and
+// ResumeItemOffset carry position across a restart. Folders already finished are
+// skipped whole; the folder that was in flight resumes at the last completed
+// chunk boundary.
+//
+// History, because this comment previously said the opposite. R-7 removed dead
+// save/clear calls for a resume path that never existed (LoadParams[ScanParams]
+// had zero callers) and recorded that the def used ResumePolicy=ResumeDrop, so a
+// full re-walk was simply accepted. The policy became ResumeRestart in #2500,
+// which stopped an interrupted scan being discarded but still re-ran it from
+// zero — library_core_ops.go said so in capitals. On 2026-08-17 a production
+// scan ran 3h50m+ against a 63,044-book library; losing that to a restart is the
+// cost this plumbing removes.
+//
+// A full re-walk remains correct and idempotent — the scan cache skips unchanged
+// files — so resuming is an optimisation, not a correctness requirement. Nothing
+// breaks if a checkpoint is missing or stale; the worst case is the old
+// behaviour of redoing work.
 func (ss *ScanService) PerformScan(ctx context.Context, req *ScanRequest, log logger.Logger) error {
 	return ss.performScanInternal(ctx, "", req, log)
 }
@@ -192,10 +225,31 @@ func (ss *ScanService) performScanInternal(ctx context.Context, opID string, req
 			return fmt.Errorf("scan canceled")
 		}
 
-		err := ss.scanFolder(ctx, folderIdx, folderPath, foldersToScan, totalFilesAcrossFolders, &processedFiles, stats, opID, log)
+		// Resume: skip folders a previous run already finished. This is the
+		// cheap half of resuming — it avoids re-walking and re-tagging an
+		// entire completed folder.
+		if folderIdx < req.ResumeFolderIdx {
+			log.Info("Resuming: skipping folder %d/%d (already completed): %s",
+				folderIdx+1, len(foldersToScan), folderPath)
+			continue
+		}
+		// Within the folder the previous run died in, skip the books it already
+		// processed. Only that one folder carries an offset; every later folder
+		// starts at zero.
+		itemOffset := 0
+		if folderIdx == req.ResumeFolderIdx {
+			itemOffset = req.ResumeItemOffset
+		}
+
+		err := ss.scanFolder(ctx, folderIdx, folderPath, foldersToScan, totalFilesAcrossFolders, &processedFiles, stats, opID, itemOffset, req.Checkpoint, log)
 		if err != nil {
 			log.Error("Error scanning folder %s: %v", folderPath, err)
 			continue
+		}
+		// The folder finished. Record that, so a restart begins at the next
+		// folder with a zero offset rather than re-entering this one.
+		if req.Checkpoint != nil {
+			req.Checkpoint(folderIdx+1, 0)
 		}
 	}
 
@@ -315,7 +369,7 @@ func (ss *ScanService) countFilesAcrossFolders(foldersToScan []string, log logge
 	return totalFilesAcrossFolders
 }
 
-func (ss *ScanService) scanFolder(ctx context.Context, folderIdx int, folderPath string, foldersToScan []string, totalFilesAcrossFolders int, processedFiles *atomic.Int32, stats *ScanStats, opID string, log logger.Logger) error {
+func (ss *ScanService) scanFolder(ctx context.Context, folderIdx int, folderPath string, foldersToScan []string, totalFilesAcrossFolders int, processedFiles *atomic.Int32, stats *ScanStats, opID string, itemOffset int, checkpoint func(folderIdx, itemOffset int), log logger.Logger) error {
 	currentProcessed := int(processedFiles.Load())
 	displayTotal := totalFilesAcrossFolders
 	if currentProcessed > displayTotal {
@@ -385,8 +439,30 @@ func (ss *ScanService) scanFolder(ctx context.Context, folderIdx int, folderPath
 			}
 		}
 
-		log.Info("Processing metadata for %d books using %d workers", len(books), workers)
-		if err := ProcessBooksParallel(ctx, books, workers, progressCallback, log.With("scanner")); err != nil {
+		// Deterministic order is what makes an offset mean the same thing across
+		// runs. ScanDirectoryParallel returns books in worker-completion order,
+		// which varies run to run — resuming at "offset 4200" against a
+		// differently-ordered slice would skip an arbitrary 4200 books and
+		// re-run others, so the sort is load-bearing, not cosmetic.
+		sort.Slice(books, func(i, j int) bool { return books[i].FilePath < books[j].FilePath })
+
+		start := itemOffset
+		if start < 0 {
+			start = 0
+		}
+		if start > len(books) {
+			start = len(books)
+		}
+		if start > 0 {
+			log.Info("Resuming folder %s at book %d/%d", folderPath, start, len(books))
+			processedFiles.Add(int32(start))
+		}
+
+		log.Info("Processing metadata for %d books using %d workers (from offset %d)", len(books), workers, start)
+		processChunk := func(ctx context.Context, chunk []Book) error {
+			return ProcessBooksParallel(ctx, chunk, workers, progressCallback, log.With("scanner"))
+		}
+		if err := ss.processBookChunks(ctx, books, start, folderIdx, checkpoint, processChunk); err != nil {
 			// Do NOT fall through to auto-organize. These books did not get
 			// their metadata extracted, so their title/author are whatever the
 			// scan started with — frequently empty. Organizing them anyway
@@ -421,6 +497,44 @@ func (ss *ScanService) scanFolder(ctx context.Context, folderIdx int, folderPath
 	// Update book count for this import path
 	ss.updateImportPathBookCount(folderPath, len(books), log)
 
+	return nil
+}
+
+// processBookChunks runs ProcessBooksParallel over books[start:] in fixed-size
+// chunks, checkpointing the absolute offset after each chunk completes.
+//
+// Chunking is what gives resume a granularity finer than "a whole folder"
+// without giving up parallelism: each chunk is still processed by the full
+// worker pool, and only the boundary between chunks is a synchronisation point.
+// A chunk is checkpointed only after ProcessBooksParallel returns success for
+// it, so a chunk that fails is re-run on resume rather than skipped.
+// process is injected rather than calling ProcessBooksParallel directly so the
+// chunk boundaries and checkpoint sequence can be tested without a database.
+func (ss *ScanService) processBookChunks(
+	ctx context.Context,
+	books []Book,
+	start int,
+	folderIdx int,
+	checkpoint func(folderIdx, itemOffset int),
+	process func(ctx context.Context, chunk []Book) error,
+) error {
+	for off := start; off < len(books); off += scanChunkSize {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		end := off + scanChunkSize
+		if end > len(books) {
+			end = len(books)
+		}
+		if err := process(ctx, books[off:end]); err != nil {
+			// No checkpoint on failure: recording `end` here would let a resume
+			// step over a chunk that never actually processed.
+			return err
+		}
+		if checkpoint != nil {
+			checkpoint(folderIdx, end)
+		}
+	}
 	return nil
 }
 

--- a/internal/scanner/service_resume_test.go
+++ b/internal/scanner/service_resume_test.go
@@ -1,0 +1,163 @@
+// file: internal/scanner/service_resume_test.go
+// version: 1.0.0
+// guid: 2b7c9e14-6a83-4f52-b0d7-8e41c6a9d375
+// last-edited: 2026-08-17
+
+package scanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func booksN(n int) []Book {
+	out := make([]Book, n)
+	for i := range out {
+		out[i] = Book{FilePath: fmt.Sprintf("/lib/%06d.m4b", i)}
+	}
+	return out
+}
+
+// TestProcessBookChunks_CheckpointsAbsoluteOffsets is the contract the resume
+// path depends on: each checkpoint must name the absolute position in the folder,
+// because that value is fed straight back as ResumeItemOffset next run.
+func TestProcessBookChunks_CheckpointsAbsoluteOffsets(t *testing.T) {
+	ss := &ScanService{}
+	books := booksN(scanChunkSize*2 + 37)
+
+	var marks []int
+	err := ss.processBookChunks(context.Background(), books, 0, 3,
+		func(_ int, off int) { marks = append(marks, off) },
+		func(_ context.Context, _ []Book) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []int{scanChunkSize, scanChunkSize * 2, len(books)}
+	if len(marks) != len(want) {
+		t.Fatalf("expected %d checkpoints, got %d (%v)", len(want), len(marks), marks)
+	}
+	for i := range want {
+		if marks[i] != want[i] {
+			t.Fatalf("checkpoint %d: got %d, want %d (all: %v)", i, marks[i], want[i], marks)
+		}
+	}
+}
+
+// TestProcessBookChunks_ResumeSkipsPrefix verifies the offset actually skips work
+// rather than merely relabelling it.
+func TestProcessBookChunks_ResumeSkipsPrefix(t *testing.T) {
+	ss := &ScanService{}
+	books := booksN(scanChunkSize * 4)
+	start := scanChunkSize * 2
+
+	var processed int
+	var firstSeen string
+	err := ss.processBookChunks(context.Background(), books, start, 0, nil,
+		func(_ context.Context, chunk []Book) error {
+			if processed == 0 && len(chunk) > 0 {
+				firstSeen = chunk[0].FilePath
+			}
+			processed += len(chunk)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processed != len(books)-start {
+		t.Fatalf("expected %d books processed after resuming at %d, got %d",
+			len(books)-start, start, processed)
+	}
+	if want := books[start].FilePath; firstSeen != want {
+		t.Fatalf("resume started at %q, want %q", firstSeen, want)
+	}
+}
+
+// TestProcessBookChunks_FailedChunkIsNotCheckpointed is the safety property. If a
+// chunk errors and we checkpointed past it anyway, a resume would step over books
+// that were never processed and nothing would ever revisit them.
+func TestProcessBookChunks_FailedChunkIsNotCheckpointed(t *testing.T) {
+	ss := &ScanService{}
+	books := booksN(scanChunkSize * 3)
+
+	var marks []int
+	calls := 0
+	err := ss.processBookChunks(context.Background(), books, 0, 0,
+		func(_ int, off int) { marks = append(marks, off) },
+		func(_ context.Context, _ []Book) error {
+			calls++
+			if calls == 2 {
+				return errors.New("chunk 2 exploded")
+			}
+			return nil
+		},
+	)
+	if err == nil {
+		t.Fatal("expected the failing chunk to surface an error")
+	}
+	if len(marks) != 1 || marks[0] != scanChunkSize {
+		t.Fatalf("only the FIRST chunk should be checkpointed; got %v", marks)
+	}
+}
+
+// TestProcessBookChunks_ResumeBeyondEndDoesNothing covers a stale checkpoint
+// pointing past the current book count (files removed since the previous run).
+func TestProcessBookChunks_ResumeBeyondEndDoesNothing(t *testing.T) {
+	ss := &ScanService{}
+	books := booksN(10)
+	ran := 0
+	err := ss.processBookChunks(context.Background(), books, 999, 0, nil,
+		func(_ context.Context, chunk []Book) error { ran += len(chunk); return nil },
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ran != 0 {
+		t.Fatalf("a stale offset past the end must process nothing, processed %d", ran)
+	}
+}
+
+// TestProcessBookChunks_CancelStopsBetweenChunks proves cancellation is honoured
+// at a chunk boundary rather than running the whole folder to completion.
+func TestProcessBookChunks_CancelStopsBetweenChunks(t *testing.T) {
+	ss := &ScanService{}
+	books := booksN(scanChunkSize * 5)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	chunks := 0
+	err := ss.processBookChunks(ctx, books, 0, 0, nil,
+		func(_ context.Context, _ []Book) error {
+			chunks++
+			if chunks == 2 {
+				cancel()
+			}
+			return nil
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if chunks != 2 {
+		t.Fatalf("expected to stop after the cancelling chunk, ran %d chunks", chunks)
+	}
+}
+
+// TestProcessBookChunks_NoCheckpointFnIsSafe pins that the feature is optional.
+func TestProcessBookChunks_NoCheckpointFnIsSafe(t *testing.T) {
+	ss := &ScanService{}
+	books := booksN(scanChunkSize + 1)
+	processed := 0
+	err := ss.processBookChunks(context.Background(), books, 0, 0, nil,
+		func(_ context.Context, chunk []Book) error { processed += len(chunk); return nil },
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processed != len(books) {
+		t.Fatalf("expected all %d books processed, got %d", len(books), processed)
+	}
+}

--- a/internal/server/library_core_ops.go
+++ b/internal/server/library_core_ops.go
@@ -1,7 +1,7 @@
 // file: internal/server/library_core_ops.go
-// version: 1.6.0
+// version: 1.3.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-08-16
+// last-edited: 2026-08-17
 
 // library_core_ops registers the scan, organize, and transcode OperationDefs
 // that previously went through the legacy BridgeQueue.
@@ -31,6 +31,21 @@ import (
 type libraryScanParams struct {
 	FolderPath  *string `json:"folder_path,omitempty"`
 	ForceUpdate *bool   `json:"force_update,omitempty"`
+
+	// ResumeFolderIdx / ResumeItemOffset are written by the scan's own
+	// Checkpoint calls and merged back into params by resumeRestart() before
+	// Run is re-invoked. They are not part of the public trigger payload — a
+	// caller may set them, but normally they arrive only from a checkpoint.
+	ResumeFolderIdx  int `json:"resume_folder_idx,omitempty"`
+	ResumeItemOffset int `json:"resume_item_offset,omitempty"`
+}
+
+// libraryScanCheckpoint is the state blob persisted mid-scan. Its JSON field
+// names must match libraryScanParams exactly: resumeRestart() merges the blob
+// into the params object, so a mismatch silently resumes from zero.
+type libraryScanCheckpoint struct {
+	ResumeFolderIdx  int `json:"resume_folder_idx"`
+	ResumeItemOffset int `json:"resume_item_offset"`
 }
 
 type libraryOrganizeParams struct {
@@ -73,13 +88,21 @@ func (s *Server) RegisterLibraryScanOp(reg *opsregistry.Registry) error {
 		// to 2026-08-16 ended that way, and not one library.scan has ever reached
 		// `completed`. They were not crashing; they were being discarded by policy.
 		//
-		// ⚠️ THIS RE-RUNS THE SCAN FROM THE START, IT DOES NOT CONTINUE MID-SCAN.
-		// resumeRestart() merges a saved checkpoint blob into params, but
-		// libraryScanParams has no checkpoint fields and nothing in the scan path
-		// calls Checkpoint(), so there is no state to merge. Re-queueing is still
-		// strictly better than dropping — a scan is incremental and skips what is
-		// already ingested — but real mid-scan resume needs the params struct to
-		// carry a phase + high-water mark first. Tracked in todo.d.
+		// This now genuinely continues mid-scan. resumeRestart() merges the saved
+		// checkpoint blob into params; libraryScanParams carries matching
+		// resume_folder_idx / resume_item_offset fields, and the scan path calls
+		// Checkpoint() after every completed chunk of books and every completed
+		// folder.
+		//
+		// Until 2026-08-17 this comment read "⚠️ THIS RE-RUNS THE SCAN FROM THE
+		// START" — accurate at the time, because nothing in the scan path called
+		// Checkpoint() and there was no state to merge. A 3h50m production scan
+		// that day made the cost concrete.
+		//
+		// Resume granularity is one chunk (scanChunkSize books), NOT one book:
+		// a restart repeats at most the chunk that was in flight. Per-folder
+		// granularity would have been useless here — one production folder holds
+		// ~14,000 items, so a whole folder is hours of work on its own.
 		ResumePolicy:   opsregistry.ResumeRestart,
 		ConcurrencyKey: "library.scan",
 		Permissions:    []auth.Permission{auth.PermScanTrigger},
@@ -106,9 +129,26 @@ func (s *Server) RegisterLibraryScanOp(reg *opsregistry.Registry) error {
 			}
 			logging.Info(ctx, "library scan starting", "folder_path", folderPath)
 
+			if p.ResumeFolderIdx > 0 || p.ResumeItemOffset > 0 {
+				logging.Info(ctx, "library scan resuming from checkpoint",
+					"folder_idx", p.ResumeFolderIdx, "item_offset", p.ResumeItemOffset)
+			}
+
 			scanReq := &scanner.ScanRequest{
-				FolderPath:  p.FolderPath,
-				ForceUpdate: p.ForceUpdate,
+				FolderPath:       p.FolderPath,
+				ForceUpdate:      p.ForceUpdate,
+				ResumeFolderIdx:  p.ResumeFolderIdx,
+				ResumeItemOffset: p.ResumeItemOffset,
+				Checkpoint: func(folderIdx, itemOffset int) {
+					// Errors are deliberately swallowed: a checkpoint is an
+					// optimisation for the NEXT run, and failing the scan
+					// because we could not record where it got to would trade a
+					// working scan for a lost one.
+					_ = reporter.Checkpoint(libraryScanCheckpoint{
+						ResumeFolderIdx:  folderIdx,
+						ResumeItemOffset: itemOffset,
+					})
+				},
 			}
 			progress := registryProgressAdapter{r: reporter}
 			err := s.scanService.PerformScan(ctx, scanReq, operations.LoggerFromReporter(progress))

--- a/todo.d/20260816-library-scan-real-checkpoint-resume.md
+++ b/todo.d/20260816-library-scan-real-checkpoint-resume.md
@@ -1,16 +1,16 @@
-- [ ] **`library.scan` "resume" currently means "start over".** `ResumePolicy` moved
-      from `ResumeDrop` to `ResumeRestart` on 2026-08-16, which stops a restart from
-      silently discarding the scan — but it re-runs from the beginning.
-      `resumeRestart()` merges a saved checkpoint blob into params, and the scan has
-      nothing to merge: `libraryScanParams` carries only `folder_path` and
-      `force_update`, and nothing in the scan path calls `Checkpoint()`. For a
-      ~5-hour full scan that is a lot of re-walking. Give the params struct a phase
-      + high-water mark and checkpoint per batch, so a restart continues instead of
-      restarting. The v2 machinery (`GetOpStateV2`, `HighWaterProgress`,
-      `LastCheckpointAt`) is already there and unused by this op.
-
 - [ ] **`library.import`, `library.organize` and `library.transcode` still carry the
       4h ceiling and `ResumeDrop`.** Only `library.scan` was changed, deliberately —
       it is the one measured to exceed 4h. Check whether the others can also exceed
       their ceiling on a 63k-book library before assuming they are fine; `organize`
       in particular touches every book.
+
+- [ ] **Convert the remaining long-running `ResumeDrop` ops to real resume.** The
+      mechanism now exists: `registry.RunItems` gained `ResumeFrom`,
+      `CheckpointEvery` and `CheckpointStateFn` (concurrent-safe via a
+      contiguous-completion watermark), and 51 call sites route through it. As of
+      2026-08-17 the live registry reports 140 defs: 100 `drop`, 19 `restart`, 19
+      `requeue`, 2 `ask`. Work through the `drop` list and convert the ones that are
+      both long-running and idempotent per item — `metadata.batch-apply-cached`,
+      `reconcile.apply` and the full-library sweeps first. Ops that are short-lived
+      or unsafe to re-enter should STAY `drop` and get a comment saying why; an
+      honest drop is better than a resume that does not work.


### PR DESCRIPTION
Two commits: the mechanism, then the first and most expensive consumer.

## Why

Measured on the live registry, 2026-08-17:

| | |
|---|---|
| Op definitions | 140 |
| `ResumePolicy = drop` | **100** |
| `restart` / `requeue` / `ask` | 19 / 19 / 2 |
| Files anywhere that call `Checkpoint()` | **6** |
| Call sites routed through `RunItems` | **51** |

`restart` was weaker than it sounds — it re-dispatches *with saved state*, and almost nothing saved any. `library_core_ops.go` said so in capitals: `⚠️ THIS RE-RUNS THE SCAN FROM THE START, IT DOES NOT CONTINUE MID-SCAN.` A production scan that day ran **3h50m+** over 63,044 books; a restart discarded all of it.

## Root cause

`RunItems` already had `CheckpointFn` and `ProgressOffset`, but `run_items.go:54` refused to checkpoint in concurrent mode — "parallel writes to reporter.Checkpoint would race on the shared state blob". CLAUDE.md **mandates** a worker pool for whole-library loops, so every op that matters ran concurrent and could not checkpoint. That one hole is why `drop` was the honest policy for 100 defs.

## Commit 1 — `RunItems` resume (`60c913a6`)

Contiguous-completion **watermark**. A completion *count* is not a resume point under out-of-order completion: items `{0,1,2,5}` finished is "4 completed", and resuming at index 4 silently skips 3 and 4. The tracker records which indices finished and reports only the unbroken prefix from zero — correct regardless of completion order. Items above the watermark re-run, which is free given per-item idempotence.

A **failed item never advances the watermark**, so a resume retries it instead of stepping over it.

`ResumeFrom` slices the completed prefix and shifts `ProgressOffset` while pinning `ProgressTotal` to the original length, so a resumed op reports `4200/14000` rather than restarting its denominator.

Zero values reproduce previous behaviour exactly.

## Commit 2 — `library.scan` mid-scan resume (`d64de1b9`)

Checkpoints `resume_folder_idx` / `resume_item_offset` after every completed chunk and every completed folder.

**Per-chunk, not per-folder** — you flagged this directly: one folder holds ~14,000 items, so both the tag pass and the metadata pass run for hours *inside* a single folder, and "folder 3 of 5" would still throw away most of a day.

Books are **sorted by `FilePath` before chunking**, and that sort is load-bearing: `ScanDirectoryParallel` returns worker-completion order, which varies per run, so resuming at offset 4200 against a differently-ordered slice would skip an arbitrary 4200 and re-run others.

Also corrects the stale `R-7` comment that asserted there was intentionally no resume plumbing and cited a policy changed in #2500.

## Verification

`go build ./...` clean; both packages vet clean; scanner + registry tests green under `-race`.

**Six mutation tests, all caught** — each guarantee was deliberately reverted and the intended test failed:

| mutation | caught by |
|---|---|
| checkpoint failed items too | `Watermark_FailedItemDoesNotAdvance` (reached 6, item 3 failed) |
| watermark → plain count | `Watermark_StopsAtAGap` (claimed 3 mid-gap) |
| drop the `ProgressOffset` shift | `ResumeFrom_KeepsAbsoluteProgress` (40 vs 100) |
| checkpoint a failed chunk | `FailedChunkIsNotCheckpointed` (`[500 1000]`) |
| checkpoint relative offset | `CheckpointsAbsoluteOffsets` (`[500 500 37]`) |
| ignore the resume offset | `ResumeSkipsPrefix` (2000 vs 1000) |

## Scope

This is the mechanism plus the worst offender. Converting the remaining `drop` ops is filed in `todo.d/` — ops that are short-lived or unsafe to re-enter should **stay** `drop` with a comment saying why, since an honest drop beats a resume that does not work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS