### PR TITLE
refactor(server): dissolve the maintenance.job bridge into 37 per-job ops

### DIFF
--- a/changelog.d/20260817_200000_dissolve_maintenance_job_bridge.md
+++ b/changelog.d/20260817_200000_dissolve_maintenance_job_bridge.md
@@ -1,0 +1,14 @@
+### Changed
+
+- Maintenance jobs now register one operation definition each (`maintenance.<job-id>`)
+  instead of sharing a single `maintenance.job` definition. Each job's resume policy,
+  timeout, concurrency key, liveness mode and capabilities now come from the job's own
+  `Policy()` declaration rather than one hardcoded set applied to all 37. Per-job
+  variation was structurally impossible before this.
+
+### Removed
+
+- The `maintenance.job` operation ID. An in-flight operation still naming it at restart
+  is dropped with a warning, which is the same path it took before — the shared
+  definition's policy was already "drop on restart", so behaviour across the upgrade is
+  unchanged.

--- a/internal/server/maintenance_dispatcher.go
+++ b/internal/server/maintenance_dispatcher.go
@@ -1,7 +1,7 @@
 // file: internal/server/maintenance_dispatcher.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 55555555-5555-5555-5555-555555555555
-// last-edited: 2026-08-14
+// last-edited: 2026-08-17
 
 package server
 
@@ -186,7 +186,7 @@ func (s *Server) runMaintenanceJob(c *gin.Context) {
 			"opID", opID, "jobID", jobID, "dryRun", dryRun, "err", err)
 	}
 
-	if _, err := s.opRegistry.EnqueueOp(c.Request.Context(), "maintenance.job", maintenanceJobOpParams{
+	if _, err := s.opRegistry.EnqueueOp(c.Request.Context(), maintenanceOpID(jobID), maintenanceJobOpParams{
 		LegacyOpID: opID,
 		JobID:      jobID,
 		DryRun:     dryRun,

--- a/internal/server/maintenance_job_op.go
+++ b/internal/server/maintenance_job_op.go
@@ -1,7 +1,7 @@
 // file: internal/server/maintenance_job_op.go
-// version: 1.2.0
+// version: 2.0.0
 // guid: 7f3a9c21-4b8e-4d56-a123-0e5f6c7d8e9f
-// last-edited: 2026-05-16
+// last-edited: 2026-08-17
 
 package server
 
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/activity"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
@@ -19,36 +18,78 @@ import (
 
 type maintenanceJobOpParams struct {
 	LegacyOpID string `json:"legacy_op_id"`
-	JobID      string `json:"job_id"`
-	DryRun     bool   `json:"dry_run"`
+	// JobID is redundant now that each job has its own OperationDef — the job is
+	// captured in the closure, not looked up from params. It is retained because
+	// resume reads params written by an older build (operations.SaveParams /
+	// LoadParams in maintenance_dispatcher.go and server_lifecycle.go), and
+	// dropping the field would silently discard it from those rows.
+	JobID  string `json:"job_id"`
+	DryRun bool   `json:"dry_run"`
 }
 
-// RegisterMaintenanceJobOp registers the "maintenance.job" OperationDef which runs
-// any named maintenance job by ID.
-func (s *Server) RegisterMaintenanceJobOp(reg *opsregistry.Registry) error {
+// maintenanceOpID returns the v2 operation ID for a maintenance job.
+//
+// Job IDs are kebab-case and contain no ':', the only character RegisterOp
+// rejects, so the prefixed form is always a legal op ID. Verified against all 37:
+// zero contain ':' and zero collide with the 144 op IDs already registered.
+func maintenanceOpID(jobID string) string { return "maintenance." + jobID }
+
+// RegisterMaintenanceJobOps registers one OperationDef per maintenance job.
+//
+// This replaces the single "maintenance.job" bridge, which registered ONE
+// OperationDef for all 37 jobs and therefore had to hardcode one policy for every
+// one of them — per-job variation was structurally impossible. Each def now reads
+// its job's Policy() (declared in PR-1, #2531) for resume, timeout, concurrency
+// key, liveness, and capabilities.
+//
+// The "maintenance.job" ID is retired. That strands no data: an in-flight v2 row
+// whose def_id no longer resolves is dropped by resumeAfterStartup
+// (registry/resume.go:58, "unknown def at startup"), and the bridge's policy was
+// ResumeDrop, so such a row took the drop path before this change too. The
+// observable difference across the deploy is one extra warning line.
+//
+// Permissions stay hardcoded to settings.manage rather than consulting the
+// PermissionAware interface. The bridge did the same, and per-job access control
+// is enforced separately by the dispatcher; wiring PermissionAware into the
+// OperationDef would be a behaviour change and belongs in its own PR.
+func (s *Server) RegisterMaintenanceJobOps(reg *opsregistry.Registry) error {
+	for _, job := range maintenance.All() {
+		if err := s.registerMaintenanceJobOp(reg, job); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// registerMaintenanceJobOp registers the OperationDef for a single job.
+func (s *Server) registerMaintenanceJobOp(reg *opsregistry.Registry, job maintenance.MaintenanceJob) error {
+	policy := job.Policy()
+	jobID := job.ID()
+
 	return reg.RegisterOp(opsregistry.OperationDef{
-		ID:              "maintenance.job",
-		Liveness: opsregistry.LivenessManual,
+		ID:              maintenanceOpID(jobID),
+		Liveness:        policy.Liveness,
 		Plugin:          "maintenance",
-		DisplayName:     "Maintenance Job",
-		Description:     "Run a named maintenance job.",
+		DisplayName:     job.Name(),
+		Description:     job.Description(),
 		DefaultPriority: opsregistry.PriorityNormal,
 		Cancellable:     true,
 		Isolate:         false,
-		Timeout:         4 * time.Hour,
-		ResumePolicy:    opsregistry.ResumeDrop,
-		ConcurrencyKey:  "", // parallel maintenance jobs allowed
+		Timeout:         policy.Timeout,
+		ResumePolicy:    policy.ResumePolicy,
+		ConcurrencyKey:  policy.ConcurrencyKey,
 		Permissions:     []auth.Permission{auth.PermSettingsManage},
-		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite},
+		Capabilities:    policy.Capabilities,
 		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
 			var p maintenanceJobOpParams
-			if err := json.Unmarshal(rawParams, &p); err != nil {
-				return fmt.Errorf("maintenance.job: decode params: %w", err)
+			// Params may legitimately be empty (a requeue re-enqueues with nil),
+			// in which case the zero value is correct: DryRun false, no legacy ID.
+			if len(rawParams) > 0 {
+				if err := json.Unmarshal(rawParams, &p); err != nil {
+					return fmt.Errorf("%s: decode params: %w", maintenanceOpID(jobID), err)
+				}
 			}
-			job, err := maintenance.Get(p.JobID)
-			if err != nil {
-				return fmt.Errorf("maintenance.job: job %q not found: %w", p.JobID, err)
-			}
+
 			store := s.Store()
 			ctx = maintenance.WithOperationID(ctx, p.LegacyOpID)
 			progress := registryProgressAdapter{r: reporter}
@@ -62,14 +103,10 @@ func (s *Server) RegisterMaintenanceJobOp(reg *opsregistry.Registry) error {
 			// by the job; fall back to the job name.
 			if s.activityWriter != nil && p.LegacyOpID != "" {
 				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
-				if sum, serr := store.GetOperationSummaryLog(p.LegacyOpID); serr == nil && sum != nil {
-					if sum.Result != nil {
-						activity.EmitInfo(s.activityWriter, p.LegacyOpID, job.ID(), job.ID(), *sum.Result, activity.AlwaysShow)
-					} else {
-						activity.EmitInfo(s.activityWriter, p.LegacyOpID, job.ID(), job.ID(), job.Name(), activity.AlwaysShow)
-					}
+				if sum, serr := store.GetOperationSummaryLog(p.LegacyOpID); serr == nil && sum != nil && sum.Result != nil {
+					activity.EmitInfo(s.activityWriter, p.LegacyOpID, jobID, jobID, *sum.Result, activity.AlwaysShow)
 				} else {
-					activity.EmitInfo(s.activityWriter, p.LegacyOpID, job.ID(), job.ID(), job.Name(), activity.AlwaysShow)
+					activity.EmitInfo(s.activityWriter, p.LegacyOpID, jobID, jobID, job.Name(), activity.AlwaysShow)
 				}
 			}
 
@@ -79,5 +116,5 @@ func (s *Server) RegisterMaintenanceJobOp(reg *opsregistry.Registry) error {
 }
 
 func init() {
-	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterMaintenanceJobOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterMaintenanceJobOps(reg) })
 }

--- a/internal/server/maintenance_job_op_test.go
+++ b/internal/server/maintenance_job_op_test.go
@@ -1,0 +1,108 @@
+// file: internal/server/maintenance_job_op_test.go
+// version: 1.0.0
+// guid: d6fc8245-22c3-4636-a194-c57f613cf3af
+// last-edited: 2026-08-17
+
+package server
+
+import (
+	"log/slog"
+	"testing"
+
+	dbmocks "github.com/falkcorp/audiobook-organizer/internal/database/mocks"
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
+	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// PR-2 replaced the single "maintenance.job" OperationDef with one def per job.
+// These tests assert the two properties that swap depends on: every job gets a
+// def, and every def carries that job's OWN policy rather than a shared default.
+//
+// Why a zero-value &Server{} is enough: registration never dereferences the
+// Server. It is captured by the Run closure, which these tests do not invoke.
+// (Same rationale as w3decodeReg in op_params_decode_test.go.)
+func maintReg(t *testing.T) *opsregistry.Registry {
+	t.Helper()
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().UpsertOpDefinitionV2(mock.Anything).Return(nil).Maybe()
+	return opsregistry.New(m, slog.New(slog.DiscardHandler), 1, nil)
+}
+
+// TestEveryMaintenanceJobGetsItsOwnOp checks that all registered jobs are
+// reachable under "maintenance.<jobID>".
+//
+// It asserts per-job presence by name, not just a count, so dropping a job from
+// the registration loop names the job it dropped. Mutation-checked: deleting one
+// job from the loop fails here rather than passing quietly.
+func TestEveryMaintenanceJobGetsItsOwnOp(t *testing.T) {
+	jobs := maintenance.All()
+	require.NotEmpty(t, jobs, "no maintenance jobs registered — the test would assert nothing")
+
+	reg := maintReg(t)
+	require.NoError(t, (&Server{}).RegisterMaintenanceJobOps(reg))
+
+	for _, job := range jobs {
+		wantID := "maintenance." + job.ID()
+		def, ok := reg.Def(wantID)
+		require.Truef(t, ok, "job %q has no OperationDef at %q", job.ID(), wantID)
+		require.Equal(t, wantID, def.ID)
+		require.NotNil(t, def.Run, "job %q registered a nil Run", job.ID())
+		require.Equal(t, "maintenance", def.Plugin)
+	}
+}
+
+// TestMaintenanceOpCarriesTheJobsOwnPolicy is the test that would have been
+// impossible before PR-2: while one def served all 37 jobs, every job
+// necessarily reported the bridge's hardcoded policy. Each field here is one the
+// bridge used to fix for everyone.
+func TestMaintenanceOpCarriesTheJobsOwnPolicy(t *testing.T) {
+	reg := maintReg(t)
+	require.NoError(t, (&Server{}).RegisterMaintenanceJobOps(reg))
+
+	for _, job := range maintenance.All() {
+		job := job
+		t.Run(job.ID(), func(t *testing.T) {
+			def, ok := reg.Def("maintenance." + job.ID())
+			require.True(t, ok)
+
+			policy := job.Policy()
+			require.Equal(t, policy.ResumePolicy, def.ResumePolicy, "ResumePolicy")
+			require.Equal(t, policy.Timeout, def.Timeout, "Timeout")
+			require.Equal(t, policy.ConcurrencyKey, def.ConcurrencyKey, "ConcurrencyKey")
+			require.Equal(t, policy.Liveness, def.Liveness, "Liveness")
+			require.Equal(t, policy.Capabilities, def.Capabilities, "Capabilities")
+
+			// Display metadata comes from the job, not a shared string.
+			require.Equal(t, job.Name(), def.DisplayName)
+			require.Equal(t, job.Description(), def.Description)
+		})
+	}
+}
+
+// TestBridgeOpIDIsRetired guards the swap itself. "maintenance.job" must no
+// longer resolve — an in-flight v2 row naming it is dropped by
+// resumeAfterStartup's unknown-def branch, which is the same path the bridge's
+// own ResumeDrop policy already took.
+func TestBridgeOpIDIsRetired(t *testing.T) {
+	reg := maintReg(t)
+	require.NoError(t, (&Server{}).RegisterMaintenanceJobOps(reg))
+
+	_, ok := reg.Def("maintenance.job")
+	require.False(t, ok, `the "maintenance.job" bridge def must not be registered`)
+}
+
+// TestMaintenanceOpIDIsRegistrable checks the op IDs PR-2 mints against the only
+// two constraints RegisterOp enforces on an ID: non-empty, and no ':'. Job IDs
+// are kebab-case today; this fails if one ever arrives colon-separated (the
+// LEGACY v1 op type in maintenance_dispatcher.go IS "maintenance:"+jobID, so the
+// mistake is one character away).
+func TestMaintenanceOpIDIsRegistrable(t *testing.T) {
+	for _, job := range maintenance.All() {
+		id := maintenanceOpID(job.ID())
+		require.NotEmpty(t, job.ID(), "a job reported an empty ID")
+		require.NotContains(t, id, ":", "op id %q contains ':', which RegisterOp rejects", id)
+		require.Equal(t, "maintenance."+job.ID(), id)
+	}
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 3.19.0
+// version: 3.20.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-08-17
 
@@ -303,7 +303,7 @@ func (s *Server) resumeLegacyOp(opID, opType string) {
 					slog.Info("No saved params for interrupted maintenance job; resuming with the advertised dry_run default",
 						"opID", opID, "jobID", jobID, "dryRun", enqParams.DryRun)
 				}
-				if _, enqErr := s.opRegistry.EnqueueOp(context.Background(), "maintenance.job", enqParams); enqErr != nil {
+				if _, enqErr := s.opRegistry.EnqueueOp(context.Background(), maintenanceOpID(jobID), enqParams); enqErr != nil {
 					slog.Warn("Failed to re-enqueue maintenance job () via v2", "opID", opID, "jobID", jobID, "enqErr", enqErr)
 					_ = store.UpdateOperationError(opID, "failed to resume: "+enqErr.Error())
 				}


### PR DESCRIPTION
## What

The `maintenance.job` bridge registered **one** `OperationDef` for all 37 maintenance jobs, and therefore hardcoded a single policy for every one of them. Per-job resume / timeout / concurrency / liveness variation was *structurally impossible* while it stood.

Each job now registers its own def at `maintenance.<job-id>`, reading the `ExecutionPolicy` it declared in PR-1 (#2531).

## Verified before the swap

| Check | Result |
|---|---|
| Job IDs containing `:` (the only char `RegisterOp` rejects) | **0 of 37** |
| Collisions between `maintenance.<id>` and already-registered op IDs | **0** (against 144) |
| References to the literal `"maintenance.job"` | 5 Go, **0 in `web/`** |

Each count was taken with a positive control asserting the instrument could see a known-present value — an earlier naive grep for these same figures returned a false 0.

## Why retiring the ID strands no data

An in-flight v2 row whose `def_id` no longer resolves is dropped by `resumeAfterStartup`'s unknown-def branch (`internal/operations/registry/resume.go:58`), and the bridge's own policy was already `ResumeDrop` — so such a row took the drop path before this change too. The observable difference across the deploy is one extra warning line.

## Tests, and the mutation evidence

Four tests in `internal/server/maintenance_job_op_test.go`. Both were mutation-checked rather than trusted green:

- **Drop one job from the registration loop** → `TestEveryMaintenanceJobGetsItsOwnOp` fails naming `dedup-books`.
- **Replace `job.Policy()` with the bridge's shared `DefaultPolicy()`** → `TestMaintenanceOpCarriesTheJobsOwnPolicy` fails on exactly **4** jobs: `backfill-file-hashes`, `bulk-fetch-metadata`, `recompute-book-aggregates`, `retention-and-hygiene`.

That second result is the one worth reading. It matches PR-1's own doc comment ("true for 33 of the 37") and is the evidence that the per-job wiring *changes something*: those 4 jobs get a genuinely different policy than the bridge gave them, and the other 33 are provably unchanged.

## Deliberately not in scope

Permissions stay hardcoded to `settings.manage` rather than consulting the `PermissionAware` interface. The bridge did the same, and the dispatcher enforces per-job access control separately — wiring it into the `OperationDef` would be a behaviour change and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t