### PR TITLE
fix(abs): register HEAD for the byte-serving routes

### DIFF
--- a/changelog.d/20260817_170000_fix_head_file_routes.md
+++ b/changelog.d/20260817_170000_fix_head_file_routes.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **`HEAD` now works on the ABS byte-serving routes** — `/api/items/:id/file/:ino`,
+  `.../download`, and `/api/items/:id/cover`. gin registers one method per call,
+  so a GET-only route answered `HEAD` with **404, not 405**, which is
+  indistinguishable from "this file does not exist".
+
+  That silently destroyed a real measurement. A probe built to find `book_file`
+  rows with no bytes behind them reported **100% of 1,786 files missing** and
+  passed its own sanity check, because a fabricated file id returned the same 404
+  as every real one. A uniformly-dead instrument agrees with any hypothesis.
+
+  No handler changed. These routes already end in `http.ServeContent`, which
+  omits the body for `HEAD` while still sending `Content-Length`, `Content-Type`,
+  `ETag` and `Accept-Ranges`, and the ABS auth middleware already accepted
+  `?token=` on `MethodHead`. Only the routing table was missing.

--- a/internal/server/handlers/abs/handler.go
+++ b/internal/server/handlers/abs/handler.go
@@ -450,11 +450,35 @@ func (h *Handler) Register(r gin.IRouter) {
 	// (cover images fetchable by anyone who knows a 36-char item UUID; no metadata,
 	// no audio, no progress) is the owner-accepted, documented tradeoff.
 	r.GET("/api/items/:id/cover", h.ItemCover)
+	r.HEAD("/api/items/:id/cover", h.ItemCover)
 
 	// ── Phase 5b: playback ──────────────────────────────────────────────────
 	r.POST("/api/items/:id/play", auth, h.Play)
 	r.GET("/api/items/:id/file/:ino", auth, h.ItemFile)
 	r.GET("/api/items/:id/file/:ino/download", auth, h.ItemFileDownload)
+
+	// HEAD on the byte-serving routes.
+	//
+	// gin registers one method per call, so a GET-only route answers HEAD with
+	// 404 — not 405 — which is indistinguishable from "this file does not
+	// exist". That cost a real measurement: a probe built to find book_file rows
+	// with no bytes behind them reported 100% of 1,786 files missing, and passed
+	// its own sanity check, because a fabricated ino returned the same 404 as
+	// every real one. A uniformly-dead instrument agrees with any hypothesis.
+	//
+	// Verified against production before this change, on the SAME url:
+	//   GET  /api/items/<real>  -> 200
+	//   HEAD /api/items/<real>  -> 404
+	// and after, the pair must differ only in the presence of a body.
+	//
+	// No handler change is needed. Every one of these ends in
+	// httputil.ServeFileWithRange -> http.ServeContent, which already omits the
+	// body for HEAD while still writing Content-Length, Content-Type, ETag and
+	// Accept-Ranges. ABSRequireAuth likewise already accepts ?token= on
+	// MethodHead (middleware/absauth.go:578,603) — the routing table was the
+	// only thing missing.
+	r.HEAD("/api/items/:id/file/:ino", auth, h.ItemFile)
+	r.HEAD("/api/items/:id/file/:ino/download", auth, h.ItemFileDownload)
 	r.POST("/api/session/:id/sync", auth, h.SessionSync)
 	r.POST("/api/session/:id/close", auth, h.SessionClose)
 

--- a/internal/server/handlers/abs/head_routes_test.go
+++ b/internal/server/handlers/abs/head_routes_test.go
@@ -51,6 +51,22 @@ func seedServableFile(t *testing.T) (seed *oracleSeed, itemID, ino string, size 
 		LibraryState: strp("organized"), IsPrimaryVersion: boolp(true),
 	}, []database.BookFile{{ID: "head-file", BookID: bookID, FilePath: realPath}}, nil)
 
+	// A REAL cover on disk, at the layout CoverPathForBook globs for.
+	//
+	// Without this the cover test is worthless and was measurably so: with no
+	// cover present, GET answers 404 and HEAD answers 404, so "the two agree"
+	// holds even with the HEAD route unregistered. Removing the registration
+	// survived the mutation run until this file existed — the same
+	// uniformly-dead-instrument failure this whole test file is about, reproduced
+	// inside the test for it.
+	coversDir := filepath.Join(seed.root, "covers")
+	if err := os.MkdirAll(coversDir, 0o750); err != nil {
+		t.Fatalf("MkdirAll(covers): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(coversDir, bookID+".jpg"), []byte("jpeg-ish bytes"), 0o600); err != nil {
+		t.Fatalf("WriteFile(cover): %v", err)
+	}
+
 	id, err := seed.lib.MintOrGetSyncFileID(bookID, "head-file")
 	if err != nil {
 		t.Fatalf("MintOrGetSyncFileID: %v", err)
@@ -140,6 +156,13 @@ func TestHeadRoutes_CoverAcceptsHead(t *testing.T) {
 	get, _ := h.do(t, request{method: http.MethodGet, path: path})
 	head, _ := h.do(t, request{method: http.MethodHead, path: path})
 
+	// The known-good half. Asserted FIRST and fatally: if the fixture has no
+	// cover, GET is 404, HEAD is 404, and the agreement check below passes with
+	// the route unregistered.
+	if get.Code != http.StatusOK {
+		t.Fatalf("GET %s = %d, want 200 — with no cover present both methods 404 "+
+			"and the agreement assertion below proves nothing", path, get.Code)
+	}
 	if head.Code != get.Code {
 		t.Fatalf("HEAD %s = %d but GET = %d; the two must agree on whether a "+
 			"cover exists", path, head.Code, get.Code)

--- a/internal/server/handlers/abs/head_routes_test.go
+++ b/internal/server/handlers/abs/head_routes_test.go
@@ -1,0 +1,157 @@
+// file: internal/server/handlers/abs/head_routes_test.go
+// version: 1.0.0
+// guid: 9c4e17b0-3a58-4d2f-8e61-b0d5c7a92f14
+// last-edited: 2026-08-17
+
+package abs_test
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// 🔴 WHY THESE TESTS EXIST. gin registers one method per call, so a GET-only
+// route answers HEAD with 404 — not 405. That is indistinguishable from "this
+// file does not exist", and it silently destroyed a real measurement: a probe
+// built to find book_file rows with no bytes behind them reported 100% of 1,786
+// files missing and passed its own sanity check, because a fabricated ino
+// returned the same 404 as every real one.
+//
+// A uniformly-dead instrument agrees with every hypothesis. So every test below
+// asserts a known-GOOD and a known-BAD value in the SAME run: if the router ever
+// goes back to answering 404 for everything, the good half fails rather than the
+// suite going quietly green.
+
+// seedServableFile builds one book whose byte are actually ON DISK, plus the sync
+// file that addresses it. It is the deliberate inverse of seedFileServing, which
+// seeds a path that does not exist.
+func seedServableFile(t *testing.T) (seed *oracleSeed, itemID, ino string, size int64) {
+	t.Helper()
+	seed = seedOracleLibrary(t)
+
+	intp := func(i int) *int { return &i }
+	strp := func(s string) *string { return &s }
+	boolp := func(b bool) *bool { return &b }
+
+	const bookID = "head-book"
+	realPath := filepath.Join(t.TempDir(), "present.m4b")
+	payload := []byte("not really an m4b, but it is real bytes on a real disk")
+	if err := os.WriteFile(realPath, payload, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	seed.lib.addBook(&database.Book{
+		ID: bookID, Title: "Head Route Book",
+		Duration:     intp(3600),
+		LibraryState: strp("organized"), IsPrimaryVersion: boolp(true),
+	}, []database.BookFile{{ID: "head-file", BookID: bookID, FilePath: realPath}}, nil)
+
+	id, err := seed.lib.MintOrGetSyncFileID(bookID, "head-file")
+	if err != nil {
+		t.Fatalf("MintOrGetSyncFileID: %v", err)
+	}
+	return seed, mustSyncID(t, seed, bookID), id, int64(len(payload))
+}
+
+// HEAD must reach the handler and agree with GET about whether the bytes exist.
+//
+// The GET assertion is not incidental — it is the known-good half. Without it a
+// router that 404s every method passes the "HEAD is not 404" check by accident
+// the moment someone changes the fixture.
+func TestHeadRoutes_HeadAgreesWithGetOnAFilePresentOnDisk(t *testing.T) {
+	seed, itemID, ino, size := seedServableFile(t)
+	h, tok := harnessFor(t, seed)
+
+	for _, suffix := range []string{"", "/download"} {
+		path := "/api/items/" + itemID + "/file/" + ino + suffix
+		t.Run("path="+path, func(t *testing.T) {
+			get, _ := h.do(t, request{method: http.MethodGet, path: path, headers: bearer(tok)})
+			head, _ := h.do(t, request{method: http.MethodHead, path: path, headers: bearer(tok)})
+
+			// Known-good: the file is really there, so GET must succeed. If this
+			// fails the HEAD assertion below proves nothing.
+			if get.Code != http.StatusOK {
+				t.Fatalf("GET %s = %d, want 200 — the fixture is not serving, so "+
+					"the HEAD result carries no information", path, get.Code)
+			}
+			if head.Code != get.Code {
+				t.Fatalf("HEAD %s = %d but GET = %d; a GET-only gin route answers "+
+					"HEAD with 404, which reads as 'file missing' to any probe",
+					path, head.Code, get.Code)
+			}
+
+			// HEAD is not merely routed — it must be a real HEAD: same metadata,
+			// no body. Registering HEAD against a handler that streamed the body
+			// anyway would pass a status-only check while doubling the bytes a
+			// probe pulls over the network.
+			if head.Body.Len() != 0 {
+				t.Errorf("HEAD %s returned a %d-byte body; HEAD must not carry one",
+					path, head.Body.Len())
+			}
+			if got := head.Header().Get("Content-Length"); got != strconv.FormatInt(size, 10) {
+				t.Errorf("HEAD %s Content-Length = %q, want %q — the header is the "+
+					"entire point of a HEAD probe", path, got, strconv.FormatInt(size, 10))
+			}
+			if got := head.Header().Get("Accept-Ranges"); got != "bytes" {
+				t.Errorf("HEAD %s Accept-Ranges = %q, want \"bytes\"", path, got)
+			}
+		})
+	}
+}
+
+// Known-bad, in the same package as the known-good above: a HEAD for bytes that
+// are genuinely absent must still 404. Registering HEAD must not turn every
+// probe into a 200 — that would be the opposite failure, and just as silent.
+func TestHeadRoutes_HeadStill404sWhenTheBytesAreReallyMissing(t *testing.T) {
+	seed, itemID, ino, _ := seedFileServing(t) // path deliberately never created
+	h, tok := harnessFor(t, seed)
+
+	for _, tc := range []struct {
+		name string
+		ino  string
+	}{
+		{"bytes missing from disk", ino},
+		{"ino not in this book", "sf-does-not-exist"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := "/api/items/" + itemID + "/file/" + tc.ino + "/download"
+			head, _ := h.do(t, request{method: http.MethodHead, path: path, headers: bearer(tok)})
+			if head.Code != http.StatusNotFound {
+				t.Fatalf("HEAD %s = %d, want 404; HEAD must report absence as "+
+					"absence, not as success", path, head.Code)
+			}
+		})
+	}
+}
+
+// The cover route is registered without the auth middleware by protocol
+// requirement, so it needs its own coverage: a HEAD there must not fall through
+// to the SPA index or a 404 either.
+func TestHeadRoutes_CoverAcceptsHead(t *testing.T) {
+	seed, itemID, _, _ := seedServableFile(t)
+	h, _ := harnessFor(t, seed)
+
+	path := "/api/items/" + itemID + "/cover"
+	get, _ := h.do(t, request{method: http.MethodGet, path: path})
+	head, _ := h.do(t, request{method: http.MethodHead, path: path})
+
+	if head.Code != get.Code {
+		t.Fatalf("HEAD %s = %d but GET = %d; the two must agree on whether a "+
+			"cover exists", path, head.Code, get.Code)
+	}
+
+	// Deliberately NO body assertion here, unlike the file-route test above.
+	//
+	// httptest.ResponseRecorder does not emulate net/http's transport-level HEAD
+	// body suppression — the real server discards the body for HEAD whatever the
+	// handler wrote. So a recorder body assertion tests only HANDLER-level
+	// suppression. That is meaningful for the file routes, where
+	// http.ServeContent skips the body itself, and meaningless here, where the
+	// not-found path answers via c.JSON and would be suppressed a layer lower.
+	// Asserting it anyway would fail against correct production behaviour.
+}


### PR DESCRIPTION
gin registers one method per call, so a GET-only route answers `HEAD` with **404, not 405** — indistinguishable from "this file does not exist."

## Why it matters

That silently destroyed a real measurement. A probe built to find `book_file` rows with no bytes behind them reported **100% of 1,786 files missing** and passed its own sanity check, because a fabricated ino returned the same 404 as every real one. A uniformly-dead instrument agrees with any hypothesis.

Verified against production before the change, on the **same URL**:

| request | status |
|---|---|
| `GET /api/items/<real>` | **200** |
| `HEAD /api/items/<real>` | **404** |
| `GET /api/items/<bogus>` | 404 |
| `HEAD /api/items/<bogus>` | 404 |

(My first probe was itself uniformly dead — `GET` on a real *ino* also 404s, because that item's files are among the 41.8% with no bytes. The 200 above is from an endpoint that genuinely serves, which is what makes the comparison mean anything.)

## What changed

Three route registrations. **No handler changed.** All three end in `ServeFileWithRange` → `http.ServeContent`, which omits the body for HEAD while still writing `Content-Length`, `Content-Type`, `ETag` and `Accept-Ranges`. `ABSRequireAuth` already accepted `?token=` on `MethodHead` (`middleware/absauth.go:578,603`) — someone anticipated HEAD; only the routing table was missing.

## Verification

Full `abs` package green (30.7s), `go vet` clean. Every registration mutation-tested:

| Mutation | Result |
|---|---|
| unregister `HEAD /file/:ino` | ✅ killed |
| unregister `HEAD /file/:ino/download` | ✅ killed |
| unregister `HEAD /cover` | ❌ **survived** → fixed |

**The cover mutation surviving is the finding worth keeping.** That test asserted only "HEAD and GET agree" — and with no cover in the fixture both answered 404, so it agreed while both were dead. The test for uniformly-dead instruments was itself a uniformly-dead instrument. Seeding a real cover makes GET 200, the known-good half is now asserted first and fatally, and the mutation is killed.

Every test here asserts a known-good **and** a known-bad in the same run, so a router regressing to 404-for-everything fails the good half instead of going quietly green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS