### PR TITLE
docs(todo): file the LLM host GPU cooling investigation [skip changelog]

### DIFF
--- a/todo.d/20260817-investigate-llm-host-gpu-cooling.md
+++ b/todo.d/20260817-investigate-llm-host-gpu-cooling.md
@@ -1,0 +1,16 @@
+- [ ] **Investigate the LLM host's GPU cooling before running another full `library.scan`.**
+      Measured 2026-08-17 during the scan's AI-parsing phase: the card held **97 °C against
+      its own 95 °C shutdown spec** (slowdown 92 °C, max-operating 88 °C, target 83 °C),
+      with `HW Thermal Slowdown: Active` and a cumulative slowdown counter of
+      8,737,239,236 us (~2h 25m). Clocks were pinned at 1860 MHz against a 2130 MHz
+      maximum — ~87% of rated clock — at 92–93% sustained utilization.
+      Cancelling the load dropped it 97 °C → 61 °C in 70 s and cleared the latched
+      throttle, so the cooler does move heat; sustained 100%-duty inference simply
+      exceeds it. **`nvidia-smi` reports `[Unknown Error]` for fan speed on this card,
+      which is unexplained and is the one thing warranting a physical look.**
+      Two knock-ons, both recorded in `docs/plans/2026-08-17-split-scan-ai-phase.md`:
+      a client-side worker pool on the AI batch loop is off the table (the GPU is
+      saturated, not idle), and the measured "AI parsing is 69.4% of scan wall-clock"
+      figure is thermally confounded — any re-measurement must record GPU temperature
+      and clock alongside it. Recovering 1860 → 2130 MHz is ~14.5% on the phase that is
+      ~69% of the scan, for zero code risk.


### PR DESCRIPTION
Follow-up to #2527, which retracted the AI-batch concurrency recommendation on
thermal evidence.

That retraction left the *finding* documented in a plan doc and the *action it
implies* nowhere — no tracked work item said "have someone look at this card."
This adds the `todo.d/` fragment.

The measurement, for reference:

```
GPU Current Temp        : 97 C
GPU Shutdown Temp       : 95 C      <-- above its own shutdown spec
HW Thermal Slowdown     : Active
HW Thermal Slowdown ctr : 8,737,239,236 us   (~2h 25m cumulative)
clocks                  : 1860 MHz against a 2130 MHz max (~87% of rated)
utilization             : 92-93% sustained
fan speed               : [Unknown Error]
```

Cancelling the load dropped the card 97 C → 61 C in 70 s and cleared the latched
throttle, so the cooler works — this is sustained 100%-duty inference exceeding
it, not a failed fan. The `[Unknown Error]` fan sensor is the part that warrants
a physical look.

Fragment is headerless per the `todo.d/` exemption (verified before commit).
`[skip changelog]` because filing a todo is not a changelog-worthy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsssaXSKwYAeEcV218SsnS
