### PR TITLE
chore(ci): delete the inert check-mock-fresh gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # file: Makefile
-# version: 2.19.0
+# version: 2.20.0
 # guid: c1d2e3f4-g5h6-7890-ijkl-m1234567890n
-# last-edited: 2026-08-16
+# last-edited: 2026-08-17
 
 BINARY := audiobook-organizer
 ROOT_DIR := $(shell git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -22,7 +22,7 @@ BACKUP_DIR  ?= $(CURDIR)/backups
         web-install web-build web-dev web-test web-lint web-lint-memory \
         test test-short test-all test-all-short test-nightly test-frontend test-e2e test-e2e-demo \
         coverage coverage-check coverage-check-short ci \
-        vet mocks mocks-check check-mock-fresh staticcheck oplint sdkguard \
+        vet mocks mocks-check staticcheck oplint sdkguard \
         docker docker-run docker-stop \
         release-dry-run release-snapshot version \
         build-mtls-bridge build-mtls-bridge-windows \
@@ -301,13 +301,20 @@ mocks-check:
 	fi
 	@echo "✅ Mocks are up to date"
 
-## check-mock-fresh: Check that MockStore is up to date with the Store interface
-check-mock-fresh:
-	@echo "==> Checking mock freshness..."
-	go generate ./internal/database/...
-	git diff --exit-code internal/database/mocks/ || \
-		(echo "ERROR: MockStore is stale. Run 'make generate' and commit." && exit 1)
-	@echo "==> Mock is fresh."
+## (removed 2026-08-17) check-mock-fresh — deleted, not repaired. It claimed to
+## catch a stale MockStore and could not: it ran `go generate
+## ./internal/database/...` in a repo with ZERO //go:generate directives (mocks
+## come from .mockery.yaml), so the regeneration was a no-op and the following
+## `git diff --exit-code internal/database/mocks/` only ever detected a dirty
+## worktree. Measured: add a method to the Store interface and leave the mock
+## alone — the exact drift the docstring named — and it printed "Mock is fresh"
+## and exited 0. Its own error message told you to run `make generate`, a target
+## that does not exist. Coverage lost by removing it: none. Store/mock
+## divergence is a COMPILE error via the assertions at
+## internal/database/iface_assert.go:12 and internal/database/mock_store.go:30,
+## `vet` (a test-short prerequisite) runs over every package, and `mocks-check`
+## below regenerates from .mockery.yaml and diffs. All three go red on that same
+## mutation. Do not reintroduce this target; add cases to mocks-check instead.
 
 ## staticcheck: Run staticcheck (install: go install honnef.co/go/tools/cmd/staticcheck@latest)
 staticcheck:
@@ -488,7 +495,7 @@ coverage-check-short:
 	echo "✅ Coverage $$coverage% meets floor $$floor%"
 
 ## ci: Fast CI check (short tests — prop tests skipped; use test-nightly for full suite)
-ci: mocks-check check-mock-fresh staticcheck sdkguard test-all-short coverage-check-short
+ci: mocks-check staticcheck sdkguard test-all-short coverage-check-short
 	@echo "✅ All CI checks passed!"
 
 ## build-mtls-bridge: Build the mTLS bridge binary (macOS)

--- a/changelog.d/20260817_143000_delete_inert_check_mock_fresh.md
+++ b/changelog.d/20260817_143000_delete_inert_check_mock_fresh.md
@@ -1,0 +1,23 @@
+### Removed
+
+- **`make check-mock-fresh` deleted.** The target claimed to catch a `MockStore` that had
+  drifted from the `Store` interface, and could not: it ran `go generate
+  ./internal/database/...` in a repo with zero `//go:generate` directives (mocks are
+  generated from `.mockery.yaml`), so its regeneration step was a no-op and the
+  `git diff --exit-code` that followed only ever detected an uncommitted edit. Measured by
+  adding a method to `Store` and leaving the mock alone — the exact drift it named — it
+  printed `==> Mock is fresh.` and exited 0. Its failure message also told you to run
+  `make generate`, a target that does not exist.
+
+  It was deleted rather than repaired because no coverage depends on it: `Store`/mock
+  divergence is a compile error via the assertions at `internal/database/iface_assert.go:12`
+  and `internal/database/mock_store.go:30`, `vet` runs over every package as a `test-short`
+  prerequisite, and `mocks-check` regenerates from `.mockery.yaml` and diffs. All three go
+  red on the same mutation. `make ci` now runs one mock gate instead of two.
+
+### Fixed
+
+- Corrected the `registry.Reporter` implementer counts in `reporter_db.go` and `reporter.go`
+  (21 → 24 types, 13 → 15 test fakes). The old figures came from a name-shaped estimate; the
+  new ones are structural — every implementer must declare `RunPhase`, and `sdk.Reporter` is
+  a type alias of `registry.Reporter` rather than a second interface.

--- a/docs/audits/2026-08-16-manual-mock-inventory.md
+++ b/docs/audits/2026-08-16-manual-mock-inventory.md
@@ -1,7 +1,7 @@
 <!-- file: docs/audits/2026-08-16-manual-mock-inventory.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 4e91b7c2-8d35-4a6f-b012-7c5ea93d16f8 -->
-<!-- last-edited: 2026-08-16 -->
+<!-- last-edited: 2026-08-17 -->
 
 # Manual-mock inventory and remediation backlog
 
@@ -26,7 +26,7 @@ of the mock-generation config produces code nobody imports.
 | Hand-written doubles found by name pattern | **116** across **101** files |
 | Additional doubles proven to exist beyond that pattern | **≥60** (see §2) |
 | **Estimated true population** | **≈175** |
-| Hand-written impls of one single interface (`registry.Reporter`) | **13 files** |
+| Hand-written impls of one single interface (`registry.Reporter`) | **22** (15 test fakes + 7 prod adapters) |
 
 **Four findings drive everything below:**
 
@@ -34,9 +34,14 @@ of the mock-generation config produces code nobody imports.
    not a well-formed statement.
 2. **The migration that would have fixed this was abandoned mid-flight** (§4). Commit
    `7f2a01e2` is titled "pt 1"; pt 2 never landed.
-3. **CI cannot see any of this** (§5). Both mock gates verify that *listed* mocks are fresh;
-   neither can detect an interface that was never listed. One of the two gates is inert and
-   can never fail at all.
+3. **CI cannot see any of this** (§5). Both mock gates verified that *listed* mocks are
+   fresh; neither can detect an interface that was never listed. One of the two was inert
+   for its stated purpose and was **deleted on 2026-08-17** (§5b) — but note the correction
+   there: `registry.Reporter` is *not* an instance of this blind spot. It has no generated
+   mock and needs none, because every one of its 22 non-production implementers must declare
+   `RunPhase`, so widening the interface is a compile error in all of them at once. The
+   compiler is a stronger gate than a freshness check; do not "fix" this by adding Reporter
+   to `.mockery.yaml`.
 4. **Over-generation is real and concentrated** (§6). 42% of the largest generated file is
    mocks nobody imports.
 
@@ -108,18 +113,41 @@ and then stopped.
 
 ### 5a. The never-listed blind spot
 
-`make ci` runs two mock gates:
+`make ci` runs two mock gates (one as of 2026-08-17 — see 5b):
 
 - `mocks-check` — runs `mockery`, then `git diff --quiet` over `internal/**/mocks/**` plus
   the two in-package `_test.go` mocks. **This is a real gate.**
-- `check-mock-fresh` — see 5b.
+- `check-mock-fresh` — **deleted 2026-08-17**, see 5b. `make ci` now runs one mock gate.
 
 Both answer *"are the mocks we generate up to date?"* **Neither can answer *"is there an
 interface we should be generating and aren't?"*** Every one of the ~175 hand-written doubles
 is therefore green by construction. This is the structural hole the entire inventory lives
 in, and closing it (§9) matters more than any individual conversion.
 
-### 5b. `check-mock-fresh` is inert — it can never fail
+### 5b. `check-mock-fresh` is inert — ✅ DELETED 2026-08-17
+
+> **Resolved, and the original wording below was half wrong — corrected here so the
+> sharper claim is the one that propagates.** The target was deleted, not repaired.
+> It is *not* true that it "can never fail": `git diff --exit-code
+> internal/database/mocks/` fires on **any** uncommitted edit under that directory, so
+> it is a live *dirty-worktree* detector. What it cannot do is the job it was named
+> for. Measured both ways on 2026-08-17:
+>
+> | probe | condition | `check-mock-fresh` | `mocks-check` |
+> |---|---|---|---|
+> | 1 | append a junk line to the committed `mock_store.go` | **exit 2 (fails)** | — |
+> | 2 | add a method to the `Store` interface, leave the mock untouched | **exit 0, prints "Mock is fresh"** | **exit 2 (fails)** |
+>
+> Probe 2 is the failure mode the docstring named, and it is the one the target
+> misses. Probe 1 is why "never fails" is falsifiable in one command — do not repeat it.
+>
+> **Coverage lost by deleting it: none.** Store/mock divergence is a *compile* error via
+> the assertions at `internal/database/iface_assert.go:12` and
+> `internal/database/mock_store.go:30`; `vet` (a `test-short` prerequisite, so already in
+> `make ci`) runs over every package; and `mocks-check` goes red on probe 2 as well.
+> Three independent gates already own it.
+
+The original finding, for the record:
 
 ```make
 check-mock-fresh:

--- a/docs/plans/2026-08-17-maintenance-jobs-to-v2-ops.md
+++ b/docs/plans/2026-08-17-maintenance-jobs-to-v2-ops.md
@@ -1,5 +1,5 @@
 <!-- file: docs/plans/2026-08-17-maintenance-jobs-to-v2-ops.md -->
-<!-- version: 1.3.1 -->
+<!-- version: 1.4.0 -->
 <!-- guid: 4a71e8c3-92d6-4f15-b03a-7e8d5c1946fb -->
 <!-- last-edited: 2026-08-17 -->
 
@@ -248,10 +248,16 @@ mutation.
   registered count, so a job silently dropped during conversion fails the build's tests, not
   production. 37 is the number to assert against (verified three ways: 37 `Run` receivers, 37
   files, 37 non-test `maintenance.Register` calls).
-- ⚠️ **`registry.Reporter` has no mock gate.** It is hand-rolled in **25 test files under 21
-  names** and appears **0×** in `.mockery.yaml`; `check-mock-fresh` is inert (0 `//go:generate`).
-  This migration touches Reporter usage, so `go build` is the only thing catching drift. Fixing
-  that gate is tracked separately and should land early.
+- ✅ **`registry.Reporter` needs no mock gate — RETRACTED, this bullet was wrong.** The
+  "25 test files under 21 names" figure was a naming grep. Counted structurally on 2026-08-17
+  (every implementer must declare `RunPhase`; `sdk.Reporter` is a type ALIAS, not a second
+  interface; zero interface-embedders): **24 implementers — 2 production, 7 production
+  adapters, 15 test fakes**, none behind a build tag, all compiled by `go test ./...`. It
+  appears 0× in `.mockery.yaml` and correctly so: widening `Reporter` is a compile error in
+  all 24 at once, which is a stronger gate than any freshness check. `go build` catching drift
+  is the *design*, not a gap. `check-mock-fresh` was separately inert for its own stated
+  purpose and was deleted on 2026-08-17 — see
+  `docs/audits/2026-08-16-manual-mock-inventory.md` §5b for the two probes.
 
 ## Rollback
 

--- a/internal/maintenance/jobs/policy_declaration_test.go
+++ b/internal/maintenance/jobs/policy_declaration_test.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/policy_declaration_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 6d2f8b41-9e73-4c05-a8d6-1b47e903fa25
 // last-edited: 2026-08-17
 
@@ -64,7 +64,7 @@ func TestEveryJobDeclaresAUsablePolicy(t *testing.T) {
 					"default silently applies instead of the declared 4h", p.Timeout)
 			}
 			if len(p.Capabilities) == 0 {
-				t.Errorf("Capabilities is empty; every job reached through the bridge "+
+				t.Errorf("Capabilities is empty; every job reached through the bridge " +
 					"holds library read+write today, so empty is a regression")
 			}
 		})

--- a/internal/operations/registry/reporter.go
+++ b/internal/operations/registry/reporter.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/reporter.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-08-16
+// last-edited: 2026-08-17
 
 package registry
 
@@ -36,7 +36,7 @@ type Reporter interface {
 // reporter cannot say.
 //
 // Reporter itself deliberately does not carry OpID: see the comment on
-// (*dbReporter).OpID for why widening the interface would cost twenty-one edits
+// (*dbReporter).OpID for why widening the interface would cost twenty-four edits
 // for a concern that only the scheduler has. The production reporter implements
 // it; a fake that does not simply yields "".
 //

--- a/internal/operations/registry/reporter_db.go
+++ b/internal/operations/registry/reporter_db.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/reporter_db.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 1a2b3c4d-5e6f-7890-abcd-ef0123456789
-// last-edited: 2026-07-18
+// last-edited: 2026-08-17
 
 package registry
 
@@ -78,8 +78,8 @@ type dbReporter struct {
 	// atomic nanosecond clock. Called at the very top of UpdateProgress before
 	// any lock or DB write, so the watchdog always sees a fresh timestamp even
 	// when UpdateOpProgressV2 is blocked behind PebbleDB compaction.
-	touchProgressFn      func()
-	synchronous          bool          // legacy: write DB on every UpdateProgress
+	touchProgressFn       func()
+	synchronous           bool          // legacy: write DB on every UpdateProgress
 	progressFlushInterval time.Duration // how often lazy flush fires (0 = no lazy flush)
 
 	runCtx context.Context
@@ -526,10 +526,17 @@ func (r *dbReporter) Trigger(ctx context.Context, eventName string, payload any)
 
 // OpID returns the id of the run this reporter belongs to.
 //
-// It is deliberately NOT part of the Reporter interface. Twenty-one types
-// implement Reporter and thirteen of them are test fakes that model progress and
+// It is deliberately NOT part of the Reporter interface. Twenty-four types
+// implement Reporter and fifteen of them are test fakes that model progress and
 // nothing else; adding a method would edit all of them for a concern none of
-// them has. This follows the same optional-capability pattern legacy_op_status.go
+// them has. (Counted structurally on 2026-08-17 — every implementer must declare
+// RunPhase, and `git grep "^func (.*) RunPhase("` returns exactly 24 with zero
+// interface-embedders; sdk.Reporter is a type ALIAS of this interface, not a
+// second one, so the sdk.Reporter fakes are in that 24. The previous figures,
+// 21 and 13, were a name-shaped estimate.) This is also why Reporter needs no
+// generated mock: widening it is a compile error in all 24 at once, which is a
+// stronger gate than any freshness check.
+// This follows the same optional-capability pattern legacy_op_status.go
 // uses for legacyOpStore: production runs on dbReporter, which has it, and
 // callers reach it through ReporterOpID, which degrades to "" rather than
 // panicking on a reporter that does not.

--- a/internal/operations/registry/run_items_p2_test.go
+++ b/internal/operations/registry/run_items_p2_test.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/run_items_p2_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 4f8a2c6e-1b93-4d57-8e0a-2c9b1d3e4f60
-// last-edited: 2026-07-18
+// last-edited: 2026-08-17
 
 package registry_test
 
@@ -29,12 +29,12 @@ func (r *p2ProgReporter) UpdateProgress(current, _ int, _ string) error {
 	r.mu.Unlock()
 	return nil
 }
-func (r *p2ProgReporter) SetCurrentItem(string)                         {}
-func (r *p2ProgReporter) Log(slog.Level, string, ...slog.Attr) error    { return nil }
-func (r *p2ProgReporter) Logger() *slog.Logger                          { return slog.Default() }
-func (r *p2ProgReporter) Checkpoint(any) error                          { return nil }
-func (r *p2ProgReporter) IsCanceled() bool                              { return false }
-func (r *p2ProgReporter) Trigger(context.Context, string, any) error    { return nil }
+func (r *p2ProgReporter) SetCurrentItem(string)                      {}
+func (r *p2ProgReporter) Log(slog.Level, string, ...slog.Attr) error { return nil }
+func (r *p2ProgReporter) Logger() *slog.Logger                       { return slog.Default() }
+func (r *p2ProgReporter) Checkpoint(any) error                       { return nil }
+func (r *p2ProgReporter) IsCanceled() bool                           { return false }
+func (r *p2ProgReporter) Trigger(context.Context, string, any) error { return nil }
 func (r *p2ProgReporter) RunPhase(ctx context.Context, _ string, fn func(context.Context, registry.Reporter) error) error {
 	return fn(ctx, r)
 }

--- a/todo.d/20260816-store-iface-out-of-scope-defects.md
+++ b/todo.d/20260816-store-iface-out-of-scope-defects.md
@@ -72,6 +72,9 @@ proposal's scope stays reviewable. Items marked ⚠ are agent-reported and not h
       (`scanner_coverage_test.go:655`) because importing the mocks package would cycle.
       Delete the `Scanner:` entry from `.mockery.yaml`; keep the hand-written double.
 - [ ] `internal/operations/mocks` — 206 generated lines, effectively unreferenced.
-- [ ] `Makefile` `check-mock-fresh` — runs `go generate` where the repo has **zero**
-      `//go:generate` directives, so the diff is always clean and the gate can never fail.
-      It runs in `make ci`. Delete it or give it a real directive.
+- [x] `Makefile` `check-mock-fresh` — **DELETED 2026-08-17.** Ran `go generate` where the
+      repo has **zero** `//go:generate` directives, so its regeneration step was a no-op and
+      the following `git diff` only detected a dirty worktree. Measured: mutate the `Store`
+      interface and leave the mock alone and it printed "Mock is fresh", exit 0. Deleted
+      rather than repaired — `iface_assert.go:12`, `mock_store.go:30`, `vet` and `mocks-check`
+      all already go red on that mutation, so no coverage was lost.


### PR DESCRIPTION
## What

Deletes `make check-mock-fresh`. It claimed to catch a `MockStore` that had drifted from the `Store` interface, and could not.

It ran `go generate ./internal/database/...` in a repo with **zero** `//go:generate` directives — mocks here come from `.mockery.yaml`, not from source-embedded directives — so the regeneration step was a no-op, and the `git diff --exit-code internal/database/mocks/` that followed only ever detected an uncommitted edit.

## Evidence

| probe | condition | `check-mock-fresh` | `mocks-check` |
|---|---|---|---|
| 1 | append a junk line to the committed `mock_store.go` | **exit 2 (fails)** | — |
| 2 | add a method to the `Store` interface, leave the mock untouched — *the exact drift its docstring names* | **exit 0, prints `==> Mock is fresh.`** | **exit 2 (fails)** |

Probe 2 is the job it was named for and the one it misses. Probe 1 is why the sharper claim matters: it is **not** true that it "can never fail" — it is a live *dirty-worktree* detector. That correction is in the PR because the looser version was already propagating through three docs and is falsifiable in one command.

Its failure message also instructed the reader to run `make generate` — a target that does not exist. Confirmed three ways: `^generate:` grep, the full `make -pRrq` database (which expands the `-include Makefile.local`), and running it (`exit 2`).

## Why delete, not repair

Repairing it would mean re-implementing `mocks-check`. Nothing depends on it:

- `internal/database/iface_assert.go:12` and `internal/database/mock_store.go:30` make `Store`/mock divergence a **compile error**
- `vet` runs over every package and is a `test-short` prerequisite, so it is already inside `make ci`
- `mocks-check` regenerates from `.mockery.yaml` and diffs

All three go red on probe 2. **Coverage lost: none.** `make ci` now runs one mock gate instead of two.

## Retraction: `registry.Reporter` is not a gate blind spot

A prior note held that `registry.Reporter` was hand-rolled in "25 test files under 21 names" with no mock gate. That was a naming grep. Counted **structurally** — every implementer must declare `RunPhase`, `sdk.Reporter` is a type **alias** rather than a second interface, and there are zero interface-embedders:

**24 implementers** — 2 production, 7 production adapters, 15 test fakes. None behind a build tag; all compiled by `go test ./...`.

Widening `Reporter` is therefore a compile error in all 24 at once, which is a *stronger* gate than any freshness check. It correctly has no `.mockery.yaml` entry, and adding one would buy new tests a stock fake without retiring a single hand-rolled one. The stale in-code counts (`21 types / 13 fakes`) in `reporter_db.go` and `reporter.go` are corrected to `24 / 15`.

## Also in this PR

- `gofmt` on `policy_declaration_test.go` (the follow-up to #2531) and on the two `registry` files touched here — both were already unformatted at `origin/main`.
- **Separately reported, deliberately not swept here:** 168 files repo-wide fail `gofmt -l`, and `make ci` has no gofmt gate at all.

## Verification

- `make -n ci` → exit 0, no unresolved targets; `make check-mock-fresh` → `No rule to make target` (negative control)
- `make help` unaffected (it is hardcoded `echo` lines, not parsed from `##` comments)
- `go build ./...` exit 0 · `go test ./internal/operations/registry/...` ok · `go test ./internal/maintenance/...` ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t