### PR TITLE
feat(maintenance): give chapters-backfill real checkpoint/resume

### DIFF
--- a/changelog.d/20260817_150000_feat_chapters_backfill_resume.md
+++ b/changelog.d/20260817_150000_feat_chapters_backfill_resume.md
@@ -1,0 +1,29 @@
+### Changed
+
+- **`maintenance.chapters-backfill` now resumes where it stopped.** It carries the
+  longest timeout in the codebase (24 hours) over a whole-library enumeration, and
+  ran under `ResumePolicy=Drop` — so a restart mid-run threw away up to a day of
+  ffprobe work and began again at book zero.
+
+  It converts because of two properties it already had: each item probes and
+  persists entirely within itself, accumulating nothing a later phase consumes,
+  and it is explicitly idempotent — a book that already has stored chapters
+  short-circuits on a single key lookup. `maintenance.duration-backfill` has
+  neither (its first phase builds an in-memory fix list for its second phase to
+  apply), so that op deliberately stays on `Drop`.
+
+  Three details that are easy to get wrong, each pinned by a test that was
+  verified to fail without it:
+
+  - **The checkpoint carries every parameter, not just the position.** Checkpoint
+    state is *merged* into the resumed run's parameters, so any omitted field
+    returns as its zero value — dropping `apply` would silently downgrade a live
+    run to a dry run, and dropping `bookIds` would widen a bounded cohort run to
+    the whole library. Both failures look exactly like success.
+  - **`limit` now caps the operation, not the attempt.** A twice-restarted run
+    with `limit=100` could otherwise write 300 books while every individual
+    attempt honoured its cap.
+  - **Book IDs are sorted before the run.** A watermark counts positions, so it
+    means nothing without a stable order. Both stores enumerate in ID order
+    today, but resuming must not depend on two implementations continuing to
+    agree — that class of silent divergence is what #2399 was.

--- a/internal/plugins/maintenance/chapters_backfill.go
+++ b/internal/plugins/maintenance/chapters_backfill.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/chapters_backfill.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 5d3b7e14-9c62-4a8f-b0d7-2e6194af8c35
-// last-edited: 2026-08-13
+// last-edited: 2026-08-17
 
 // Package maintenance — op maintenance.chapters-backfill.
 //
@@ -70,6 +70,7 @@ import (
 	"log/slog"
 	"os"
 	"runtime"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -93,7 +94,34 @@ type chaptersBackfillParams struct {
 	// BookIDs restricts the run to an explicit set. Used to exercise the op
 	// against a bounded cohort before a whole-library pass.
 	BookIDs []string `json:"bookIds,omitempty"`
+
+	// ResumeFrom is the contiguous-completion watermark a previous attempt
+	// reached: every item below it is provably finished. RunItems slices the
+	// work at this index. The registry merges checkpoint JSON back into params
+	// on ResumeRestart (registry/resume.go), so this arrives populated on a
+	// resumed run and is zero on a fresh one.
+	//
+	// The watermark is only meaningful against a STABLE item order, which is
+	// why runChaptersBackfill sorts the IDs. Books created or deleted between
+	// attempts still shift positions; because IDs are monotonic, creations land
+	// past the watermark and are unaffected, while a deletion below it shifts
+	// the tail left and leaves a few books unexamined until the next run. That
+	// is bounded and self-correcting, and it is the reason resuming is an
+	// optimisation here rather than a correctness mechanism.
+	ResumeFrom int `json:"resumeFrom,omitempty"`
+
+	// AlreadyPersisted carries the write count across a restart so Limit stays
+	// a cap on the WHOLE operation rather than on each attempt. Without it a
+	// twice-restarted run with limit=100 could write 300 books while every
+	// individual attempt honoured its cap.
+	AlreadyPersisted int `json:"alreadyPersisted,omitempty"`
 }
+
+// chaptersBackfillCheckpointEvery is how many completed books pass between
+// checkpoint writes. It trades checkpoint volume against how much work a
+// restart repeats: at 200 a killed run re-probes at most 200 containers, while
+// a 63,000-book library writes ~315 checkpoints rather than 63,000.
+const chaptersBackfillCheckpointEvery = 200
 
 // chapterProbeTimeout bounds one ffprobe invocation. Mirrors
 // probe_directory_books.go's probeFileTimeout: ffprobe reads only the container
@@ -146,7 +174,7 @@ type chapterPersister interface {
 func (p *Plugin) chaptersBackfillDef() sdk.OperationDef {
 	return sdk.OperationDef{
 		ID:          "maintenance.chapters-backfill",
-		Liveness: sdk.LivenessRunItems,
+		Liveness:    sdk.LivenessRunItems,
 		Plugin:      "maintenance",
 		DisplayName: "Backfill embedded chapters (single-file books)",
 		Description: "Extracts the embedded chapter timeline from single-file audiobook containers that have none " +
@@ -155,7 +183,16 @@ func (p *Plugin) chaptersBackfillDef() sdk.OperationDef {
 			"never probed. Multi-file books are skipped deliberately: their persisted form is identical to the " +
 			"live synthesis and would go stale undetectably. Refuses to run when ffprobe is unavailable. " +
 			"DRY RUN unless {\"apply\": true}.",
-		ResumePolicy:    sdk.ResumeDrop,
+		// ResumeRestart, not Drop. This op has the longest Timeout in the
+		// codebase (24h) and re-enumerates the whole library, so an interrupted
+		// run used to throw away a day of ffprobe work. Every item is
+		// self-contained — it probes and persists inside the item function and
+		// accumulates nothing that a later phase consumes — and it is
+		// explicitly idempotent, skipping any book that already has stored
+		// chapters. Those two properties are what make a watermark safe here;
+		// they are exactly what maintenance.duration-backfill lacks, which is
+		// why that op stays on Drop.
+		ResumePolicy:    sdk.ResumeRestart,
 		DefaultPriority: sdk.PriorityLow,
 		// Shares the ffprobe lane with the other whole-library probe op so the
 		// two cannot saturate every core at once.
@@ -272,6 +309,37 @@ func (p *Plugin) runChaptersBackfill(ctx context.Context, raw json.RawMessage, r
 		_ = reporter.Log(slog.LevelInfo, fmt.Sprintf("restricted to %d explicit book IDs", len(ids)))
 	}
 
+	// A resume watermark counts positions, so the positions have to mean the
+	// same thing on the next attempt. Both stores happen to enumerate in ID
+	// order today (Pebble iterates the book: keyspace, memdb the ID index), but
+	// resuming correctly must not depend on two implementations continuing to
+	// agree — that class of silent divergence is what #2399 was. Sorting here
+	// makes the ordering contract local to this file and testable without a
+	// database. It also covers the explicit-BookIDs path, where the caller's
+	// order is arbitrary; this op is order-independent, so reordering is free.
+	sort.Strings(ids)
+
+	// Clamp rather than trust. A checkpoint written before books were deleted
+	// can name a watermark past the current end; RunItems would return an empty
+	// slice and the op would report success having examined nothing.
+	resumeFrom := params.ResumeFrom
+	if resumeFrom < 0 {
+		resumeFrom = 0
+	}
+	if resumeFrom > len(ids) {
+		resumeFrom = len(ids)
+	}
+	if resumeFrom > 0 {
+		_ = reporter.Log(slog.LevelInfo, fmt.Sprintf(
+			"resuming at book %d/%d (%d already persisted by earlier attempts)",
+			resumeFrom, len(ids), params.AlreadyPersisted))
+	}
+
+	// Writes completed by earlier attempts. Kept separate from c.persisted so
+	// the end-of-run summary still reports what THIS attempt did, while Limit
+	// is enforced against the operation's lifetime total.
+	priorPersisted := int64(params.AlreadyPersisted)
+
 	var c chaptersBackfillCounters
 
 	// CONCURRENCY (CLAUDE.md mandate): a whole-library loop doing one subprocess
@@ -355,7 +423,7 @@ func (p *Plugin) runChaptersBackfill(ctx context.Context, raw json.RawMessage, r
 			c.wouldPersist.Add(1)
 			return nil
 		}
-		if params.Limit > 0 && c.persisted.Load() >= int64(params.Limit) {
+		if params.Limit > 0 && priorPersisted+c.persisted.Load() >= int64(params.Limit) {
 			c.wouldPersist.Add(1)
 			return nil
 		}
@@ -377,6 +445,26 @@ func (p *Plugin) runChaptersBackfill(ctx context.Context, raw json.RawMessage, r
 		Concurrency:   runtime.NumCPU(),
 		ProgressTotal: len(ids),
 		ErrMode:       registry.ErrModeCollect,
+		ResumeFrom:    resumeFrom,
+		// Throttle: one checkpoint per 200 completed books. The watermark is a
+		// contiguous prefix, so a restart re-probes at most 200 books — cheap,
+		// since a re-probe is a container-header read and books that already
+		// have chapters short-circuit on a single Pebble get.
+		CheckpointEvery: chaptersBackfillCheckpointEvery,
+		// Every field is carried, not just the watermark. Checkpoint JSON is
+		// MERGED into the resumed run's params, so anything omitted here comes
+		// back as its zero value: dropping Apply would silently downgrade a
+		// live run to a dry run on restart, and dropping BookIDs would widen a
+		// cohort run to the whole library.
+		CheckpointStateFn: func(ctx context.Context, watermark int) error {
+			return reporter.Checkpoint(chaptersBackfillParams{
+				Apply:            params.Apply,
+				Limit:            params.Limit,
+				BookIDs:          params.BookIDs,
+				ResumeFrom:       watermark,
+				AlreadyPersisted: int(priorPersisted + c.persisted.Load()),
+			})
+		},
 		// Reports ELIGIBLE (= persisted + wouldPersist), not persisted. A dry
 		// run never increments persisted, so a label reading it sat at zero for
 		// the whole run and was indistinguishable from a run finding nothing —

--- a/internal/plugins/maintenance/chapters_backfill_test.go
+++ b/internal/plugins/maintenance/chapters_backfill_test.go
@@ -853,3 +853,65 @@ func TestChaptersBackfill_LimitCountsWritesFromEarlierAttempts(t *testing.T) {
 		}
 	}
 }
+
+// chbfReversingStore hands back ListBookIDs in DESCENDING order.
+//
+// Both production stores enumerate ascending today, so the sort in
+// runChaptersBackfill is invisible against either of them — the guarantee it
+// provides only becomes observable against a store that disagrees. This is that
+// store. It is not hypothetical: ListBooksByITunesPID diverged between the
+// Pebble and memdb paths and shipped (#2399), and a resume watermark counts
+// positions, so an order change silently redefines what "already done" means.
+type chbfReversingStore struct {
+	database.Store
+}
+
+func (d *chbfReversingStore) Unwrap() database.Store { return d.Store }
+
+func (d *chbfReversingStore) ListBookIDs() ([]string, error) {
+	ids, err := d.Store.ListBookIDs()
+	if err != nil {
+		return nil, err
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(ids)))
+	return ids, nil
+}
+
+// The watermark must mean the same books no matter what order the store
+// enumerates in.
+func TestChaptersBackfill_ResumeIsStableAgainstStoreEnumerationOrder(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	chbfStubFFprobe(t)
+	(&chbfProbeSpy{result: chbfChapters()}).install(t)
+
+	s := chbfStore(t)
+	const total, skip = 5, 2
+	ids := chbfSeedSorted(t, s, total)
+
+	raw, err := json.Marshal(chaptersBackfillParams{Apply: true, ResumeFrom: skip})
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	p := &Plugin{deps: fakeDeps{store: &chbfReversingStore{Store: s}}}
+	if err := p.runChaptersBackfill(context.Background(), raw, &chbfCheckpointSpy{}); err != nil {
+		t.Fatalf("runChaptersBackfill: %v", err)
+	}
+
+	// Same expectation as the ascending-store case: the two LOWEST ids are the
+	// completed prefix. Without the sort, a descending store makes the same
+	// watermark skip the two HIGHEST instead — the same number of books, a
+	// different set, and no error anywhere.
+	for i, id := range ids {
+		got, _ := s.GetChaptersForBook(id)
+		if i < skip && len(got) != 0 {
+			t.Fatalf("book %d got %d chapters; with a descending store the "+
+				"watermark selected a different set of books than it names", i, len(got))
+		}
+		if i >= skip && len(got) != 6 {
+			t.Fatalf("book %d got %d chapters, want 6; the watermark skipped "+
+				"books that were never processed", i, len(got))
+		}
+	}
+}

--- a/internal/plugins/maintenance/chapters_backfill_test.go
+++ b/internal/plugins/maintenance/chapters_backfill_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/chapters_backfill_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 8a41c0e6-52b7-4d93-9f18-7c3ea05b61d4
-// last-edited: 2026-08-13
+// last-edited: 2026-08-17
 
 package maintenance
 
@@ -11,7 +11,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -657,5 +659,197 @@ func TestChaptersBackfill_FallsBackWhenBookFilePathIsMissingNotOnlyEmpty(t *test
 				t.Fatalf("summary = %q, want it to contain %q", summary, want)
 			}
 		})
+	}
+}
+
+// ── case 11: resume ─────────────────────────────────────────────────────────
+//
+// maintenance.chapters-backfill carries the longest Timeout in the codebase
+// (24h) over a whole-library enumeration, so an interrupted run used to throw
+// away a day of ffprobe work under ResumePolicy=Drop. It is now ResumeRestart
+// with a contiguous-completion watermark.
+//
+// The tests below assert the two properties that make that safe — the prefix is
+// really skipped, and the checkpoint carries the WHOLE parameter set — plus the
+// two ways the watermark can be wrong: a stale index past the end, and a Limit
+// that forgets what earlier attempts already wrote.
+
+// chbfCheckpointSpy captures every checkpoint payload the op writes. The
+// embedded fakeReporter discards them, which is the behaviour every other test
+// here wants; resume is the one property that cannot be observed without them.
+type chbfCheckpointSpy struct {
+	fakeReporter
+	mu     sync.Mutex
+	states []chaptersBackfillParams
+}
+
+func (r *chbfCheckpointSpy) Checkpoint(state any) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if p, ok := state.(chaptersBackfillParams); ok {
+		r.states = append(r.states, p)
+	}
+	return nil
+}
+
+func (r *chbfCheckpointSpy) last(t *testing.T) chaptersBackfillParams {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.states) == 0 {
+		t.Fatal("no checkpoint was written; a ResumeRestart op that never " +
+			"checkpoints resumes from zero, which is the bug this replaced")
+	}
+	return r.states[len(r.states)-1]
+}
+
+func chbfRunSpying(t *testing.T, s *database.PebbleStore, params chaptersBackfillParams) *chbfCheckpointSpy {
+	t.Helper()
+	raw, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	rep := &chbfCheckpointSpy{}
+	p := &Plugin{deps: fakeDeps{store: &chbfDecorator{Store: s}}}
+	if err := p.runChaptersBackfill(context.Background(), raw, rep); err != nil {
+		t.Fatalf("runChaptersBackfill: %v", err)
+	}
+	return rep
+}
+
+// chbfSeedSorted seeds n books and returns their IDs in the SAME order the op
+// processes them, which is sorted order — not creation order.
+func chbfSeedSorted(t *testing.T, s *database.PebbleStore, n int) []string {
+	t.Helper()
+	ids := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		ids = append(ids, chbfSeedBook(t, s, fmt.Sprintf("Book %02d", i), 1))
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// ResumeFrom must skip exactly the completed prefix — no more, no less.
+//
+// Asserted by CHAPTER STATE rather than by probe count, because a probe count
+// alone passes against an op that probed everything and wrote nothing.
+func TestChaptersBackfill_ResumeFromSkipsExactlyTheCompletedPrefix(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	chbfStubFFprobe(t)
+	(&chbfProbeSpy{result: chbfChapters()}).install(t)
+
+	s := chbfStore(t)
+	const total, skip = 5, 2
+	ids := chbfSeedSorted(t, s, total)
+
+	chbfRunSpying(t, s, chaptersBackfillParams{Apply: true, ResumeFrom: skip})
+
+	for i, id := range ids {
+		got, _ := s.GetChaptersForBook(id)
+		if i < skip && len(got) != 0 {
+			t.Fatalf("book %d (below the watermark) got %d chapters; the resume "+
+				"prefix was re-processed, so resuming buys nothing", i, len(got))
+		}
+		if i >= skip && len(got) != 6 {
+			t.Fatalf("book %d (at or above the watermark) got %d chapters, want 6; "+
+				"the resume slice skipped work that was never done", i, len(got))
+		}
+	}
+}
+
+// The checkpoint must carry EVERY field, not just the watermark.
+//
+// Checkpoint JSON is merged into the resumed run's params, so any field omitted
+// here comes back as its zero value. Dropping Apply silently downgrades a live
+// run to a dry run on restart; dropping BookIDs widens a bounded cohort run to
+// the whole library. Both failures look like success.
+func TestChaptersBackfill_CheckpointCarriesEveryParamNotJustTheWatermark(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	chbfStubFFprobe(t)
+	(&chbfProbeSpy{result: chbfChapters()}).install(t)
+
+	s := chbfStore(t)
+	ids := chbfSeedSorted(t, s, 3)
+	cohort := []string{ids[0], ids[1]}
+
+	rep := chbfRunSpying(t, s, chaptersBackfillParams{
+		Apply: true, Limit: 7, BookIDs: cohort,
+	})
+	got := rep.last(t)
+
+	if !got.Apply {
+		t.Fatal("checkpoint dropped Apply: a restart would silently become a dry run")
+	}
+	if got.Limit != 7 {
+		t.Fatalf("checkpoint Limit = %d, want 7: a restart would lose the write cap", got.Limit)
+	}
+	if len(got.BookIDs) != len(cohort) {
+		t.Fatalf("checkpoint BookIDs = %v, want %v: a restart would widen a "+
+			"2-book cohort run to the whole library", got.BookIDs, cohort)
+	}
+	if got.ResumeFrom != len(cohort) {
+		t.Fatalf("checkpoint ResumeFrom = %d, want %d (all cohort items completed)",
+			got.ResumeFrom, len(cohort))
+	}
+	if got.AlreadyPersisted != len(cohort) {
+		t.Fatalf("checkpoint AlreadyPersisted = %d, want %d: without the running "+
+			"total, Limit resets to full budget on every restart",
+			got.AlreadyPersisted, len(cohort))
+	}
+}
+
+// A watermark past the end must not be trusted.
+//
+// Books deleted between attempts shorten the list, so a stored watermark can
+// exceed it. Slicing on that index panics; trusting it silently reports success
+// having examined nothing.
+func TestChaptersBackfill_ResumeFromPastTheEndIsClampedNotFatal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	chbfStubFFprobe(t)
+	spy := &chbfProbeSpy{result: chbfChapters()}
+	spy.install(t)
+
+	s := chbfStore(t)
+	chbfSeedSorted(t, s, 3)
+
+	chbfRunSpying(t, s, chaptersBackfillParams{Apply: true, ResumeFrom: 99})
+
+	if n := spy.calls.Load(); n != 0 {
+		t.Fatalf("probed %d books past an exhausted watermark, want 0", n)
+	}
+}
+
+// Limit is a cap on the OPERATION, not on each attempt.
+//
+// Asserted at the saturated boundary (AlreadyPersisted >= Limit) rather than
+// mid-budget, because the budget check reads a counter that several workers
+// evaluate concurrently: partway through, the exact number of writes that slip
+// past is racy, while "already over budget" is deterministic for every worker.
+func TestChaptersBackfill_LimitCountsWritesFromEarlierAttempts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	chbfStubFFprobe(t)
+	(&chbfProbeSpy{result: chbfChapters()}).install(t)
+
+	s := chbfStore(t)
+	ids := chbfSeedSorted(t, s, 4)
+
+	chbfRunSpying(t, s, chaptersBackfillParams{
+		Apply: true, Limit: 3, AlreadyPersisted: 3,
+	})
+
+	for i, id := range ids {
+		if got, _ := s.GetChaptersForBook(id); len(got) != 0 {
+			t.Fatalf("book %d was written with the limit already spent by earlier "+
+				"attempts (%d chapters); limit=3 became an unbounded 3-per-restart",
+				i, len(got))
+		}
 	}
 }


### PR DESCRIPTION
`maintenance.chapters-backfill` carries the longest `Timeout` in the codebase (24h) over a whole-library enumeration, and ran under `ResumePolicy=Drop` — an interrupted run threw away up to a day of ffprobe work and restarted at book zero.

## Why this op converts and `duration-backfill` does not

Two properties already present here make a watermark safe:

1. The item function **probes and persists entirely within itself** — it accumulates nothing that a later phase consumes.
2. It is **explicitly idempotent** — a book with stored chapters short-circuits on one Pebble get.

`maintenance.duration-backfill` has neither: its phase 1 accumulates `fixesByBook` in memory for phase 2 to apply, so a watermark would silently drop the fixes for every skipped book. It stays on `Drop`, and the def comment now says why.

## Changes

- `ResumePolicy` Drop → Restart, driven by `RunItems` `ResumeFrom` / `CheckpointEvery` / `CheckpointStateFn` (contiguous-completion watermark, checkpoint every 200 books).
- **The checkpoint carries every param, not just the watermark.** Checkpoint JSON is *merged* into the resumed params, so an omitted field returns as its zero value: dropping `Apply` downgrades a live run to a dry run; dropping `BookIDs` widens a cohort run to the whole library.
- **`AlreadyPersisted`** keeps `Limit` a cap on the operation rather than on each attempt — without it, `limit=100` twice-restarted could write 300.
- **IDs are sorted.** A watermark counts positions, so correctness must not rest on two store implementations continuing to agree — that divergence class is what #2399 was.

## Verification

`go build ./...`, `go vet` clean. All 16 `TestChaptersBackfill*` pass.

Green tests were not trusted on their own — every guarantee was reverted and the specific test confirmed to fail:

| Mutation | Result |
|---|---|
| drop `ResumeFrom` from RunItems | ✅ killed |
| drop `Apply` from checkpoint | ✅ killed |
| drop `BookIDs` from checkpoint | ✅ killed |
| drop `AlreadyPersisted` from checkpoint | ✅ killed |
| drop `priorPersisted` from Limit check | ✅ killed |
| drop `sort.Strings(ids)` | ❌ **survived** → fixed |

The sort mutation surviving is the finding worth keeping: both stores already enumerate ascending, so the sort was invisible to the suite and the guarantee was aspirational. `chbfReversingStore` (a store that enumerates descending) now makes it observable, and the same mutation is killed.

Not yet exercised against production — this op is manual-trigger only and a `library.scan` is currently running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS