### PR TITLE
feat(maintenance): repair dead book_file rows without ever emptying a book

### DIFF
--- a/changelog.d/20260817_120000_feat_missing_file_repair.md
+++ b/changelog.d/20260817_120000_feat_missing_file_repair.md
@@ -1,0 +1,18 @@
+### Added
+
+- **`maintenance.missing-file-repair`** — deletes `book_file` rows whose bytes are
+  gone, so downloads stop 404ing on rows that point at nothing.
+
+  It deliberately does NOT repair everything. A row is only deleted when its book
+  keeps at least one surviving file. Measured on a 120-book sample, 5 books had
+  *every* row dead; deleting those would leave the book with no files at all,
+  turning a wrong index into a lost book. Those books are skipped and named in the
+  report for a human to look at.
+
+  A book with any path that cannot be stat'd is skipped entirely, including its
+  confirmed-missing siblings — "I could not tell" is not "it is gone", and one
+  unmounted share must not present a whole tree as deletable.
+
+  **Dry run by default.** `{"apply": true}` is required to delete anything, and
+  `max_deletes` caps the blast radius of a single run. Every deleted path is
+  logged before the delete so the change is reconstructible from the operation log.

--- a/internal/plugins/maintenance/missing_file_repair.go
+++ b/internal/plugins/maintenance/missing_file_repair.go
@@ -1,0 +1,309 @@
+// file: internal/plugins/maintenance/missing_file_repair.go
+// version: 1.0.0
+// guid: 50b5022c-9d86-467d-991e-2be9cddf4847
+// last-edited: 2026-08-17
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// missingFileRepairDeleteBatch bounds one DeleteBookFilesByIDs call. The store
+// doc records that per-row DeleteBookFile pays a fixed cost of ~1.35s/row, so
+// batching is not a micro-optimisation here — at 552 rows the difference is
+// twelve minutes versus a moment.
+const missingFileRepairDeleteBatch = 200
+
+// missingFileRepairSampleLimit bounds how many example paths and book IDs are
+// carried in the report.
+const missingFileRepairSampleLimit = 60
+
+// missingFileRepairParams are the JSON parameters accepted by the op.
+type missingFileRepairParams struct {
+	// Apply must be set explicitly to delete anything. The zero value is a DRY
+	// RUN, so triggering this op with no params reports what it would do and
+	// changes nothing. Defaulting the destructive direction to "off" is the
+	// point: the safe outcome must be what you get by forgetting a flag.
+	Apply bool `json:"apply"`
+
+	// PathPrefix restricts the sweep to rows whose FilePath begins with it.
+	PathPrefix string `json:"path_prefix"`
+
+	// MaxDeletes caps how many rows a single run may delete. 0 uses the default
+	// below. It exists so a mistaken PathPrefix, or a mount that vanished
+	// between the audit and this run, cannot delete the library in one pass.
+	MaxDeletes int `json:"max_deletes"`
+}
+
+// missingFileRepairDefaultMax is the ceiling applied when MaxDeletes is unset.
+// The 2026-08-17 sample projected ~552 dead rows per 120 books; this is
+// deliberately generous enough for a real repair and far below "everything".
+const missingFileRepairDefaultMax = 20000
+
+// repairPlan is what the sweep decides BEFORE anything is deleted. It is
+// computed identically in dry-run and apply mode — apply simply also executes
+// it — so what you review is exactly what runs.
+type repairPlan struct {
+	BooksExamined          int
+	BooksRepairable        int // ≥1 dead row AND ≥1 surviving row → safe to prune
+	BooksFullyBroken       int // every row dead → SKIPPED, never touched
+	BooksSkippedUnreadable int // ≥1 row we could not stat → SKIPPED
+	BooksIntact            int
+
+	RowsToDelete []string // book_file IDs, only from repairable books
+	SamplePaths  []string
+	FullyBroken  []string // book IDs, for you to look at by hand
+	Unreadable   []string // paths that could not be stat'd
+
+	CappedAt int // >0 when MaxDeletes truncated the plan
+}
+
+func (p repairPlan) summary() string {
+	return fmt.Sprintf(
+		"books=%d repairable=%d fully-broken(skipped)=%d unreadable(skipped)=%d intact=%d rows_to_delete=%d",
+		p.BooksExamined, p.BooksRepairable, p.BooksFullyBroken,
+		p.BooksSkippedUnreadable, p.BooksIntact, len(p.RowsToDelete))
+}
+
+func (p *Plugin) missingFileRepairDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "maintenance.missing-file-repair",
+		Liveness:    sdk.LivenessRunItems,
+		Plugin:      "maintenance",
+		DisplayName: "Missing file repair",
+		Description: "Deletes book_file rows whose bytes are gone, but ONLY for books that still " +
+			"have at least one surviving file. Books whose every row is dead are skipped and " +
+			"reported, never emptied — deleting their rows would turn a wrong index into a lost " +
+			"book. Books with any un-stat-able path are skipped too. DRY RUN by default: pass " +
+			"{\"apply\": true} to actually delete.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.missing-file-repair",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runMissingFileRepair,
+	}
+}
+
+func (p *Plugin) runMissingFileRepair(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	var params missingFileRepairParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+
+	plan, err := planMissingFileRepair(ctx, store, params, reporter)
+	if err != nil {
+		return err
+	}
+
+	log := reporter.Logger()
+	mode := "DRY RUN"
+	if params.Apply {
+		mode = "APPLY"
+	}
+	log.Info("missing-file-repair plan", "mode", mode, "summary", plan.summary(),
+		"sample_paths", plan.SamplePaths)
+	if len(plan.FullyBroken) > 0 {
+		log.Warn("missing-file-repair: books with NO surviving file were skipped — "+
+			"these need a human decision, not an automatic delete",
+			"count", plan.BooksFullyBroken, "book_ids", plan.FullyBroken)
+	}
+	if len(plan.Unreadable) > 0 {
+		log.Warn("missing-file-repair: paths could not be stat'd; their books were skipped entirely",
+			"count", len(plan.Unreadable), "sample", plan.Unreadable)
+	}
+	if plan.CappedAt > 0 {
+		log.Warn("missing-file-repair: plan truncated by max_deletes",
+			"cap", plan.CappedAt, "run_again_to_continue", true)
+	}
+
+	if !params.Apply {
+		log.Info("missing-file-repair: DRY RUN complete — nothing was deleted. "+
+			"Re-run with {\"apply\": true} to execute this exact plan.",
+			"rows_that_would_be_deleted", len(plan.RowsToDelete))
+		return nil
+	}
+
+	deleted, err := applyMissingFileRepair(ctx, store, plan, reporter)
+	log.Info("missing-file-repair complete", "mode", mode, "rows_deleted", deleted,
+		"books_skipped_fully_broken", plan.BooksFullyBroken)
+	return err
+}
+
+// planMissingFileRepair stats every candidate row and decides, per BOOK, what is
+// safe to prune. Returned as a value so the decisions can be asserted directly in
+// tests rather than inferred from side effects.
+func planMissingFileRepair(ctx context.Context, store database.Store, params missingFileRepairParams, reporter sdk.Reporter) (repairPlan, error) {
+	log := reporter.Logger()
+	maxDeletes := params.MaxDeletes
+	if maxDeletes <= 0 {
+		maxDeletes = missingFileRepairDefaultMax
+	}
+	log.Info("missing-file-repair start", "apply", params.Apply,
+		"path_prefix", params.PathPrefix, "max_deletes", maxDeletes)
+
+	files, err := store.GetAllBookFilesCore()
+	if err != nil {
+		return repairPlan{}, fmt.Errorf("load book files: %w", err)
+	}
+
+	items := make([]missingFileItem, 0, len(files))
+	for i := range files {
+		path := strings.TrimSpace(files[i].FilePath)
+		if path == "" {
+			continue
+		}
+		if params.PathPrefix != "" && !strings.HasPrefix(path, params.PathPrefix) {
+			continue
+		}
+		items = append(items, missingFileItem{idx: len(items), file: files[i]})
+	}
+
+	results := make([]fileExistence, len(items))
+	var missing, present, unreadable atomic.Int64
+
+	prog := sdk.NewProgress(reporter, len(items))
+	prog.Start(fmt.Sprintf("Checking %d book_file path(s)…", len(items)))
+
+	err = registry.RunItems(ctx, reporter, items, func(_ context.Context, it missingFileItem) error {
+		switch _, serr := os.Stat(it.file.FilePath); {
+		case serr == nil:
+			results[it.idx] = filePresent
+			present.Add(1)
+		case os.IsNotExist(serr):
+			results[it.idx] = fileMissing
+			missing.Add(1)
+		default:
+			results[it.idx] = fileUnreadable
+			unreadable.Add(1)
+		}
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: missingFileStatConcurrency,
+		ErrMode:     registry.ErrModeCollect,
+		Label: func(i, t int) string {
+			return fmt.Sprintf("Checked %d/%d paths (missing=%d)", i+1, t, missing.Load())
+		},
+	})
+	if err != nil {
+		return repairPlan{}, fmt.Errorf("stat sweep: %w", err)
+	}
+
+	// Group by book. The safety decision is per BOOK, not per row: whether a
+	// dead row may be deleted depends entirely on whether its book keeps
+	// something else.
+	type bookState struct {
+		deadIDs    []string
+		deadPaths  []string
+		present    int
+		unreadable int
+	}
+	books := map[string]*bookState{}
+	order := make([]string, 0, len(items))
+	for i, it := range items {
+		st := books[it.file.BookID]
+		if st == nil {
+			st = &bookState{}
+			books[it.file.BookID] = st
+			order = append(order, it.file.BookID)
+		}
+		switch results[i] {
+		case filePresent:
+			st.present++
+		case fileMissing:
+			st.deadIDs = append(st.deadIDs, it.file.ID)
+			st.deadPaths = append(st.deadPaths, it.file.FilePath)
+		case fileUnreadable:
+			st.unreadable++
+		}
+	}
+
+	plan := repairPlan{BooksExamined: len(books)}
+	for _, id := range order {
+		st := books[id]
+		switch {
+		case st.unreadable > 0:
+			// "I could not tell" is not "it is gone". One unmounted share would
+			// otherwise present an entire tree as deletable.
+			plan.BooksSkippedUnreadable++
+		case len(st.deadIDs) == 0:
+			plan.BooksIntact++
+		case st.present == 0:
+			// Every row dead. Deleting them all leaves a book with no files at
+			// all — a wrong index becomes a lost book. Skipped by design.
+			plan.BooksFullyBroken++
+			if len(plan.FullyBroken) < missingFileRepairSampleLimit {
+				plan.FullyBroken = append(plan.FullyBroken, id)
+			}
+		default:
+			plan.BooksRepairable++
+			for i, rowID := range st.deadIDs {
+				if len(plan.RowsToDelete) >= maxDeletes {
+					plan.CappedAt = maxDeletes
+					break
+				}
+				plan.RowsToDelete = append(plan.RowsToDelete, rowID)
+				if len(plan.SamplePaths) < missingFileRepairSampleLimit {
+					plan.SamplePaths = append(plan.SamplePaths, st.deadPaths[i])
+				}
+			}
+		}
+	}
+
+	// Collect a sample of unreadable paths for the report.
+	for i, it := range items {
+		if results[i] == fileUnreadable && len(plan.Unreadable) < missingFileRepairSampleLimit {
+			plan.Unreadable = append(plan.Unreadable, it.file.FilePath)
+		}
+	}
+	sort.Strings(plan.FullyBroken)
+
+	return plan, nil
+}
+
+// applyMissingFileRepair executes a plan. Every deleted path is logged before the
+// delete, so the change is reconstructible from the operation log rather than
+// merely gone.
+func applyMissingFileRepair(ctx context.Context, store database.Store, plan repairPlan, reporter sdk.Reporter) (int, error) {
+	log := reporter.Logger()
+	deleted := 0
+	for off := 0; off < len(plan.RowsToDelete); off += missingFileRepairDeleteBatch {
+		if err := ctx.Err(); err != nil {
+			return deleted, err
+		}
+		end := off + missingFileRepairDeleteBatch
+		if end > len(plan.RowsToDelete) {
+			end = len(plan.RowsToDelete)
+		}
+		batch := plan.RowsToDelete[off:end]
+		log.Info("missing-file-repair: deleting batch", "from", off, "to", end, "ids", batch)
+		if err := store.DeleteBookFilesByIDs(batch); err != nil {
+			return deleted, fmt.Errorf("delete rows [%d:%d]: %w", off, end, err)
+		}
+		deleted += len(batch)
+		_ = reporter.UpdateProgress(deleted, len(plan.RowsToDelete),
+			fmt.Sprintf("Deleted %d/%d dead rows", deleted, len(plan.RowsToDelete)))
+	}
+	return deleted, nil
+}

--- a/internal/plugins/maintenance/missing_file_repair_test.go
+++ b/internal/plugins/maintenance/missing_file_repair_test.go
@@ -1,0 +1,196 @@
+// file: internal/plugins/maintenance/missing_file_repair_test.go
+// version: 1.0.0
+// guid: c47f0a91-5e6b-4d28-93af-2b8054e17c6d
+// last-edited: 2026-08-17
+
+package maintenance
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// repairFixture reuses the audit fixture's shape — real files on disk, real
+// absent paths beside them — and adds a row that cannot be stat'd at all.
+//
+// The NUL byte is rejected by Go before it reaches the syscall, so it produces
+// an error that is neither nil nor IsNotExist on every platform. That is the
+// "I could not tell" case, and it is the one that must never license a delete.
+func repairFixture(t *testing.T) []database.BookFileCore {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write fixture %s: %v", name, err)
+		}
+		return p
+	}
+	return []database.BookFileCore{
+		// intact — nothing to do.
+		{ID: "f1", BookID: "intact", FilePath: write("intact-1.m4b")},
+		// partial — the live shape. f2 is a phantom row; f3 survives.
+		{ID: "f2", BookID: "partial", FilePath: filepath.Join(dir, "gone.m4b")},
+		{ID: "f3", BookID: "partial", FilePath: write("partial-real.m4b")},
+		// allgone — every row dead. MUST NOT be touched.
+		{ID: "f4", BookID: "allgone", FilePath: filepath.Join(dir, "vanished-1.m4b")},
+		{ID: "f5", BookID: "allgone", FilePath: filepath.Join(dir, "vanished-2.m4b")},
+		// unsure — one dead row, one un-stat-able row. MUST NOT be touched.
+		{ID: "f6", BookID: "unsure", FilePath: filepath.Join(dir, "missing.m4b")},
+		{ID: "f7", BookID: "unsure", FilePath: filepath.Join(dir, "cannot\x00stat.m4b")},
+	}
+}
+
+func planRepair(t *testing.T, rows []database.BookFileCore, params missingFileRepairParams) repairPlan {
+	t.Helper()
+	store := &database.MockStore{
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return rows, nil },
+	}
+	plan, err := planMissingFileRepair(context.Background(), store, params, &fakeReporter{})
+	if err != nil {
+		t.Fatalf("planMissingFileRepair: %v", err)
+	}
+	return plan
+}
+
+// TestMissingFileRepair_DeletesOnlyFromBooksThatKeepAFile is the whole contract.
+func TestMissingFileRepair_DeletesOnlyFromBooksThatKeepAFile(t *testing.T) {
+	plan := planRepair(t, repairFixture(t), missingFileRepairParams{})
+
+	got := append([]string(nil), plan.RowsToDelete...)
+	sort.Strings(got)
+	if len(got) != 1 || got[0] != "f2" {
+		t.Fatalf("only f2 (dead row in a book that keeps f3) may be deleted; got %v", got)
+	}
+
+	for _, c := range []struct {
+		name      string
+		got, want int
+	}{
+		{"BooksExamined", plan.BooksExamined, 4},
+		{"BooksRepairable", plan.BooksRepairable, 1},
+		{"BooksFullyBroken", plan.BooksFullyBroken, 1},
+		{"BooksSkippedUnreadable", plan.BooksSkippedUnreadable, 1},
+		{"BooksIntact", plan.BooksIntact, 1},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s = %d, want %d", c.name, c.got, c.want)
+		}
+	}
+}
+
+// TestMissingFileRepair_NeverEmptiesABook is the property that made this a
+// decision rather than a cleanup: deleting every row of a book whose files are
+// all gone turns a wrong index into a book with nothing at all.
+func TestMissingFileRepair_NeverEmptiesABook(t *testing.T) {
+	plan := planRepair(t, repairFixture(t), missingFileRepairParams{})
+	for _, id := range plan.RowsToDelete {
+		if id == "f4" || id == "f5" {
+			t.Fatalf("row %s belongs to a book with NO surviving file and must never be deleted; plan=%v",
+				id, plan.RowsToDelete)
+		}
+	}
+	if plan.BooksFullyBroken != 1 {
+		t.Fatalf("the fully-broken book must be counted for review, got %d", plan.BooksFullyBroken)
+	}
+	if len(plan.FullyBroken) != 1 || plan.FullyBroken[0] != "allgone" {
+		t.Fatalf("the fully-broken book must be NAMED so it can be looked at by hand, got %v", plan.FullyBroken)
+	}
+}
+
+// TestMissingFileRepair_UnreadableBlocksTheWholeBook covers the unmounted-share
+// scenario: a path we could not stat must not be read as "the file is gone", and
+// must protect its siblings too.
+func TestMissingFileRepair_UnreadableBlocksTheWholeBook(t *testing.T) {
+	plan := planRepair(t, repairFixture(t), missingFileRepairParams{})
+	for _, id := range plan.RowsToDelete {
+		if id == "f6" {
+			t.Fatal("f6 is a confirmed-missing row, but its book also has an un-stat-able path; " +
+				"the book must be skipped entirely rather than partially pruned")
+		}
+	}
+	if plan.BooksSkippedUnreadable != 1 {
+		t.Fatalf("expected 1 book skipped for unreadability, got %d", plan.BooksSkippedUnreadable)
+	}
+}
+
+// TestMissingFileRepair_MaxDeletesCaps verifies the blast-radius limit truncates
+// and says so, rather than silently doing less than it reports.
+func TestMissingFileRepair_MaxDeletesCaps(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "live.m4b")
+	if err := os.WriteFile(live, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	rows := []database.BookFileCore{{ID: "keep", BookID: "b", FilePath: live}}
+	for i := 0; i < 10; i++ {
+		rows = append(rows, database.BookFileCore{
+			ID:       filepath.Join("dead", string(rune('a'+i))),
+			BookID:   "b",
+			FilePath: filepath.Join(dir, "gone-"+string(rune('a'+i))+".m4b"),
+		})
+	}
+
+	plan := planRepair(t, rows, missingFileRepairParams{MaxDeletes: 4})
+	if len(plan.RowsToDelete) != 4 {
+		t.Fatalf("MaxDeletes=4 should cap the plan at 4 rows, got %d", len(plan.RowsToDelete))
+	}
+	if plan.CappedAt != 4 {
+		t.Fatalf("a truncated plan must report CappedAt so the run is known to be partial, got %d", plan.CappedAt)
+	}
+}
+
+// TestMissingFileRepair_ApplyIsOptIn pins that the destructive direction is what
+// you have to ask for, not what you get by forgetting a flag.
+func TestMissingFileRepair_ApplyIsOptIn(t *testing.T) {
+	var p missingFileRepairParams
+	if p.Apply {
+		t.Fatal("the zero value of missingFileRepairParams must be a DRY RUN")
+	}
+}
+
+// TestMissingFileRepair_ApplyDeletesExactlyThePlan checks the apply step executes
+// the reviewed plan and nothing beyond it.
+func TestMissingFileRepair_ApplyDeletesExactlyThePlan(t *testing.T) {
+	var deleted []string
+	store := &database.MockStore{
+		DeleteBookFilesByIDsFunc: func(ids []string) error {
+			deleted = append(deleted, ids...)
+			return nil
+		},
+	}
+	plan := repairPlan{RowsToDelete: []string{"a", "b", "c"}}
+
+	n, err := applyMissingFileRepair(context.Background(), store, plan, &fakeReporter{})
+	if err != nil {
+		t.Fatalf("applyMissingFileRepair: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("expected 3 rows deleted, got %d", n)
+	}
+	sort.Strings(deleted)
+	if len(deleted) != 3 || deleted[0] != "a" || deleted[1] != "b" || deleted[2] != "c" {
+		t.Fatalf("apply must delete exactly the planned IDs, got %v", deleted)
+	}
+}
+
+// TestMissingFileRepair_ApplyDeletesNothingForAnEmptyPlan guards the case where
+// the sweep finds nothing safe to do.
+func TestMissingFileRepair_ApplyDeletesNothingForAnEmptyPlan(t *testing.T) {
+	called := false
+	store := &database.MockStore{
+		DeleteBookFilesByIDsFunc: func(_ []string) error { called = true; return nil },
+	}
+	n, err := applyMissingFileRepair(context.Background(), store, repairPlan{}, &fakeReporter{})
+	if err != nil {
+		t.Fatalf("applyMissingFileRepair: %v", err)
+	}
+	if n != 0 || called {
+		t.Fatalf("an empty plan must issue no deletes at all (n=%d, called=%v)", n, called)
+	}
+}

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/plugin.go
-// version: 1.19.0
+// version: 1.20.0
 // guid: b2c3d4e5-f6a7-8901-bcde-123456789012
-// last-edited: 2026-08-14
+// last-edited: 2026-08-17
 
 package maintenance
 
@@ -60,6 +60,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.authorConjunctionRepairDef(),
 		p.purgeEmptyAuthorsDef(),
 		p.missingFileAuditDef(),
+		p.missingFileRepairDef(),
 		p.seriesNormalizeDef(),
 		p.seriesPruneDef(),
 		p.resolveProductionAuthorsDef(),

--- a/todo.d/20260817-decide-missing-book-file-row-repair.md
+++ b/todo.d/20260817-decide-missing-book-file-row-repair.md
@@ -1,17 +1,19 @@
-- [ ] **Decide the repair for `book_file` rows whose bytes are gone.** `maintenance.missing-file-audit`
-      now measures them (41.8% of rows in a 120-book sample; every one under the organizer's own
-      destination tree, none under the iTunes tree). Two candidate repairs, which differ in kind:
-      delete the phantom row, or re-point it at the surviving file. Deleting is **not** uniformly
-      safe — books whose every row is missing would be left with no files at all, so those need a
-      separate decision. Run the audit library-wide first, then choose. Also worth answering: why
-      the organizer recorded destination rows it never populated (suspect the library-wide move
-      in #2479).
+- [ ] **Decide what to do with the books whose EVERY `book_file` row is dead.** The
+      general repair is decided and built (`maintenance.missing-file-repair`, option
+      "delete only where the book keeps a surviving file"), but it deliberately
+      skips books with no surviving file — 5 of 120 in the sample. Deleting their
+      rows would leave the book with nothing at all. Options: locate the audio by
+      filename/size/hash and re-point the row, mark the book as missing rather than
+      deleting, or leave it. The repair op names these books in its report, so run
+      the audit + a dry run first and decide against the real list.
+
+- [ ] **Answer why the organizer recorded destination rows it never populated.**
+      Every dead path is under the organizer's own destination tree and none under
+      the iTunes tree, which points at the library-wide move in #2479. The repair
+      cleans up the symptom; this is the cause, and without it the rows come back.
+
 - [ ] **Register `HEAD` for the audio/file routes.** The server registers no `HEAD` handler
       anywhere, so `HEAD /api/items/:id/file/:ino/download` 404s on a file that exists. Upstream
       Audiobookshelf runs on Express, which auto-answers `HEAD` for a `GET` route; gin does not.
       Not currently causing failures — the production journal shows real clients only send `GET` —
       but any client that preflights with `HEAD` would see "file not found".
-- [ ] **Differentiate the five `"file not found"` returns** in `internal/server/handlers/abs/stream.go`
-      (lines 53/78/95/145/159). They mean ino-absent, no syncfile for this book, no `book_file` for
-      the syncfile's `CurrentFileID`, `filepath.Abs` failed, and bytes-missing — and none of them
-      logs, so every one presents identically and the next report is undiagnosable.


### PR DESCRIPTION
The action half of the missing-file audit (#2515). Option A from the decision: delete only where it is safe, report the rest.

## What it does

41.8% of `book_file` rows in a 120-book production sample point at bytes that are not on disk — that is why downloads answer "file not found". This deletes those rows, **but only from books that keep at least one surviving file**.

That is the common shape: a phantom row at the organizer's destination sitting beside a real, playable file still in the iTunes tree. Removing the phantom costs nothing.

## What it refuses to do

**Books whose every row is dead are skipped and named** — 5 of 120 in the sample. Deleting their rows would leave the book with no files at all, converting a wrong index into a lost book. That is a decision for a person, not an unattended sweep.

**A book with any un-stat-able path is skipped entirely**, including rows under it that were confirmed missing. "I could not tell" is not "it is gone" — without that rule a single unmounted share would present a whole tree as deletable.

## Safety design

- **Dry run is the zero value.** `{"apply": true}` is required to delete. Forgetting the flag yields the safe outcome.
- `max_deletes` bounds one run, and the plan reports `CappedAt` when truncated rather than silently doing less than it claims.
- Every deleted path is logged **before** the delete, so the change is reconstructible from the operation log.
- The plan is computed identically in dry-run and apply mode — apply just also executes it — so what you review is exactly what runs.
- Deletes batch through `DeleteBookFilesByIDs` (200/batch); per-row `DeleteBookFile` costs ~1.35s/row per its own store doc, which at 552 rows is twelve minutes versus a moment.

## Verification

`go build ./...` and `go vet` clean; tests green. The fixture builds **real** files and real absent paths in a tmpdir, because `os.Stat` is the entire product of this op — a faked filesystem would pass just as happily with the stat inverted.

**Three mutation tests, all caught:**

| mutation | caught by | evidence |
|---|---|---|
| allow emptying a book | `NeverEmptiesABook` | plan became `[f2 f4 f5]` — would have emptied `allgone` |
| treat unreadable as missing | `UnreadableBlocksTheWholeBook` | 0 books skipped instead of 1 |
| ignore `max_deletes` | `MaxDeletesCaps` | 10 rows planned against a cap of 4 |

## Sequencing

Per the decision: **deploy → run the library-wide audit → review → dry run → apply.** 41.8% is extrapolated from 120 books; the true fully-broken count is what decides how much care the apply step needs. This PR ships the tool, it does not run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS