### PR TITLE
feat(maintenance): declare per-job execution policy on all 37 jobs (PR-1)

### DIFF
--- a/changelog.d/20260817_120000_maintenance_job_execution_policy.md
+++ b/changelog.d/20260817_120000_maintenance_job_execution_policy.md
@@ -1,0 +1,16 @@
+### Changed
+
+- Every maintenance job now declares its own execution policy (`ResumePolicy`, `Timeout`,
+  `ConcurrencyKey`, `Liveness`, `Capabilities`) via a new `Policy()` method on
+  `maintenance.MaintenanceJob`. Nothing reads these yet — the `maintenance.job` bridge still
+  supplies its own hardcoded values — so behaviour is unchanged. This is the declaration step
+  that lets each job become its own v2 `OperationDef` in a follow-up.
+
+### Fixed
+
+- Corrected the resume policy planned for maintenance jobs that report `CanResume()` but store no
+  checkpoint. They were slated to declare `ResumeRestart`, which means *reload the last
+  checkpoint*; the value meaning *re-run from zero* is `ResumeRequeue`. The mislabel was not
+  cosmetic: the watchdog writes an `uncheckpointed` strike against every `ResumeRestart`
+  operation that goes quiet, and a separate guard force-drops one whose progress high-water mark
+  never advances — both of which describe a job that never checkpoints.

--- a/internal/maintenance/job.go
+++ b/internal/maintenance/job.go
@@ -1,14 +1,16 @@
 // file: internal/maintenance/job.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 11111111-1111-1111-1111-111111111111
-// last-edited: 2026-04-28
+// last-edited: 2026-08-17
 
 package maintenance
 
 import (
 	"context"
+	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 )
 
 type contextKey string
@@ -52,6 +54,124 @@ type PermissionAware interface {
 	Permission() string
 }
 
+// ExecutionPolicy declares how the operations registry should schedule, time out,
+// and resume a job. It is the set of knobs an OperationDef needs that CanResume()
+// cannot express.
+//
+// It exists because the maintenance.job bridge (internal/server/maintenance_job_op.go)
+// registers ONE OperationDef for all 37 jobs and therefore hardcodes a single policy
+// for every one of them — per-job variation is structurally impossible while the
+// bridge stands. Declaring the policy on the job is the step that makes the 37
+// separate OperationDefs of PR-2 a wiring change rather than a design change.
+//
+// Nothing reads this yet. The bridge still runs and still supplies its own hardcoded
+// values, so adding these declarations is behaviour-preserving by construction.
+//
+// ⚠️ The zero value is INVALID and deliberately so: ResumeUnspecified and
+// LivenessUnspecified are both `= iota` = 0, and RegisterOp rejects each
+// (registry.go:433). A job returning ExecutionPolicy{} therefore compiles but would
+// fail at server startup in PR-2. TestEveryJobDeclaresAUsablePolicy pulls that
+// failure back to `go test`, where it belongs — do not delete it.
+type ExecutionPolicy struct {
+	// ResumePolicy says what happens to an in-flight run when the server restarts.
+	//
+	// Choosing between the two non-drop values is not a naming preference:
+	//   - ResumeRestart means "reload last checkpoint, call Run again". The watchdog
+	//     writes an `uncheckpointed` strike for EVERY ResumeRestart op that goes
+	//     quiet (watchdog.go:156, which substitutes a default interval at :159-162 —
+	//     the comment at :154 claiming it only applies to ops that set
+	//     MinCheckpointInterval is stale against its own code). checkInfiniteRestart
+	//     additionally force-drops one at ResumeCount>=3 with HighWaterProgress==0,
+	//     the permanent state of a job that never checkpoints. So this value is only
+	//     correct for a job that actually checkpoints.
+	//   - ResumeRequeue means "re-run from zero", and its doc restricts it to
+	//     idempotent ops.
+	ResumePolicy opsregistry.ResumePolicy
+
+	// Timeout caps a single run. Zero would mean "registry default" (120m
+	// in-process); every job here states 4h explicitly because that is what the
+	// bridge supplies today.
+	Timeout time.Duration
+
+	// ConcurrencyKey serializes ops sharing a non-empty key. Empty means this job
+	// may run concurrently with itself — which is what the bridge allows today for
+	// all 37, so empty is the behaviour-preserving value rather than an oversight.
+	ConcurrencyKey string
+
+	// Liveness declares how the job keeps the watchdog informed. LivenessManual
+	// means the job calls UpdateProgress itself; note that Log does NOT stamp
+	// liveness, so a job that only logs is struck as never_reported.
+	Liveness opsregistry.LivenessMode
+
+	// Capabilities are the system capabilities the job needs.
+	Capabilities []opsregistry.Capability
+}
+
+// DefaultPolicy returns exactly what the maintenance.job bridge hardcodes for all
+// 37 jobs today (internal/server/maintenance_job_op.go:38-42): ResumeDrop, a 4h
+// timeout, no concurrency key, LivenessManual, and library read+write.
+//
+// A job whose Policy() is DefaultPolicy() is asserting "the bridge's behaviour is
+// correct for me" — which is the behaviour-preserving default and true for 33 of
+// the 37. Reviewing this PR therefore means checking DefaultPolicy() once against
+// the bridge, then confirming the four exceptions below; it does not mean reading
+// 37 struct literals for a transposed field.
+//
+// ConcurrencyKey is deliberately empty. That is what the bridge allows today, so
+// it is the behaviour-preserving value — not an oversight. PR-2 is where per-job
+// keys become expressible, and where a job that must not run twice concurrently
+// should get one.
+func DefaultPolicy() ExecutionPolicy {
+	return ExecutionPolicy{
+		ResumePolicy:   opsregistry.ResumeDrop,
+		Timeout:        4 * time.Hour,
+		ConcurrencyKey: "",
+		Liveness:       opsregistry.LivenessManual,
+		Capabilities: []opsregistry.Capability{
+			opsregistry.CapLibraryRead,
+			opsregistry.CapLibraryWrite,
+		},
+	}
+}
+
+// RestartPolicy is DefaultPolicy with ResumeRestart — "reload last checkpoint and
+// call Run again".
+//
+// ⚠️ Correct ONLY for a job that actually checkpoints. The watchdog writes an
+// `uncheckpointed` strike against every ResumeRestart op that goes quiet, and
+// checkInfiniteRestart force-drops one whose HighWaterProgress never leaves 0.
+// Use RequeuePolicy for a job that re-runs from scratch.
+func RestartPolicy() ExecutionPolicy {
+	p := DefaultPolicy()
+	p.ResumePolicy = opsregistry.ResumeRestart
+	return p
+}
+
+// RequeuePolicy is DefaultPolicy with ResumeRequeue — "re-run from zero".
+//
+// ⚠️ Restricted to jobs that are BOTH idempotent AND free of a dry_run parameter.
+// The second condition is not theoretical: the two requeue implementations
+// disagree about params. registry.resumeRequeue (resume.go) carries
+// Params: row.Params forward, but server.resumeV2Op (server_lifecycle.go:122-127)
+// re-enqueues with literal nil — under which DryRun unmarshals to Go's zero value,
+// false, silently turning an interrupted PREVIEW into a real mutation. That is the
+// exact bug maintenance_dispatcher.go:180 already exists to prevent.
+//
+// Until that divergence is resolved (todo.d/20260817-resumerequeue-two-divergent-implementations.md),
+// a job advertising dry_run keeps DefaultPolicy's ResumeDrop.
+func RequeuePolicy() ExecutionPolicy {
+	p := DefaultPolicy()
+	p.ResumePolicy = opsregistry.ResumeRequeue
+	return p
+}
+
+// PolicyAware is satisfied by every MaintenanceJob. It is a separate interface
+// only so that PR-2's registration code can accept the policy without depending
+// on the rest of the v1 job surface, which PR-2 deletes.
+type PolicyAware interface {
+	Policy() ExecutionPolicy
+}
+
 // MaintenanceJob is the interface that every maintenance job must satisfy.
 type MaintenanceJob interface {
 	// ID returns the kebab-case identifier used in route paths and operation types.
@@ -65,7 +185,17 @@ type MaintenanceJob interface {
 	// DefaultParams returns a struct with default parameter values (used by the frontend).
 	DefaultParams() any
 	// CanResume reports whether the job supports checkpoint-based resume after restart.
+	//
+	// Deprecated by PR-1 but still load-bearing: resumeLegacyOp
+	// (internal/server/server_lifecycle.go) gates on this today. Policy().ResumePolicy
+	// is the value PR-2 registers; CanResume goes away with the legacy sweep in PR-3.
+	// Where the two disagree, Policy() is the intended one — see
+	// TestPolicyAgreesWithCanResume for the exact permitted disagreements.
 	CanResume() bool
+
+	// Policy declares how the registry should schedule, time out, and resume this
+	// job. See ExecutionPolicy — the zero value is invalid.
+	Policy() ExecutionPolicy
 	// Run executes the job. startFrom is the checkpoint index for resumable jobs (0 = fresh start).
 	Run(ctx context.Context, store database.Store, reporter ProgressReporter, dryRun bool) error
 }

--- a/internal/maintenance/jobs/backfill_book_files.go
+++ b/internal/maintenance/jobs/backfill_book_files.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/backfill_book_files.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1000005-0000-0000-0000-000000000005
-// last-edited: 2026-07-07
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -13,7 +13,8 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
 	ulid "github.com/oklog/ulid/v2"
-	"log/slog")
+	"log/slog"
+)
 
 func init() { maintenance.Register(&backfillBookFilesJob{}) }
 
@@ -72,4 +73,9 @@ func (j *backfillBookFilesJob) Run(ctx context.Context, store database.Store, re
 	_ = created
 	slog.Info("backfill-book-files complete")
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *backfillBookFilesJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/backfill_file_hashes.go
+++ b/internal/maintenance/jobs/backfill_file_hashes.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/backfill_file_hashes.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1000014-0000-0000-0000-000000000014
-// last-edited: 2026-07-06
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -14,17 +14,25 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"github.com/falkcorp/audiobook-organizer/internal/operations"
 	"github.com/falkcorp/audiobook-organizer/internal/scanner"
-	"log/slog")
+	"log/slog"
+)
 
 func init() { maintenance.Register(&backfillFileHashesJob{}) }
 
 type backfillFileHashesJob struct{}
 
-func (j *backfillFileHashesJob) ID() string          { return "backfill-file-hashes" }
-func (j *backfillFileHashesJob) Name() string        { return "Backfill File Hashes" }
-func (j *backfillFileHashesJob) Category() string    { return "files" }
-func (j *backfillFileHashesJob) DefaultParams() any  { return struct{ DryRun bool `json:"dry_run"` }{DryRun: false} }
-func (j *backfillFileHashesJob) Description() string { return "Compute and store file hashes for book_files missing them" }
+func (j *backfillFileHashesJob) ID() string       { return "backfill-file-hashes" }
+func (j *backfillFileHashesJob) Name() string     { return "Backfill File Hashes" }
+func (j *backfillFileHashesJob) Category() string { return "files" }
+func (j *backfillFileHashesJob) DefaultParams() any {
+	return struct {
+		DryRun bool `json:"dry_run"`
+	}{DryRun: false}
+}
+func (j *backfillFileHashesJob) Description() string {
+	return "Compute and store file hashes for book_files missing them"
+}
+
 // Job supports checkpoint-based resume after restart.
 func (j *backfillFileHashesJob) CanResume() bool { return true }
 func (j *backfillFileHashesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
@@ -101,4 +109,11 @@ func (j *backfillFileHashesJob) Run(ctx context.Context, store database.Store, r
 
 	slog.Info("backfill-file-hashes complete")
 	return nil
+}
+
+// Policy: ResumeRestart because this job checkpoints via
+// operations.SaveCheckpoint, so a resumed run has real progress to reload.
+// PR-2 moves it to reporter.Checkpoint; the policy is unchanged by that move.
+func (j *backfillFileHashesJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.RestartPolicy()
 }

--- a/internal/maintenance/jobs/backfill_itunes_positions.go
+++ b/internal/maintenance/jobs/backfill_itunes_positions.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/backfill_itunes_positions.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 19a97553-68fc-4ef6-a326-cc9e694d8698
-// last-edited: 2026-08-16
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -591,4 +591,9 @@ func (j *backfillITunesPositionsJob) authoritativeDurationSec(store bookFileRead
 		return float64(*book.Duration), true
 	}
 	return 0, false
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *backfillITunesPositionsJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/backfill_metadata_source_hash.go
+++ b/internal/maintenance/jobs/backfill_metadata_source_hash.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/backfill_metadata_source_hash.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1000015-0000-0000-0000-000000000015
-// last-edited: 2026-07-07
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -12,7 +12,8 @@ import (
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
-	"log/slog")
+	"log/slog"
+)
 
 func init() { maintenance.Register(&backfillMetadataSourceHashJob{}) }
 
@@ -99,4 +100,9 @@ func bookMetadataSourceAndID(book *database.BookCore) (string, string) {
 		}
 	}
 	return "", ""
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *backfillMetadataSourceHashJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/backfill_sync_ids.go
+++ b/internal/maintenance/jobs/backfill_sync_ids.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/backfill_sync_ids.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 85ae5c94-d001-49d9-9f65-97f73f32522b
-// last-edited: 2026-07-30
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -147,4 +147,9 @@ func (j *backfillSyncIDsJob) Run(ctx context.Context, store database.Store, repo
 	reporter.Log("info", summary, nil)
 
 	return runErr
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *backfillSyncIDsJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/bulk_deluge_import.go
+++ b/internal/maintenance/jobs/bulk_deluge_import.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/bulk_deluge_import.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: a2b8c6d7-9e0f-1a2b-3c4d-5e6f7a8b9c0d
-// last-edited: 2026-08-16
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -267,4 +267,14 @@ func bdi_ioCopy(src, dest string) error {
 		return fmt.Errorf("io.Copy: %w", err)
 	}
 	return nil
+}
+
+// Policy: ResumeDrop, which is what the bridge does today — deliberately NOT
+// ResumeRequeue despite CanResume() being true and this job checkpointing nothing.
+// It advertises dry_run:true, and server.resumeV2Op re-enqueues with nil params,
+// under which DryRun would silently resolve to false and run the job for real.
+// Revisit in PR-2, where the replay is testable. See RequeuePolicy's doc comment
+// and todo.d/20260817-resumerequeue-two-divergent-implementations.md.
+func (j *bulkDelugeImportJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/bulk_fetch_metadata.go
+++ b/internal/maintenance/jobs/bulk_fetch_metadata.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/bulk_fetch_metadata.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b3c9d7e8-0f1a-2b3c-4d5e-6f7a8b9c0d1e
-// last-edited: 2026-07-07
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -316,4 +316,12 @@ func bmf_stripChapterFromTitle(title string) string {
 		return title
 	}
 	return strings.TrimSpace(cleaned)
+}
+
+// Policy: ResumeRequeue — CanResume() is true but this job checkpoints nothing,
+// so "resume" already means re-run from zero. It is the ONLY one of the six such
+// jobs safe to declare here, because it is the only one with no dry_run parameter
+// to lose to the nil-params requeue path (see RequeuePolicy's doc comment).
+func (j *bulkFetchMetadataJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.RequeuePolicy()
 }

--- a/internal/maintenance/jobs/cleanup_backups.go
+++ b/internal/maintenance/jobs/cleanup_backups.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/cleanup_backups.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: a1000021-0000-0000-0000-000000000021
-// last-edited: 2026-05-01
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -14,7 +14,8 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
-	"log/slog")
+	"log/slog"
+)
 
 func init() { maintenance.Register(&cleanupBackupsJob{}) }
 
@@ -57,11 +58,16 @@ func (j *cleanupBackupsJob) Run(ctx context.Context, _ database.Store, reporter 
 			}
 		} else {
 			removed++
-			slog.Info("would remove"+path)
+			slog.Info("would remove" + path)
 		}
 		return nil
 	})
 	_ = removed
 	slog.Info("cleanup-backups complete")
 	return err
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *cleanupBackupsJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/cleanup_empty_folders.go
+++ b/internal/maintenance/jobs/cleanup_empty_folders.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/cleanup_empty_folders.go
-// version: 1.2.1
+// version: 1.3.0
 // guid: a1000006-0000-0000-0000-000000000006
-// last-edited: 2026-05-05
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -94,4 +94,14 @@ func (j *cleanupEmptyFoldersJob) Run(ctx context.Context, _ database.Store, repo
 
 	slog.Info("cleanup-empty-folders complete — checked dirs, removed (dry_run)", "dirs_count", len(dirs), "removed", removed, "dryRun", dryRun)
 	return nil
+}
+
+// Policy: ResumeDrop, which is what the bridge does today — deliberately NOT
+// ResumeRequeue despite CanResume() being true and this job checkpointing nothing.
+// It advertises dry_run:true, and server.resumeV2Op re-enqueues with nil params,
+// under which DryRun would silently resolve to false and run the job for real.
+// Revisit in PR-2, where the replay is testable. See RequeuePolicy's doc comment
+// and todo.d/20260817-resumerequeue-two-divergent-implementations.md.
+func (j *cleanupEmptyFoldersJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/cleanup_organize_mess.go
+++ b/internal/maintenance/jobs/cleanup_organize_mess.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/cleanup_organize_mess.go
-// version: 2.1.1
+// version: 2.2.0
 // guid: a1000007-0000-0000-0000-000000000007
-// last-edited: 2026-05-01
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -166,4 +166,9 @@ func comAllAlpha(s string) bool {
 		}
 	}
 	return len(s) > 0
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *cleanupOrganizeMess) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/cleanup_series.go
+++ b/internal/maintenance/jobs/cleanup_series.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/cleanup_series.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: a1000002-0000-0000-0000-000000000002
-// last-edited: 2026-08-16
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -194,4 +194,9 @@ func csNormalizeSeriesName(name string) string {
 	s = csNonAlphanumRE.ReplaceAllString(s, " ")
 	fields := strings.FieldsFunc(s, unicode.IsSpace)
 	return strings.Join(fields, " ")
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *cleanupSeriesJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/dedup_books.go
+++ b/internal/maintenance/jobs/dedup_books.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/dedup_books.go
-// version: 2.5.0
+// version: 2.6.0
 // guid: a1000010-0000-0000-0000-000000000010
-// last-edited: 2026-08-16
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -505,4 +505,9 @@ func ddFilterLive(books []database.Book, deletedIDs map[string]bool) []database.
 		}
 	}
 	return out
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *dedupBooksJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/enrich_book_files.go
+++ b/internal/maintenance/jobs/enrich_book_files.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/enrich_book_files.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1000009-0000-0000-0000-000000000009
-// last-edited: 2026-07-06
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -14,7 +14,8 @@ import (
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
-	"log/slog")
+	"log/slog"
+)
 
 func init() { maintenance.Register(&enrichBookFilesJob{}) }
 
@@ -92,4 +93,9 @@ func (j *enrichBookFilesJob) Run(ctx context.Context, store database.Store, repo
 	_ = updated
 	slog.Info("enrich-book-files complete")
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *enrichBookFilesJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/fix_author_narrator_swap.go
+++ b/internal/maintenance/jobs/fix_author_narrator_swap.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_author_narrator_swap.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: a1000003-0000-0000-0000-000000000003
-// last-edited: 2026-07-07
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -103,4 +103,9 @@ func (j *fixAuthorNarratorSwapJob) Run(ctx context.Context, store database.Store
 
 	slog.Info("Done found applied dryRun", "found", found, "applied", applied, "dryRun", dryRun)
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *fixAuthorNarratorSwapJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/fix_book_file_paths.go
+++ b/internal/maintenance/jobs/fix_book_file_paths.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_book_file_paths.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1000011-0000-0000-0000-000000000011
-// last-edited: 2026-07-06
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -11,7 +11,8 @@ import (
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
-	"log/slog")
+	"log/slog"
+)
 
 func init() { maintenance.Register(&fixBookFilePathsJob{}) }
 
@@ -80,4 +81,9 @@ func (j *fixBookFilePathsJob) Run(ctx context.Context, store database.Store, rep
 	_ = marked
 	slog.Info("fix-book-file-paths complete")
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *fixBookFilePathsJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/fix_file_modes.go
+++ b/internal/maintenance/jobs/fix_file_modes.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_file_modes.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6d3a9f82-1e47-4b50-8c2d-5f9e7a3b1c48
-// last-edited: 2026-08-14
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -84,4 +84,9 @@ func (j *fixFileModesJob) Run(ctx context.Context, store database.Store, reporte
 		return fmt.Errorf("fix-file-modes: %d chmods failed", failed)
 	}
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *fixFileModesJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/fix_library_states.go
+++ b/internal/maintenance/jobs/fix_library_states.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_library_states.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1000008-0000-0000-0000-000000000008
-// last-edited: 2026-07-07
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -11,7 +11,8 @@ import (
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
-	"log/slog")
+	"log/slog"
+)
 
 func init() { maintenance.Register(&fixLibraryStatesJob{}) }
 
@@ -76,4 +77,9 @@ func (j *fixLibraryStatesJob) Run(ctx context.Context, store database.Store, rep
 	_ = fixed
 	slog.Info("fix-library-states complete")
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *fixLibraryStatesJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/fix_read_by_narrator.go
+++ b/internal/maintenance/jobs/fix_read_by_narrator.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_read_by_narrator.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: a1000001-0000-0000-0000-000000000001
-// last-edited: 2026-08-16
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -214,4 +214,9 @@ func rbnrStringDeref(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *fixReadByNarratorJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/fix_version_groups.go
+++ b/internal/maintenance/jobs/fix_version_groups.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_version_groups.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: a1000004-0000-0000-0000-000000000004
-// last-edited: 2026-08-16
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -316,4 +316,9 @@ func vgCreateBookFiles(store bookFileCreator, book *database.Book, filePaths []s
 		}
 	}
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *fixVersionGroupsJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/generate_itl_tests.go
+++ b/internal/maintenance/jobs/generate_itl_tests.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/generate_itl_tests.go
-// version: 1.3.1
+// version: 1.4.0
 // guid: b7e3f1a2-4c5d-6e7f-8a9b-0c1d2e3f4a5b
-// last-edited: 2026-07-16
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -17,7 +17,8 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"github.com/falkcorp/audiobook-organizer/internal/util"
 
-	"log/slog")
+	"log/slog"
+)
 
 func init() { maintenance.Register(&generateITLTestsJob{}) }
 
@@ -77,4 +78,9 @@ func (j *generateITLTestsJob) Run(ctx context.Context, store database.Store, rep
 		outputDir, len(allBooks), len(allBookFiles))
 	slog.Info(done)
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *generateITLTestsJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/merge_chapter_groups.go
+++ b/internal/maintenance/jobs/merge_chapter_groups.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/merge_chapter_groups.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1000020-0000-0000-0000-000000000020
-// last-edited: 2026-07-07
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -65,4 +65,9 @@ func (j *mergeChapterGroupsJob) Run(ctx context.Context, store database.Store, r
 	}
 	slog.Info("merge-chapter-groups complete merged", "merged", merged)
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *mergeChapterGroupsJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/normalize_primary_flags.go
+++ b/internal/maintenance/jobs/normalize_primary_flags.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/normalize_primary_flags.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4b8e2d19-7c5a-4f60-9d3b-1e6a8c4f2b07
-// last-edited: 2026-08-14
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -133,4 +133,9 @@ func (j *normalizePrimaryFlagsJob) Run(ctx context.Context, store database.Store
 		return fmt.Errorf("normalize-primary-flags: %d of %d writes failed", errCount, len(toFix))
 	}
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *normalizePrimaryFlagsJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/policy_declaration_test.go
+++ b/internal/maintenance/jobs/policy_declaration_test.go
@@ -1,0 +1,192 @@
+// file: internal/maintenance/jobs/policy_declaration_test.go
+// version: 1.0.0
+// guid: 6d2f8b41-9e73-4c05-a8d6-1b47e903fa25
+// last-edited: 2026-08-17
+
+package jobs_test
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
+	_ "github.com/falkcorp/audiobook-organizer/internal/maintenance/jobs"
+	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+)
+
+// wantJobCount is the number of registered maintenance jobs. Verified five ways on
+// 2026-08-17: 37 `maintenance.Register` calls under internal/maintenance/jobs, 37
+// files containing one, 37 Run receivers, 37 non-test job files — and, most
+// conclusively, exactly 37 compiler errors when Policy() was first added to the
+// MaintenanceJob interface.
+//
+// A four-way agreement is not what makes this trustworthy; a naming-shaped survey
+// of the same population returned 35 and was wrong. The compiler is the instrument
+// that cannot miss one, because a job that fails to implement the interface cannot
+// build.
+const wantJobCount = 37
+
+// TestEveryJobDeclaresAUsablePolicy is the reason ExecutionPolicy can be a struct
+// rather than five separate interface methods.
+//
+// The compile break from adding Policy() guarantees every job AUTHOR was forced to
+// answer, but not that the ANSWER is usable: `return maintenance.ExecutionPolicy{}`
+// compiles cleanly and yields ResumeUnspecified and LivenessUnspecified, both of
+// which are `= iota` = 0. RegisterOp rejects each (registry.go:433-434) — but only
+// at server startup, which in PR-2 means a failed deploy rather than a failed build.
+//
+// This test moves that failure to `go test`. Do not delete it without first
+// converting ExecutionPolicy's fields into separate interface methods.
+func TestEveryJobDeclaresAUsablePolicy(t *testing.T) {
+	jobs := maintenance.All()
+	if len(jobs) == 0 {
+		t.Fatal("no maintenance jobs registered; this test would pass vacuously")
+	}
+	if len(jobs) != wantJobCount {
+		t.Errorf("registered job count = %d, want %d — if a job was added or removed "+
+			"deliberately, update wantJobCount; if not, one was silently dropped",
+			len(jobs), wantJobCount)
+	}
+
+	for _, job := range jobs {
+		t.Run(job.ID(), func(t *testing.T) {
+			p := job.Policy()
+
+			if p.ResumePolicy == opsregistry.ResumeUnspecified {
+				t.Errorf("ResumePolicy is ResumeUnspecified (the zero value); "+
+					"RegisterOp would reject %q at server startup", job.ID())
+			}
+			if p.Liveness == opsregistry.LivenessUnspecified {
+				t.Errorf("Liveness is LivenessUnspecified (the zero value); "+
+					"RegisterOp would reject %q at server startup", job.ID())
+			}
+			if p.Timeout <= 0 {
+				t.Errorf("Timeout is %v; a non-positive timeout means the registry "+
+					"default silently applies instead of the declared 4h", p.Timeout)
+			}
+			if len(p.Capabilities) == 0 {
+				t.Errorf("Capabilities is empty; every job reached through the bridge "+
+					"holds library read+write today, so empty is a regression")
+			}
+		})
+	}
+}
+
+// TestPolicyIsBehaviourPreservingVersusTheBridge pins PR-1's central claim: that
+// these declarations change nothing, because they restate what
+// internal/server/maintenance_job_op.go already hardcodes for all 37 jobs.
+//
+// The four documented exceptions are listed explicitly rather than skipped, so that
+// a fifth job quietly drifting off the bridge's policy fails here instead of being
+// discovered in PR-2 as an unexplained behaviour change.
+func TestPolicyIsBehaviourPreservingVersusTheBridge(t *testing.T) {
+	// What the bridge hardcodes today (maintenance_job_op.go:38-42).
+	const (
+		bridgeResume         = opsregistry.ResumeDrop
+		bridgeLiveness       = opsregistry.LivenessManual
+		bridgeConcurrencyKey = ""
+	)
+
+	// The only jobs permitted to differ, and in the only field they may differ in.
+	wantResumeOverride := map[string]opsregistry.ResumePolicy{
+		"backfill-file-hashes":      opsregistry.ResumeRestart,
+		"recompute-book-aggregates": opsregistry.ResumeRestart,
+		"retention-and-hygiene":     opsregistry.ResumeRestart,
+		"bulk-fetch-metadata":       opsregistry.ResumeRequeue,
+	}
+
+	jobs := maintenance.All()
+	if len(jobs) == 0 {
+		t.Fatal("no maintenance jobs registered; this test would pass vacuously")
+	}
+
+	seenOverrides := 0
+	for _, job := range jobs {
+		t.Run(job.ID(), func(t *testing.T) {
+			p := job.Policy()
+
+			if p.Liveness != bridgeLiveness {
+				t.Errorf("Liveness = %v, want %v (the bridge's value); PR-1 is "+
+					"behaviour-preserving and does not change liveness", p.Liveness, bridgeLiveness)
+			}
+			if p.ConcurrencyKey != bridgeConcurrencyKey {
+				t.Errorf("ConcurrencyKey = %q, want %q; the bridge allows all 37 to run "+
+					"concurrently today, so a key here is a behaviour change and belongs in PR-2",
+					p.ConcurrencyKey, bridgeConcurrencyKey)
+			}
+
+			want, isOverride := wantResumeOverride[job.ID()]
+			if !isOverride {
+				want = bridgeResume
+			}
+			if p.ResumePolicy != want {
+				t.Errorf("ResumePolicy = %v, want %v", p.ResumePolicy, want)
+			}
+			if isOverride {
+				seenOverrides++
+			}
+		})
+	}
+
+	if seenOverrides != len(wantResumeOverride) {
+		t.Errorf("matched %d of %d declared resume overrides; a job ID in "+
+			"wantResumeOverride does not exist, so its override is not being checked",
+			seenOverrides, len(wantResumeOverride))
+	}
+}
+
+// TestPolicyAgreesWithCanResume documents the exact permitted disagreements between
+// the old CanResume() bool and the new Policy().ResumePolicy, so the gap is a
+// reviewed decision rather than an accident.
+//
+// CanResume() is still load-bearing — resumeLegacyOp gates on it — and it survives
+// until PR-3. Where the two disagree, Policy() is the intended value.
+func TestPolicyAgreesWithCanResume(t *testing.T) {
+	// CanResume()==true but ResumeDrop: jobs that checkpoint nothing AND advertise
+	// dry_run:true. They cannot take ResumeRequeue until the two requeue
+	// implementations stop disagreeing about params — server.resumeV2Op re-enqueues
+	// with nil, under which DryRun resolves to false and a preview runs for real.
+	// See todo.d/20260817-resumerequeue-two-divergent-implementations.md.
+	gatedByDryRun := map[string]bool{
+		"bulk-deluge-import":      true,
+		"cleanup-empty-folders":   true,
+		"refetch-missing-authors": true,
+		"repair-missing-files":    true,
+		"scan-composer-tags":      true,
+	}
+
+	jobs := maintenance.All()
+	if len(jobs) == 0 {
+		t.Fatal("no maintenance jobs registered; this test would pass vacuously")
+	}
+
+	resumable, gated := 0, 0
+	for _, job := range jobs {
+		p := job.Policy()
+		dropped := p.ResumePolicy == opsregistry.ResumeDrop
+
+		switch {
+		case job.CanResume() && dropped:
+			resumable++
+			if !gatedByDryRun[job.ID()] {
+				t.Errorf("%s: CanResume()==true but ResumePolicy==ResumeDrop, and it is "+
+					"not one of the documented dry_run-gated jobs. Either give it a real "+
+					"resume policy or add it to gatedByDryRun with a reason.", job.ID())
+			} else {
+				gated++
+			}
+		case job.CanResume():
+			resumable++
+		case !job.CanResume() && !dropped:
+			t.Errorf("%s: CanResume()==false but ResumePolicy==%v; a job that cannot "+
+				"resume should not be restarted or requeued", job.ID(), p.ResumePolicy)
+		}
+	}
+
+	if want := 9; resumable != want {
+		t.Errorf("jobs with CanResume()==true = %d, want %d", resumable, want)
+	}
+	if want := len(gatedByDryRun); gated != want {
+		t.Errorf("dry_run-gated jobs matched = %d, want %d; an ID in gatedByDryRun "+
+			"does not exist or no longer reports CanResume()==true", gated, want)
+	}
+}

--- a/internal/maintenance/jobs/purge_ua_duplicates.go
+++ b/internal/maintenance/jobs/purge_ua_duplicates.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/purge_ua_duplicates.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7a4d1e58-9c26-4b73-b0f2-5e8c3a6d9f41
-// last-edited: 2026-08-14
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -275,4 +275,9 @@ func max64(a, b int64) int64 {
 		return a
 	}
 	return b
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *purgeUADuplicatesJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/recompute_book_aggregates.go
+++ b/internal/maintenance/jobs/recompute_book_aggregates.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/recompute_book_aggregates.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 9b0c1d2e-3f4a-5b6c-7d8e-9f0a1b2c3d4e
-// last-edited: 2026-08-16
+// last-edited: 2026-08-17
 
 // Maintenance job: recompute-book-aggregates
 //
@@ -242,4 +242,11 @@ func (j *recomputeBookAggregatesJob) runViaInterface(
 	}
 	slog.Info("recompute-book-aggregates (fallback) complete", "updated", updated, "failed", failed, "dry_run", dryRun)
 	return nil
+}
+
+// Policy: ResumeRestart because this job checkpoints via
+// operations.SaveCheckpoint, so a resumed run has real progress to reload.
+// PR-2 moves it to reporter.Checkpoint; the policy is unchanged by that move.
+func (j *recomputeBookAggregatesJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.RestartPolicy()
 }

--- a/internal/maintenance/jobs/recompute_itunes_paths.go
+++ b/internal/maintenance/jobs/recompute_itunes_paths.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/recompute_itunes_paths.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1000013-0000-0000-0000-000000000013
-// last-edited: 2026-07-06
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -11,7 +11,8 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
-	"log/slog")
+	"log/slog"
+)
 
 func init() { maintenance.Register(&recomputeITunesPathsJob{}) }
 
@@ -79,4 +80,9 @@ func (j *recomputeITunesPathsJob) Run(ctx context.Context, store database.Store,
 	_ = updated
 	slog.Info("recompute-itunes-paths complete")
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *recomputeITunesPathsJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/refetch_missing_authors.go
+++ b/internal/maintenance/jobs/refetch_missing_authors.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/refetch_missing_authors.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: a1000012-0000-0000-0000-000000000012
-// last-edited: 2026-07-07
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -203,4 +203,14 @@ func fileExt(path string) string {
 		}
 	}
 	return ""
+}
+
+// Policy: ResumeDrop, which is what the bridge does today — deliberately NOT
+// ResumeRequeue despite CanResume() being true and this job checkpointing nothing.
+// It advertises dry_run:true, and server.resumeV2Op re-enqueues with nil params,
+// under which DryRun would silently resolve to false and run the job for real.
+// Revisit in PR-2, where the replay is testable. See RequeuePolicy's doc comment
+// and todo.d/20260817-resumerequeue-two-divergent-implementations.md.
+func (j *refetchMissingAuthorsJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/relink_missing_to_itunes.go
+++ b/internal/maintenance/jobs/relink_missing_to_itunes.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/relink_missing_to_itunes.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: e0f6a4d5-7b8c-9d0e-1f2a-3b4c5d6e7f80
-// last-edited: 2026-08-16
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -443,4 +443,9 @@ func rmt_disambiguate(matches []string, authorName, title string) string {
 		return cands[0].path
 	}
 	return ""
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *relinkMissingToITunesJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/relink_report.go
+++ b/internal/maintenance/jobs/relink_report.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/relink_report.go
-// version: 2.4.0
+// version: 2.5.0
 // guid: a1000022-0000-0000-0000-000000000022
-// last-edited: 2026-07-07
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -279,4 +279,9 @@ func rrDisambiguate(matches []string, authorName, title string) string {
 		return cands[0].path
 	}
 	return ""
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *relinkReportJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/repair_missing_files.go
+++ b/internal/maintenance/jobs/repair_missing_files.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/repair_missing_files.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: f1a7b5e6-8c9d-0e1f-2a3b-4c5d6e7f8a90
-// last-edited: 2026-08-16
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -570,4 +570,14 @@ func rmfr_repairOne(
 		res.Applied = true
 	}
 	return res
+}
+
+// Policy: ResumeDrop, which is what the bridge does today — deliberately NOT
+// ResumeRequeue despite CanResume() being true and this job checkpointing nothing.
+// It advertises dry_run:true, and server.resumeV2Op re-enqueues with nil params,
+// under which DryRun would silently resolve to false and run the job for real.
+// Revisit in PR-2, where the replay is testable. See RequeuePolicy's doc comment
+// and todo.d/20260817-resumerequeue-two-divergent-implementations.md.
+func (j *repairMissingFilesJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/retention_and_hygiene.go
+++ b/internal/maintenance/jobs/retention_and_hygiene.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/retention_and_hygiene.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: e7c9d4a2-f1b3-49a8-8c4f-7d2e5a1f3c9e
-// last-edited: 2026-08-16
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -349,4 +349,11 @@ func isDeadPrefixSweepDone(store retentionFlagStore, flagName string) (bool, err
 // setDeadPrefixSweepDone sets the completion flag.
 func setDeadPrefixSweepDone(store retentionFlagStore, flagName string) error {
 	return store.SetSetting(flagName, "true", "boolean", false)
+}
+
+// Policy: ResumeRestart because this job checkpoints via
+// operations.SaveCheckpoint, so a resumed run has real progress to reload.
+// PR-2 moves it to reporter.Checkpoint; the policy is unchanged by that move.
+func (j *retentionAndHygieneJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.RestartPolicy()
 }

--- a/internal/maintenance/jobs/revert_metadata_fetch.go
+++ b/internal/maintenance/jobs/revert_metadata_fetch.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/revert_metadata_fetch.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: c8d4e2b3-5f6a-7b8c-9d0e-1f2a3b4c5d6e
-// last-edited: 2026-04-28
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -209,4 +209,9 @@ func (j *revertMetadataFetchJob) Run(ctx context.Context, store database.Store, 
 	summary := fmt.Sprintf("Reverted %d books (skipped: %d, errors: %d)", reverted, skipped, errors)
 	slog.Info(summary)
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *revertMetadataFetchJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/scan_chapter_groups.go
+++ b/internal/maintenance/jobs/scan_chapter_groups.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/scan_chapter_groups.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1000019-0000-0000-0000-000000000019
-// last-edited: 2026-07-07
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -48,4 +48,9 @@ func (j *scanChapterGroupsJob) Run(ctx context.Context, store database.Store, re
 	}
 	slog.Info("scan-chapter-groups complete groups", "groups_count", len(groups))
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *scanChapterGroupsJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/scan_composer_tags.go
+++ b/internal/maintenance/jobs/scan_composer_tags.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/scan_composer_tags.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: d9e5f3c4-6a7b-8c9d-0e1f-2a3b4c5d6e7f
-// last-edited: 2026-07-07
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -277,4 +277,14 @@ func sct_categorize(composer, author, narrator, fixMode string) (category, willW
 		return "composer_equals_narrator", ""
 	}
 	return "composer_mismatch", willWrite
+}
+
+// Policy: ResumeDrop, which is what the bridge does today — deliberately NOT
+// ResumeRequeue despite CanResume() being true and this job checkpointing nothing.
+// It advertises dry_run:true, and server.resumeV2Op re-enqueues with nil params,
+// under which DryRun would silently resolve to false and run the job for real.
+// Revisit in PR-2, where the replay is testable. See RequeuePolicy's doc comment
+// and todo.d/20260817-resumerequeue-two-divergent-implementations.md.
+func (j *scanComposerTagsJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/scan_duplicate_files.go
+++ b/internal/maintenance/jobs/scan_duplicate_files.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/scan_duplicate_files.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1000016-0000-0000-0000-000000000016
-// last-edited: 2026-07-06
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -57,4 +57,9 @@ func (j *scanDuplicateFilesJob) Run(ctx context.Context, store database.Store, r
 	}
 	slog.Info("scan-duplicate-files complete duplicate groups", "dups", dups)
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *scanDuplicateFilesJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/scan_duration_mismatch.go
+++ b/internal/maintenance/jobs/scan_duration_mismatch.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/scan_duration_mismatch.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1000018-0000-0000-0000-000000000018
-// last-edited: 2026-07-07
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -59,4 +59,9 @@ func (j *scanDurationMismatchJob) Run(ctx context.Context, store database.Store,
 	}
 	slog.Info("scan-duration-mismatch complete mismatches", "mismatches", mismatches)
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *scanDurationMismatchJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/scan_metadata_hash_dups.go
+++ b/internal/maintenance/jobs/scan_metadata_hash_dups.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/scan_metadata_hash_dups.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1000017-0000-0000-0000-000000000017
-// last-edited: 2026-07-07
+// last-edited: 2026-08-17
 
 package jobs
 
@@ -57,4 +57,9 @@ func (j *scanMetadataHashDupsJob) Run(ctx context.Context, store database.Store,
 	}
 	slog.Info("scan-metadata-hash-dups complete duplicate groups", "dups", dups)
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *scanMetadataHashDupsJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/maintenance/jobs/sweep_pebble_metrics_ttl.go
+++ b/internal/maintenance/jobs/sweep_pebble_metrics_ttl.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/sweep_pebble_metrics_ttl.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b8c9d0e1-f2a3-0008-1234-000000000008
-// last-edited: 2026-07-31
+// last-edited: 2026-08-17
 
 // Package jobs — maintenance job: sweep expired Pebble metrics snapshots.
 //
@@ -81,4 +81,9 @@ func (j *sweepPebbleMetricsTTLJob) Run(
 	reporter.Log("info", msg, nil)
 	reporter.SetTotal(int(deleted))
 	return nil
+}
+
+// Policy declares the bridge's existing behaviour verbatim: see DefaultPolicy.
+func (j *sweepPebbleMetricsTTLJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
 }

--- a/internal/plugins/maintenance/missing_file_audit.go
+++ b/internal/plugins/maintenance/missing_file_audit.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/missing_file_audit.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 4e1c7a92-3b58-4d06-9f21-8c5a0e7b3d64
 // last-edited: 2026-08-17
 
@@ -26,21 +26,30 @@ import (
 // 🔴 WHY THIS EXISTS. Downloads fail with "file not found" because a large share
 // of book_file rows point at paths that hold no bytes.
 //
-// ⚠️ THE NUMBERS BELOW CAME FROM A 120-BOOK SAMPLE AND THE FULL POPULATION
-// CONTRADICTS THEM IN BOTH DIRECTIONS. Superseded 2026-08-17 by a full-library
-// run of this op (all 532,296 rows) — see
+// ⚠️ THE NUMBERS BELOW CAME FROM A 120-BOOK SAMPLE AND THE SAMPLE WAS NOT
+// REPRESENTATIVE. Superseded 2026-08-17 by a full-library run of this op (all
+// 532,296 rows across 61,528 books) — see
 // docs/audits/2026-08-17-missing-file-audit-full-population.md:
 //
-//	                                  120-book sample   full population
-//	rows missing                      41.8%             13.52%  (71,954/532,296)
-//	books with NO surviving file      5                 16,265
-//	missing rows under the iTunes tree  0 ("nothing")   1,006
+//	                                  120-book sample     full population
+//	rows missing                      41.8% (552/1,322)   13.52% (71,954/532,296)
+//	books with NO surviving file      5     (4.2%)        16,265 (26.4%)
+//	missing rows under the iTunes tree  0   ("nothing")   1,006
 //
-// So the sample overstated the row rate by 3x and understated the
-// books-with-nothing-left count by more than three orders of magnitude. Sampling
-// error alone does not produce that; treat the sample figures as retired, not as
-// a rough guide. `unreadable` is 0 across all 532,296 rows, so none of this is a
-// flapping mount.
+// The books-with-nothing-left gap is not sampling noise, and the arithmetic says
+// so rather than an adjective: at the population rate p = 0.2644, a random n = 120
+// draw expects 31.7 such books (sd 4.83). Observing 5 is z = −5.53, exact
+// P(X ≤ 5) = 1.3e−10. The sample was drawn from a non-representative slice.
+//
+// ⚠️ COMPARE RATES, NOT COUNTS. It is tempting to say the sample "understated by
+// 3,253×" (5 → 16,265). That is a ratio of raw counts across populations of 120
+// and 61,528 and it means nothing. The comparable figure is the RATE ratio,
+// 4.2% → 26.4% = 6.3×. For the same reason, do not claim the sample "overstated
+// the row rate by 3×": the sample averaged 11.0 rows/book against the
+// population's 8.6, so the two percentages have different denominators and
+// neither corrects the other.
+//
+// `unreadable` is 0 across all 532,296 rows, so none of this is a flapping mount.
 //
 // 🔴 The "EVERY missing path was under the organizer's own tree, nothing under
 // iTunes" claim below is FALSE as written — 1,006 missing rows are under the

--- a/internal/plugins/maintenance/missing_file_audit.go
+++ b/internal/plugins/maintenance/missing_file_audit.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/missing_file_audit.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 4e1c7a92-3b58-4d06-9f21-8c5a0e7b3d64
 // last-edited: 2026-08-17
 
@@ -24,16 +24,33 @@ import (
 // --- missing-file-audit ---
 //
 // 🔴 WHY THIS EXISTS. Downloads fail with "file not found" because a large share
-// of book_file rows point at paths that hold no bytes. Measured on the live
-// library 2026-08-17 over a 120-book sample: 552 of 1,322 rows (41.8%) were
-// missing, and 49 of the 120 books (41%) had at least one dead file. Five books
-// had NO surviving file at all.
+// of book_file rows point at paths that hold no bytes.
 //
-// The shape is specific and it is what makes this worth its own op: EVERY missing
-// path was under the organizer's own destination tree
-// (/mnt/bigdata/books/audiobook-organizer/...), while nothing under the iTunes
-// tree was missing. The typical broken book carries two rows — a phantom at the
-// organized path and the real file still in the iTunes tree:
+// ⚠️ THE NUMBERS BELOW CAME FROM A 120-BOOK SAMPLE AND THE FULL POPULATION
+// CONTRADICTS THEM IN BOTH DIRECTIONS. Superseded 2026-08-17 by a full-library
+// run of this op (all 532,296 rows) — see
+// docs/audits/2026-08-17-missing-file-audit-full-population.md:
+//
+//	                                  120-book sample   full population
+//	rows missing                      41.8%             13.52%  (71,954/532,296)
+//	books with NO surviving file      5                 16,265
+//	missing rows under the iTunes tree  0 ("nothing")   1,006
+//
+// So the sample overstated the row rate by 3x and understated the
+// books-with-nothing-left count by more than three orders of magnitude. Sampling
+// error alone does not produce that; treat the sample figures as retired, not as
+// a rough guide. `unreadable` is 0 across all 532,296 rows, so none of this is a
+// flapping mount.
+//
+// 🔴 The "EVERY missing path was under the organizer's own tree, nothing under
+// iTunes" claim below is FALSE as written — 1,006 missing rows are under the
+// iTunes tree, and 61 carry a mangled "/X:/books/itunes/Audiobooks" path. The
+// claim was true of the sample and was never true of the library. It is kept
+// here rather than deleted because the two-row shape it describes is real and
+// still the common case; only the "EVERY"/"nothing" quantifiers were wrong.
+//
+// The typical broken book carries two rows — a phantom at the organized path and
+// the real file still in the iTunes tree:
 //
 //	MISSING .../audiobook-organizer/Morgan Rice/.../A Vow of Glory - ... .m4b
 //	OK      .../itunes/iTunes Media/Audiobooks/Morgan Rice/01 The Sorcerer's ... .m4b

--- a/internal/server/maintenance_dryrun_default_test.go
+++ b/internal/server/maintenance_dryrun_default_test.go
@@ -49,6 +49,14 @@ func (j *dryRunProbeJob) Category() string    { return "test" }
 func (j *dryRunProbeJob) DefaultParams() any  { return j.params }
 func (j *dryRunProbeJob) CanResume() bool     { return j.canResume }
 
+// Policy satisfies the interface for these probes. DefaultPolicy is the honest
+// value: the probes exercise the dry_run persistence path, which the bridge drives
+// with its own hardcoded policy, so a probe declaring anything else would be
+// asserting a behaviour these tests do not exercise.
+func (j *dryRunProbeJob) Policy() maintenance.ExecutionPolicy {
+	return maintenance.DefaultPolicy()
+}
+
 func (j *dryRunProbeJob) Run(_ context.Context, _ database.Store, _ maintenance.ProgressReporter, dryRun bool) error {
 	j.mu.Lock()
 	j.runs = append(j.runs, dryRun)

--- a/todo.d/20260817-repair-missing-files-tier2-cross-book-repoint.md
+++ b/todo.d/20260817-repair-missing-files-tier2-cross-book-repoint.md
@@ -22,14 +22,30 @@ A hit rewrites the row via `UpdateBookFile` at `:566`, setting `FilePath`, `Orig
 `Missing=false`, `FileSize` and `Format` — so the row ends up pointing at an unrelated book's
 audio while *looking* fully repaired. There is no post-write verification of book identity.
 
-**Reachability, measured on the live organizer tree by the prod-ops lane (their measurement, not
-mine):** 4,082 files carry bare-digit basenames across 517 distinct names, and **170 of those
-appear exactly once**, so `case 1:` is reachable rather than theoretical. Controls in the same
-call: normal-named mp3s under one author = 35; a planted nonexistent name = 0.
+**Reachability — measure the ROW side, not the DISK side.** Both numbers exist and only one bounds
+the risk. All measurements by the prod-ops lane; recorded here as theirs.
 
-⚠️ **Still unmeasured, and it is the number that decides severity:** how many *actual* missing
-`book_file` rows currently carry a basename that is a singleton in the index. That is what turns
-this from reachable into actively-firing, and it needs the row set. Measure it before rating this.
+*On-disk* (does the corpus contain singleton basenames at all): 4,082 files carry bare-digit
+basenames across 517 distinct names, **170 of them singletons**. Controls: normal-named mp3s under
+one author = 35; a planted nonexistent name = 0.
+
+*Row-side* (do actual missing rows resolve to a singleton — the only way to reach `case 1:`):
+building the same index tier 2 builds, 379,527 distinct basenames over both search roots, and
+looking up every distinct basename from 260 sampled missing rows gives **1 singleton
+("Dungeon of Pride.m4b") / 101 multi / 1 absent** (planted control ✓).
+
+**So the on-disk figure overstates the risk and the row-side figure is the one to quote: ~1 in
+102.** This corrects the first version of this fragment, which cited the on-disk numbers as
+reachability — the same count-the-wrong-population error the audit header warns about.
+
+The track-slash population specifically does **not** mis-repoint: `131.mp3` occurs **9** times, not
+once (settled by direct `find` after two parses disagreed; known-good control `166.mp3` = 172,
+planted bad control = 0). Nine occurrences reach the multi-match branch, which narrows by parent
+directory — stored parent `Zero History - 2` matches none of the nine real parents — and falls
+through to zero. **A miss, not a mis-repoint.**
+
+⚠️ Consequence for prioritisation: this defect is real and worth fixing on its own merits, but it
+is **not** what blocks the track-slash repair. Do not sequence the repair behind it.
 
 Bare-digit basenames are common because of the `segment_title_format` slash bug (default
 `{title} - {track}/{total_tracks}`, `f29c3ce6` → `c54721c7`, documented at

--- a/todo.d/20260817-repair-missing-files-tier2-cross-book-repoint.md
+++ b/todo.d/20260817-repair-missing-files-tier2-cross-book-repoint.md
@@ -1,0 +1,62 @@
+### `repair-missing-files` tier 2 can repoint a row at another book's audio
+
+`rmfr_repairOne` in `internal/maintenance/jobs/repair_missing_files.go` resolves a missing
+`book_file` row through four tiers. **Tier 2 (`:292-339`) accepts a unique basename match with no
+ownership check at all.**
+
+```go
+paths := idx[base]            // filename index across ALL search roots
+switch len(paths) {
+case 1:
+    candidate, method = paths[0], "filename"   // ← :299-301, accepted unconditionally
+```
+
+The `default:` branch immediately below (`:304-337`) narrows multi-match candidates by parent
+directory and then by author last name. The `case 1:` branch does neither. The asymmetry is the
+bug: the code already encodes that a bare basename is insufficient evidence of identity, but
+applies that knowledge only when the match is ambiguous. **One match is evidence of uniqueness,
+not of correctness** — a singleton basename elsewhere in the search roots is no more likely to
+belong to this book than one of several.
+
+A hit rewrites the row via `UpdateBookFile` at `:566`, setting `FilePath`, `OriginalFilename`,
+`Missing=false`, `FileSize` and `Format` — so the row ends up pointing at an unrelated book's
+audio while *looking* fully repaired. There is no post-write verification of book identity.
+
+**Reachability, measured on the live organizer tree by the prod-ops lane (their measurement, not
+mine):** 4,082 files carry bare-digit basenames across 517 distinct names, and **170 of those
+appear exactly once**, so `case 1:` is reachable rather than theoretical. Controls in the same
+call: normal-named mp3s under one author = 35; a planted nonexistent name = 0.
+
+⚠️ **Still unmeasured, and it is the number that decides severity:** how many *actual* missing
+`book_file` rows currently carry a basename that is a singleton in the index. That is what turns
+this from reachable into actively-firing, and it needs the row set. Measure it before rating this.
+
+Bare-digit basenames are common because of the `segment_title_format` slash bug (default
+`{title} - {track}/{total_tracks}`, `f29c3ce6` → `c54721c7`, documented at
+`internal/organizer/pathbuild.go:139-158`): a row reading `.../Zero History - 70/131.mp3` is one
+filename, "track 70 of 131", whose `/` became a path separator. Its basename is `131.mp3`.
+
+**These two findings compound, which is why neither should be fixed in isolation:**
+`repair-missing-files` advertises `dry_run:true`, and per
+`todo.d/20260817-resumerequeue-two-divergent-implementations.md` an interrupted dry run can come
+back as a real run through the nil-params requeue path. A silent preview→apply transition on a job
+whose tier 2 can repoint across books is a worse outcome than either defect alone. The prod-ops
+lane declined to run this job as a prod dry run for exactly this reason and read the tiers
+statically instead.
+
+Fix direction: require tier 2's `case 1:` to pass the same parent-directory / author narrowing the
+multi-match branch already applies, or reject the single match outright and let tiers 3-4 handle
+it. Either way the accept path should carry a same-book assertion before `UpdateBookFile`.
+
+Separately — and this does **not** fix the above — none of the four tiers resolves the track-slash
+shape, so repointing that population needs new candidate logic rather than a wiring change:
+
+- tier 1 (`:281`, iTunes PID → XML Location): organizer-tree rows have no `ITunesPersistentID`.
+- tier 2 (`:292`): looks up `131.mp3`; the real file is `Zero History - 70.mp3`.
+- tier 3 (`:341`, stem-prefix in same dir): `os.ReadDir` on the phantom parent — 25/25 distinct
+  parents absent on the live tree, with three positive controls present in the same batch.
+- tier 4 (`:366`, author + title-prefixed album dir): stats `<album>/131.mp3` (absent), and its
+  single-audio-file fallback does not apply to books holding 130+ files.
+
+`repair_missing_files.go` remains the right model for the *write* (`:566` field set) and for
+dry-run-returns-a-plan (`res.Method` / `res.NewPath` per row); only the candidate search is unfit.

--- a/todo.d/20260817-resumerequeue-two-divergent-implementations.md
+++ b/todo.d/20260817-resumerequeue-two-divergent-implementations.md
@@ -36,3 +36,12 @@ mutations, different lanes.
 Fix direction: resolve the divergence rather than test around it — have `resumeV2Op` read the v1
 row's saved params and pass them through, so both paths replay params identically. Then add a
 conformance test: one fixture, both implementations, assert the resumed params are equal.
+
+**Compounds with a second defect in the same job.** `repair-missing-files` tier 2 accepts a unique
+basename match with no same-book check (`repair_missing_files.go:299-301`), so it can repoint a row
+at an unrelated book's audio — see
+`todo.d/20260817-repair-missing-files-tier2-cross-book-repoint.md`. A silent preview→apply
+transition on *that* job is worse than either defect alone, and it is why the prod-ops lane read
+the tiers statically rather than running a prod dry run to test them. Fix the params divergence
+before anyone is asked to trust a dry run of a repointing job.
+


### PR DESCRIPTION
Stacked on #2529 (base = `refactor/maintenance-jobs-to-v2`). Review that first; this PR's diff is only its own commits.

## What

Adds `Policy() ExecutionPolicy` to `maintenance.MaintenanceJob`, declaring the `ResumePolicy` / `Timeout` / `ConcurrencyKey` / `Liveness` / `Capabilities` that `OperationDef` needs and `CanResume()` cannot express.

**Behaviour-preserving by construction — nothing reads these yet.** The `maintenance.job` bridge still runs and still supplies its own hardcoded values. This is the declaration step that makes PR-2 a wiring change against declarations already reviewed in isolation.

## How to review this in five minutes

**33 of 37 jobs return `DefaultPolicy()`**, which restates the bridge verbatim (`maintenance_job_op.go:38-42`). Check `DefaultPolicy()` once against the bridge, then read the four exceptions — you do not need to read 37 struct literals looking for a transposed field. That is why this uses named constructors rather than inline literals.

| job | policy | why |
|---|---|---|
| `backfill-file-hashes` | `ResumeRestart` | checkpoints today |
| `recompute-book-aggregates` | `ResumeRestart` | checkpoints today |
| `retention-and-hygiene` | `ResumeRestart` | checkpoints today |
| `bulk-fetch-metadata` | `ResumeRequeue` | no `dry_run` param to lose |

## The correction this PR encodes

The plan originally mapped the six `CanResume()`-but-checkpointless jobs to `ResumeRestart`, reasoning that "re-run from scratch is exactly `ResumeRestart`'s semantics." That is backwards against `types.go:169-173` — `ResumeRestart` means *reload last checkpoint*; *re-run from zero* is `ResumeRequeue`. The mislabel has runtime teeth:

- `watchdog.go:156` gates the `uncheckpointed` strike on `ResumePolicy == ResumeRestart`, and `:159-162` substitutes a default when `MinCheckpointInterval` is left zero — so it fires for **every** `ResumeRestart` op, not (as the stale comment at `:154` claims) only those that set the field. A 4h job that never checkpoints would write one `op_strikes_v2` row per 5-minute window.
- `worker.go:158-163` force-drops any `ResumeRestart` op at `ResumeCount >= 3` with `HighWaterProgress == 0` — the permanent state of a job that never checkpoints.

## Why five jobs are held at `ResumeDrop`

The remaining five checkpointless-but-resumable jobs advertise `dry_run: true` and stay at `ResumeDrop`, each saying so at its declaration. **`ResumeRequeue` has two live divergent implementations:** `registry.resumeRequeue` (`resume.go`) carries `Params: row.Params` forward, but `server.resumeV2Op` (`server_lifecycle.go:122-127`) re-enqueues with literal `nil`, under which `DryRun` unmarshals to `false` and an interrupted preview runs for real. Two of the five are `cleanup-empty-folders` (removes directories) and `repair-missing-files` (rewrites `book_file` rows).

Filed as `todo.d/20260817-resumerequeue-two-divergent-implementations.md`. Revisit in PR-2 where the replay is testable.

## Tests

Three new tests, all **mutation-tested** rather than trusted green:

| mutation | caught by |
|---|---|
| a job returns `ExecutionPolicy{}` | `TestEveryJobDeclaresAUsablePolicy` |
| `ResumeRequeue` → `ResumeRestart` swap | `TestPolicyIsBehaviourPreservingVersusTheBridge` |
| a gated job upgraded to `ResumeRequeue` | both the above + `TestPolicyAgreesWithCanResume` |
| a job silently gains a `ConcurrencyKey` | `TestPolicyIsBehaviourPreservingVersusTheBridge` |

4/4 caught; negative control (unmutated tree) passes.

The struct-vs-five-methods choice needs that first test: `ExecutionPolicy{}` compiles and yields `ResumeUnspecified` (`= iota` = 0), which `RegisterOp` rejects only at **server startup**. The test pulls that failure back to `go test`.

The job count is asserted at **37**, which the compiler confirmed by emitting exactly 37 `missing method Policy` errors. An earlier name-shaped survey of the same population said 35.

## Also in this PR

- `missing_file_audit.go` header retired: its figures came from a 120-book sample that the full-population run contradicts (rows missing 41.8% → 13.52%; books with no surviving file 5 → 16,265; missing rows under the iTunes tree 0 → 1,006). At the population rate a random n=120 draw expects 31.7 fully-broken books (sd 4.83); observing 5 is z = −5.53, exact P(X≤5) = 1.3e−10 — a non-representative slice, not noise. Coordinated with the prod-ops lane (#2530), who measured it.
- `repair-missing-files` tier 2 filed as a cross-book repoint risk: `:299-301` accepts a unique basename match with no ownership check while the branch below narrows by parent dir and author. Row-side reachability ~1 in 102 (not the on-disk 170 — different population).
- 9 job files were already `gofmt`-dirty at `HEAD` (malformed import blocks) and are formatted here; incidental to touching them, not caused by this change.

## Verification

`go build ./...` clean · `go vet ./...` clean · `go test ./internal/maintenance/... ./internal/plugins/maintenance/... ./internal/server/` pass, including the four pre-existing dry-run/resume invariant tests this must not disturb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t
