### PR TITLE
refactor(maintenance): narrow MaintenanceJob.Run from Store to JobStore

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 10.31.0 -->
+<!-- version: 10.32.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-08-14 -->
+<!-- last-edited: 2026-08-17 -->
 
 # Project TODO — live items only
 
@@ -5204,8 +5204,20 @@ Companion docs:
     Type-only change (no runtime/data impact); existing `mocks.Store` already satisfies
     every sub-interface so no wave triggers a mockery regen. Old sweep tooling
     (`scripts/{check_store_noops,narrow_struct_services,apply_narrowing}.py`) survives but
-    its hardcoded file lists must be regenerated. **Not started; deferred behind the
-    dedup+review consolidation work (items 50–52).**
+    its hardcoded file lists must be regenerated. ~~Not started~~ — **PARTIALLY DONE
+    2026-08-17 (PR #2534): the `internal/maintenance/jobs` consumer is narrowed.**
+    `MaintenanceJob.Run` now takes a 12-sub-interface `maintenance.JobStore` (187 methods)
+    instead of `database.Store` (40 sub-interfaces, 398 methods) — a 53.0% cut across all
+    37 jobs, with zero `Run` body changes and 8 job files dropping their
+    `internal/database` import entirely. The union was measured from call sites (a lower
+    bound) and then PROVEN by the type checker: the build only passes if every job and
+    every helper it reaches fits inside the 12. Also confirmed the note above: no mockery
+    regen was triggered, and exactly **1** test fake needed editing.
+    ⚠️ Correcting an overclaim carried in earlier notes: **this does NOT delete
+    `database.MockStore`** — it is imported far beyond this package and satisfies
+    `JobStore` too, so the 14 job tests that build one still compile unchanged.
+    **Still not started:** the 8 `internal/server/handlers/*/interfaces.go` +
+    `internal/server/interfaces.go` DI seams, which remain the bulk of this item.
 41. ~~**4.10 — MergeService mock-store unit tests** (H1:2789)~~ — DONE: `internal/merge`
     coverage 70.3%→96.6%. Added 34 tests across external-ID reassignment, ITL-removal
     enqueue, loser soft-delete, nil/empty-override wipe-safety, version-group integrity

--- a/changelog.d/20260817_203000_narrow_maintenance_job_store.md
+++ b/changelog.d/20260817_203000_narrow_maintenance_job_store.md
@@ -1,0 +1,15 @@
+### Changed
+
+- Maintenance jobs now receive a `maintenance.JobStore` instead of the full
+  `database.Store`. `Store` resolves to 398 methods across 40 sub-interfaces; the 37 jobs
+  between them use 12 of those sub-interfaces — 187 methods, a 53% smaller contract. A job
+  that needs a genuinely new database capability now has to add a line to `JobStore`, which
+  makes widening it a visible decision rather than a silent one.
+- Two metadata-cache helpers in the database package (`GetCachedMetadataFetchWithMaxAge`,
+  `PutCachedMetadataFetch`) now take the `RawKVStore` they were already limited to using,
+  rather than the whole store.
+
+### Removed
+
+- The write-only package-level store global in `internal/maintenance` (`InjectStore` /
+  `GetStore`). It was set once at startup and never read by anything.

--- a/docs/executive-summaries/2026-08-31-august-monthly-roundup-executive-summary.md
+++ b/docs/executive-summaries/2026-08-31-august-monthly-roundup-executive-summary.md
@@ -1,11 +1,11 @@
 <!-- file: docs/executive-summaries/2026-08-31-august-monthly-roundup-executive-summary.md -->
-<!-- version: 1.4.0 -->
+<!-- version: 1.5.0 -->
 <!-- guid: e7a3f109-52d8-4c6b-91f4-08b7c2d64e35 -->
-<!-- last-edited: 2026-08-16 -->
+<!-- last-edited: 2026-08-17 -->
 
 # Executive Summary: August 2026 Monthly Roundup
 
-**Period covered:** 2026-08-01 through 2026-08-16 (**month in progress** — this is
+**Period covered:** 2026-08-01 through 2026-08-17 (**month in progress** — this is
 updated as work lands, not a closed record).
 **Individual write-ups this consolidates:** the seven dated summaries in this directory
 from 2026-08-04 to 2026-08-09, linked inline below.
@@ -242,6 +242,41 @@ because the second commit created the thing the first had verified did not exist
 second: simply *viewing* a rule-based collection wrote it back to disk every time,
 which would have made every collection look freshly modified on every glance and
 defeated the caching the app relies on to stay fast.
+
+---
+
+## 7. August 17: a check that could not fail, and the cleanup jobs
+
+Three changes that are invisible from the app but change what the code can quietly get
+wrong.
+
+**A safety check was deleted rather than repaired, because it was proven unable to fail.**
+One of the automated checks claimed to catch a specific kind of mistake: a piece of
+scaffolding drifting out of step with the real thing it stands in for. It was tested by
+deliberately making exactly that mistake — and it reported success. The reason is
+mundane: it was rebuilding the scaffolding with a command that, in this project, rebuilds
+nothing, then checking whether anything had changed. Nothing ever had. It was removed
+rather than fixed, because three other checks *do* catch that mistake, and all three were
+confirmed to go red on the same deliberate break. **A check nobody has ever seen fail is
+not evidence of health.**
+
+**The 37 maintenance jobs each got their own registration.** These are the one-off cleanup
+tasks — repairing file links, recomputing totals, tidying up duplicates. All 37 shared a
+single registration, which meant they also shared one answer to questions like "if the
+server restarts mid-run, what happens?" and "how long may this take?". Giving each job its
+own entry made per-job answers possible for the first time, and **four jobs turned out to
+need a different answer than the shared one gave them.** The other 33 were confirmed
+unchanged rather than assumed so.
+
+**And those jobs' reach into the database was cut roughly in half.** Every cleanup job was
+handed a key to all **398** database operations, whether it needed them or not. Measuring
+what they actually use gave **187** — so that is what they get now. This is a guardrail,
+not a fix: nothing was doing the wrong thing, but a job that starts reaching somewhere new
+now has to say so where a reviewer will see it.
+
+Worth recording honestly: an earlier framing of this work claimed it would delete a large
+piece of test scaffolding. **It does not,** and that was corrected before the work shipped
+rather than discovered afterward.
 
 ---
 

--- a/internal/database/metadata_fetch_cache.go
+++ b/internal/database/metadata_fetch_cache.go
@@ -1,7 +1,7 @@
 // file: internal/database/metadata_fetch_cache.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 9e8d7c6b-5a4f-3e2d-1c0b-9a8b7c6d5e4f
-// last-edited: 2026-06-23
+// last-edited: 2026-08-17
 
 package database
 
@@ -70,7 +70,7 @@ func metadataFetchCacheKey(bookID, source string) string {
 // falls through to the API path. The entry is NOT deleted — it
 // remains available for diagnostics and will be overwritten on
 // the next successful fetch.
-func GetCachedMetadataFetchWithMaxAge(store Store, bookID, source string, maxAge time.Duration) (*CachedMetadataEntry, bool, error) {
+func GetCachedMetadataFetchWithMaxAge(store RawKVStore, bookID, source string, maxAge time.Duration) (*CachedMetadataEntry, bool, error) {
 	if bookID == "" || source == "" {
 		return nil, false, nil
 	}
@@ -113,7 +113,7 @@ func GetCachedMetadataFetchWithMaxAge(store Store, bookID, source string, maxAge
 //
 // Thin wrapper around GetCachedMetadataFetchWithMaxAge(maxAge=0)
 // kept for backward compatibility.
-func GetCachedMetadataFetch(store Store, bookID, source string) (*CachedMetadataEntry, error) {
+func GetCachedMetadataFetch(store RawKVStore, bookID, source string) (*CachedMetadataEntry, error) {
 	entry, _, err := GetCachedMetadataFetchWithMaxAge(store, bookID, source, 0)
 	return entry, err
 }
@@ -126,7 +126,7 @@ func GetCachedMetadataFetch(store Store, bookID, source string) (*CachedMetadata
 // the caller but never fails the outer fetch, per the same
 // principle as the embedding cache: the cache is an
 // optimization, not a correctness layer.
-func PutCachedMetadataFetch(store Store, bookID, source string, results json.RawMessage, bestScore float64) error {
+func PutCachedMetadataFetch(store RawKVStore, bookID, source string, results json.RawMessage, bestScore float64) error {
 	if bookID == "" || source == "" {
 		return nil
 	}
@@ -151,7 +151,7 @@ func PutCachedMetadataFetch(store Store, bookID, source string, results json.Raw
 // InvalidateCachedMetadataFetch removes the cache entry for
 // a single (bookID, source) pair. Called after a metadata
 // apply so the next fetch refreshes from the source.
-func InvalidateCachedMetadataFetch(store Store, bookID, source string) error {
+func InvalidateCachedMetadataFetch(store RawKVStore, bookID, source string) error {
 	if bookID == "" || source == "" {
 		return nil
 	}
@@ -165,7 +165,7 @@ func InvalidateCachedMetadataFetch(store Store, bookID, source string) error {
 // CountCachedMetadataFetches returns the number of entries currently
 // stored in the DB-backed metadata fetch cache. Used by the cache stats
 // handler to populate the Size field for this non-in-memory cache.
-func CountCachedMetadataFetches(store Store) (int64, error) {
+func CountCachedMetadataFetches(store RawKVStore) (int64, error) {
 	return store.CountPrefix("metadata_fetch_cache:")
 }
 
@@ -173,7 +173,7 @@ func CountCachedMetadataFetches(store Store) (int64, error) {
 // cache entry for a single book. Called when the book's title
 // or author changes — any cached candidate is now stale because
 // it was queried against different search terms.
-func InvalidateAllCachedMetadataFetchesForBook(store Store, bookID string) error {
+func InvalidateAllCachedMetadataFetchesForBook(store RawKVStore, bookID string) error {
 	if bookID == "" {
 		return nil
 	}

--- a/internal/maintenance/job.go
+++ b/internal/maintenance/job.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/job.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 11111111-1111-1111-1111-111111111111
 // last-edited: 2026-08-17
 
@@ -64,8 +64,11 @@ type PermissionAware interface {
 // bridge stands. Declaring the policy on the job is the step that makes the 37
 // separate OperationDefs of PR-2 a wiring change rather than a design change.
 //
-// Nothing reads this yet. The bridge still runs and still supplies its own hardcoded
-// values, so adding these declarations is behaviour-preserving by construction.
+// As of PR-2 the bridge is gone and RegisterMaintenanceJobOps reads this per job,
+// so a value here is now load-bearing rather than declarative. Four jobs
+// (backfill-file-hashes, bulk-fetch-metadata, recompute-book-aggregates,
+// retention-and-hygiene) declare something other than DefaultPolicy(); the other
+// 33 assert the bridge's old behaviour was correct for them.
 //
 // ⚠️ The zero value is INVALID and deliberately so: ResumeUnspecified and
 // LivenessUnspecified are both `= iota` = 0, and RegisterOp rejects each
@@ -165,6 +168,40 @@ func RequeuePolicy() ExecutionPolicy {
 	return p
 }
 
+// JobStore is the database surface a maintenance job may use.
+//
+// It replaces database.Store in Run's signature. Store embeds 40 sub-interfaces
+// resolving to 398 methods; the 37 jobs together touch 12 of them — 187 methods,
+// a 53% smaller contract. The union was measured from every direct store.X() call
+// in the job bodies plus the parameter types of every helper a job hands `store`
+// to, not from a naming pattern.
+//
+// Listing the sub-interfaces rather than the methods is deliberate: it mirrors how
+// database.Store itself is built, so a job needing a genuinely new capability adds
+// one line here and that line is the review surface. Widening it should feel like
+// a decision.
+//
+// What this does NOT do: it does not delete database.MockStore. MockStore is
+// imported far beyond this package and satisfies JobStore too, so the 14 job tests
+// that build one still compile unchanged. What it buys is a bounded contract and
+// the option of a small per-job double.
+//
+// Nothing here is a new type — all 12 already existed in internal/database.
+type JobStore interface {
+	database.BookStore
+	database.BookFileStore
+	database.AuthorStore
+	database.OperationStore
+	database.SeriesStore
+	database.ExternalIDStore
+	database.UserStore
+	database.UserPositionStore
+	database.UserTagStore
+	database.SettingsStore
+	database.MetadataStore
+	database.RawKVStore
+}
+
 // PolicyAware is satisfied by every MaintenanceJob. It is a separate interface
 // only so that PR-2's registration code can accept the policy without depending
 // on the rest of the v1 job surface, which PR-2 deletes.
@@ -197,10 +234,5 @@ type MaintenanceJob interface {
 	// job. See ExecutionPolicy — the zero value is invalid.
 	Policy() ExecutionPolicy
 	// Run executes the job. startFrom is the checkpoint index for resumable jobs (0 = fresh start).
-	Run(ctx context.Context, store database.Store, reporter ProgressReporter, dryRun bool) error
+	Run(ctx context.Context, store JobStore, reporter ProgressReporter, dryRun bool) error
 }
-
-var store database.Store
-
-func InjectStore(s database.Store) { store = s }
-func GetStore() database.Store     { return store }

--- a/internal/maintenance/jobs/backfill_book_files.go
+++ b/internal/maintenance/jobs/backfill_book_files.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/backfill_book_files.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1000005-0000-0000-0000-000000000005
 // last-edited: 2026-08-17
 
@@ -9,11 +9,12 @@ import (
 	"context"
 	"path/filepath"
 
+	"log/slog"
+
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
 	ulid "github.com/oklog/ulid/v2"
-	"log/slog"
 )
 
 func init() { maintenance.Register(&backfillBookFilesJob{}) }
@@ -32,7 +33,7 @@ func (j *backfillBookFilesJob) Description() string {
 	return "Create book_files rows for books that have none"
 }
 func (j *backfillBookFilesJob) CanResume() bool { return false }
-func (j *backfillBookFilesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *backfillBookFilesJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return err

--- a/internal/maintenance/jobs/backfill_file_hashes.go
+++ b/internal/maintenance/jobs/backfill_file_hashes.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/backfill_file_hashes.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: a1000014-0000-0000-0000-000000000014
 // last-edited: 2026-08-17
 
@@ -10,11 +10,12 @@ import (
 	"fmt"
 	"time"
 
+	"log/slog"
+
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"github.com/falkcorp/audiobook-organizer/internal/operations"
 	"github.com/falkcorp/audiobook-organizer/internal/scanner"
-	"log/slog"
 )
 
 func init() { maintenance.Register(&backfillFileHashesJob{}) }
@@ -35,7 +36,7 @@ func (j *backfillFileHashesJob) Description() string {
 
 // Job supports checkpoint-based resume after restart.
 func (j *backfillFileHashesJob) CanResume() bool { return true }
-func (j *backfillFileHashesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *backfillFileHashesJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	files, err := store.GetAllBookFilesCore()
 	if err != nil {
 		return err

--- a/internal/maintenance/jobs/backfill_file_hashes_test.go
+++ b/internal/maintenance/jobs/backfill_file_hashes_test.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/backfill_file_hashes_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f01234567890
-// last-edited: 2026-07-06
+// last-edited: 2026-08-17
 
 package jobs_test
 
@@ -39,7 +39,7 @@ func TestBackfillFileHashesJob_SkipsAlreadyHashed(t *testing.T) {
 	var setCalled bool
 	store := &database.MockStore{
 		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
-		SetBookFileHashFunc: func(id, h string) error { setCalled = true; return nil },
+		SetBookFileHashFunc:     func(id, h string) error { setCalled = true; return nil },
 	}
 
 	j, err := maintenance.Get("backfill-file-hashes")
@@ -64,7 +64,7 @@ func TestBackfillFileHashesJob_HashesNewFile(t *testing.T) {
 	var gotHash string
 	store := &database.MockStore{
 		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
-		SetBookFileHashFunc: func(id, h string) error { gotHash = h; return nil },
+		SetBookFileHashFunc:     func(id, h string) error { gotHash = h; return nil },
 	}
 
 	j, err := maintenance.Get("backfill-file-hashes")
@@ -83,7 +83,7 @@ func TestBackfillFileHashesJob_DryRun_SkipsWrite(t *testing.T) {
 	var setCalled bool
 	store := &database.MockStore{
 		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
-		SetBookFileHashFunc: func(id, h string) error { setCalled = true; return nil },
+		SetBookFileHashFunc:     func(id, h string) error { setCalled = true; return nil },
 	}
 
 	j, err := maintenance.Get("backfill-file-hashes")
@@ -98,7 +98,7 @@ func TestBackfillFileHashesJob_MissingFile_Warns(t *testing.T) {
 	rep := &noopReporter{}
 	store := &database.MockStore{
 		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
-		SetBookFileHashFunc: func(id, h string) error { setCalled = true; return nil },
+		SetBookFileHashFunc:     func(id, h string) error { setCalled = true; return nil },
 	}
 
 	j, err := maintenance.Get("backfill-file-hashes")

--- a/internal/maintenance/jobs/backfill_itunes_positions.go
+++ b/internal/maintenance/jobs/backfill_itunes_positions.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/backfill_itunes_positions.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 19a97553-68fc-4ef6-a326-cc9e694d8698
 // last-edited: 2026-08-17
 
@@ -192,7 +192,7 @@ const (
 	outcomeFailed
 )
 
-func (j *backfillITunesPositionsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *backfillITunesPositionsJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	userID, err := ResolveITunesPositionBackfillUser(store)
 	if err != nil {
 		return fmt.Errorf("backfill-itunes-positions: %w", err)
@@ -271,7 +271,7 @@ func (j *backfillITunesPositionsJob) Run(ctx context.Context, store database.Sto
 // Every failure path logs the book ID and returns outcomeFailed rather than
 // returning nil quietly: a silently skipped book is a listening position the
 // owner loses without ever being told.
-func (j *backfillITunesPositionsJob) migrateOne(store database.Store, bookmarkStore database.BookmarkStore, userID, bookID string, dryRun bool) migrateResult {
+func (j *backfillITunesPositionsJob) migrateOne(store maintenance.JobStore, bookmarkStore database.BookmarkStore, userID, bookID string, dryRun bool) migrateResult {
 	book, err := store.GetBookByID(bookID)
 	if err != nil {
 		slog.Warn("backfill-itunes-positions: get book failed", "book", bookID, "err", err)

--- a/internal/maintenance/jobs/backfill_metadata_source_hash.go
+++ b/internal/maintenance/jobs/backfill_metadata_source_hash.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/backfill_metadata_source_hash.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1000015-0000-0000-0000-000000000015
 // last-edited: 2026-08-17
 
@@ -10,9 +10,10 @@ import (
 	"crypto/sha256"
 	"fmt"
 
+	"log/slog"
+
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
-	"log/slog"
 )
 
 func init() { maintenance.Register(&backfillMetadataSourceHashJob{}) }
@@ -31,7 +32,7 @@ func (j *backfillMetadataSourceHashJob) Description() string {
 	return "Compute MetadataSourceHash for books that have one missing"
 }
 func (j *backfillMetadataSourceHashJob) CanResume() bool { return false }
-func (j *backfillMetadataSourceHashJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *backfillMetadataSourceHashJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return err

--- a/internal/maintenance/jobs/backfill_sync_ids.go
+++ b/internal/maintenance/jobs/backfill_sync_ids.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/backfill_sync_ids.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 85ae5c94-d001-49d9-9f65-97f73f32522b
 // last-edited: 2026-08-17
 
@@ -51,7 +51,7 @@ func (j *backfillSyncIDsJob) DefaultParams() any {
 // checkpointing, unlike backfill_file_hashes.go's resumeIndex.
 func (j *backfillSyncIDsJob) CanResume() bool { return false }
 
-func (j *backfillSyncIDsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *backfillSyncIDsJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	syncStore := database.AsSyncIdentityStore(store)
 	fileStore := database.AsSyncFileStore(store)
 	if syncStore == nil || fileStore == nil {

--- a/internal/maintenance/jobs/bulk_deluge_import.go
+++ b/internal/maintenance/jobs/bulk_deluge_import.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/bulk_deluge_import.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: a2b8c6d7-9e0f-1a2b-3c4d-5e6f7a8b9c0d
 // last-edited: 2026-08-17
 
@@ -40,7 +40,7 @@ func (j *bulkDelugeImportJob) Description() string {
 func (j *bulkDelugeImportJob) DefaultParams() any { return &bdi_params{DryRun: true} }
 func (j *bulkDelugeImportJob) CanResume() bool    { return true }
 
-func (j *bulkDelugeImportJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *bulkDelugeImportJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	opID := maintenance.OperationIDFromCtx(ctx)
 
 	maxBooks := 0

--- a/internal/maintenance/jobs/bulk_fetch_metadata.go
+++ b/internal/maintenance/jobs/bulk_fetch_metadata.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/bulk_fetch_metadata.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: b3c9d7e8-0f1a-2b3c-4d5e-6f7a8b9c0d1e
 // last-edited: 2026-08-17
 
@@ -42,7 +42,7 @@ func (j *bulkFetchMetadataJob) DefaultParams() any { return &bmf_params{} }
 func (j *bulkFetchMetadataJob) CanResume() bool    { return true }
 func (j *bulkFetchMetadataJob) Permission() string { return string(auth.PermLibraryEditMetadata) }
 
-func (j *bulkFetchMetadataJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *bulkFetchMetadataJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	opID := maintenance.OperationIDFromCtx(ctx)
 
 	preferAudible := false

--- a/internal/maintenance/jobs/cleanup_backups.go
+++ b/internal/maintenance/jobs/cleanup_backups.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/cleanup_backups.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1000021-0000-0000-0000-000000000021
 // last-edited: 2026-08-17
 
@@ -11,10 +11,10 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/falkcorp/audiobook-organizer/internal/config"
-	"github.com/falkcorp/audiobook-organizer/internal/database"
-	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"log/slog"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 )
 
 func init() { maintenance.Register(&cleanupBackupsJob{}) }
@@ -35,7 +35,7 @@ func (j *cleanupBackupsJob) Description() string {
 	return "Delete .backup and .bak files from the library root"
 }
 func (j *cleanupBackupsJob) CanResume() bool { return false }
-func (j *cleanupBackupsJob) Run(ctx context.Context, _ database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *cleanupBackupsJob) Run(ctx context.Context, _ maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	root := config.AppConfig.RootDir
 	if root == "" {
 		slog.Warn("cleanup-backups RootDir not configured")

--- a/internal/maintenance/jobs/cleanup_empty_folders.go
+++ b/internal/maintenance/jobs/cleanup_empty_folders.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/cleanup_empty_folders.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1000006-0000-0000-0000-000000000006
 // last-edited: 2026-08-17
 
@@ -12,10 +12,10 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/falkcorp/audiobook-organizer/internal/config"
-	"github.com/falkcorp/audiobook-organizer/internal/database"
-	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"log/slog"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 )
 
 func init() { maintenance.Register(&cleanupEmptyFoldersJob{}) }
@@ -35,7 +35,7 @@ func (j *cleanupEmptyFoldersJob) Description() string {
 }
 func (j *cleanupEmptyFoldersJob) CanResume() bool { return true }
 
-func (j *cleanupEmptyFoldersJob) Run(ctx context.Context, _ database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *cleanupEmptyFoldersJob) Run(ctx context.Context, _ maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	root := config.AppConfig.RootDir
 	if root == "" {
 		slog.Warn("cleanup-empty-folders RootDir not configured")

--- a/internal/maintenance/jobs/cleanup_organize_mess.go
+++ b/internal/maintenance/jobs/cleanup_organize_mess.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/cleanup_organize_mess.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: a1000007-0000-0000-0000-000000000007
 // last-edited: 2026-08-17
 
@@ -15,10 +15,10 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/falkcorp/audiobook-organizer/internal/config"
-	"github.com/falkcorp/audiobook-organizer/internal/database"
-	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"log/slog"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 )
 
 func init() { maintenance.Register(&cleanupOrganizeMess{}) }
@@ -38,7 +38,7 @@ func (j *cleanupOrganizeMess) Description() string {
 }
 func (j *cleanupOrganizeMess) CanResume() bool { return false }
 
-func (j *cleanupOrganizeMess) Run(ctx context.Context, _ database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *cleanupOrganizeMess) Run(ctx context.Context, _ maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	rootDir := config.AppConfig.RootDir
 	if rootDir == "" {
 		return fmt.Errorf("root_dir is not configured")

--- a/internal/maintenance/jobs/cleanup_series.go
+++ b/internal/maintenance/jobs/cleanup_series.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/cleanup_series.go
-// version: 2.4.0
+// version: 2.5.0
 // guid: a1000002-0000-0000-0000-000000000002
 // last-edited: 2026-08-17
 
@@ -12,9 +12,10 @@ import (
 	"strings"
 	"unicode"
 
+	"log/slog"
+
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
-	"log/slog"
 )
 
 func init() { maintenance.Register(&cleanupSeriesJob{}) }
@@ -34,7 +35,7 @@ func (j *cleanupSeriesJob) Description() string {
 }
 func (j *cleanupSeriesJob) CanResume() bool { return false }
 
-func (j *cleanupSeriesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *cleanupSeriesJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	allSeries, err := store.GetAllSeries()
 	if err != nil {
 		return fmt.Errorf("failed to list series: %w", err)

--- a/internal/maintenance/jobs/dedup_books.go
+++ b/internal/maintenance/jobs/dedup_books.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/dedup_books.go
-// version: 2.6.0
+// version: 2.7.0
 // guid: a1000010-0000-0000-0000-000000000010
 // last-edited: 2026-08-17
 
@@ -38,7 +38,7 @@ func (j *dedupBooksJob) DefaultParams() any {
 func (j *dedupBooksJob) Description() string { return "Detect and merge duplicate books" }
 func (j *dedupBooksJob) CanResume() bool     { return false }
 
-func (j *dedupBooksJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *dedupBooksJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	allBooks, err := ddFetchAllBooksPaginated(store)
 	if err != nil {
 		return fmt.Errorf("failed to list books: %w", err)
@@ -326,7 +326,7 @@ func ddBookScore(b *database.Book) int {
 	return score
 }
 
-func ddMergeDuplicateBook(store database.Store, keeper *database.Book, dup *database.Book, dryRun bool, enqueuer maintenance.WriteBackEnqueuer) error {
+func ddMergeDuplicateBook(store maintenance.JobStore, keeper *database.Book, dup *database.Book, dryRun bool, enqueuer maintenance.WriteBackEnqueuer) error {
 	if dryRun {
 		return nil
 	}

--- a/internal/maintenance/jobs/enrich_book_files.go
+++ b/internal/maintenance/jobs/enrich_book_files.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/enrich_book_files.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1000009-0000-0000-0000-000000000009
 // last-edited: 2026-08-17
 
@@ -12,9 +12,10 @@ import (
 	"strconv"
 	"strings"
 
+	"log/slog"
+
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
-	"log/slog"
 )
 
 func init() { maintenance.Register(&enrichBookFilesJob{}) }
@@ -35,7 +36,7 @@ func (j *enrichBookFilesJob) Description() string {
 	return "Backfill track numbers for book_files from filenames"
 }
 func (j *enrichBookFilesJob) CanResume() bool { return false }
-func (j *enrichBookFilesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *enrichBookFilesJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	files, err := store.GetAllBookFilesCore()
 	if err != nil {
 		return err

--- a/internal/maintenance/jobs/fix_author_narrator_swap.go
+++ b/internal/maintenance/jobs/fix_author_narrator_swap.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/fix_author_narrator_swap.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: a1000003-0000-0000-0000-000000000003
 // last-edited: 2026-08-17
 
@@ -10,9 +10,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/falkcorp/audiobook-organizer/internal/database"
-	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"log/slog"
+
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 )
 
 func init() { maintenance.Register(&fixAuthorNarratorSwapJob{}) }
@@ -32,7 +32,7 @@ func (j *fixAuthorNarratorSwapJob) Description() string {
 }
 func (j *fixAuthorNarratorSwapJob) CanResume() bool { return false }
 
-func (j *fixAuthorNarratorSwapJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *fixAuthorNarratorSwapJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	const batchSize = 500
 	offset := 0
 	var found, applied int

--- a/internal/maintenance/jobs/fix_book_file_paths.go
+++ b/internal/maintenance/jobs/fix_book_file_paths.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/fix_book_file_paths.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1000011-0000-0000-0000-000000000011
 // last-edited: 2026-08-17
 
@@ -9,9 +9,10 @@ import (
 	"context"
 	"os"
 
+	"log/slog"
+
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
-	"log/slog"
 )
 
 func init() { maintenance.Register(&fixBookFilePathsJob{}) }
@@ -30,7 +31,7 @@ func (j *fixBookFilePathsJob) Description() string {
 	return "Mark book_files as missing when they no longer exist on disk"
 }
 func (j *fixBookFilePathsJob) CanResume() bool { return false }
-func (j *fixBookFilePathsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *fixBookFilePathsJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	files, err := store.GetAllBookFilesCore()
 	if err != nil {
 		return err

--- a/internal/maintenance/jobs/fix_file_modes.go
+++ b/internal/maintenance/jobs/fix_file_modes.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/fix_file_modes.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 6d3a9f82-1e47-4b50-8c2d-5f9e7a3b1c48
 // last-edited: 2026-08-17
 
@@ -11,7 +11,6 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 )
 
@@ -43,7 +42,7 @@ func (j *fixFileModesJob) Description() string {
 }
 func (j *fixFileModesJob) CanResume() bool { return false } // idempotent
 
-func (j *fixFileModesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *fixFileModesJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	files, err := store.GetAllBookFilesCore()
 	if err != nil {
 		return fmt.Errorf("list book files: %w", err)

--- a/internal/maintenance/jobs/fix_library_states.go
+++ b/internal/maintenance/jobs/fix_library_states.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/fix_library_states.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1000008-0000-0000-0000-000000000008
 // last-edited: 2026-08-17
 
@@ -9,9 +9,9 @@ import (
 	"context"
 	"os"
 
-	"github.com/falkcorp/audiobook-organizer/internal/database"
-	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"log/slog"
+
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 )
 
 func init() { maintenance.Register(&fixLibraryStatesJob{}) }
@@ -30,7 +30,7 @@ func (j *fixLibraryStatesJob) Description() string {
 	return "Reconcile library_state field based on filesystem presence"
 }
 func (j *fixLibraryStatesJob) CanResume() bool { return false }
-func (j *fixLibraryStatesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *fixLibraryStatesJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return err

--- a/internal/maintenance/jobs/fix_read_by_narrator.go
+++ b/internal/maintenance/jobs/fix_read_by_narrator.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/fix_read_by_narrator.go
-// version: 2.4.0
+// version: 2.5.0
 // guid: a1000001-0000-0000-0000-000000000001
 // last-edited: 2026-08-17
 
@@ -11,9 +11,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"log/slog"
+
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
-	"log/slog"
 )
 
 func init() { maintenance.Register(&fixReadByNarratorJob{}) }
@@ -33,7 +34,7 @@ func (j *fixReadByNarratorJob) Description() string {
 }
 func (j *fixReadByNarratorJob) CanResume() bool { return false }
 
-func (j *fixReadByNarratorJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *fixReadByNarratorJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	allBooks, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return fmt.Errorf("failed to list books: %w", err)

--- a/internal/maintenance/jobs/fix_version_groups.go
+++ b/internal/maintenance/jobs/fix_version_groups.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/fix_version_groups.go
-// version: 2.4.0
+// version: 2.5.0
 // guid: a1000004-0000-0000-0000-000000000004
 // last-edited: 2026-08-17
 
@@ -13,11 +13,12 @@ import (
 	"regexp"
 	"strings"
 
+	"log/slog"
+
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
 	"github.com/oklog/ulid/v2"
-	"log/slog"
 )
 
 func init() { maintenance.Register(&fixVersionGroupsJob{}) }
@@ -35,7 +36,7 @@ func (j *fixVersionGroupsJob) DefaultParams() any {
 func (j *fixVersionGroupsJob) Description() string { return "Fix and normalize version groups" }
 func (j *fixVersionGroupsJob) CanResume() bool     { return false }
 
-func (j *fixVersionGroupsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *fixVersionGroupsJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	allBooks, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return fmt.Errorf("failed to list books: %w", err)
@@ -273,7 +274,7 @@ func vgBestMatchSubdir(parent, title string) string {
 	return bestPath
 }
 
-func vgFixAuthorDirPath(store database.Store, book *database.BookCore, subdir string) error {
+func vgFixAuthorDirPath(store maintenance.JobStore, book *database.BookCore, subdir string) error {
 	current, err := store.GetBookByID(book.ID)
 	if err != nil {
 		return fmt.Errorf("GetBookByID: %w", err)

--- a/internal/maintenance/jobs/generate_itl_tests.go
+++ b/internal/maintenance/jobs/generate_itl_tests.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/generate_itl_tests.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: b7e3f1a2-4c5d-6e7f-8a9b-0c1d2e3f4a5b
 // last-edited: 2026-08-17
 
@@ -33,7 +33,7 @@ func (j *generateITLTestsJob) Description() string {
 func (j *generateITLTestsJob) DefaultParams() any { return nil }
 func (j *generateITLTestsJob) CanResume() bool    { return false }
 
-func (j *generateITLTestsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *generateITLTestsJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	if config.AppConfig.RootDir == "" {
 		return fmt.Errorf("root_dir is not configured")
 	}

--- a/internal/maintenance/jobs/merge_chapter_groups.go
+++ b/internal/maintenance/jobs/merge_chapter_groups.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/merge_chapter_groups.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1000020-0000-0000-0000-000000000020
 // last-edited: 2026-08-17
 
@@ -9,10 +9,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"log/slog"
+
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"github.com/falkcorp/audiobook-organizer/internal/scanner"
-	"log/slog"
 )
 
 func init() { maintenance.Register(&mergeChapterGroupsJob{}) }
@@ -31,7 +31,7 @@ func (j *mergeChapterGroupsJob) Description() string {
 	return "Merge multi-chapter book files into consolidated book records"
 }
 func (j *mergeChapterGroupsJob) CanResume() bool { return false }
-func (j *mergeChapterGroupsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *mergeChapterGroupsJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return err

--- a/internal/maintenance/jobs/normalize_primary_flags.go
+++ b/internal/maintenance/jobs/normalize_primary_flags.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/normalize_primary_flags.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 4b8e2d19-7c5a-4f60-9d3b-1e6a8c4f2b07
 // last-edited: 2026-08-17
 
@@ -54,7 +54,7 @@ func (j *normalizePrimaryFlagsJob) Description() string {
 }
 func (j *normalizePrimaryFlagsJob) CanResume() bool { return false } // idempotent single pass
 
-func (j *normalizePrimaryFlagsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *normalizePrimaryFlagsJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	// One limit-0 call = one consistent snapshot; offset pages over the async
 	// memdb can skip or repeat rows on snapshot swap (see reconcile #2443).
 	books, err := store.GetAllBooksCore(0, 0)

--- a/internal/maintenance/jobs/purge_ua_duplicates.go
+++ b/internal/maintenance/jobs/purge_ua_duplicates.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/purge_ua_duplicates.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7a4d1e58-9c26-4b73-b0f2-5e8c3a6d9f41
 // last-edited: 2026-08-17
 
@@ -65,7 +65,7 @@ func (j *purgeUADuplicatesJob) CanResume() bool { return false } // idempotent
 // pass by accident.
 const uaProbeSize = 64 * 1024
 
-func (j *purgeUADuplicatesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *purgeUADuplicatesJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	root := config.AppConfig.RootDir
 	if root == "" {
 		return fmt.Errorf("purge-unknown-author-duplicates: RootDir not configured")

--- a/internal/maintenance/jobs/recompute_book_aggregates.go
+++ b/internal/maintenance/jobs/recompute_book_aggregates.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/recompute_book_aggregates.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 9b0c1d2e-3f4a-5b6c-7d8e-9f0a1b2c3d4e
 // last-edited: 2026-08-17
 
@@ -54,7 +54,7 @@ func (j *recomputeBookAggregatesJob) DefaultParams() any {
 
 func (j *recomputeBookAggregatesJob) Run(
 	ctx context.Context,
-	store database.Store,
+	store maintenance.JobStore,
 	reporter maintenance.ProgressReporter,
 	dryRun bool,
 ) error {

--- a/internal/maintenance/jobs/recompute_itunes_paths.go
+++ b/internal/maintenance/jobs/recompute_itunes_paths.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/recompute_itunes_paths.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1000013-0000-0000-0000-000000000013
 // last-edited: 2026-08-17
 
@@ -8,10 +8,11 @@ package jobs
 import (
 	"context"
 
+	"log/slog"
+
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
-	"log/slog"
 )
 
 func init() { maintenance.Register(&recomputeITunesPathsJob{}) }
@@ -30,7 +31,7 @@ func (j *recomputeITunesPathsJob) Description() string {
 	return "Recompute iTunes path mapping for all book files"
 }
 func (j *recomputeITunesPathsJob) CanResume() bool { return false }
-func (j *recomputeITunesPathsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *recomputeITunesPathsJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	files, err := store.GetAllBookFilesCore()
 	if err != nil {
 		return err

--- a/internal/maintenance/jobs/refetch_missing_authors.go
+++ b/internal/maintenance/jobs/refetch_missing_authors.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/refetch_missing_authors.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: a1000012-0000-0000-0000-000000000012
 // last-edited: 2026-08-17
 
@@ -33,7 +33,7 @@ func (j *refetchMissingAuthorsJob) Description() string {
 func (j *refetchMissingAuthorsJob) DefaultParams() any { return &rma_params{DryRun: true} }
 func (j *refetchMissingAuthorsJob) CanResume() bool    { return true }
 
-func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	opID := maintenance.OperationIDFromCtx(ctx)
 
 	// Load all books without an author. Core-typed: the filter/lookup below

--- a/internal/maintenance/jobs/relink_missing_to_itunes.go
+++ b/internal/maintenance/jobs/relink_missing_to_itunes.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/relink_missing_to_itunes.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: e0f6a4d5-7b8c-9d0e-1f2a-3b4c5d6e7f80
 // last-edited: 2026-08-17
 
@@ -17,7 +17,6 @@ import (
 	"strings"
 
 	"github.com/falkcorp/audiobook-organizer/internal/config"
-	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"github.com/falkcorp/audiobook-organizer/internal/util"
 )
@@ -43,7 +42,7 @@ func (j *relinkMissingToITunesJob) DefaultParams() any {
 }
 func (j *relinkMissingToITunesJob) CanResume() bool { return false }
 
-func (j *relinkMissingToITunesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *relinkMissingToITunesJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	iTunesRoot := config.AppConfig.ITunes.MediaRoot
 	organizerRoot := config.AppConfig.RootDir
 

--- a/internal/maintenance/jobs/relink_report.go
+++ b/internal/maintenance/jobs/relink_report.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/relink_report.go
-// version: 2.5.0
+// version: 2.6.0
 // guid: a1000022-0000-0000-0000-000000000022
 // last-edited: 2026-08-17
 
@@ -15,10 +15,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/falkcorp/audiobook-organizer/internal/config"
-	"github.com/falkcorp/audiobook-organizer/internal/database"
-	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"log/slog"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 )
 
 func init() { maintenance.Register(&relinkReportJob{}) }
@@ -38,7 +38,7 @@ func (j *relinkReportJob) Description() string {
 }
 func (j *relinkReportJob) CanResume() bool { return false }
 
-func (j *relinkReportJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+func (j *relinkReportJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, _ bool) error {
 	iTunesRoot := config.AppConfig.ITunes.MediaRoot
 	organizerRoot := config.AppConfig.RootDir
 

--- a/internal/maintenance/jobs/repair_missing_files.go
+++ b/internal/maintenance/jobs/repair_missing_files.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/repair_missing_files.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: f1a7b5e6-8c9d-0e1f-2a3b-4c5d6e7f8a90
 // last-edited: 2026-08-17
 
@@ -40,7 +40,7 @@ func (j *repairMissingFilesJob) DefaultParams() any {
 }
 func (j *repairMissingFilesJob) CanResume() bool { return true }
 
-func (j *repairMissingFilesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *repairMissingFilesJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	opID := maintenance.OperationIDFromCtx(ctx)
 
 	searchRoots := rmfr_searchRoots()

--- a/internal/maintenance/jobs/retention_and_hygiene.go
+++ b/internal/maintenance/jobs/retention_and_hygiene.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/retention_and_hygiene.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: e7c9d4a2-f1b3-49a8-8c4f-7d2e5a1f3c9e
 // last-edited: 2026-08-17
 
@@ -35,7 +35,7 @@ func (j *retentionAndHygieneJob) Description() string {
 }
 func (j *retentionAndHygieneJob) CanResume() bool { return true }
 
-func (j *retentionAndHygieneJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *retentionAndHygieneJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	slog.Info("retention-and-hygiene job starting", "dry_run", dryRun)
 
 	// (1) Operation/OperationLog retention sweep: delete older than N days (default 90).

--- a/internal/maintenance/jobs/retention_and_hygiene_test.go
+++ b/internal/maintenance/jobs/retention_and_hygiene_test.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/retention_and_hygiene_test.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: f8d0e5b9-c2a4-5b1d-9e7f-8c3d2a1b0f5e
 // last-edited: 2026-08-17
 
@@ -534,9 +534,9 @@ func writeOperationRaw(t *testing.T, store database.Store, id string, createdAt 
 // external jobs_test package and is not visible from the internal jobs package.
 type nopReporter struct{}
 
-func (r *nopReporter) SetTotal(_ int)                     {}
-func (r *nopReporter) Increment()                         {}
-func (r *nopReporter) Log(_ string, _ string, _ *string)  {}
+func (r *nopReporter) SetTotal(_ int)                    {}
+func (r *nopReporter) Increment()                        {}
+func (r *nopReporter) Log(_ string, _ string, _ *string) {}
 
 // opstateSweepMock builds a MockStore holding opstate keys for four operations:
 // one running (must be KEPT — the resume path may still load it), one completed

--- a/internal/maintenance/jobs/revert_metadata_fetch.go
+++ b/internal/maintenance/jobs/revert_metadata_fetch.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/revert_metadata_fetch.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c8d4e2b3-5f6a-7b8c-9d0e-1f2a3b4c5d6e
 // last-edited: 2026-08-17
 
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 )
 
@@ -34,7 +33,7 @@ func (j *revertMetadataFetchJob) Description() string {
 func (j *revertMetadataFetchJob) DefaultParams() any { return &rmf_params{OperationIDs: []string{}} }
 func (j *revertMetadataFetchJob) CanResume() bool    { return false }
 
-func (j *revertMetadataFetchJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *revertMetadataFetchJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	opID := maintenance.OperationIDFromCtx(ctx)
 
 	// Load parameters: fetch_op_ids from operation params if stored.

--- a/internal/maintenance/jobs/scan_chapter_groups.go
+++ b/internal/maintenance/jobs/scan_chapter_groups.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/scan_chapter_groups.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1000019-0000-0000-0000-000000000019
 // last-edited: 2026-08-17
 
@@ -9,10 +9,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"log/slog"
+
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"github.com/falkcorp/audiobook-organizer/internal/scanner"
-	"log/slog"
 )
 
 func init() { maintenance.Register(&scanChapterGroupsJob{}) }
@@ -31,7 +31,7 @@ func (j *scanChapterGroupsJob) Description() string {
 	return "Report books that look like multi-chapter parts of the same audiobook"
 }
 func (j *scanChapterGroupsJob) CanResume() bool { return false }
-func (j *scanChapterGroupsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+func (j *scanChapterGroupsJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, _ bool) error {
 	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return err

--- a/internal/maintenance/jobs/scan_composer_tags.go
+++ b/internal/maintenance/jobs/scan_composer_tags.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/scan_composer_tags.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: d9e5f3c4-6a7b-8c9d-0e1f-2a3b4c5d6e7f
 // last-edited: 2026-08-17
 
@@ -41,7 +41,7 @@ func (j *scanComposerTagsJob) DefaultParams() any {
 }
 func (j *scanComposerTagsJob) CanResume() bool { return true }
 
-func (j *scanComposerTagsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+func (j *scanComposerTagsJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, dryRun bool) error {
 	opID := maintenance.OperationIDFromCtx(ctx)
 
 	// Load fix_mode from persisted params when resuming.

--- a/internal/maintenance/jobs/scan_duplicate_files.go
+++ b/internal/maintenance/jobs/scan_duplicate_files.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/scan_duplicate_files.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1000016-0000-0000-0000-000000000016
 // last-edited: 2026-08-17
 
@@ -9,9 +9,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/falkcorp/audiobook-organizer/internal/database"
-	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"log/slog"
+
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 )
 
 func init() { maintenance.Register(&scanDuplicateFilesJob{}) }
@@ -30,7 +30,7 @@ func (j *scanDuplicateFilesJob) Description() string {
 	return "Scan for book files sharing the same hash"
 }
 func (j *scanDuplicateFilesJob) CanResume() bool { return false }
-func (j *scanDuplicateFilesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+func (j *scanDuplicateFilesJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, _ bool) error {
 	files, err := store.GetAllBookFilesCore()
 	if err != nil {
 		return err

--- a/internal/maintenance/jobs/scan_duration_mismatch.go
+++ b/internal/maintenance/jobs/scan_duration_mismatch.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/scan_duration_mismatch.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1000018-0000-0000-0000-000000000018
 // last-edited: 2026-08-17
 
@@ -9,9 +9,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/falkcorp/audiobook-organizer/internal/database"
-	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"log/slog"
+
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 )
 
 func init() { maintenance.Register(&scanDurationMismatchJob{}) }
@@ -30,7 +30,7 @@ func (j *scanDurationMismatchJob) Description() string {
 	return "Report books whose local duration differs significantly from Audible runtime"
 }
 func (j *scanDurationMismatchJob) CanResume() bool { return false }
-func (j *scanDurationMismatchJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+func (j *scanDurationMismatchJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, _ bool) error {
 	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return err

--- a/internal/maintenance/jobs/scan_metadata_hash_dups.go
+++ b/internal/maintenance/jobs/scan_metadata_hash_dups.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/scan_metadata_hash_dups.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1000017-0000-0000-0000-000000000017
 // last-edited: 2026-08-17
 
@@ -9,9 +9,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/falkcorp/audiobook-organizer/internal/database"
-	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"log/slog"
+
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 )
 
 func init() { maintenance.Register(&scanMetadataHashDupsJob{}) }
@@ -30,7 +30,7 @@ func (j *scanMetadataHashDupsJob) Description() string {
 	return "Scan for books sharing the same metadata source hash"
 }
 func (j *scanMetadataHashDupsJob) CanResume() bool { return false }
-func (j *scanMetadataHashDupsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+func (j *scanMetadataHashDupsJob) Run(ctx context.Context, store maintenance.JobStore, reporter maintenance.ProgressReporter, _ bool) error {
 	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return err

--- a/internal/maintenance/jobs/sweep_pebble_metrics_ttl.go
+++ b/internal/maintenance/jobs/sweep_pebble_metrics_ttl.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/sweep_pebble_metrics_ttl.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b8c9d0e1-f2a3-0008-1234-000000000008
 // last-edited: 2026-08-17
 
@@ -43,7 +43,7 @@ func (j *sweepPebbleMetricsTTLJob) DefaultParams() any {
 // a different backend (SQLite or mock) the job is a no-op so CI tests pass.
 func (j *sweepPebbleMetricsTTLJob) Run(
 	ctx context.Context,
-	store database.Store,
+	store maintenance.JobStore,
 	reporter maintenance.ProgressReporter,
 	dryRun bool,
 ) error {

--- a/internal/server/maintenance_dryrun_default_test.go
+++ b/internal/server/maintenance_dryrun_default_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/maintenance_dryrun_default_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6c1d84af-97b2-4e30-8f55-2b70e9c14d63
-// last-edited: 2026-08-14
+// last-edited: 2026-08-17
 
 package server
 
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
 	"github.com/falkcorp/audiobook-organizer/internal/operations"
 	"github.com/gin-gonic/gin"
@@ -57,7 +56,7 @@ func (j *dryRunProbeJob) Policy() maintenance.ExecutionPolicy {
 	return maintenance.DefaultPolicy()
 }
 
-func (j *dryRunProbeJob) Run(_ context.Context, _ database.Store, _ maintenance.ProgressReporter, dryRun bool) error {
+func (j *dryRunProbeJob) Run(_ context.Context, _ maintenance.JobStore, _ maintenance.ProgressReporter, dryRun bool) error {
 	j.mu.Lock()
 	j.runs = append(j.runs, dryRun)
 	j.mu.Unlock()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 2.40.0
+// version: 2.41.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-08-16
+// last-edited: 2026-08-17
 
 package server
 
@@ -579,8 +579,7 @@ func NewServer(store database.Store) *Server {
 	// Propagate rootDir into the store so LibraryStats can split organized vs unorganized.
 	resolvedStore.SetRootDir(config.AppConfig.RootDir)
 
-	// Inject the store into the maintenance package so jobs can access it.
-	maintenance.InjectStore(resolvedStore)
+	// Inject the iTunes write-back enqueuer into the maintenance package.
 	if server.writeBackBatcher != nil {
 		maintenance.InjectEnqueuer(server.writeBackBatcher)
 	}

--- a/todo.d/20260817-make-ci-is-red-on-main-at-staticcheck.md
+++ b/todo.d/20260817-make-ci-is-red-on-main-at-staticcheck.md
@@ -1,0 +1,29 @@
+- [ ] **`make ci` cannot pass on `main` — staticcheck has 10 findings and aborts the target**
+
+  Measured 2026-08-17 by running `make staticcheck` at `origin/main` (detached) and on a
+  feature branch and diffing the two lists: **10 findings, byte-identical on both**. The
+  feature branch introduced none and removed none. Because `staticcheck` runs before
+  `test-all-short` and `coverage-check-short` in the `ci:` target, `make ci` exits 1 on a
+  clean checkout of `main`, and the two stages after it never run at all.
+
+  Why this went unnoticed: GitHub CI merges PRs green, so whatever the required checks run,
+  it is not this target. The documented local gate and the enforced remote gate disagree —
+  which means "I ran `make ci`" currently proves less than it reads.
+
+  The 10 findings (8 are dead code, 1 is a real nil-deref candidate):
+
+  - `internal/metafetch/service_apply.go:637` — **SA5011 possible nil pointer dereference**,
+    with the contradicting nil-check at `:662`. This is the one with a bug behind it.
+  - `internal/plugins/maintenance/regroup_shattered_ai_test.go:180` — SA4006/SA4010, an
+    `append` result that is never used. A test that discards what it builds.
+  - U1000 unused: `dlIntPtr` + `dlInt64Ptr`
+    (`internal/database/dataloss_preserve_invariant_test.go:26-27`), `(*Plugin).pathRepairDef`
+    (`internal/plugins/itunes/path_repair.go:16`), `updatedBooks` field
+    (`internal/plugins/maintenance/author_conjunction_repair_test.go:22`), `udRowByItem`
+    (`internal/server/handlers/abs/userdata_test.go:332`), `errString`
+    (`internal/server/handlers/metadata_cache.go:403`), `operationV2ToLegacy`
+    (`internal/server/handlers/operations/handler.go:114`).
+
+  Fix order that matters: triage the SA5011 first (it is the only one that can misbehave at
+  runtime), then clear the U1000s, then decide whether staticcheck belongs in the required
+  remote checks — a gate that only fails locally trains people to skip it.


### PR DESCRIPTION
Follows #2533. Independent of it in code, but rebased on top so the `ExecutionPolicy` doc comment can reference `RegisterMaintenanceJobOps`.

## What

`database.Store` embeds 40 sub-interfaces resolving to **398 methods**. The 37 maintenance jobs between them touch **12** of those sub-interfaces — **187 methods**. `Run` now takes `maintenance.JobStore`, a union of exactly those 12.

| | before | after |
|---|---|---|
| methods | 398 | **187** (−53.0%) |
| sub-interfaces | 40 | **12** |
| job `Run` bodies changed | — | **0** |
| test fakes needing an edit | — | **1** |
| job files that no longer import `internal/database` at all | — | **8** |

## Why the compiler is the test here

The union was measured from every direct `store.X()` call in the job bodies plus the parameter type of every helper a job hands `store` to. That is a **lower bound by construction** — a call-site probe cannot see pass-through usage, and an earlier version of this measurement was wrong for exactly that reason.

Swapping the parameter type is what converts the estimate into a proof: `go build ./...` succeeds only if all 37 jobs *and* every helper they reach genuinely fit inside those 12. No test asserts the union; the type checker does, and it can't be fooled.

## Three things that looked like blockers and were not

- **The `As*Store` capability probes take `s any`,** and `AsCapability` dispatches on the **dynamic** type (`s.(T)`, `s.(StoreUnwrapper)`). Boxing the same concrete value in a narrower interface is invisible to them, so `AsPebbleStore` still resolves through the Bleve decorator exactly as before. No new nil path in `recompute-book-aggregates` or `sweep-pebble-metrics-ttl`.
- **`operations.{ClearState,LoadCheckpoint,SaveCheckpoint}`** already took `database.OperationStore`, which is inside the union.
- **The metadata-cache helpers** took the full `Store` but the entire file uses exactly 5 methods — `GetRaw`, `SetRaw`, `DeleteRaw`, `ScanPrefix`, `CountPrefix` — and `database.RawKVStore` already declared exactly those 5. All **6** exported functions in that file now take it, not just the 2 that were blocking; leaving siblings on the wide type is how these drift back.

## Also removed

The package-level store global in `internal/maintenance`. `InjectStore` was called once at startup and `GetStore` had **zero** readers anywhere in the tree — write-only.

## What this does NOT do

**It does not delete `database.MockStore`.** MockStore is imported far beyond this package and satisfies `JobStore` too, so the 14 job tests that build one still compile unchanged. This buys a bounded contract and the *option* of a small per-job double — not a deletion. Flagging that explicitly because the earlier framing of this work overclaimed it.

## Verification

- `go build ./...`, `go vet` on maintenance/server/database: clean.
- `go test ./internal/maintenance/... ./internal/server/... ./internal/database/...`: no failures.
- `make staticcheck` diffed against `origin/main`: **identical 10 findings on both**, so this branch introduces none. Those 10 pre-date it and make `make ci` red on `main` itself — filed as a todo fragment in this PR, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TAPsYa3Mmz8hC4azezX5t